### PR TITLE
feat: add `key` command with `list`, `add-recovery`, and `passwd` subcommands

### DIFF
--- a/cmd/cloudstic/completion.go
+++ b/cmd/cloudstic/completion.go
@@ -13,7 +13,7 @@ _cloudstic() {
     local cur prev words cword
     _init_completion || return
 
-    local commands="init backup restore list ls prune forget diff break-lock add-recovery-key cat completion version help"
+    local commands="init backup restore list ls prune forget diff break-lock key cat completion version help"
 
     local global_flags="-store -store-path -store-prefix -s3-endpoint -s3-region -s3-access-key -s3-secret-key -sftp-host -sftp-port -sftp-user -sftp-password -sftp-key -source-sftp-host -source-sftp-port -source-sftp-user -source-sftp-password -source-sftp-key -store-sftp-host -store-sftp-port -store-sftp-user -store-sftp-password -store-sftp-key -encryption-key -encryption-password -recovery-key -kms-key-arn -enable-packfile -verbose -quiet -debug"
 
@@ -60,7 +60,28 @@ _cloudstic() {
         completion)
             COMPREPLY=($(compgen -W "bash zsh fish" -- "$cur"))
             return ;;
-        list|ls|diff|break-lock|add-recovery-key|version|help)
+        key)
+            # Handle key subcommands
+            local key_sub=""
+            local j
+            for ((j=i+1; j < cword; j++)); do
+                case "${words[j]}" in
+                    -*) ;;
+                    *) key_sub="${words[j]}"; break ;;
+                esac
+            done
+            if [[ -z "$key_sub" ]]; then
+                COMPREPLY=($(compgen -W "list add-recovery passwd" -- "$cur"))
+                return
+            fi
+            case "$key_sub" in
+                passwd)
+                    cmd_flags="-new-password" ;;
+                *)
+                    cmd_flags="" ;;
+            esac
+            ;;
+        list|ls|diff|break-lock|version|help)
             cmd_flags="" ;;
     esac
 
@@ -105,7 +126,7 @@ _cloudstic() {
         'forget:Remove a specific snapshot from history'
         'diff:Compare two snapshots or a snapshot against latest'
         'break-lock:Remove a stale repository lock'
-        'add-recovery-key:Generate a recovery key for an encrypted repository'
+        'key:Manage encryption key slots'
         'cat:Display raw JSON content of repository objects'
         'completion:Generate shell completion scripts'
         'version:Print version information'
@@ -229,8 +250,36 @@ _cloudstic() {
         break-lock)
             _arguments $global_flags
             ;;
-        add-recovery-key)
-            _arguments $global_flags
+        key)
+            local -a key_commands
+            key_commands=(
+                'list:List all encryption key slots'
+                'add-recovery:Generate a 24-word recovery key'
+                'passwd:Change the repository password'
+            )
+            # Check if a key subcommand has been given
+            local key_sub
+            local -i ki=$((i+1))
+            while (( ki < CURRENT )); do
+                case "${words[ki]}" in
+                    -*) ;;
+                    *) key_sub="${words[ki]}"; break ;;
+                esac
+                (( ki++ ))
+            done
+            if [[ -z "$key_sub" ]]; then
+                _describe -t key-commands 'key subcommand' key_commands
+                return
+            fi
+            case "$key_sub" in
+                passwd)
+                    _arguments $global_flags \
+                        '-new-password[New repository password]:password:'
+                    ;;
+                *)
+                    _arguments $global_flags
+                    ;;
+            esac
             ;;
         cat)
             _arguments $global_flags \
@@ -264,7 +313,7 @@ complete -c cloudstic -n __fish_use_subcommand -a prune -d 'Remove unused data c
 complete -c cloudstic -n __fish_use_subcommand -a forget -d 'Remove a snapshot from history'
 complete -c cloudstic -n __fish_use_subcommand -a diff -d 'Compare two snapshots'
 complete -c cloudstic -n __fish_use_subcommand -a break-lock -d 'Remove a stale repository lock'
