### PR TITLE
feat: add shell completions for bash, zsh, and fish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ backup_store/
 restore_out/
 .envrc
 .idea/
-cloudstic
+/bin/cloudstic
 dist/
 
 # Test output

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,6 +43,7 @@ brews:
     license: "MIT"
     install: |
       bin.install "cloudstic"
+      generate_completions_from_executable(bin/"cloudstic", "completion")
     test: |
       system "#{bin}/cloudstic", "version"
 

--- a/cmd/cloudstic/completion.go
+++ b/cmd/cloudstic/completion.go
@@ -1,0 +1,345 @@
+package main
+
+import (
+	"fmt"
+	"io"
+)
+
+// completionBash writes a bash completion script to w.
+func completionBash(w io.Writer) {
+	_, _ = fmt.Fprint(w, `# bash completion for cloudstic
+
+_cloudstic() {
+    local cur prev words cword
+    _init_completion || return
+
+    local commands="init backup restore list ls prune forget diff break-lock add-recovery-key cat completion version help"
+
+    local global_flags="-store -store-path -store-prefix -s3-endpoint -s3-region -s3-access-key -s3-secret-key -sftp-host -sftp-port -sftp-user -sftp-password -sftp-key -source-sftp-host -source-sftp-port -source-sftp-user -source-sftp-password -source-sftp-key -store-sftp-host -store-sftp-port -store-sftp-user -store-sftp-password -store-sftp-key -encryption-key -encryption-password -recovery-key -kms-key-arn -enable-packfile -verbose -quiet -debug"
+
+    # Identify the subcommand
+    local cmd=""
+    local i
+    for ((i=1; i < cword; i++)); do
+        case "${words[i]}" in
+            -*)
+                # skip flags and their values
+                case "${words[i]}" in
+                    -store|-store-path|-store-prefix|-s3-endpoint|-s3-region|-s3-access-key|-s3-secret-key|-sftp-host|-sftp-port|-sftp-user|-sftp-password|-sftp-key|-source-sftp-host|-source-sftp-port|-source-sftp-user|-source-sftp-password|-source-sftp-key|-store-sftp-host|-store-sftp-port|-store-sftp-user|-store-sftp-password|-store-sftp-key|-encryption-key|-encryption-password|-recovery-key|-kms-key-arn|-source|-source-path|-drive-id|-root-folder|-tag|-output|-keep-last|-keep-hourly|-keep-daily|-keep-weekly|-keep-monthly|-keep-yearly|-group-by|-snapshot|-account|-path|-json)
+                        ((i++)) ;;
+                esac
+                ;;
+            *)
+                cmd="${words[i]}"
+                break
+                ;;
+        esac
+    done
+
+    # Complete subcommand
+    if [[ -z "$cmd" ]]; then
+        COMPREPLY=($(compgen -W "$commands" -- "$cur"))
+        return
+    fi
+
+    # Complete flags per subcommand
+    local cmd_flags=""
+    case "$cmd" in
+        init)
+            cmd_flags="-recovery -no-encryption" ;;
+        backup)
+            cmd_flags="-source -source-path -drive-id -root-folder -tag -dry-run" ;;
+        restore)
+            cmd_flags="-output -dry-run" ;;
+        prune)
+            cmd_flags="-dry-run" ;;
+        forget)
+            cmd_flags="-prune -dry-run -keep-last -keep-hourly -keep-daily -keep-weekly -keep-monthly -keep-yearly -tag -source -account -path -group-by" ;;
+        cat)
+            cmd_flags="-json" ;;
+        completion)
+            COMPREPLY=($(compgen -W "bash zsh fish" -- "$cur"))
+            return ;;
+        list|ls|diff|break-lock|add-recovery-key|version|help)
+            cmd_flags="" ;;
+    esac
+
+    if [[ "$cur" == -* ]]; then
+        COMPREPLY=($(compgen -W "$cmd_flags $global_flags" -- "$cur"))
+        return
+    fi
+
+    # Value completions for specific flags
+    case "$prev" in
+        -store)
+            COMPREPLY=($(compgen -W "local b2 s3 sftp" -- "$cur"))
+            return ;;
+        -source)
+            COMPREPLY=($(compgen -W "local sftp gdrive gdrive-changes onedrive onedrive-changes" -- "$cur"))
+            return ;;
+        -source-path|-store-path|-sftp-key|-source-sftp-key|-store-sftp-key|-output)
+            _filedir
+            return ;;
+    esac
+}
+
+complete -F _cloudstic cloudstic
+`)
+}
+
+// completionZsh writes a zsh completion script to w.
+func completionZsh(w io.Writer) {
+	_, _ = fmt.Fprint(w, `#compdef cloudstic
+
+# zsh completion for cloudstic
+
+_cloudstic() {
+    local -a commands
+    commands=(
+        'init:Initialize a new repository'
+        'backup:Create a new backup snapshot from a source'
+        'restore:Restore files from a backup snapshot'
+        'list:List all backup snapshots in the repository'
+        'ls:List files within a specific snapshot'
+        'prune:Remove unused data chunks from the repository'
+        'forget:Remove a specific snapshot from history'
+        'diff:Compare two snapshots or a snapshot against latest'
+        'break-lock:Remove a stale repository lock'
+        'add-recovery-key:Generate a recovery key for an encrypted repository'
+        'cat:Display raw JSON content of repository objects'
+        'completion:Generate shell completion scripts'
+        'version:Print version information'
+        'help:Show usage information'
+    )
+
+    local -a global_flags
+    global_flags=(
+        '-store[Storage backend]:backend:(local b2 s3 sftp)'
+        '-store-path[Local/SFTP path or bucket name]:path:_files'
+        '-store-prefix[Key prefix for B2/S3 objects]:prefix:'
+        '-s3-endpoint[S3 compatible endpoint URL]:url:'
+        '-s3-region[S3 region]:region:'
+        '-s3-access-key[S3 access key ID]:key:'
+        '-s3-secret-key[S3 secret access key]:secret:'
+        '-sftp-host[SFTP server hostname]:host:_hosts'
+        '-sftp-port[SFTP server port]:port:'
+        '-sftp-user[SFTP username]:user:_users'
+        '-sftp-password[SFTP password]:password:'
+        '-sftp-key[Path to SSH private key]:key:_files'
+        '-source-sftp-host[Override SFTP source hostname]:host:_hosts'
+        '-source-sftp-port[Override SFTP source port]:port:'
+        '-source-sftp-user[Override SFTP source username]:user:'
+        '-source-sftp-password[Override SFTP source password]:password:'
+        '-source-sftp-key[Override SFTP source private key]:key:_files'
+        '-store-sftp-host[Override SFTP store hostname]:host:_hosts'
+        '-store-sftp-port[Override SFTP store port]:port:'
+        '-store-sftp-user[Override SFTP store username]:user:'
+        '-store-sftp-password[Override SFTP store password]:password:'
+        '-store-sftp-key[Override SFTP store private key]:key:_files'
+        '-encryption-key[Platform key (hex-encoded)]:key:'
+        '-encryption-password[Password for encryption]:password:'
+        '-recovery-key[Recovery key (24-word mnemonic)]:words:'
+        '-kms-key-arn[AWS KMS key ARN]:arn:'
+        '-enable-packfile[Bundle small objects into packs]'
+        '-verbose[Log detailed operations]'
+        '-quiet[Suppress progress bars]'
+        '-debug[Log every store request]'
+    )
+
+    # Check if a subcommand has been given
+    local cmd
+    local -i i=2
+    while (( i < CURRENT )); do
+        case "${words[i]}" in
+            -*)
+                # Skip flags with values
+                case "${words[i]}" in
+                    -store|-store-path|-store-prefix|-s3-endpoint|-s3-region|-s3-access-key|-s3-secret-key|-sftp-host|-sftp-port|-sftp-user|-sftp-password|-sftp-key|-source-sftp-host|-source-sftp-port|-source-sftp-user|-source-sftp-password|-source-sftp-key|-store-sftp-host|-store-sftp-port|-store-sftp-user|-store-sftp-password|-store-sftp-key|-encryption-key|-encryption-password|-recovery-key|-kms-key-arn|-source|-source-path|-drive-id|-root-folder|-tag|-output|-keep-last|-keep-hourly|-keep-daily|-keep-weekly|-keep-monthly|-keep-yearly|-group-by|-snapshot|-account|-path)
+                        (( i++ )) ;;
+                esac
+                ;;
+            *)
+                cmd="${words[i]}"
+                break
+                ;;
+        esac
+        (( i++ ))
+    done
+
+    if [[ -z "$cmd" ]]; then
+        _describe -t commands 'cloudstic command' commands
+        _arguments $global_flags
+        return
+    fi
+
+    case "$cmd" in
+        init)
+            _arguments $global_flags \
+                '-recovery[Generate a 24-word recovery key]' \
+                '-no-encryption[Create an unencrypted repository]'
+            ;;
+        backup)
+            _arguments $global_flags \
+                '-source[Source type]:type:(local sftp gdrive gdrive-changes onedrive onedrive-changes)' \
+                '-source-path[Path to source directory]:path:_files' \
+                '-drive-id[Shared drive ID]:id:' \
+                '-root-folder[Root folder ID]:id:' \
+                '*-tag[Tag for the snapshot]:tag:' \
+                '-dry-run[Scan without writing]'
+            ;;
+        restore)
+            _arguments $global_flags \
+                '-output[Output ZIP file path]:path:_files' \
+                '-dry-run[Show what would be restored]' \
+                ':snapshot ID:'
+            ;;
+        list)
+            _arguments $global_flags
+            ;;
+        ls)
+            _arguments $global_flags \
+                ':snapshot ID:'
+            ;;
+        prune)
+            _arguments $global_flags \
+                '-dry-run[Show what would be deleted]'
+            ;;
+        forget)
+            _arguments $global_flags \
+                '-prune[Run prune after forgetting]' \
+                '-dry-run[Show what would be removed]' \
+                '-keep-last[Keep N most recent snapshots]:count:' \
+                '-keep-hourly[Keep N hourly snapshots]:count:' \
+                '-keep-daily[Keep N daily snapshots]:count:' \
+                '-keep-weekly[Keep N weekly snapshots]:count:' \
+                '-keep-monthly[Keep N monthly snapshots]:count:' \
+                '-keep-yearly[Keep N yearly snapshots]:count:' \
+                '*-tag[Filter by tag]:tag:' \
+                '-source[Filter by source type]:type:' \
+                '-account[Filter by account]:account:' \
+                '-path[Filter by path]:path:' \
+                '-group-by[Group snapshots by fields]:fields:' \
+                ':snapshot ID:'
+            ;;
+        diff)
+            _arguments $global_flags \
+                ':snapshot 1:' \
+                ':snapshot 2:'
+            ;;
+        break-lock)
+            _arguments $global_flags
+            ;;
+        add-recovery-key)
+            _arguments $global_flags
+            ;;
+        cat)
+            _arguments $global_flags \
+                '-json[Suppress non-JSON output]' \
+                '*:object key:'
+            ;;
+        completion)
+            _arguments ':shell:(bash zsh fish)'
+            ;;
+    esac
+}
+
+_cloudstic "$@"
+`)
+}
+
+// completionFish writes a fish completion script to w.
+func completionFish(w io.Writer) {
+	_, _ = fmt.Fprint(w, `# fish completion for cloudstic
+
+# Disable file completions by default
+complete -c cloudstic -f
+
+# Subcommands
+complete -c cloudstic -n __fish_use_subcommand -a init -d 'Initialize a new repository'
+complete -c cloudstic -n __fish_use_subcommand -a backup -d 'Create a new backup snapshot'
+complete -c cloudstic -n __fish_use_subcommand -a restore -d 'Restore files from a snapshot'
+complete -c cloudstic -n __fish_use_subcommand -a list -d 'List all backup snapshots'
+complete -c cloudstic -n __fish_use_subcommand -a ls -d 'List files within a snapshot'
+complete -c cloudstic -n __fish_use_subcommand -a prune -d 'Remove unused data chunks'
+complete -c cloudstic -n __fish_use_subcommand -a forget -d 'Remove a snapshot from history'
+complete -c cloudstic -n __fish_use_subcommand -a diff -d 'Compare two snapshots'
+complete -c cloudstic -n __fish_use_subcommand -a break-lock -d 'Remove a stale repository lock'
+complete -c cloudstic -n __fish_use_subcommand -a add-recovery-key -d 'Generate a recovery key'
+complete -c cloudstic -n __fish_use_subcommand -a cat -d 'Display raw JSON of repository objects'
+complete -c cloudstic -n __fish_use_subcommand -a completion -d 'Generate shell completion scripts'
+complete -c cloudstic -n __fish_use_subcommand -a version -d 'Print version information'
+complete -c cloudstic -n __fish_use_subcommand -a help -d 'Show usage information'
+
+# Global flags (available for all subcommands)
+complete -c cloudstic -l store -x -a 'local b2 s3 sftp' -d 'Storage backend'
+complete -c cloudstic -l store-path -r -F -d 'Local/SFTP path or bucket name'
+complete -c cloudstic -l store-prefix -x -d 'Key prefix for B2/S3 objects'
+complete -c cloudstic -l s3-endpoint -x -d 'S3 compatible endpoint URL'
+complete -c cloudstic -l s3-region -x -d 'S3 region'
+complete -c cloudstic -l s3-access-key -x -d 'S3 access key ID'
+complete -c cloudstic -l s3-secret-key -x -d 'S3 secret access key'
+complete -c cloudstic -l sftp-host -x -d 'SFTP server hostname'
+complete -c cloudstic -l sftp-port -x -d 'SFTP server port'
+complete -c cloudstic -l sftp-user -x -d 'SFTP username'
+complete -c cloudstic -l sftp-password -x -d 'SFTP password'
+complete -c cloudstic -l sftp-key -r -F -d 'Path to SSH private key'
+complete -c cloudstic -l source-sftp-host -x -d 'Override: SFTP source hostname'
+complete -c cloudstic -l source-sftp-port -x -d 'Override: SFTP source port'
+complete -c cloudstic -l source-sftp-user -x -d 'Override: SFTP source username'
+complete -c cloudstic -l source-sftp-password -x -d 'Override: SFTP source password'
+complete -c cloudstic -l source-sftp-key -r -F -d 'Override: SFTP source private key'
+complete -c cloudstic -l store-sftp-host -x -d 'Override: SFTP store hostname'
+complete -c cloudstic -l store-sftp-port -x -d 'Override: SFTP store port'
+complete -c cloudstic -l store-sftp-user -x -d 'Override: SFTP store username'
+complete -c cloudstic -l store-sftp-password -x -d 'Override: SFTP store password'
+complete -c cloudstic -l store-sftp-key -r -F -d 'Override: SFTP store private key'
+complete -c cloudstic -l encryption-key -x -d 'Platform key (hex-encoded)'
+complete -c cloudstic -l encryption-password -x -d 'Password for encryption'
+complete -c cloudstic -l recovery-key -x -d 'Recovery key (24-word mnemonic)'
+complete -c cloudstic -l kms-key-arn -x -d 'AWS KMS key ARN'
+complete -c cloudstic -l enable-packfile -d 'Bundle small objects into packs'
+complete -c cloudstic -l verbose -d 'Log detailed operations'
+complete -c cloudstic -l quiet -d 'Suppress progress bars'
+complete -c cloudstic -l debug -d 'Log every store request'
+
+# init
+complete -c cloudstic -n '__fish_seen_subcommand_from init' -l recovery -d 'Generate a 24-word recovery key'
+complete -c cloudstic -n '__fish_seen_subcommand_from init' -l no-encryption -d 'Create an unencrypted repository'
+
+# backup
+complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l source -x -a 'local sftp gdrive gdrive-changes onedrive onedrive-changes' -d 'Source type'
+complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l source-path -r -F -d 'Path to source directory'
+complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l drive-id -x -d 'Shared drive ID'
+complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l root-folder -x -d 'Root folder ID'
+complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l tag -x -d 'Tag for the snapshot'
+complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l dry-run -d 'Scan without writing'
+
+# restore
+complete -c cloudstic -n '__fish_seen_subcommand_from restore' -l output -r -F -d 'Output ZIP file path'
+complete -c cloudstic -n '__fish_seen_subcommand_from restore' -l dry-run -d 'Show what would be restored'
+
+# prune
+complete -c cloudstic -n '__fish_seen_subcommand_from prune' -l dry-run -d 'Show what would be deleted'
+
+# forget
+complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l prune -d 'Run prune after forgetting'
+complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l dry-run -d 'Show what would be removed'
+complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l keep-last -x -d 'Keep N most recent snapshots'
+complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l keep-hourly -x -d 'Keep N hourly snapshots'
+complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l keep-daily -x -d 'Keep N daily snapshots'
+complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l keep-weekly -x -d 'Keep N weekly snapshots'
+complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l keep-monthly -x -d 'Keep N monthly snapshots'
+complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l keep-yearly -x -d 'Keep N yearly snapshots'
+complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l tag -x -d 'Filter by tag'
+complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l source -x -d 'Filter by source type'
+complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l account -x -d 'Filter by account'
+complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l path -x -d 'Filter by path'
+complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l group-by -x -d 'Group snapshots by fields'
+
+# cat
+complete -c cloudstic -n '__fish_seen_subcommand_from cat' -l json -d 'Suppress non-JSON output'
+
+# completion
+complete -c cloudstic -n '__fish_seen_subcommand_from completion' -a 'bash zsh fish' -d 'Shell type'
+`)
+}

