### PR TITLE
docs: fix inconsistencies in spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ cloudstic backup -source local -source-path ~/Documents -encryption-password "my
 
 ## Documentation
 
+Full documentation is available at **[docs.cloudstic.com](https://docs.cloudstic.com)**.
+
+This repository also contains developer-focused reference docs:
+
 - [User Guide](docs/user-guide.md): commands, setup, encryption, retention policies
 - [Source API](docs/sources.md): source interface, implementations, and how to add a new source
 - [Specification](docs/spec.md): object types, backup/restore flow, HAMT structure

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -54,7 +54,9 @@ Cloudstic is a content-addressable backup system designed for flat cloud storage
 | `forget`           | Remove a snapshot (and optionally prune afterwards)      |
 | `prune`            | Mark-and-sweep garbage collection of unreachable objects |
 | `break-lock`       | Force-remove a stale repository lock                     |
-| `add-recovery-key` | Add a BIP39 recovery key slot to the repository          |
+| `key list`         | List all encryption key slots in the repository          |
+| `key passwd`       | Change (rotate) the repository password                  |
+| `key add-recovery` | Add a BIP39 recovery key slot to the repository          |
 
 ---
 
@@ -185,7 +187,8 @@ Object key: `node/<sha256-of-serialized-json>`
     "generator": "cloudstic-cli"
   },
   "tags": ["daily", "important"],
-  "change_token": "12345"
+  "change_token": "12345",
+  "exclude_hash": "d4c3b2a1..."
 }
 ```
 
@@ -196,6 +199,7 @@ Object key: `node/<sha256-of-serialized-json>`
 | `meta`         | Free-form key-value metadata (generator, etc.)                       |
 | `tags`         | User-defined labels for retention policies                           |
 | `change_token` | Opaque token for incremental sources (omitted when not applicable)   |
+| `exclude_hash` | SHA-256 of the concatenated exclude patterns used for this snapshot  |
 
 * Every snapshot is a **complete checkpoint** — no delta replay needed.
 * Structural sharing via the HAMT minimises the number of new nodes.
@@ -206,9 +210,10 @@ Incremental sources (`gdrive-changes`) record an opaque `change_token` in each s
 
 The token format is source-specific:
 
-| Source           | Token type                           |
-|------------------|--------------------------------------|
-| `gdrive-changes` | Google Drive Changes API start page token |
+| Source              | Token type                                    |
+|---------------------|-----------------------------------------------|
+| `gdrive-changes`    | Google Drive Changes API start page token     |
+| `onedrive-changes`  | Microsoft OneDrive delta API next-link/token  |
 
 ### 6. Packfiles (`packs/` and `index/packs`)
 
@@ -220,8 +225,9 @@ To avoid issuing hundreds of thousands of S3 `PUT` and `GET` requests for tiny m
 
 ### 7. Index
 
-* A single `index/latest` pointer for quick access to the most recent snapshot.
-* Snapshot discovery uses `store.List("snapshot/")` — no per-sequence pointers needed.
+#### index/latest
+
+A mutable pointer to the most recent snapshot:
 
 ```json
 {
@@ -230,7 +236,13 @@ To avoid issuing hundreds of thousands of S3 `PUT` and `GET` requests for tiny m
 }
 ```
 
-Clients fetch `index/latest` to find the head. To list all snapshots, list the `snapshot/` prefix directly.
+#### index/snapshots
+
+A catalog of lightweight snapshot summaries used to avoid fetching each full snapshot object individually. Stored as a JSON array of `SnapshotSummary` objects (same fields as `Snapshot` minus the HAMT root detail). Self-heals via reconciliation with `LIST snapshot/` on load — if the catalog is missing or stale it is rebuilt automatically.
+
+#### index/packs
+
+When packfiles are enabled, a bbolt database mapping logical object keys to their byte offset and length within a packfile. Rebuilt automatically if stale.
 
 ---
 

--- a/docs/storage-model.md
+++ b/docs/storage-model.md
@@ -12,7 +12,9 @@ stored under a key derived from its hash. Objects are immutable once written.
 | `filemeta/`  | File metadata (name, size, mod time, content hash)    |
 | `node/`      | HAMT tree nodes (directory structure)                 |
 | `snapshot/`  | Root object tying a tree to a point in time           |
-| `index/`     | Mutable pointers (`latest`, `packs` catalog)           |
+| `index/latest`     | Mutable pointer to the most recent snapshot            |
+| `index/snapshots`  | Snapshot catalog (lightweight summaries, self-healing) |
+| `index/packs`      | Pack catalog — offset map for objects inside packfiles  |
 
 ## Write Order During Backup
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2,6 +2,8 @@
 
 Cloudstic is a content-addressable backup tool that creates encrypted, deduplicated snapshots of your files — from local directories, SFTP servers, Google Drive, or OneDrive — and stores them locally, on Amazon S3, Backblaze B2, or a remote SFTP server.
 
+> Full documentation (with guides, examples, and API reference) is available at **[docs.cloudstic.com](https://docs.cloudstic.com)**.
+
 ## Table of Contents
 
 - [Quick Start](#quick-start)
@@ -1105,6 +1107,10 @@ cloudstic restore -recovery-key "word1 word2 ... word24"
 ### Adding a recovery key later
 
 ```bash
+# Interactive — prompts for current password
+cloudstic key add-recovery
+
+# Non-interactive
 cloudstic key add-recovery -encryption-password "my passphrase"
 
 # For KMS-managed repositories


### PR DESCRIPTION
## Summary
Fix inconsistencies in specification documentation.

## What Changes
- Clean up wording and alignment issues in `docs/spec.md`.