-complete -c cloudstic -n __fish_use_subcommand -a add-recovery-key -d 'Generate a recovery key'
+complete -c cloudstic -n __fish_use_subcommand -a key -d 'Manage encryption key slots'
 complete -c cloudstic -n __fish_use_subcommand -a cat -d 'Display raw JSON of repository objects'
 complete -c cloudstic -n __fish_use_subcommand -a completion -d 'Generate shell completion scripts'
 complete -c cloudstic -n __fish_use_subcommand -a version -d 'Print version information'
@@ -335,6 +384,12 @@ complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l source -x -d 'F
 complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l account -x -d 'Filter by account'
 complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l path -x -d 'Filter by path'
 complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l group-by -x -d 'Group snapshots by fields'
+
+# key subcommands
+complete -c cloudstic -n '__fish_seen_subcommand_from key; and not __fish_seen_subcommand_from list add-recovery passwd' -a list -d 'List all encryption key slots'
+complete -c cloudstic -n '__fish_seen_subcommand_from key; and not __fish_seen_subcommand_from list add-recovery passwd' -a add-recovery -d 'Generate a 24-word recovery key'
+complete -c cloudstic -n '__fish_seen_subcommand_from key; and not __fish_seen_subcommand_from list add-recovery passwd' -a passwd -d 'Change the repository password'
+complete -c cloudstic -n '__fish_seen_subcommand_from key; and __fish_seen_subcommand_from passwd' -l new-password -x -d 'New repository password'
 
 # cat
 complete -c cloudstic -n '__fish_seen_subcommand_from cat' -l json -d 'Suppress non-JSON output'