--- a/cmd/cloudstic/completion_test.go
+++ b/cmd/cloudstic/completion_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestCompletionBash(t *testing.T) {
+	var buf bytes.Buffer
+	completionBash(&buf)
+	out := buf.String()
+
+	if out == "" {
+		t.Fatal("bash completion output is empty")
+	}
+
+	// Verify it's a valid bash completion script
+	for _, marker := range []string{
+		"_cloudstic()",
+		"complete -F _cloudstic cloudstic",
+		// All commands are listed
+		"init", "backup", "restore", "list", "ls", "prune", "forget",
+		"diff", "break-lock", "add-recovery-key", "cat", "completion",
+		// Global flags
+		"-store", "-encryption-password", "-verbose",
+		// Command-specific flags
+		"-dry-run", "-recovery", "-source", "-output",
+		// Value completions
+		"local b2 s3 sftp",
+		"gdrive", "onedrive",
+	} {
+		if !strings.Contains(out, marker) {
+			t.Errorf("bash completion missing expected marker: %q", marker)
+		}
+	}
+}
+
+func TestCompletionZsh(t *testing.T) {
+	var buf bytes.Buffer
+	completionZsh(&buf)
+	out := buf.String()
+
+	if out == "" {
+		t.Fatal("zsh completion output is empty")
+	}
+
+	for _, marker := range []string{
+		"#compdef cloudstic",
+		"_cloudstic()",
+		`_cloudstic "$@"`,
+		// Commands with descriptions
+		"init:Initialize a new repository",
+		"backup:Create a new backup snapshot",
+		"completion:Generate shell completion scripts",
+		// Global flags with descriptions
+		"-store[Storage backend]",
+		"-verbose[Log detailed operations]",
+		// Subcommand-specific flags
+		"-recovery[Generate a 24-word recovery key]",
+		"-dry-run[Scan without writing]",
+		"-keep-last[Keep N most recent snapshots]",
+		// Value completions
+		"(local b2 s3 sftp)",
+		"(local sftp gdrive gdrive-changes onedrive onedrive-changes)",
+		"(bash zsh fish)",
+	} {
+		if !strings.Contains(out, marker) {
+			t.Errorf("zsh completion missing expected marker: %q", marker)
+		}
+	}
+}
+
+func TestCompletionFish(t *testing.T) {
+	var buf bytes.Buffer
+	completionFish(&buf)
+	out := buf.String()
+
+	if out == "" {
+		t.Fatal("fish completion output is empty")
+	}
+
+	for _, marker := range []string{
+		"complete -c cloudstic -f",
+		// Subcommands
+		"complete -c cloudstic -n __fish_use_subcommand -a init",
+		"complete -c cloudstic -n __fish_use_subcommand -a backup",
+		"complete -c cloudstic -n __fish_use_subcommand -a completion",
+		// Global flags
+		"complete -c cloudstic -l store -x",
+		"complete -c cloudstic -l verbose",
+		// Command-specific flags
+		"__fish_seen_subcommand_from init",
+		"__fish_seen_subcommand_from backup",
+		"__fish_seen_subcommand_from forget",
+		"-l dry-run",
+		"-l keep-last",
+		"-l recovery",
+		// Value completions
+		"'local b2 s3 sftp'",
+		"'local sftp gdrive gdrive-changes onedrive onedrive-changes'",
+		"'bash zsh fish'",
+	} {
+		if !strings.Contains(out, marker) {
+			t.Errorf("fish completion missing expected marker: %q", marker)
+		}
+	}
+}
+
+func TestCompletionE2E(t *testing.T) {
+	if !shouldRun(Hermetic) {
+		t.Skip("skipping hermetic test")
+	}
+
+	bin := buildBinary(t)
+
+	// Test each shell
+	for _, shell := range []string{"bash", "zsh", "fish"} {
+		t.Run(shell, func(t *testing.T) {
+			out := run(t, bin, "completion", shell)
+			if out == "" {
+				t.Fatalf("completion %s produced empty output", shell)
+			}
+			// Verify it contains the command name at minimum
+			if !strings.Contains(out, "cloudstic") {
+				t.Errorf("completion %s output missing 'cloudstic'", shell)
+			}
+		})
+	}
+
+	// Test unsupported shell
+	out := runExpectFail(t, bin, "completion", "powershell")
+	if !strings.Contains(out, "Unsupported shell") {
+		t.Errorf("Expected unsupported shell error, got: %s", out)
+	}
+
+	// Test no shell argument
+	out = runExpectFail(t, bin, "completion")
+	if !strings.Contains(out, "Usage:") {
+		t.Errorf("Expected usage message, got: %s", out)
+	}
+}

