### PR TITLE
feat: add TTY password prompt for encrypted repositories

### DIFF
--- a/cmd/cloudstic/main.go
+++ b/cmd/cloudstic/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cloudstic/cli/internal/ui"
 	"github.com/cloudstic/cli/pkg/crypto"
 	"github.com/cloudstic/cli/pkg/store"
+	"github.com/moby/term"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -303,16 +304,34 @@ func (g *globalFlags) openStore() (store.ObjectStore, []byte, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	if len(platformKey) == 0 && *g.encryptionPassword == "" && *g.recoveryKey == "" {
-		return nil, nil, fmt.Errorf("repository is encrypted -- provide --encryption-key, --encryption-password, or --recovery-key")
-	}
-
 	slots, err := g.loadKeySlots(raw)
 	if err != nil {
 		return nil, nil, fmt.Errorf("load encryption key slots: %w", err)
 	}
 	if len(slots) == 0 {
 		return nil, nil, fmt.Errorf("repository is encrypted but no key slots found")
+	}
+
+	if len(platformKey) == 0 && *g.encryptionPassword == "" && *g.recoveryKey == "" {
+		hasPasswordSlot := false
+		for _, s := range slots {
+			if s.SlotType == "password" {
+				hasPasswordSlot = true
+				break
+			}
+		}
+
+		if hasPasswordSlot && term.IsTerminal(os.Stdin.Fd()) {
+			pw, err := ui.PromptPassword("Repository password")
+			if err != nil {
+				return nil, nil, fmt.Errorf("read password: %w", err)
+			}
+			*g.encryptionPassword = pw
+		}
+
+		if *g.encryptionPassword == "" {
+			return nil, nil, fmt.Errorf("repository is encrypted -- provide --encryption-key, --encryption-password, or --recovery-key")
+		}
 	}
 
 	encKey, err := openExistingSlots(slots, platformKey, *g.encryptionPassword, *g.recoveryKey)
@@ -459,10 +478,34 @@ func runInit() {
 	hasEncryptionCreds := len(platformKey) > 0 || password != ""
 
 	if !hasEncryptionCreds && !*noEncryption {
-		fmt.Fprintln(os.Stderr, "Error: encryption is required by default.")
-		fmt.Fprintln(os.Stderr, "Provide --encryption-password or --encryption-key to encrypt your repository.")
-		fmt.Fprintln(os.Stderr, "To create an unencrypted repository, pass --no-encryption (not recommended).")
-		os.Exit(1)
+		if term.IsTerminal(os.Stdin.Fd()) {
+			pw, err := ui.PromptPassword("Enter new repository password")
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to read password: %v\n", err)
+				os.Exit(1)
+			}
+			if pw == "" {
+				fmt.Fprintln(os.Stderr, "Error: encryption password cannot be empty.")
+				os.Exit(1)
+			}
+			// Confirm password
+			pw2, err := ui.PromptPassword("Confirm repository password")
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to read password confirmation: %v\n", err)
+				os.Exit(1)
+			}
+			if pw != pw2 {
+				fmt.Fprintln(os.Stderr, "Error: passwords do not match.")
+				os.Exit(1)
+			}
+			password = pw
+			hasEncryptionCreds = true
+		} else {
+			fmt.Fprintln(os.Stderr, "Error: encryption is required by default.")
+			fmt.Fprintln(os.Stderr, "Provide --encryption-password or --encryption-key to encrypt your repository.")
+			fmt.Fprintln(os.Stderr, "To create an unencrypted repository, pass --no-encryption (not recommended).")
+			os.Exit(1)
+		}
 	}
 
 	encrypted := hasEncryptionCreds

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/jedib0t/go-pretty/v6 v6.7.5
 	github.com/jotfs/fastcdc-go v0.2.0
+	github.com/moby/term v0.5.0
 	github.com/pkg/sftp v1.13.10
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/minio v0.40.0
@@ -19,6 +20,7 @@ require (
 	golang.org/x/crypto v0.48.0
 	golang.org/x/oauth2 v0.35.0
 	golang.org/x/sync v0.19.0
+	golang.org/x/term v0.40.0
 	google.golang.org/api v0.256.0
 )
 
@@ -79,7 +81,6 @@ require (
 	github.com/moby/sys/sequential v0.6.0 // indirect
 	github.com/moby/sys/user v0.4.0 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect
-	github.com/moby/term v0.5.0 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
@@ -100,7 +101,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.39.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
-	golang.org/x/term v0.40.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260209200024-4cfbd4190f57 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260209200024-4cfbd4190f57 // indirect

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -1,0 +1,24 @@
+package ui
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+// PromptPassword prompts the user for a password on the terminal without echoing.
+func PromptPassword(prompt string) (string, error) {
+	fmt.Fprintf(os.Stderr, "%s: ", prompt)
+
+	// We use os.Stdin.Fd() to read from the terminal.
+	// golang.org/x/term.ReadPassword handles disabling echo.
+	pw, err := term.ReadPassword(int(os.Stdin.Fd()))
+	fmt.Fprintln(os.Stderr) // Move to the next line after the password is entered
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(pw)), nil
+}


### PR DESCRIPTION
This PR adds a secure TTY password prompt for the Cloudstic CLI. This allows users to interactively provide their repository password when it's not present in environment variables or command-line flags.

### Changes Included:
- **Internal UI**: Added `PromptPassword` utility in `internal/ui/prompt.go` that uses `golang.org/x/term` to disable echo during password entry.
- **CLI Commands**:
    - Updated `openStore()` in `cmd/cloudstic/main.go` to prompt for a password if required (i.e., when a password key slot exists and no credentials are provided) in interactive environments.
    - Updated `runInit()` in `cmd/cloudstic/main.go` to prompt for a new password (with confirmation) if no encryption credentials are provided and `--no-encryption` is not specified.

### Verification:
- Confirmed that the project compiles successfully with the new changes.
- Manually verified the password prompt behavior in a local terminal environment.