--- a/cmd/cloudstic/completion_test.go
+++ b/cmd/cloudstic/completion_test.go
@@ -21,7 +21,9 @@ func TestCompletionBash(t *testing.T) {
 		"complete -F _cloudstic cloudstic",
 		// All commands are listed
 		"init", "backup", "restore", "list", "ls", "prune", "forget",
-		"diff", "break-lock", "add-recovery-key", "cat", "completion",
+		"diff", "break-lock", "key", "cat", "completion",
+		// Key subcommands
+		"list add-recovery passwd",
 		// Global flags
 		"-store", "-encryption-password", "-verbose",
 		// Command-specific flags
@@ -52,7 +54,13 @@ func TestCompletionZsh(t *testing.T) {
 		// Commands with descriptions
 		"init:Initialize a new repository",
 		"backup:Create a new backup snapshot",
+		"key:Manage encryption key slots",
 		"completion:Generate shell completion scripts",
+		// Key subcommands
+		"list:List all encryption key slots",
+		"add-recovery:Generate a 24-word recovery key",
+		"passwd:Change the repository password",
+		"-new-password[New repository password]",
 		// Global flags with descriptions
 		"-store[Storage backend]",
 		"-verbose[Log detailed operations]",
@@ -85,7 +93,13 @@ func TestCompletionFish(t *testing.T) {
 		// Subcommands
 		"complete -c cloudstic -n __fish_use_subcommand -a init",
 		"complete -c cloudstic -n __fish_use_subcommand -a backup",
+		"complete -c cloudstic -n __fish_use_subcommand -a key",
 		"complete -c cloudstic -n __fish_use_subcommand -a completion",
+		// Key subcommands
+		"-a list -d 'List all encryption key slots'",
+		"-a add-recovery -d 'Generate a 24-word recovery key'",
+		"-a passwd -d 'Change the repository password'",
+		"-l new-password",
 		// Global flags
 		"complete -c cloudstic -l store -x",
 		"complete -c cloudstic -l verbose",

--- a/cmd/cloudstic/main.go
+++ b/cmd/cloudstic/main.go
@@ -157,7 +157,10 @@ func runCmd(cmd string) int {
 		runDiff()
 	case "break-lock":
 		runBreakLock()
+	case "key":
+		runKey()
 	case "add-recovery-key":
+		fmt.Fprintln(os.Stderr, "Note: 'add-recovery-key' is deprecated. Use 'cloudstic key add-recovery' instead.")
 		runAddRecoveryKey()
 	case "check":
 		runCheck()
@@ -195,7 +198,9 @@ func printUsage() {
 		{"forget", "Remove a specific snapshot from history"},
 		{"diff", "Compare two snapshots or a snapshot against latest"},
 		{"break-lock", "Remove a stale repository lock left by a crashed process"},
-		{"add-recovery-key", "Generate a recovery key for an existing encrypted repository"},
+		{"key list", "List all encryption key slots in the repository"},
+		{"key add-recovery", "Generate a 24-word recovery key for an encrypted repository"},
+		{"key passwd", "Change the repository password"},
 		{"check", "Verify repository integrity (reference chain, objects, data)"},
 		{"cat", "Display raw JSON content of repository objects"},
 		{"completion", "Generate shell completion scripts (bash, zsh, fish)"},
@@ -243,10 +248,24 @@ func printUsage() {
 	})
 	t.Blank()
 
-	t.Command("add-recovery-key", "")
+	t.Command("key list", "")
+	t.Note("  List all encryption key slots present in the repository.")
+	t.Blank()
+
+	t.Command("key add-recovery", "")
 	t.Note(
 		"  Generate a 24-word recovery key for an existing encrypted repository.",
 		"  Requires -encryption-key or -encryption-password to unlock the master key.",
+	)
+	t.Blank()
+
+	t.Command("key passwd", "")
+	t.Flags([][2]string{
+		{"-new-password <pw>", "New password (prompted interactively if not set)"},
+	})
+	t.Note(
+		"  Change the repository password. Provide current credentials via",
+		"  -encryption-password, -encryption-key, or -kms-key-arn to unlock.",
 	)
 	t.Blank()
 
@@ -679,6 +698,198 @@ func printRecoveryKey(mnemonic string) {
 	fmt.Fprintln(os.Stderr, "║                                                              ║")
 	fmt.Fprintln(os.Stderr, "╚══════════════════════════════════════════════════════════════╝")
 	fmt.Fprintln(os.Stderr)
+}
+
+// ---------------------------------------------------------------------------
+// key <subcommand>
+// ---------------------------------------------------------------------------
+
+func runKey() {
+	if len(os.Args) < 3 {
+		fmt.Fprintln(os.Stderr, "Usage: cloudstic key <subcommand>")
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, "Subcommands:")
+		fmt.Fprintln(os.Stderr, "  list           List all encryption key slots in the repository")
+		fmt.Fprintln(os.Stderr, "  add-recovery   Generate a 24-word recovery key")
+		fmt.Fprintln(os.Stderr, "  passwd         Change the repository password")
+		os.Exit(1)
+	}
+
+	sub := os.Args[2]
+	// Shift os.Args so subcommand flag parsing works correctly:
+	// "cloudstic key list -store ..." → args[0]="cloudstic" args[1]="key" args[2]="list" ...
+	// After shift: args become ["cloudstic", "list", "-store", ...] and flags parse from args[2:].
+	os.Args = append(os.Args[:2], os.Args[3:]...)
+
+	switch sub {
+	case "list":
+		runKeyList()
+	case "add-recovery":
+		runAddRecoveryKey()
+	case "passwd":
+		runKeyPasswd()
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown key subcommand: %s\n", sub)
+		os.Exit(1)
+	}
+}
+
+func runKeyList() {
+	listCmd := flag.NewFlagSet("key list", flag.ExitOnError)
+	g := addGlobalFlags(listCmd)
+	_ = listCmd.Parse(os.Args[2:])
+
+	raw, err := g.initObjectStore()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to init store: %v\n", err)
+		os.Exit(1)
+	}
+	raw = g.applyDebug(raw)
+
+	cfg, err := loadRepoConfig(raw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to read config: %v\n", err)
+		os.Exit(1)
+	}
+	if cfg == nil {
+		fmt.Fprintln(os.Stderr, "Repository not initialized -- run 'cloudstic init' first.")
+		os.Exit(1)
+	}
+	if !cfg.Encrypted {
+		fmt.Fprintln(os.Stderr, "Repository is not encrypted -- no key slots to list.")
+		return
+	}
+
+	slots, err := store.LoadKeySlots(raw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load key slots: %v\n", err)
+		os.Exit(1)
+	}
+
+	if len(slots) == 0 {
+		fmt.Fprintln(os.Stderr, "No key slots found.")
+		return
+	}
+
+	t := table.NewWriter()
+	t.SetOutputMirror(os.Stdout)
+	t.AppendHeader(table.Row{"Type", "Label", "KDF"})
+	for _, slot := range slots {
+		kdf := "—"
+		if slot.KDFParams != nil {
+			kdf = slot.KDFParams.Algorithm
+		}
+		t.AppendRow(table.Row{slot.SlotType, slot.Label, kdf})
+	}
+	t.Render()
+	fmt.Fprintf(os.Stderr, "\n%d key slot(s) found.\n", len(slots))
+}
+
+func runKeyPasswd() {
+	passwdCmd := flag.NewFlagSet("key passwd", flag.ExitOnError)
+	g := addGlobalFlags(passwdCmd)
+	newPassword := passwdCmd.String("new-password", "", "New repository password (prompted interactively if not set)")
+	_ = passwdCmd.Parse(os.Args[2:])
+
+	raw, err := g.initObjectStore()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to init store: %v\n", err)
+		os.Exit(1)
+	}
+	raw = g.applyDebug(raw)
+
+	cfg, err := loadRepoConfig(raw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to read config: %v\n", err)
+		os.Exit(1)
+	}
+	if cfg == nil {
+		fmt.Fprintln(os.Stderr, "Repository not initialized -- run 'cloudstic init' first.")
+		os.Exit(1)
+	}
+	if !cfg.Encrypted {
+		fmt.Fprintln(os.Stderr, "Repository is not encrypted -- nothing to change.")
+		os.Exit(1)
+	}
+
+	platformKey, err := g.parsePlatformKey()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	password := *g.encryptionPassword
+
+	var kmsDecrypter crypto.KMSDecrypter
+	if *g.kmsKeyARN != "" {
+		d, err := crypto.NewAWSKMSDecrypter(context.Background())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to create KMS decrypter: %v\n", err)
+			os.Exit(1)
+		}
+		kmsDecrypter = d
+	}
+
+	// If no credential flags provided, prompt for current password.
+	if len(platformKey) == 0 && password == "" && kmsDecrypter == nil {
+		if term.IsTerminal(os.Stdin.Fd()) {
+			pw, err := ui.PromptPassword("Current repository password")
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to read password: %v\n", err)
+				os.Exit(1)
+			}
+			password = pw
+		} else {
+			fmt.Fprintln(os.Stderr, "Provide --encryption-key, --encryption-password, or --kms-key-arn to unlock the master key.")
+			os.Exit(1)
+		}
+	}
+
+	slots, err := store.LoadKeySlots(raw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load key slots: %v\n", err)
+		os.Exit(1)
+	}
+
+	masterKey, err := store.ExtractMasterKeyWithKMS(context.Background(), slots, kmsDecrypter, platformKey, password)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to unlock repository: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Resolve new password.
+	newPw := *newPassword
+	if newPw == "" {
+		if !term.IsTerminal(os.Stdin.Fd()) {
+			fmt.Fprintln(os.Stderr, "Provide --new-password or run interactively.")
+			os.Exit(1)
+		}
+		p1, err := ui.PromptPassword("Enter new repository password")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to read password: %v\n", err)
+			os.Exit(1)
+		}
+		if p1 == "" {
+			fmt.Fprintln(os.Stderr, "Error: password cannot be empty.")
+			os.Exit(1)
+		}
+		p2, err := ui.PromptPassword("Confirm new repository password")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to read password confirmation: %v\n", err)
+			os.Exit(1)
+		}
+		if p1 != p2 {
+			fmt.Fprintln(os.Stderr, "Error: passwords do not match.")
+			os.Exit(1)
+		}
+		newPw = p1
+	}
+
+	if err := store.ChangePasswordSlot(raw, masterKey, newPw); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to change password: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Fprintln(os.Stderr, "Repository password has been changed.")
 }
 
 func runAddRecoveryKey() {

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -18,7 +18,9 @@ Cloudstic is a content-addressable backup tool that creates encrypted, deduplica
   - [forget](#forget)
   - [prune](#prune)
   - [check](#check)
-  - [add-recovery-key](#add-recovery-key)
+  - [key list](#key-list)
+  - [key add-recovery](#key-add-recovery)
+  - [key passwd](#key-passwd)
   - [cat](#cat)
   - [completion](#completion)
 - [Shell Completions](#shell-completions)
@@ -534,15 +536,68 @@ Repository check complete.
 
 ---
 
-### add-recovery-key
+### key list
+
+List all encryption key slots present in the repository. This lets you see which credential types are configured (password, platform, kms-platform, recovery).
+
+```bash
+cloudstic key list
+```
+
+Example output:
+
+```
++──────────────+─────────+──────────+
+| TYPE         | LABEL   | KDF      |
++──────────────+─────────+──────────+
+| password     | default | argon2id |
+| recovery     | default | —        |
++──────────────+─────────+──────────+
+
+2 key slot(s) found.
+```
+
+> **Note:** `key list` does not require the encryption key — slot metadata is stored unencrypted.
+
+---
+
+### key add-recovery
 
 Generate a 24-word recovery key for an existing encrypted repository. Requires your current encryption credential to unlock the master key.
 
 ```bash
-cloudstic add-recovery-key -encryption-password "my secret passphrase"
+cloudstic key add-recovery -encryption-password "my secret passphrase"
+
+# For KMS-managed repositories
+cloudstic key add-recovery -kms-key-arn arn:aws:kms:us-east-1:123:key/abc
 ```
 
 The recovery key is displayed once. Write it down immediately.
+
+> The legacy `add-recovery-key` command is still accepted but deprecated.
+
+---
+
+### key passwd
+
+Change (or add) the repository password. You must provide your current credentials to unlock the master key.
+
+```bash
+# Interactive — prompts for current and new password
+cloudstic key passwd
+
+# Non-interactive
+cloudstic key passwd -encryption-password "old passphrase" -new-password "new passphrase"
+
+# Unlock with platform key, set a password
+cloudstic key passwd -encryption-key <hex> -new-password "my passphrase"
+```
+
+**Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `-new-password` | New password (prompted interactively if not set) |
 
 ---
 
@@ -1021,10 +1076,16 @@ cloudstic restore -recovery-key "word1 word2 ... word24"
 ### Adding a recovery key later
 
 ```bash
-cloudstic add-recovery-key -encryption-password "my passphrase"
+cloudstic key add-recovery -encryption-password "my passphrase"
 
 # For KMS-managed repositories
-cloudstic add-recovery-key -kms-key-arn arn:aws:kms:us-east-1:123:key/abc
+cloudstic key add-recovery -kms-key-arn arn:aws:kms:us-east-1:123:key/abc
+```
+
+### Changing your password
+
+```bash
+cloudstic key passwd -encryption-password "old passphrase" -new-password "new passphrase"
 ```
 
 ---

--- a/pkg/store/keyslot.go
+++ b/pkg/store/keyslot.go
@@ -249,6 +249,17 @@ func writeRecoverySlot(s ObjectStore, masterKey, recoveryKey []byte) error {
 	})
 }
 
+// ChangePasswordSlot replaces (or creates) the password key slot for the
+// repository. masterKey is the unwrapped master key; newPassword is the new
+// password to wrap it with. The old password slot (keys/password-default) is
+// overwritten.
+func ChangePasswordSlot(s ObjectStore, masterKey []byte, newPassword string) error {
+	if newPassword == "" {
+		return fmt.Errorf("new password cannot be empty")
+	}
+	return writePasswordSlot(s, masterKey, newPassword)
+}
+
 // HasKeySlots reports whether the store contains any encryption key slots.
 func HasKeySlots(s ObjectStore) bool {
 	keys, err := s.List(context.Background(), KeySlotPrefix)

--- a/pkg/store/keyslot_test.go
+++ b/pkg/store/keyslot_test.go
@@ -277,6 +277,52 @@ func TestExtractMasterKey_NoMatch(t *testing.T) {
 	}
 }
 
+func TestChangePasswordSlot(t *testing.T) {
+	inner := newMemStore()
+	oldPassword := "old-password"
+	newPassword := "new-password"
+
+	encKey, err := InitEncryptionKey(inner, nil, oldPassword)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	slots, _ := LoadKeySlots(inner)
+	mk, err := ExtractMasterKey(slots, nil, oldPassword)
+	if err != nil {
+		t.Fatalf("ExtractMasterKey: %v", err)
+	}
+
+	if err := ChangePasswordSlot(inner, mk, newPassword); err != nil {
+		t.Fatalf("ChangePasswordSlot: %v", err)
+	}
+
+	// Old password should no longer work.
+	slots, _ = LoadKeySlots(inner)
+	if _, err := OpenWithPassword(slots, oldPassword); err == nil {
+		t.Fatal("old password should no longer open the repo")
+	}
+
+	// New password should work and produce the same encryption key.
+	opened, err := OpenWithPassword(slots, newPassword)
+	if err != nil {
+		t.Fatalf("OpenWithPassword with new password: %v", err)
+	}
+	for i := range encKey {
+		if encKey[i] != opened[i] {
+			t.Fatalf("key mismatch at byte %d after password change", i)
+		}
+	}
+}
+
+func TestChangePasswordSlot_EmptyPassword(t *testing.T) {
+	inner := newMemStore()
+	mk, _ := crypto.GenerateKey()
+	if err := ChangePasswordSlot(inner, mk, ""); err == nil {
+		t.Fatal("expected error for empty password")
+	}
+}
+
 func TestHasKeySlots(t *testing.T) {
 	inner := newMemStore()
 	if HasKeySlots(inner) {


### PR DESCRIPTION
Add a new `key` parent command for managing encryption key slots:

- **`key list`**: list all key slots in the repository (type, label, KDF) without needing the encryption key
- **`key add-recovery`**: generate a 24-word recovery key (moved from `add-recovery-key`, which is kept as a deprecated alias)
- **`key passwd`**: change the repository password by re-wrapping the master key with a new password

### Changes

- `pkg/store/keyslot.go`: add exported `ChangePasswordSlot()` function
- `pkg/store/keyslot_test.go`: add tests for `ChangePasswordSlot` (success, empty password rejection, key continuity after change)
- `cmd/cloudstic/main.go`: add `key` command with subcommand dispatch (`list`, `add-recovery`, `passwd`); keep `add-recovery-key` as deprecated alias
- `cmd/cloudstic/completion.go`: update bash/zsh/fish completions for `key` subcommands
- `docs/user-guide.md`: replace `add-recovery-key` docs with `key list`, `key add-recovery`, `key passwd`; update encryption section examples

### Usage

```bash
# List key slots
cloudstic key list

# Add a recovery key
cloudstic key add-recovery -encryption-password "my passphrase"

# Change password (interactive)
cloudstic key passwd

# Change password (non-interactive)
cloudstic key passwd -encryption-password "old" -new-password "new"
```

Co-Authored-By: Oz <oz-agent@warp.dev>