### PR TITLE
perf: 7.7x faster S3 uploads via adaptive concurrency (250s → 32s)

### DIFF
--- a/docs/benchmark-results.md
+++ b/docs/benchmark-results.md
@@ -1,13 +1,23 @@
 # Benchmark Results
 
 Dataset: 1.0 GB (500MB random, 500MB highly compressible zero data, 10,000 small files)
-Target Type: Local File System (`local`)
+
+## Local File System
 
 | Metric | Cloudstic | Restic | Borg |
 | :--- | :--- | :--- | :--- |
-| **Initial Backup Time / Peak Mem** | 5.83s / 319.32 MB | 1.82s / 346.81 MB | 2.49s / 172.65 MB |
-| **Incremental (No Changes)** | 0.85s / 165.78 MB | 1.13s / 100.85 MB | 0.81s / 80.60 MB |
-| **Incremental (1 File Changed)** | 0.93s / 180.42 MB | 1.14s / 115.73 MB | 0.79s / 81.54 MB |
+| **Initial Backup Time / Peak Mem** | 5.83s / 319 MB | 1.82s / 347 MB | 2.49s / 173 MB |
+| **Incremental (No Changes)** | 0.85s / 166 MB | 1.13s / 101 MB | 0.81s / 81 MB |
+| **Incremental (1 File Changed)** | 0.93s / 180 MB | 1.14s / 116 MB | 0.79s / 82 MB |
 | **Final Repository Size** | 585 MB | 503 MB | 506 MB |
 
-Note: Cloudstic currently consumes slightly more actual disk space for repositories compared to Restic and Borg (roughly 80MB on the 10,000 files benchmark). This is an architectural side-effect of its "1-to-1 object mapping" design that intentionally avoids Packfiles. In packfile-based systems, small files and their metadata are tightly batched and compressed together into monolithic blobs. In Cloudstic, every file gets an individual `filemeta` entry encrypted separately. When storing 10,000 small files, this overhead accumulates (about ~39MB for `filemeta` objects and their encryption padding). While resulting in slightly higher size, this guarantees pristine file-level object deduplication and drastically simplified remote synching capabilities natively on S3.
+## AWS S3 (us-east-1)
+
+| Metric | Cloudstic | Restic |
+| :--- | :--- | :--- |
+| **Initial Backup Time / Peak Mem** | 32.47s / 752 MB | 17.22s / 503 MB |
+| **Incremental (No Changes)** | 9.23s / 186 MB | 2.55s / 97 MB |
+| **Incremental (1 File Changed)** | 10.69s / 204 MB | 3.25s / 104 MB |
+
+> **Note on performance differences:** Cloudstic uses a "1-to-1 object mapping" design that intentionally avoids packfiles. Every file gets an individual encrypted object. On local storage, this results in a modest overhead (~3x on initial backup) due to filesystem metadata operations. On S3, the gap narrows to ~2x on initial backup thanks to 128-concurrent uploads, but Cloudstic still issues ~20,000 individual PUT requests vs Restic's ~30 large packfile uploads. This design enables native S3-level object deduplication, simplified syncing, and file-level granularity that packfile-based tools cannot offer.
+

--- a/internal/engine/backup_upload.go
+++ b/internal/engine/backup_upload.go
@@ -9,9 +9,10 @@ import (
 
 	"github.com/cloudstic/cli/internal/core"
 	"github.com/cloudstic/cli/internal/ui"
+	"github.com/cloudstic/cli/pkg/store"
 )
 
-const uploadConcurrency = 10
+const defaultUploadConcurrency = 10
 
 // inlineThreshold is the maximum file size for which content is stored inline
 // in the Content object rather than as separate chunk objects.
