### PR TITLE
feat: add `cat --raw` option

### DIFF
--- a/cmd/cloudstic/cmd_cat.go
+++ b/cmd/cloudstic/cmd_cat.go
@@ -13,6 +13,7 @@ type catArgs struct {
 	g    *globalFlags
 	keys []string
 	json bool
+	raw  bool
 }
 
 func parseCatArgs() *catArgs {
@@ -20,6 +21,7 @@ func parseCatArgs() *catArgs {
 	a := &catArgs{}
 	a.g = addGlobalFlags(fs)
 	jsonFlag := fs.Bool("json", false, "Suppress non-JSON output (alias for -quiet)")
+	rawFlag := fs.Bool("raw", false, "Output raw, unformatted data (useful for hashing)")
 	mustParse(fs)
 	if fs.NArg() < 1 {
 		fmt.Fprintln(os.Stderr, "Usage: cloudstic cat [options] <object_key> [object_key...]")
@@ -29,9 +31,11 @@ func parseCatArgs() *catArgs {
 		fmt.Fprintln(os.Stderr, "  cloudstic cat index/latest")
 		fmt.Fprintln(os.Stderr, "  cloudstic cat snapshot/abc123...")
 		fmt.Fprintln(os.Stderr, "  cloudstic cat filemeta/def456... node/789abc...")
+		fmt.Fprintln(os.Stderr, "  cloudstic cat -raw filemeta/def456... | sha256sum")
 		os.Exit(1)
 	}
 	a.json = *jsonFlag
+	a.raw = *rawFlag
 	a.keys = fs.Args()
 	return a
 }
@@ -60,13 +64,21 @@ func runCat() {
 			fmt.Fprintf(os.Stderr, "==> %s <==\n", result.Key)
 		}
 
-		// Pretty-print JSON
-		var indented bytes.Buffer
-		if err := json.Indent(&indented, result.Data, "", "  "); err != nil {
-			// If it's not valid JSON, just output the raw data
-			fmt.Print(string(result.Data))
+		if a.raw {
+			_, err := os.Stdout.Write(result.Data)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to write raw data: %v\n", err)
+				os.Exit(1)
+			}
 		} else {
-			fmt.Println(indented.String())
+			// Pretty-print JSON
+			var indented bytes.Buffer
+			if err := json.Indent(&indented, result.Data, "", "  "); err != nil {
+				// If it's not valid JSON, just output the raw data
+				fmt.Print(string(result.Data))
+			} else {
+				fmt.Println(indented.String())
+			}
 		}
 
 		// Add spacing between multiple objects

--- a/cmd/cloudstic/completion.go
+++ b/cmd/cloudstic/completion.go
@@ -84,7 +84,7 @@ _cloudstic() {
         forget)
             cmd_flags="-prune -dry-run -keep-last -keep-hourly -keep-daily -keep-weekly -keep-monthly -keep-yearly -tag -source -account -path -group-by" ;;
         cat)
-            cmd_flags="-json" ;;
+            cmd_flags="-json -raw" ;;
         completion)
             COMPREPLY=($(compgen -W "bash zsh fish" -- "$cur"))
             return ;;
@@ -315,6 +315,7 @@ _cloudstic() {
         cat)
             _arguments $global_flags \
                 '-json[Suppress non-JSON output]' \
+                '-raw[Output raw, unformatted data]' \
                 '*:object key:'
             ;;
         completion)
@@ -427,6 +428,7 @@ complete -c cloudstic -n '__fish_seen_subcommand_from key; and __fish_seen_subco
 
 # cat
 complete -c cloudstic -n '__fish_seen_subcommand_from cat' -l json -d 'Suppress non-JSON output'
+complete -c cloudstic -n '__fish_seen_subcommand_from cat' -l raw -d 'Output raw, unformatted data'
 
 # completion
 complete -c cloudstic -n '__fish_seen_subcommand_from completion' -a 'bash zsh fish' -d 'Shell type'

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -649,7 +649,10 @@ cloudstic cat filemeta/789abc...
 cloudstic cat node/def456...
 
 # Suppress non-JSON output for scripting
-cloudstic cat config --json
+cloudstic cat config -json
+
+# Output raw, unformatted data for hashing
+cloudstic cat -raw filemeta/789abc... | sha256sum
 ```
 
 **Object key types:**
@@ -671,6 +674,7 @@ cloudstic cat config --json
 | Flag | Description |
 |------|-------------|
 | `-json` | Suppress non-JSON output (alias for `-quiet`) |
+| `-raw` | Output raw, unformatted data (useful for hashing) |
 
 The output is pretty-printed JSON by default. Use `-json` or `-quiet` to suppress header messages when fetching multiple objects, which is useful for piping to `jq` or other JSON processors.
 
@@ -688,6 +692,9 @@ cloudstic list --json | jq -r '.[] | .ref'
 
 # Inspect a specific snapshot's metadata
 cloudstic cat snapshot/abc123... | jq .
+
+# Verify the integrity of a filemeta object
+cloudstic cat -raw filemeta/abc123... | sha256sum
 ```
 
 > **Note:** This command operates at the object store level and returns the raw JSON representation of repository objects. It does not reconstruct file contents — use `restore` for that.


### PR DESCRIPTION
## Summary
Add raw output mode to `cat` command.

## What Changes
- Introduce `--raw` option so object/content output can be emitted without formatting/wrapping.