--- a/cmd/cloudstic/main.go
+++ b/cmd/cloudstic/main.go
@@ -162,6 +162,8 @@ func runCmd(cmd string) int {
 		runCheck()
 	case "cat":
 		runCat()
+	case "completion":
+		runCompletion()
 	case "help", "--help", "-h":
 		printUsage()
 		return 0
@@ -195,6 +197,7 @@ func printUsage() {
 		{"add-recovery-key", "Generate a recovery key for an existing encrypted repository"},
 		{"check", "Verify repository integrity (reference chain, objects, data)"},
 		{"cat", "Display raw JSON content of repository objects"},
+		{"completion", "Generate shell completion scripts (bash, zsh, fish)"},
 	})
 
 	t.HeadingSub("GLOBAL OPTIONS", "(also settable via env vars)")
@@ -316,6 +319,11 @@ func printUsage() {
 	t.Note("  Display raw JSON for one or more repository objects.",
 		"  Object keys: snapshot/<hash>, filemeta/<hash>, content/<hash>,",
 		"  node/<hash>, chunk/<hash>, config, index/latest, keys/<slot>")
+
+	t.Command("completion", "<shell>")
+	t.Note("  Generate completion scripts for bash, zsh, or fish.",
+		"  See 'cloudstic completion --help' or the user guide for setup instructions.")
+	t.Blank()
 
 	t.Heading("EXAMPLES")
 	t.Examples(
@@ -592,7 +600,7 @@ func runInit() {
 	encrypted := hasEncryptionCreds
 
 	if encrypted {
-	slots, err := store.LoadKeySlots(raw)
+		slots, err := store.LoadKeySlots(raw)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to load key slots: %v\n", err)
 			os.Exit(1)
@@ -1154,6 +1162,33 @@ func runBreakLock() {
 		fmt.Fprintf(os.Stderr, "  Acquired:   %s\n", r.AcquiredAt)
 		fmt.Fprintf(os.Stderr, "  Expired at: %s\n", r.ExpiresAt)
 		fmt.Fprintf(os.Stderr, "  Shared:     %v\n\n", r.IsShared)
+	}
+}
+
+func runCompletion() {
+	if len(os.Args) < 3 {
+		fmt.Fprintln(os.Stderr, "Usage: cloudstic completion <shell>")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Available shells: bash, zsh, fish")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Setup:")
+		fmt.Fprintln(os.Stderr, "  bash:  source <(cloudstic completion bash)")
+		fmt.Fprintln(os.Stderr, "  zsh:   source <(cloudstic completion zsh)")
+		fmt.Fprintln(os.Stderr, "  fish:  cloudstic completion fish | source")
+		os.Exit(1)
+	}
+
+	shell := os.Args[2]
+	switch shell {
+	case "bash":
+		completionBash(os.Stdout)
+	case "zsh":
+		completionZsh(os.Stdout)
+	case "fish":
+		completionFish(os.Stdout)
+	default:
+		fmt.Fprintf(os.Stderr, "Unsupported shell: %s\nAvailable shells: bash, zsh, fish\n", shell)
+		os.Exit(1)
 	}
 }
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -20,6 +20,8 @@ Cloudstic is a content-addressable backup tool that creates encrypted, deduplica
   - [check](#check)
   - [add-recovery-key](#add-recovery-key)
   - [cat](#cat)
+  - [completion](#completion)
+- [Shell Completions](#shell-completions)
 - [Sources](#sources)
   - [Local Directory](#local-directory)
   - [SFTP](#sftp-source)
@@ -536,6 +538,66 @@ cloudstic cat snapshot/abc123... | jq .
 ```
 
 > **Note:** This command operates at the object store level and returns the raw JSON representation of repository objects. It does not reconstruct file contents — use `restore` for that.
+
+---
+
+### completion
+
+Generate shell completion scripts for bash, zsh, or fish.
+
+```bash
+cloudstic completion bash
+cloudstic completion zsh
+cloudstic completion fish
+```
+
+See [Shell Completions](#shell-completions) below for setup instructions.
+
+---
+
+## Shell Completions
+
+Cloudstic can generate tab-completion scripts for popular shells. Once set up, pressing `Tab` will complete commands, flags, and flag values (like `-store local|b2|s3|sftp` and `-source local|sftp|gdrive|...`).
+
+### Bash
+
+```bash
+# Load for current session
+source <(cloudstic completion bash)
+
+# Load permanently (add to ~/.bashrc)
+echo 'source <(cloudstic completion bash)' >> ~/.bashrc
+```
+
+> **Note:** Bash completions require the `bash-completion` package. Install it via your package manager if not already present (`brew install bash-completion` on macOS, `apt install bash-completion` on Debian/Ubuntu).
+
+### Zsh
+
+```zsh
+# Load for current session
+source <(cloudstic completion zsh)
+
+# Load permanently (add to ~/.zshrc)
+echo 'source <(cloudstic completion zsh)' >> ~/.zshrc
+```
+
+Alternatively, place the output in your `$fpath`:
+
+```zsh
+cloudstic completion zsh > "${fpath[1]}/_cloudstic"
+```
+
+> **Note:** You may need to start a new shell or run `compinit` for changes to take effect.
+
+### Fish
+
+```fish
+# Load for current session
+cloudstic completion fish | source
+
+# Load permanently
+cloudstic completion fish > ~/.config/fish/completions/cloudstic.fish
+```
 
 ---
 


### PR DESCRIPTION
## Summary

Adds `cloudstic completion <shell>` command that generates shell completion scripts for **bash**, **zsh**, and **fish**.

## What's included

- **`cmd/cloudstic/completion.go`** — Completion script generators for all three shells, writing to `io.Writer`
- **`cmd/cloudstic/completion_test.go`** — Unit tests (one per shell) + E2E test that builds the binary and exercises the command
- **`cmd/cloudstic/main.go`** — `runCompletion()` wired into the command router and usage text
- **`docs/user-guide.md`** — `completion` command reference + full "Shell Completions" section with setup instructions for bash, zsh, and fish

## Completion features

- Subcommand completion for all 14 commands
- Global flag completion (store, encryption, SFTP, etc.)
- Per-subcommand flag completion (e.g. `-source`, `-dry-run`, `-keep-*`)
- Context-aware value completion (store types, source types, file paths)
- Shell-idiomatic implementation for each target (bash-completion, zsh _arguments, fish complete)

## Usage

```bash
# Bash
cloudstic completion bash > /etc/bash_completion.d/cloudstic

# Zsh
cloudstic completion zsh > "${fpath[1]}/_cloudstic"

# Fish
cloudstic completion fish > ~/.config/fish/completions/cloudstic.fish
```

Co-Authored-By: Oz <oz-agent@warp.dev>