### PR TITLE
refactor: config-based source initialization

### DIFF
--- a/cmd/cloudstic/main.go
+++ b/cmd/cloudstic/main.go
@@ -828,7 +828,10 @@ func (g *globalFlags) sftpConfig(host, port, user, pass, key *string) (store.SFT
 func initSource(sourceType, sourcePath, driveID, rootFolder string, g *globalFlags, excludePatterns []string) (store.Source, error) {
 	switch sourceType {
 	case "local":
-		return store.NewLocalSource(sourcePath, excludePatterns...), nil
+		return store.NewLocalSource(store.LocalSourceConfig{
+			RootPath:        sourcePath,
+			ExcludePatterns: excludePatterns,
+		}), nil
 	case "sftp":
 		cfg, err := g.sftpConfig(g.sourceSFTPHost, g.sourceSFTPPort, g.sourceSFTPUser, g.sourceSFTPPassword, g.sourceSFTPKey)
 		if err != nil {
@@ -837,47 +840,59 @@ func initSource(sourceType, sourcePath, driveID, rootFolder string, g *globalFla
 		if sourcePath == "" {
 			return nil, fmt.Errorf("-source-path is required for sftp source")
 		}
-		return store.NewSFTPSource(cfg, sourcePath, excludePatterns...)
+		return store.NewSFTPSource(store.SFTPSourceConfig{
+			SFTPConfig:      cfg,
+			RootPath:        sourcePath,
+			ExcludePatterns: excludePatterns,
+		})
 	case "gdrive":
 		creds := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS") // optional; uses built-in OAuth client when empty
 		tokenPath, err := resolveTokenPath("GOOGLE_TOKEN_FILE", "google_token.json")
 		if err != nil {
 			return nil, err
 		}
-		src, err := store.NewGDriveSource(creds, tokenPath, excludePatterns...)
-		if err != nil {
-			return nil, err
-		}
-		src.DriveID = driveID
-		src.RootFolderID = rootFolder
-		return src, nil
+		return store.NewGDriveSource(store.GDriveSourceConfig{
+			CredsPath:       creds,
+			TokenPath:       tokenPath,
+			DriveID:         driveID,
+			RootFolderID:    rootFolder,
+			ExcludePatterns: excludePatterns,
+		})
 	case "gdrive-changes":
 		creds := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS") // optional; uses built-in OAuth client when empty
 		tokenPath, err := resolveTokenPath("GOOGLE_TOKEN_FILE", "google_token.json")
 		if err != nil {
 			return nil, err
 		}
-		src, err := store.NewGDriveChangeSource(creds, tokenPath, excludePatterns...)
-		if err != nil {
-			return nil, err
-		}
-		src.DriveID = driveID
-		src.RootFolderID = rootFolder
-		return src, nil
+		return store.NewGDriveChangeSource(store.GDriveSourceConfig{
+			CredsPath:       creds,
+			TokenPath:       tokenPath,
+			DriveID:         driveID,
+			RootFolderID:    rootFolder,
+			ExcludePatterns: excludePatterns,
+		})
 	case "onedrive":
 		clientID := os.Getenv("ONEDRIVE_CLIENT_ID") // optional; uses built-in OAuth client when empty
 		tokenPath, err := resolveTokenPath("ONEDRIVE_TOKEN_FILE", "onedrive_token.json")
 		if err != nil {
 			return nil, err
 		}
-		return store.NewOneDriveSource(clientID, tokenPath, excludePatterns...)
+		return store.NewOneDriveSource(store.OneDriveSourceConfig{
+			ClientID:        clientID,
+			TokenPath:       tokenPath,
+			ExcludePatterns: excludePatterns,
+		})
 	case "onedrive-changes":
 		clientID := os.Getenv("ONEDRIVE_CLIENT_ID") // optional; uses built-in OAuth client when empty
 		tokenPath, err := resolveTokenPath("ONEDRIVE_TOKEN_FILE", "onedrive_token.json")
 		if err != nil {
 			return nil, err
 		}
-		return store.NewOneDriveChangeSource(clientID, tokenPath, excludePatterns...)
+		return store.NewOneDriveChangeSource(store.OneDriveSourceConfig{
+			ClientID:        clientID,
+			TokenPath:       tokenPath,
+			ExcludePatterns: excludePatterns,
+		})
 	default:
 		return nil, fmt.Errorf("unsupported source type: %s", sourceType)
 	}

--- a/pkg/store/gdrive.go
+++ b/pkg/store/gdrive.go
@@ -19,34 +19,41 @@ import (
 	"google.golang.org/api/option"
 )
 
+// GDriveSourceConfig holds configuration for a Google Drive source.
+type GDriveSourceConfig struct {
+	CredsPath       string // path to credentials JSON; empty uses built-in OAuth client
+	TokenPath       string // where the OAuth token is cached
+	DriveID         string // shared drive ID; empty means "My Drive"
+	RootFolderID    string // restrict to a specific folder; empty means entire drive
+	ExcludePatterns []string
+}
+
 // GDriveSource implements Source for Google Drive. By default it backs up the
-// entire "My Drive" root. Set DriveID to back up a shared drive instead, and/or
-// set RootFolderID to restrict to a specific folder within the selected drive.
+// entire "My Drive" root. Set DriveID in GDriveSourceConfig to back up a
+// shared drive instead, and/or set RootFolderID to restrict to a specific
+// folder within the selected drive.
 type GDriveSource struct {
 	Service      *drive.Service
 	DriveID      string // shared drive ID; empty means "My Drive"
 	RootFolderID string // if empty, defaults to "root" (entire drive)
-	Account      string // Google account email; populated automatically if empty
+	account      string // Google account email; populated automatically
 	exclude      *ExcludeMatcher
 }
 
-// NewGDriveSource creates a new GDriveSource. If credsPath is non-empty it is
-// used as a Google credentials JSON file (user OAuth or service-account). When
-// credsPath is empty the built-in OAuth client credentials are used instead.
-// tokenPath is where the OAuth token will be cached.
-func NewGDriveSource(credsPath, tokenPath string, excludePatterns ...string) (*GDriveSource, error) {
+// NewGDriveSource creates a new GDriveSource from the given config.
+func NewGDriveSource(cfg GDriveSourceConfig) (*GDriveSource, error) {
 	ctx := context.Background()
 
 	var srv *drive.Service
 
-	if credsPath != "" {
-		b, err := os.ReadFile(credsPath)
+	if cfg.CredsPath != "" {
+		b, err := os.ReadFile(cfg.CredsPath)
 		if err != nil {
 			return nil, fmt.Errorf("read credentials file: %w", err)
 		}
 		config, err := google.ConfigFromJSON(b, drive.DriveReadonlyScope)
 		if err == nil {
-			client, err := oauthClient(config, tokenPath)
+			client, err := oauthClient(config, cfg.TokenPath)
 			if err != nil {
 				return nil, err
 			}
@@ -55,7 +62,7 @@ func NewGDriveSource(credsPath, tokenPath string, excludePatterns ...string) (*G
 				return nil, fmt.Errorf("create drive client (user auth): %w", err)
 			}
 		} else {
-			srv, err = drive.NewService(ctx, option.WithCredentialsFile(credsPath))
+			srv, err = drive.NewService(ctx, option.WithCredentialsFile(cfg.CredsPath))
 			if err != nil {
 				return nil, fmt.Errorf("create drive client: %w", err)
 			}
@@ -67,7 +74,7 @@ func NewGDriveSource(credsPath, tokenPath string, excludePatterns ...string) (*G
 			Scopes:       []string{drive.DriveReadonlyScope},
 			Endpoint:     google.Endpoint,
 		}
-		client, err := oauthClient(config, tokenPath)
+		client, err := oauthClient(config, cfg.TokenPath)
 		if err != nil {
 			return nil, err
 		}
@@ -77,11 +84,16 @@ func NewGDriveSource(credsPath, tokenPath string, excludePatterns ...string) (*G
 		}
 	}
 
-	return &GDriveSource{Service: srv, exclude: NewExcludeMatcher(excludePatterns)}, nil
+	return &GDriveSource{
+		Service:      srv,
+		DriveID:      cfg.DriveID,
+		RootFolderID: cfg.RootFolderID,
+		exclude:      NewExcludeMatcher(cfg.ExcludePatterns),
+	}, nil
 }
 
 func (s *GDriveSource) Info() core.SourceInfo {
-	account := s.Account
+	account := s.account
 	if account == "" {
 		if about, err := s.Service.About.Get().Fields("user(emailAddress)").Do(); err == nil && about.User != nil {
 			account = about.User.EmailAddress

--- a/pkg/store/gdrive_changes.go
+++ b/pkg/store/gdrive_changes.go
@@ -16,8 +16,8 @@ type GDriveChangeSource struct {
 	GDriveSource
 }
 
-func NewGDriveChangeSource(credsPath, tokenPath string, excludePatterns ...string) (*GDriveChangeSource, error) {
-	base, err := NewGDriveSource(credsPath, tokenPath, excludePatterns...)
+func NewGDriveChangeSource(cfg GDriveSourceConfig) (*GDriveChangeSource, error) {
+	base, err := NewGDriveSource(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/store/interface.go
+++ b/pkg/store/interface.go
@@ -80,7 +80,7 @@ type FileChange struct {
 	Meta core.FileMeta
 }
 
-// IncrementalSource extends Source with delta-based walking using a change
+// IncrementalSource
 // token stored in the snapshot. On the first run (empty token) the engine
 // falls back to the full Walk; on subsequent runs only changed entries are
 // emitted.

--- a/pkg/store/local_source.go
+++ b/pkg/store/local_source.go
@@ -19,19 +19,23 @@ func (s *LocalSource) Info() core.SourceInfo {
 	}
 }
 
-// LocalSource implements Source for local filesystem
+// LocalSourceConfig holds configuration for a local filesystem source.
+type LocalSourceConfig struct {
+	RootPath        string
+	ExcludePatterns []string
+}
+
+// LocalSource implements Source for local filesystem.
 type LocalSource struct {
 	RootPath string
 	exclude  *ExcludeMatcher
 }
 
-// NewLocalSource creates a local filesystem source rooted at rootPath.
-// Optional exclude patterns use gitignore-style syntax to skip files and
-// directories during Walk and Size.
-func NewLocalSource(rootPath string, excludePatterns ...string) *LocalSource {
+// NewLocalSource creates a local filesystem source from the given config.
+func NewLocalSource(cfg LocalSourceConfig) *LocalSource {
 	return &LocalSource{
-		RootPath: rootPath,
-		exclude:  NewExcludeMatcher(excludePatterns),
+		RootPath: cfg.RootPath,
+		exclude:  NewExcludeMatcher(cfg.ExcludePatterns),
 	}
 }
 

--- a/pkg/store/local_source_test.go
+++ b/pkg/store/local_source_test.go
@@ -39,7 +39,10 @@ func TestLocalSource_WithExcludes(t *testing.T) {
 		}
 	}
 
-	src := NewLocalSource(tmpDir, ".git/", "node_modules/", "*.tmp", "*.log")
+	src := NewLocalSource(LocalSourceConfig{
+		RootPath:        tmpDir,
+		ExcludePatterns: []string{".git/", "node_modules/", "*.tmp", "*.log"},
+	})
 
 	// Test Walk() — excluded files/dirs should not appear.
 	var walked []string
@@ -119,7 +122,7 @@ func TestLocalSource(t *testing.T) {
 		t.Fatalf("Failed to write file2: %v", err)
 	}
 
-	src := NewLocalSource(tmpDir)
+	src := NewLocalSource(LocalSourceConfig{RootPath: tmpDir})
 
 	// Test Info()
 	info := src.Info()

--- a/pkg/store/onedrive.go
+++ b/pkg/store/onedrive.go
@@ -16,13 +16,22 @@ import (
 	"golang.org/x/oauth2/microsoft"
 )
 
+// OneDriveSourceConfig holds configuration for a OneDrive source.
+type OneDriveSourceConfig struct {
+	ClientID        string // empty uses built-in OAuth client
+	TokenPath       string // where the OAuth token is cached
+	ExcludePatterns []string
+}
+
 type OneDriveSource struct {
 	Client  *http.Client
 	account string // cached user principal name; populated lazily by Info()
 	exclude *ExcludeMatcher
 }
 
-func NewOneDriveSource(clientID, tokenPath string, excludePatterns ...string) (*OneDriveSource, error) {
+// NewOneDriveSource creates a new OneDriveSource from the given config.
+func NewOneDriveSource(cfg OneDriveSourceConfig) (*OneDriveSource, error) {
+	clientID := cfg.ClientID
 	if clientID == "" {
 		clientID = defaultOneDriveClientID
 	}
@@ -34,17 +43,17 @@ func NewOneDriveSource(clientID, tokenPath string, excludePatterns ...string) (*
 		Endpoint: microsoft.AzureADEndpoint("common"),
 	}
 
-	token, err := loadToken(tokenPath)
+	token, err := loadToken(cfg.TokenPath)
 	if err != nil {
 		token, err = exchangeWithLocalServer(conf, oauth2.AccessTypeOffline)
 		if err != nil {
 			return nil, fmt.Errorf("onedrive auth: %w", err)
 		}
-		_ = saveTokenJSON(tokenPath, token)
+		_ = saveTokenJSON(cfg.TokenPath, token)
 	}
 
 	client := conf.Client(ctx, token)
-	return &OneDriveSource{Client: client, exclude: NewExcludeMatcher(excludePatterns)}, nil
+	return &OneDriveSource{Client: client, exclude: NewExcludeMatcher(cfg.ExcludePatterns)}, nil
 }
 
 func (s *OneDriveSource) Info() core.SourceInfo {

--- a/pkg/store/onedrive_changes.go
+++ b/pkg/store/onedrive_changes.go
@@ -19,8 +19,8 @@ type OneDriveChangeSource struct {
 	OneDriveSource
 }
 
-func NewOneDriveChangeSource(clientID, tokenPath string, excludePatterns ...string) (*OneDriveChangeSource, error) {
-	base, err := NewOneDriveSource(clientID, tokenPath, excludePatterns...)
+func NewOneDriveChangeSource(cfg OneDriveSourceConfig) (*OneDriveChangeSource, error) {
+	base, err := NewOneDriveSource(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/store/sftp_source.go
+++ b/pkg/store/sftp_source.go
@@ -10,6 +10,13 @@ import (
 	"github.com/pkg/sftp"
 )
 
+// SFTPSourceConfig holds configuration for an SFTP filesystem source.
+type SFTPSourceConfig struct {
+	SFTPConfig             // connection parameters
+	RootPath        string // remote directory to back up
+	ExcludePatterns []string
+}
+
 // SFTPSource implements Source for a remote SFTP filesystem.
 type SFTPSource struct {
 	client   *sftp.Client
@@ -19,14 +26,13 @@ type SFTPSource struct {
 }
 
 // NewSFTPSource connects to the SFTP server described by cfg and returns a
-// source rooted at rootPath. Optional exclude patterns use gitignore-style
-// syntax to skip files and directories during Walk and Size.
-func NewSFTPSource(cfg SFTPConfig, rootPath string, excludePatterns ...string) (*SFTPSource, error) {
-	client, err := dialSFTP(cfg)
+// source rooted at cfg.RootPath.
+func NewSFTPSource(cfg SFTPSourceConfig) (*SFTPSource, error) {
+	client, err := dialSFTP(cfg.SFTPConfig)
 	if err != nil {
 		return nil, fmt.Errorf("sftp source connect: %w", err)
 	}
-	return &SFTPSource{client: client, rootPath: rootPath, cfg: cfg, exclude: NewExcludeMatcher(excludePatterns)}, nil
+	return &SFTPSource{client: client, rootPath: cfg.RootPath, cfg: cfg.SFTPConfig, exclude: NewExcludeMatcher(cfg.ExcludePatterns)}, nil
 }
 
 // Close releases the underlying SFTP and SSH connections.

--- a/pkg/store/sftp_test.go
+++ b/pkg/store/sftp_test.go
@@ -199,7 +199,7 @@ func TestSFTPSource(t *testing.T) {
 	_ = seedClient.Close()
 
 	// Create SFTPSource
-	src, err := NewSFTPSource(cfg, rootPath)
+	src, err := NewSFTPSource(SFTPSourceConfig{SFTPConfig: cfg, RootPath: rootPath})
 	if err != nil {
 		t.Fatalf("NewSFTPSource failed: %v", err)
 	}


### PR DESCRIPTION
## Summary
Refactor all source constructors to use typed config structs.

## What Changes
- Introduce `LocalSourceConfig`, `SFTPSourceConfig`, `GDriveSourceConfig`, and `OneDriveSourceConfig`.
- Replace positional parameters + variadic excludes with config-based initialization.
- Move `DriveID` and `RootFolderID` into config types to avoid post-construction mutation.
- Reuse the same config model for change-source variants.

## Notes
- API-surface refactor intended to simplify call sites and improve maintainability.