### PR TITLE
feat: add snapshot catalog index (index/snapshots) for fast listing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ All objects are addressed by `<type>/<sha256>`:
 - `node/<hash>` — HAMT internal/leaf nodes
 - `snapshot/<hash>` — Point-in-time backup snapshots
 - `index/latest` — Mutable pointer to latest snapshot
+- `index/snapshots` — Snapshot catalog: lightweight summaries of all snapshots, used to avoid fetching each snapshot object individually. Self-heals via reconciliation with `LIST snapshot/` on load.
 - `index/packs` — Pack catalog (when packfiles enabled)
 - `keys/<slot>` — Encryption key slots (stored unencrypted)
 - `config` — Repository marker (unencrypted)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -512,7 +512,8 @@ cloudstic cat config --json
 | Key pattern | Description |
 |-------------|-------------|
 | `config` | Repository configuration (version, encryption status, creation time) |
-| `index/latest` | Pointer to the most recent snapshot |
+|| `index/latest` | Pointer to the most recent snapshot |
+|| `index/snapshots` | Snapshot catalog (lightweight summaries for fast listing) |
 | `snapshot/<hash>` | Snapshot metadata (creation time, root node, source info, tags) |
 | `filemeta/<hash>` | File metadata (name, size, modification time, content hash) |
 | `content/<hash>` | Content manifest (list of chunk references or inline data) |

--- a/internal/engine/backup.go
+++ b/internal/engine/backup.go
@@ -214,10 +214,13 @@ func (bm *BackupManager) Run(ctx context.Context) (*RunResult, error) {
 		}
 	}
 
-	snapRef, snapHash, err := bm.saveSnapshot(ctx, newRoot, seq+1, newToken)
+	snapRef, snapHash, snap, err := bm.saveSnapshot(ctx, newRoot, seq+1, newToken)
 	if err != nil {
 		return nil, err
 	}