@@ -43,10 +44,12 @@ func (bm *BackupManager) upload(ctx context.Context, pending []core.FileMeta, to
 
 	phase := bm.reporter.StartPhase("Uploading", totalBytes, true)
 
+	concurrency := store.GetConcurrencyHint(bm.store, defaultUploadConcurrency)
+
 	jobs := make(chan core.FileMeta, min(128, len(pending)))
 	results := make(chan uploadResult, min(128, len(pending)))
 
-	for range min(uploadConcurrency, len(pending)) {
+	for range min(concurrency, len(pending)) {
 		go func() {
 			for meta := range jobs {
 				results <- bm.processFile(ctx, meta, phase)

--- a/internal/hamt/cache.go
+++ b/internal/hamt/cache.go
@@ -227,7 +227,7 @@ func (ts *TransactionalStore) writeParallel(toWrite map[string][]byte) error {
 	jobs := make(chan job, len(toWrite))
 	errs := make(chan error, len(toWrite))
 
-	workers := min(20, len(toWrite))
+	workers := min(store.GetConcurrencyHint(ts.persistent, 20), len(toWrite))
 	for range workers {
 		go func() {
 			for j := range jobs {

--- a/pkg/store/compressed.go
+++ b/pkg/store/compressed.go
@@ -38,6 +38,8 @@ type CompressedStore struct {
 	inner ObjectStore
 }
 
+func (s *CompressedStore) Unwrap() ObjectStore { return s.inner }
+
 func NewCompressedStore(inner ObjectStore) *CompressedStore {
 	initZstd()
 	return &CompressedStore{inner: inner}

--- a/pkg/store/debug.go
+++ b/pkg/store/debug.go
@@ -27,6 +27,8 @@ type DebugStore struct {
 	calls atomic.Int64
 }
 
+func (s *DebugStore) Unwrap() ObjectStore { return s.inner }
+
 func NewDebugStore(inner ObjectStore, w io.Writer) *DebugStore {
 	return &DebugStore{inner: inner, w: w}
 }

--- a/pkg/store/encrypted.go
+++ b/pkg/store/encrypted.go
@@ -24,6 +24,8 @@ type EncryptedStore struct {
 	key []byte
 }
 
+func (s *EncryptedStore) Unwrap() ObjectStore { return s.ObjectStore }
+
 // NewEncryptedStore creates an EncryptedStore that encrypts all Put operations
 // and decrypts Get operations. The key must be 32 bytes (AES-256).
 func NewEncryptedStore(inner ObjectStore, key []byte) *EncryptedStore {

--- a/pkg/store/hybrid.go
+++ b/pkg/store/hybrid.go
@@ -22,6 +22,8 @@ type HybridStore struct {
 	store ObjectStore
 }
 
+func (s *HybridStore) Unwrap() ObjectStore { return s.store }
+
 func NewHybridStore(db TxFunc, store ObjectStore) *HybridStore {
 	return &HybridStore{db: db, store: store}
 }

--- a/pkg/store/interface.go
+++ b/pkg/store/interface.go
@@ -19,6 +19,35 @@ type ObjectStore interface {
 	TotalSize(ctx context.Context) (int64, error)
 }
 
+// ConcurrencyHinter is an optional interface that ObjectStore implementations
+// can implement to indicate the optimal number of concurrent operations.
+// Remote stores (S3) benefit from high concurrency; local stores do not.
+type ConcurrencyHinter interface {
+	ConcurrencyHint() int
+}
+
+// Unwrapper is an optional interface for wrapper stores (CompressedStore,
+// EncryptedStore, etc.) to expose their inner store for introspection.
+type Unwrapper interface {
+	Unwrap() ObjectStore
+}
+
+// GetConcurrencyHint walks the store wrapper chain and returns the first
+// ConcurrencyHint it finds, defaulting to defaultConcurrency if none exists.
+func GetConcurrencyHint(s ObjectStore, defaultConcurrency int) int {
+	for s != nil {
+		if h, ok := s.(ConcurrencyHinter); ok {
+			return h.ConcurrencyHint()
+		}
+		if u, ok := s.(Unwrapper); ok {
+			s = u.Unwrap()
+		} else {
+			break
+		}
+	}
+	return defaultConcurrency
+}
+
 // SourceSize holds the total size of a source.
 type SourceSize struct {
 	Bytes int64 `json:"bytes"`

--- a/pkg/store/keycache.go
+++ b/pkg/store/keycache.go
@@ -18,6 +18,8 @@ type KeyCacheStore struct {
 	putFlight      singleflight.Group
 }
 
+func (s *KeyCacheStore) Unwrap() ObjectStore { return s.inner }
+
 func NewKeyCacheStore(inner ObjectStore) *KeyCacheStore {
 	return &KeyCacheStore{
 		inner:          inner,

--- a/pkg/store/metered.go
+++ b/pkg/store/metered.go
@@ -12,6 +12,8 @@ type MeteredStore struct {
 	bytesWritten atomic.Int64
 }
 
+func (m *MeteredStore) Unwrap() ObjectStore { return m.ObjectStore }
+
 func NewMeteredStore(s ObjectStore) *MeteredStore {
 	return &MeteredStore{ObjectStore: s}
 }

--- a/pkg/store/quota.go
+++ b/pkg/store/quota.go
@@ -17,6 +17,8 @@ type QuotaStore struct {
 	cancel  context.CancelCauseFunc
 }
 
+func (q *QuotaStore) Unwrap() ObjectStore { return q.ObjectStore }
+
 func NewQuotaStore(inner ObjectStore, budget int64, cancel context.CancelCauseFunc) *QuotaStore {
 	return &QuotaStore{ObjectStore: inner, budget: budget, cancel: cancel}
 }

--- a/pkg/store/s3.go
+++ b/pkg/store/s3.go
@@ -6,9 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -25,9 +27,20 @@ type S3Store struct {
 
 // NewS3Store creates a new S3Store.
 // It initializes the AWS SDK config and S3 client.
+const s3Concurrency = 128
+
 func NewS3Store(ctx context.Context, endpoint, region, bucketName, accessKey, secretKey, prefix string) (*S3Store, error) {
+	// Use a high-concurrency HTTP transport for S3. Go's default limits
+	// MaxIdleConnsPerHost to 2, which severely throttles parallel uploads.
+	httpClient := awshttp.NewBuildableClient().WithTransportOptions(func(t *http.Transport) {
+		t.MaxIdleConns = 256
+		t.MaxIdleConnsPerHost = s3Concurrency
+		t.MaxConnsPerHost = s3Concurrency
+	})
+
 	opts := []func(*config.LoadOptions) error{
 		config.WithRegion(region),
+		config.WithHTTPClient(httpClient),
 	}
 
 	if accessKey != "" && secretKey != "" {
@@ -53,6 +66,12 @@ func NewS3Store(ctx context.Context, endpoint, region, bucketName, accessKey, se
 		BucketName: bucketName,
 		Prefix:     prefix,
 	}, nil
+}
+
+// ConcurrencyHint implements ConcurrencyHinter. S3 benefits from highly
+// parallel uploads since each PUT is a separate HTTP round-trip.
+func (s *S3Store) ConcurrencyHint() int {
+	return s3Concurrency
 }
 
 func (s *S3Store) key(k string) string {

--- a/scripts/benchmark/run.sh
+++ b/scripts/benchmark/run.sh
@@ -3,13 +3,23 @@
 set -e
 
 TARGET=${1:-local} # Default to local
-S3_BUCKET=${S3_BUCKET:-my-benchmark-bucket}
+S3_BUCKET=${S3_BUCKET:-cloudstic-benchmark-681494392773-us-east-1}
 AWS_REGION=${AWS_REGION:-us-east-1}
 
 if [ "$TARGET" != "local" ] && [ "$TARGET" != "s3" ]; then
     echo "Usage: $0 [local|s3]"
     exit 1
 fi
+
+# Export temporary AWS credentials for tools that don't support SSO natively (e.g. restic)
+# if [ "$TARGET" == "s3" ]; then
+#     if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+#         echo "Exporting AWS credentials from SSO session..."
+#         eval "$(aws configure export-credentials --format env 2>/dev/null)" || {
+#             echo "Warning: Could not export AWS credentials. Restic S3 benchmark may fail."
+#         }
+#     fi
+# fi
 
 echo "=== Cloudstic Benchmark ==="
 echo "Target: $TARGET"
@@ -93,12 +103,12 @@ benchmark_cloudstic() {
         local repo_size=$(du -sh "$repo" | cut -f1 | xargs)
         printf "| %-30s | %12s | %13s |\n" "Final Repo Size" "$repo_size" "-"
     else
-        $CLOUDSTIC_BIN init -store s3 -store-path "$S3_BUCKET" -store-prefix "cloudstic/" >/dev/null 2>&1
-        run_bench "Initial Backup" $CLOUDSTIC_BIN backup -store s3 -store-path "$S3_BUCKET" -store-prefix "cloudstic/" -source local -source-path "$DATA_DIR" -quiet
-        run_bench "Incremental (No Changes)" $CLOUDSTIC_BIN backup -store s3 -store-path "$S3_BUCKET" -store-prefix "cloudstic/" -source local -source-path "$DATA_DIR" -quiet
+        $CLOUDSTIC_BIN init -store s3 -encryption-password "$PASSWORD" -store-path "$S3_BUCKET" -store-prefix "cloudstic/" >/dev/null 2>&1 || true
+        run_bench "Initial Backup" $CLOUDSTIC_BIN backup -store s3 -encryption-password "$PASSWORD" -store-path "$S3_BUCKET" -store-prefix "cloudstic/" -source local -source-path "$DATA_DIR" -quiet
+        run_bench "Incremental (No Changes)" $CLOUDSTIC_BIN backup -store s3 -encryption-password "$PASSWORD" -store-path "$S3_BUCKET" -store-prefix "cloudstic/" -source local -source-path "$DATA_DIR" -quiet
         
         echo "modified" >> "$DATA_DIR/small/file_1.txt"
-        run_bench "Incremental (1 File Changed)" $CLOUDSTIC_BIN backup -store s3 -store-path "$S3_BUCKET" -store-prefix "cloudstic/" -source local -source-path "$DATA_DIR" -quiet
+        run_bench "Incremental (1 File Changed)" $CLOUDSTIC_BIN backup -store s3 -encryption-password "$PASSWORD" -store-path "$S3_BUCKET" -store-prefix "cloudstic/" -source local -source-path "$DATA_DIR" -quiet
     fi
     echo ""
 }
@@ -127,13 +137,12 @@ benchmark_restic() {
         local repo_size=$(du -sh "$repo" | cut -f1 | xargs)
         printf "| %-30s | %12s | %13s |\n" "Final Repo Size" "$repo_size" "-"
     else
-        # Assuming AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are set
-        restic init -r "s3:s3.amazonaws.com/$S3_BUCKET/restic" >/dev/null 2>&1
-        run_bench "Initial Backup" restic backup -r "s3:s3.amazonaws.com/$S3_BUCKET/restic" "$DATA_DIR"
-        run_bench "Incremental (No Changes)" restic backup -r "s3:s3.amazonaws.com/$S3_BUCKET/restic" "$DATA_DIR"
+        restic init -r "s3:s3.$AWS_REGION.amazonaws.com/$S3_BUCKET/restic" >/dev/null 2>&1 || true
+        run_bench "Initial Backup" restic backup -r "s3:s3.$AWS_REGION.amazonaws.com/$S3_BUCKET/restic" "$DATA_DIR"
+        run_bench "Incremental (No Changes)" restic backup -r "s3:s3.$AWS_REGION.amazonaws.com/$S3_BUCKET/restic" "$DATA_DIR"
         
         echo "modified" >> "$DATA_DIR/small/file_2.txt"
-        run_bench "Incremental (1 File Changed)" restic backup -r "s3:s3.amazonaws.com/$S3_BUCKET/restic" "$DATA_DIR"
+        run_bench "Incremental (1 File Changed)" restic backup -r "s3:s3.$AWS_REGION.amazonaws.com/$S3_BUCKET/restic" "$DATA_DIR"
     fi
     echo ""
 }


### PR DESCRIPTION
## Summary

S3 initial backup was **250s** — unacceptably slow compared to Restic's 17s. Root cause: 20,000 individual S3 PUT requests throttled to just 10 concurrent connections.

**Result: 250s → 32s** (7.7x faster) 🚀

## The Math

```
Before: 20,000 PUTs ÷ 10 workers = 2,000 rounds × 100ms = 200s
After:  20,000 PUTs ÷ 128 workers = 156 rounds × 100ms ≈ 16s (theoretical)
Actual: 32s (includes HAMT flush, encryption overhead, S3 throttling)
```

## Changes

### Store Interface (`pkg/store/interface.go`)
- Added `ConcurrencyHinter` interface — stores can signal their optimal concurrency
- Added `Unwrapper` interface — enables walking wrapper chains to find the underlying store
- `GetConcurrencyHint()` helper walks the chain and returns the first hint found

### S3 Store (`pkg/store/s3.go`)
- Configured custom HTTP transport with `MaxIdleConnsPerHost=128` (Go default was **2**)
- Implements `ConcurrencyHint() → 128`

### Upload Pipeline (`internal/engine/backup_upload.go`)
- Replaced hardcoded `uploadConcurrency = 10` with `store.GetConcurrencyHint(bm.store, 10)`
- Local stores still use 10; S3 automatically scales to 128

### HAMT Flush (`internal/hamt/cache.go`)
- `writeParallel` now uses `store.GetConcurrencyHint(ts.persistent, 20)` instead of hardcoded 20

### Wrapper Stores
Added `Unwrap()` to all 7 wrapper stores so the S3 concurrency hint propagates through the chain:
`CompressedStore`, `EncryptedStore`, `MeteredStore`, `KeyCacheStore`, `QuotaStore`, `DebugStore`, `HybridStore`

### Benchmark Script & Results
- Fixed regional S3 endpoint (`s3.us-east-1.amazonaws.com` vs global)
- Updated benchmark results with new S3 numbers

## S3 Benchmark Results

| Metric | Cloudstic (before) | Cloudstic (after) | Restic |
| :--- | :--- | :--- | :--- |
| **Initial Backup** | 250.69s / 371 MB | **32.47s / 752 MB** | 17.22s / 503 MB |
| **Incremental (No Changes)** | 8.75s / 186 MB | **9.23s / 186 MB** | 2.55s / 97 MB |
| **Incremental (1 File Changed)** | 10.42s / 193 MB | **10.69s / 204 MB** | 3.25s / 104 MB |

The remaining ~2x gap vs Restic is architectural: 20,000 individual PUT requests vs ~30 packfile uploads. This is the expected trade-off for 1-to-1 object mapping.