### PR TITLE
docs: add testing section to contributing guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ go fmt ./...
 
 ### E2E Test Modes
 
-E2E tests in `cmd/cloudstic/` are controlled by `CLOUDSTIC_E2E_MODE`:
+E2E tests in `e2e/` are controlled by `CLOUDSTIC_E2E_MODE`:
 - `hermetic` (default) — local filesystem + Testcontainers (MinIO, SFTP). Requires Docker.
 - `live` — real cloud vendor APIs (requires secrets).
 - `all` — runs both.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ This repository also contains developer-focused reference docs:
 - [Specification](docs/spec.md): object types, backup/restore flow, HAMT structure
 - [Encryption](docs/encryption.md): key slot design, AES-256-GCM, recovery keys
 - [Storage Model](docs/storage-model.md): content-addressable storage layout
+- [Contributing](docs/contributing.md): testing, profiling, debugging
 
 ## Cloud Service
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,6 +2,36 @@
 
 Welcome! We appreciate your help in making Cloudstic better.
 
+## Testing
+
+```bash
+# Run all tests (unit + hermetic e2e)
+go test -v -race -count=1 ./...
+
+# Run a single test
+go test -v -run TestName ./path/to/package
+
+# Run the full check script (fmt + lint + test + coverage)
+./scripts/check.sh
+```
+
+### E2E test modes
+
+E2E tests live in `e2e/` and are controlled by the `CLOUDSTIC_E2E_MODE` environment variable:
+
+- `hermetic` (default) — spins up local dependencies via Testcontainers (MinIO, SFTP). Requires Docker.
+- `live` — runs against real cloud vendor APIs. Requires secrets to be configured.
+- `all` — runs both hermetic and live.
+
+Hermetic tests are automatically skipped if `/var/run/docker.sock` is not available, so they are safe to run in environments without Docker.
+
+### What to test
+
+- Add tests for any new public API methods on `Client`.
+- Test both success and error paths.
+- Use the mock store in `internal/engine/mock_test.go` to unit test engine logic without a real backend.
+- If your change touches encryption or compression, add a round-trip test.
+
 ## Profiling
 
 If you are a developer or need to troubleshoot performance issues, you can generate standard Go profiles using the following hidden flags on any command:


### PR DESCRIPTION
## Summary
Add testing guidance to contribution documentation.

## What Changes
- Extend `docs/contributing.md` with a dedicated testing section.