+
+	// Update snapshot catalog (best-effort).
+	AppendSnapshotCatalog(bm.store, snapshotToSummary(snapRef, snap))
 
 	if err := bm.cache.FlushReachable(newRoot); err != nil {
 		return nil, fmt.Errorf("flush hamt: %w", err)
@@ -255,7 +258,7 @@ func (bm *BackupManager) loadLatestSeq() int {
 // whose Source matches the given info (Type + Account + Path).
 // Returns nil when no matching snapshot exists.
 func (bm *BackupManager) findPreviousSnapshot(info core.SourceInfo) *core.Snapshot {
-	entries, err := ListAllSnapshots(bm.store)
+	entries, err := LoadSnapshotCatalog(bm.store)
 	if err != nil {
 		return nil
 	}
@@ -271,14 +274,14 @@ func (bm *BackupManager) findPreviousSnapshot(info core.SourceInfo) *core.Snapsh
 	return nil
 }
 
-func (bm *BackupManager) saveSnapshot(ctx context.Context, root string, seq int, changeToken string) (ref, hash string, err error) {
+func (bm *BackupManager) saveSnapshot(ctx context.Context, root string, seq int, changeToken string) (ref, hash string, snap core.Snapshot, err error) {
 	meta := make(map[string]string, len(bm.cfg.meta)+1)
 	for k, v := range bm.cfg.meta {
 		meta[k] = v
 	}
 	meta["generator"] = bm.cfg.generator
 
-	snap := core.Snapshot{
+	snap = core.Snapshot{
 		Version:     1,
 		Created:     time.Now().Format(time.RFC3339),
 		Root:        root,
@@ -291,19 +294,19 @@ func (bm *BackupManager) saveSnapshot(ctx context.Context, root string, seq int,
 
 	hash, snapData, err := core.ComputeJSONHash(&snap)
 	if err != nil {
-		return "", "", err
+		return "", "", snap, err
 	}
 
 	ref = "snapshot/" + hash
 	if err := bm.store.Put(ctx, ref, snapData); err != nil {
-		return "", "", err
+		return "", "", snap, err
 	}
 
 	if err := updateLatest(bm.store, ref, seq); err != nil {
-		return "", "", err
+		return "", "", snap, err
 	}
 
-	return ref, hash, nil
+	return ref, hash, snap, nil
 }
 
 func (bm *BackupManager) trackFileMeta(ref string, fm core.FileMeta) {

--- a/internal/engine/forget.go
+++ b/internal/engine/forget.go
@@ -132,6 +132,9 @@ func (fm *ForgetManager) Run(ctx context.Context, snapshotID string, opts ...For
 		return nil, fmt.Errorf("delete snapshot %s: %w", targetRef, err)
 	}
 
+	// Update snapshot catalog (best-effort).
+	RemoveFromSnapshotCatalog(fm.store, targetRef)
+
 	if err := fm.fixupLatest(targetRef); err != nil {
 		phase.Error()
 		return nil, err
@@ -186,7 +189,7 @@ func (fm *ForgetManager) fixupLatest(deletedRef string) error {
 		return nil
 	}
 
-	entries, err := ListAllSnapshots(fm.store)
+	entries, err := LoadSnapshotCatalog(fm.store)
 	if err != nil {
 		return err
 	}
@@ -233,7 +236,7 @@ func (fm *ForgetManager) RunPolicy(ctx context.Context, opts ...ForgetOption) (*
 		return nil, fmt.Errorf("empty policy: specify at least one --keep-* option")
 	}
 
-	entries, err := ListAllSnapshots(fm.store)
+	entries, err := LoadSnapshotCatalog(fm.store)
 	if err != nil {
 		return nil, err
 	}
@@ -307,12 +310,17 @@ func (fm *ForgetManager) forgetBatch(ctx context.Context, entries []SnapshotEntr
 		toRemove[e.Ref] = true
 	}
 
+	var removedRefs []string
 	for _, e := range entries {
 		_ = fm.store.Delete(ctx, e.Ref)
+		removedRefs = append(removedRefs, e.Ref)
 	}
 
+	// Update snapshot catalog (best-effort).
+	RemoveFromSnapshotCatalog(fm.store, removedRefs...)
+
 	// Elect new latest from the remaining snapshots.
-	remaining, err := ListAllSnapshots(fm.store)
+	remaining, err := LoadSnapshotCatalog(fm.store)
 	if err != nil {
 		return err
 	}

--- a/internal/engine/list.go
+++ b/internal/engine/list.go
@@ -27,7 +27,7 @@ func NewListManager(s store.ObjectStore) *ListManager {
 
 // Run lists every snapshot in the store.
 func (lm *ListManager) Run(ctx context.Context, opts ...ListOption) (*ListResult, error) {
-	entries, err := ListAllSnapshots(lm.store)
+	entries, err := LoadSnapshotCatalog(lm.store)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/engine/snapshots.go
+++ b/internal/engine/snapshots.go
@@ -8,22 +8,192 @@ import (
 	"time"
 
 	"github.com/cloudstic/cli/internal/core"
+	"github.com/cloudstic/cli/internal/logger"
 	"github.com/cloudstic/cli/pkg/store"
 )
 
-// ListAllSnapshots enumerates every snapshot in the store.
+var snapLog = logger.New("snapshots", logger.ColorCyan)
+
+const snapshotCatalogKey = "index/snapshots"
+
+// ---------------------------------------------------------------------------
+// Snapshot catalog (index/snapshots)
+// ---------------------------------------------------------------------------
+
+// LoadSnapshotCatalog returns all snapshots, using the catalog index when
+// available and falling back to individual GETs only for snapshots that are
+// missing from the catalog. The catalog is automatically rebuilt/updated
+// whenever a mismatch with the live snapshot keys is detected.
 // Results are sorted newest-first by Created time.
-func ListAllSnapshots(s store.ObjectStore) ([]SnapshotEntry, error) {
+func LoadSnapshotCatalog(s store.ObjectStore) ([]SnapshotEntry, error) {
 	ctx := context.Background()
 
-	keys, err := s.List(ctx, "snapshot/")
+	// 1. Load catalog (best-effort).
+	var catalog []core.SnapshotSummary
+	if data, err := s.Get(ctx, snapshotCatalogKey); err == nil {
+		_ = json.Unmarshal(data, &catalog)
+	}
+
+	// 2. List live snapshot keys for reconciliation.
+	liveKeys, err := s.List(ctx, "snapshot/")
 	if err != nil {
 		return nil, err
 	}
 
-	entries := make([]SnapshotEntry, 0, len(keys))
+	liveSet := make(map[string]struct{}, len(liveKeys))
+	for _, k := range liveKeys {
+		liveSet[k] = struct{}{}
+	}
 
-	// Ensure concurrent fetch of snapshots
+	// 3. Index catalog by ref.
+	catalogMap := make(map[string]core.SnapshotSummary, len(catalog))
+	for _, s := range catalog {
+		catalogMap[s.Ref] = s
+	}
+
+	// 4. Reconcile.
+	needRebuild := false
+
+	// Find refs in live but not in catalog → need to fetch.
+	var missing []string
+	for _, k := range liveKeys {
+		if _, ok := catalogMap[k]; !ok {
+			missing = append(missing, k)
+			needRebuild = true
+		}
+	}
+
+	// Find refs in catalog but not in live → stale.
+	for _, cs := range catalog {
+		if _, ok := liveSet[cs.Ref]; !ok {
+			needRebuild = true
+			break
+		}
+	}
+
+	// 5. Fetch missing snapshot objects concurrently.
+	if len(missing) > 0 {
+		fetched := fetchSnapshots(s, missing)
+		for ref, snap := range fetched {
+			catalogMap[ref] = snapshotToSummary(ref, snap)
+		}
+	}
+
+	// 6. Build result from live keys only (drops stale).
+	entries := make([]SnapshotEntry, 0, len(liveKeys))
+	var updatedCatalog []core.SnapshotSummary
+	if needRebuild {
+		updatedCatalog = make([]core.SnapshotSummary, 0, len(liveKeys))
+	}
+
+	for _, k := range liveKeys {
+		cs, ok := catalogMap[k]
+		if !ok {
+			continue // could not fetch; skip
+		}
+		created, _ := time.Parse(time.RFC3339, cs.Created)
+		entries = append(entries, SnapshotEntry{
+			Ref: cs.Ref,
+			Snap: core.Snapshot{
+				Version:     1,
+				Created:     cs.Created,
+				Root:        cs.Root,
+				Seq:         cs.Seq,
+				Source:      cs.Source,
+				Tags:        cs.Tags,
+				ChangeToken: cs.ChangeToken,
+			},
+			Created: created,
+		})
+		if needRebuild {
+			updatedCatalog = append(updatedCatalog, cs)
+		}
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Created.After(entries[j].Created)
+	})
+
+	// 7. Persist rebuilt catalog (best-effort).
+	if needRebuild {
+		if err := SaveSnapshotCatalog(s, updatedCatalog); err != nil {
+			snapLog.Debugf("failed to persist snapshot catalog: %v", err)
+		}
+	}
+
+	return entries, nil
+}
+
+// SaveSnapshotCatalog persists the full catalog to the store.
+func SaveSnapshotCatalog(s store.ObjectStore, catalog []core.SnapshotSummary) error {
+	data, err := json.Marshal(catalog)
+	if err != nil {
+		return err
+	}
+	return s.Put(context.Background(), snapshotCatalogKey, data)
+}
+
+// AppendSnapshotCatalog loads the current catalog, appends a new summary, and
+// persists it. This is best-effort; errors are logged but not propagated.
+func AppendSnapshotCatalog(s store.ObjectStore, summary core.SnapshotSummary) {
+	ctx := context.Background()
+	var catalog []core.SnapshotSummary
+	if data, err := s.Get(ctx, snapshotCatalogKey); err == nil {
+		_ = json.Unmarshal(data, &catalog)
+	}
+	catalog = append(catalog, summary)
+	if err := SaveSnapshotCatalog(s, catalog); err != nil {
+		snapLog.Debugf("failed to append snapshot catalog: %v", err)
+	}
+}
+
+// RemoveFromSnapshotCatalog loads the current catalog, removes entries whose
+// refs match, and persists the result. This is best-effort.
+func RemoveFromSnapshotCatalog(s store.ObjectStore, refs ...string) {
+	ctx := context.Background()
+	var catalog []core.SnapshotSummary
+	if data, err := s.Get(ctx, snapshotCatalogKey); err == nil {
+		_ = json.Unmarshal(data, &catalog)
+	}
+	if len(catalog) == 0 {
+		return
+	}
+	remove := make(map[string]struct{}, len(refs))
+	for _, r := range refs {
+		remove[r] = struct{}{}
+	}
+	filtered := make([]core.SnapshotSummary, 0, len(catalog))
+	for _, cs := range catalog {
+		if _, ok := remove[cs.Ref]; !ok {
+			filtered = append(filtered, cs)
+		}
+	}
+	if err := SaveSnapshotCatalog(s, filtered); err != nil {
+		snapLog.Debugf("failed to update snapshot catalog after removal: %v", err)
+	}
+}
+
+// snapshotToSummary converts a full Snapshot and its ref into a SnapshotSummary.
+func snapshotToSummary(ref string, snap core.Snapshot) core.SnapshotSummary {
+	return core.SnapshotSummary{
+		Ref:         ref,
+		Seq:         snap.Seq,
+		Created:     snap.Created,
+		Root:        snap.Root,
+		Source:      snap.Source,
+		Tags:        snap.Tags,
+		ChangeToken: snap.ChangeToken,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Slow path (individual GETs)
+// ---------------------------------------------------------------------------
+
+// fetchSnapshots concurrently fetches and unmarshals the given snapshot keys.
+func fetchSnapshots(s store.ObjectStore, keys []string) map[string]core.Snapshot {
+	ctx := context.Background()
+	result := make(map[string]core.Snapshot, len(keys))
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 
@@ -39,25 +209,14 @@ func ListAllSnapshots(s store.ObjectStore) ([]SnapshotEntry, error) {
 			if err := json.Unmarshal(data, &snap); err != nil {
 				return
 			}
-			created, _ := time.Parse(time.RFC3339, snap.Created)
-
 			mu.Lock()
-			entries = append(entries, SnapshotEntry{
-				Ref:     k,
-				Snap:    snap,
-				Created: created,
-			})
+			result[k] = snap
 			mu.Unlock()
 		}(key)
 	}
 
 	wg.Wait()
-
-	sort.Slice(entries, func(i, j int) bool {
-		return entries[i].Created.After(entries[j].Created)
-	})
-
-	return entries, nil
+	return result
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/snapshots_test.go
+++ b/internal/engine/snapshots_test.go
@@ -1,0 +1,273 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/cloudstic/cli/internal/core"
+)
+
+// helper: store a snapshot object and return its ref.
+func putSnapshot(t *testing.T, s *MockStore, snap *core.Snapshot) string {
+	t.Helper()
+	hash, data, err := core.ComputeJSONHash(snap)
+	if err != nil {
+		t.Fatalf("ComputeJSONHash: %v", err)
+	}
+	ref := "snapshot/" + hash
+	if err := s.Put(context.Background(), ref, data); err != nil {
+		t.Fatalf("Put %s: %v", ref, err)
+	}
+	return ref
+}
+
+// helper: store a catalog directly.
+func putCatalog(t *testing.T, s *MockStore, catalog []core.SnapshotSummary) {
+	t.Helper()
+	data, err := json.Marshal(catalog)
+	if err != nil {
+		t.Fatalf("Marshal catalog: %v", err)
+	}
+	if err := s.Put(context.Background(), snapshotCatalogKey, data); err != nil {
+		t.Fatalf("Put catalog: %v", err)
+	}
+}
+
+// helper: read catalog from store.
+func readCatalog(t *testing.T, s *MockStore) []core.SnapshotSummary {
+	t.Helper()
+	data, err := s.Get(context.Background(), snapshotCatalogKey)
+	if err != nil {
+		t.Fatalf("Get catalog: %v", err)
+	}
+	var catalog []core.SnapshotSummary
+	if err := json.Unmarshal(data, &catalog); err != nil {
+		t.Fatalf("Unmarshal catalog: %v", err)
+	}
+	return catalog
+}
+
+func TestLoadSnapshotCatalog_NoCatalog(t *testing.T) {
+	s := NewMockStore()
+	now := time.Now()
+
+	snap1 := &core.Snapshot{Seq: 1, Created: now.Add(-2 * time.Hour).Format(time.RFC3339), Root: "node/a"}
+	snap2 := &core.Snapshot{Seq: 2, Created: now.Add(-1 * time.Hour).Format(time.RFC3339), Root: "node/b"}
+	ref1 := putSnapshot(t, s, snap1)
+	ref2 := putSnapshot(t, s, snap2)
+
+	entries, err := LoadSnapshotCatalog(s)
+	if err != nil {
+		t.Fatalf("LoadSnapshotCatalog: %v", err)
+	}
+
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+
+	// Should be sorted newest-first.
+	if entries[0].Ref != ref2 {
+		t.Errorf("entries[0].Ref = %s, want %s", entries[0].Ref, ref2)
+	}
+	if entries[1].Ref != ref1 {
+		t.Errorf("entries[1].Ref = %s, want %s", entries[1].Ref, ref1)
+	}
+
+	// Catalog should have been persisted.
+	catalog := readCatalog(t, s)
+	if len(catalog) != 2 {
+		t.Errorf("persisted catalog has %d entries, want 2", len(catalog))
+	}
+}
+
+func TestLoadSnapshotCatalog_WithValidCatalog(t *testing.T) {
+	s := NewMockStore()
+	now := time.Now()
+
+	snap1 := &core.Snapshot{Seq: 1, Created: now.Format(time.RFC3339), Root: "node/a",
+		Source: &core.SourceInfo{Type: "local", Path: "/data"}}
+	ref1 := putSnapshot(t, s, snap1)
+
+	// Pre-populate catalog.
+	putCatalog(t, s, []core.SnapshotSummary{
+		snapshotToSummary(ref1, *snap1),
+	})
+
+	entries, err := LoadSnapshotCatalog(s)
+	if err != nil {
+		t.Fatalf("LoadSnapshotCatalog: %v", err)
+	}
+
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Snap.Source == nil || entries[0].Snap.Source.Type != "local" {
+		t.Errorf("source not preserved from catalog")
+	}
+}
+
+func TestLoadSnapshotCatalog_ReconcilesMissingEntries(t *testing.T) {
+	s := NewMockStore()
+	now := time.Now()
+
+	snap1 := &core.Snapshot{Seq: 1, Created: now.Add(-1 * time.Hour).Format(time.RFC3339), Root: "node/a"}
+	snap2 := &core.Snapshot{Seq: 2, Created: now.Format(time.RFC3339), Root: "node/b"}
+	ref1 := putSnapshot(t, s, snap1)
+	ref2 := putSnapshot(t, s, snap2)
+
+	// Catalog only knows about snap1.
+	putCatalog(t, s, []core.SnapshotSummary{
+		snapshotToSummary(ref1, *snap1),
+	})
+
+	entries, err := LoadSnapshotCatalog(s)
+	if err != nil {
+		t.Fatalf("LoadSnapshotCatalog: %v", err)
+	}
+
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+
+	// Catalog should now contain both.
+	catalog := readCatalog(t, s)
+	if len(catalog) != 2 {
+		t.Errorf("rebuilt catalog has %d entries, want 2", len(catalog))
+	}
+
+	_ = ref2
+}
+
+func TestLoadSnapshotCatalog_RemovesStaleEntries(t *testing.T) {
+	s := NewMockStore()
+	now := time.Now()
+
+	snap1 := &core.Snapshot{Seq: 1, Created: now.Format(time.RFC3339), Root: "node/a"}
+	ref1 := putSnapshot(t, s, snap1)
+
+	// Catalog has an extra stale entry.
+	putCatalog(t, s, []core.SnapshotSummary{
+		snapshotToSummary(ref1, *snap1),
+		{Ref: "snapshot/deleted", Seq: 99, Created: now.Format(time.RFC3339), Root: "node/gone"},
+	})
+
+	entries, err := LoadSnapshotCatalog(s)
+	if err != nil {
+		t.Fatalf("LoadSnapshotCatalog: %v", err)
+	}
+
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Ref != ref1 {
+		t.Errorf("expected ref %s, got %s", ref1, entries[0].Ref)
+	}
+
+	catalog := readCatalog(t, s)
+	if len(catalog) != 1 {
+		t.Errorf("rebuilt catalog has %d entries, want 1", len(catalog))
+	}
+}
+
+func TestAppendSnapshotCatalog(t *testing.T) {
+	s := NewMockStore()
+	now := time.Now()
+
+	snap1 := &core.Snapshot{Seq: 1, Created: now.Format(time.RFC3339), Root: "node/a"}
+
+	// Start with empty catalog.
+	AppendSnapshotCatalog(s, snapshotToSummary("snapshot/abc", *snap1))
+
+	catalog := readCatalog(t, s)
+	if len(catalog) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(catalog))
+	}
+	if catalog[0].Ref != "snapshot/abc" {
+		t.Errorf("ref = %s, want snapshot/abc", catalog[0].Ref)
+	}
+
+	// Append a second.
+	snap2 := &core.Snapshot{Seq: 2, Created: now.Format(time.RFC3339), Root: "node/b"}
+	AppendSnapshotCatalog(s, snapshotToSummary("snapshot/def", *snap2))
+
+	catalog = readCatalog(t, s)
+	if len(catalog) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(catalog))
+	}
+}
+
+func TestRemoveFromSnapshotCatalog(t *testing.T) {
+	s := NewMockStore()
+	now := time.Now()
+
+	putCatalog(t, s, []core.SnapshotSummary{
+		{Ref: "snapshot/aaa", Seq: 1, Created: now.Format(time.RFC3339)},
+		{Ref: "snapshot/bbb", Seq: 2, Created: now.Format(time.RFC3339)},
+		{Ref: "snapshot/ccc", Seq: 3, Created: now.Format(time.RFC3339)},
+	})
+
+	RemoveFromSnapshotCatalog(s, "snapshot/aaa", "snapshot/ccc")
+
+	catalog := readCatalog(t, s)
+	if len(catalog) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(catalog))
+	}
+	if catalog[0].Ref != "snapshot/bbb" {
+		t.Errorf("remaining ref = %s, want snapshot/bbb", catalog[0].Ref)
+	}
+}
+
+func TestRemoveFromSnapshotCatalog_NoCatalog(t *testing.T) {
+	s := NewMockStore()
+
+	// Should not panic when catalog doesn't exist.
+	RemoveFromSnapshotCatalog(s, "snapshot/xxx")
+}
+
+func TestSnapshotToSummary(t *testing.T) {
+	src := &core.SourceInfo{Type: "gdrive", Account: "user@example.com", Path: "root-id"}
+	snap := core.Snapshot{
+		Version:     1,
+		Seq:         5,
+		Created:     "2025-01-01T00:00:00Z",
+		Root:        "node/abc",
+		Source:      src,
+		Tags:        []string{"daily"},
+		ChangeToken: "token123",
+	}
+
+	summary := snapshotToSummary("snapshot/xyz", snap)
+
+	if summary.Ref != "snapshot/xyz" {
+		t.Errorf("Ref = %s", summary.Ref)
+	}
+	if summary.Seq != 5 {
+		t.Errorf("Seq = %d", summary.Seq)
+	}
+	if summary.Root != "node/abc" {
+		t.Errorf("Root = %s", summary.Root)
+	}
+	if summary.Source == nil || summary.Source.Type != "gdrive" {
+		t.Error("Source not preserved")
+	}
+	if len(summary.Tags) != 1 || summary.Tags[0] != "daily" {
+		t.Errorf("Tags = %v", summary.Tags)
+	}
+	if summary.ChangeToken != "token123" {
+		t.Errorf("ChangeToken = %s", summary.ChangeToken)
+	}
+}
+
+func TestLoadSnapshotCatalog_EmptyRepo(t *testing.T) {
+	s := NewMockStore()
+
+	entries, err := LoadSnapshotCatalog(s)
+	if err != nil {
+		t.Fatalf("LoadSnapshotCatalog: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries, got %d", len(entries))
+	}
+}

--- a/pkg/store/pack.go
+++ b/pkg/store/pack.go
@@ -107,8 +107,9 @@ func (s *PackStore) Put(ctx context.Context, key string, data []byte) error {
 
 // isSmallObject determines if a key/data pair should be bundled into a packfile.
 func (s *PackStore) isSmallObject(key string, data []byte) bool {
-	// Don't pack the pack index itself or lock files
-	if key == indexPacksKey || strings.HasPrefix(key, "index/lock") {
+	// Don't pack the pack index itself, lock files, or the snapshot catalog
+	// (mutable indexes that are read on every operation).
+	if key == indexPacksKey || key == "index/snapshots" || strings.HasPrefix(key, "index/lock") {
 		return false
 	}
 	// We only pack metadata to keep data files randomly accessible natively.


### PR DESCRIPTION
Replace O(n) individual snapshot GETs with a single catalog GET.

During backup, list, and forget operations, the system previously had to download every snapshot object individually to find metadata (source matching, seq numbers, etc). With packfiles enabled, each GET could trigger a separate pack download (~200-800ms each).

Now a lightweight catalog at index/snapshots stores SnapshotSummary entries. On load, the catalog is reconciled against LIST snapshot/ to detect stale/missing entries, fetching only what's needed. The catalog self-heals automatically.

- LoadSnapshotCatalog: replaces all 5 ListAllSnapshots call sites
- AppendSnapshotCatalog: called after backup saves a new snapshot
- RemoveFromSnapshotCatalog: called after forget deletes snapshot(s)
- Catalog writes are best-effort; failures are logged, not propagated