### PR TITLE
feat: HMAC-based content_ref

### DIFF
--- a/client.go
+++ b/client.go
@@ -469,7 +469,7 @@ var (
 // and checking that every referenced object can be read.
 // With WithReadData(), chunk data is re-hashed for byte-level verification.
 func (c *Client) Check(ctx context.Context, opts ...CheckOption) (*CheckResult, error) {
-	mgr := engine.NewCheckManager(c.store, c.reporter)
+	mgr := engine.NewCheckManager(c.store, c.reporter, c.hmacKey)
 	return mgr.Run(ctx, opts...)
 }
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -126,7 +126,8 @@ All objects are stored under a flat key namespace of the form `<type>/<hash>`.
 ### 2. Content
 
 * References the ordered list of chunks that make up a file's content.
-* Object key: `content/<sha256-of-raw-file-content>`
+* Object key: `content/<content_ref>` (where `content_ref` is an HMAC of the
+  raw content hash when encryption is enabled, or the plain SHA-256 otherwise)
 
 ```json
 {
@@ -155,6 +156,7 @@ All objects are stored under a flat key namespace of the form `<type>/<hash>`.
   "parents": ["filemeta/<sha256>"],
   "paths": [],
   "content_hash": "<sha256-of-raw-file-content>",
+  "content_ref": "<hmac-sha256-of-content_hash>",
   "size": 21733,
   "mtime": 1710000000,
   "owner": "user@example.com",
@@ -167,12 +169,13 @@ All objects are stored under a flat key namespace of the form `<type>/<hash>`.
 | `fileId`       | Source-specific unique identifier (Google Drive ID, relative path)   |
 | `type`         | `"file"` or `"folder"`                                              |
 | `parents`      | List of `filemeta/<sha256>` refs pointing to parent metadata objects |
-| `content_hash` | SHA-256 of the raw file content (used to key the Content object)    |
+| `content_hash` | SHA-256 of the raw file content |
+| `content_ref`  | Opaque content reference used as `content/<content_ref>` key; HMAC of `content_hash` for encrypted repos, plain `content_hash` for unencrypted repos |
 | `paths`        | Reserved for future use (multi-path support)                        |
 | `extra`        | Source-specific metadata (e.g. MIME type)                           |
 
 * `fileId` is **the HAMT key**.
-* Folders have an empty `content_hash` and `size` of 0.
+* Folders have an empty `content_hash`, `content_ref`, and `size` of 0.
 * Deduplicated by SHA-256 of the canonical JSON representation.
 
 ### 4. HAMT Node

--- a/internal/core/models.go
+++ b/internal/core/models.go
@@ -35,7 +35,8 @@ type FileMeta struct {
 	Type        FileType               `json:"type"`    // "file" or "folder"
 	Parents     []string               `json:"parents"` // List of "filemeta/<sha256>" refs (NOT raw IDs)
 	Paths       []string               `json:"paths"`
-	ContentHash string                 `json:"content_hash"` // SHA256 of the file content
+	ContentHash string                 `json:"content_hash"`          // SHA256 of the file content
+	ContentRef  string                 `json:"content_ref,omitempty"` // HMAC(dedupKey, ContentHash) for secure backend lookup
 	Size        int64                  `json:"size"`
 	Mtime       int64                  `json:"mtime"` // Unix timestamp
 	Owner       string                 `json:"owner"`

--- a/internal/engine/backup.go
+++ b/internal/engine/backup.go
@@ -94,6 +94,7 @@ type BackupManager struct {
 	metaCacheMu  sync.RWMutex
 	metaCache    map[string]core.FileMeta
 	pendingMetas map[string][]byte // deferred filemeta PUTs (ref → JSON)
+	hmacKey      []byte
 }
 
 func NewBackupManager(src source.Source, dest store.ObjectStore, reporter ui.Reporter, hmacKey []byte, opts ...BackupOption) *BackupManager {
@@ -121,6 +122,7 @@ func NewBackupManager(src source.Source, dest store.ObjectStore, reporter ui.Rep
 		newMetas:     make(map[string]core.FileMeta),
 		metaCache:    make(map[string]core.FileMeta),
 		pendingMetas: make(map[string][]byte),
+		hmacKey:      hmacKey,
 	}
 }
 

--- a/internal/engine/backup_scan.go
+++ b/internal/engine/backup_scan.go
@@ -147,6 +147,12 @@ func (bm *BackupManager) detectChange(oldRoot string, meta *core.FileMeta) (chan
 
 	if meta.ContentHash == "" && oldMeta.ContentHash != "" && metadataEqual(*meta, *oldMeta) {
 		meta.ContentHash = oldMeta.ContentHash
+		meta.ContentRef = oldMeta.ContentRef
+	} else if meta.ContentHash != "" && meta.ContentHash == oldMeta.ContentHash && meta.ContentRef == "" {
+		// Source provides a hash directly. If the old meta already has a ContentRef
+		// (written by a previous backup that introduced HMAC), carry it forward so
+		// Ref() produces the same key and the entry is not falsely detected as changed.
+		meta.ContentRef = oldMeta.ContentRef
 	}
 
 	newRef, _, err := meta.Ref()

--- a/internal/engine/backup_upload.go
+++ b/internal/engine/backup_upload.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cloudstic/cli/internal/core"
 	"github.com/cloudstic/cli/internal/ui"
+	"github.com/cloudstic/cli/pkg/crypto"
 	"github.com/cloudstic/cli/pkg/store"
 )
 
@@ -115,6 +116,7 @@ func (bm *BackupManager) processFile(ctx context.Context, meta core.FileMeta, ph
 	}
 
 	meta.ContentHash = contentHash
+	meta.ContentRef = contentRef
 	meta.Size = size
 
 	metaRef, metaData, err := meta.Ref()
@@ -133,18 +135,24 @@ func (bm *BackupManager) processFile(ctx context.Context, meta core.FileMeta, ph
 	}
 }
 
-// uploadContent streams, chunks, and stores the file content. If the content
-// already exists (dedup by hash), the upload is skipped and contentRef is empty.
-// Small files (below inlineThreshold) are stored inline in the Content object
-// to reduce the number of backend API calls.
+// uploadContent streams, chunks, and stores file content. Skips upload on dedup (contentChunks nil), stores small files inline.
 func (bm *BackupManager) uploadContent(ctx context.Context, meta core.FileMeta, phase ui.Phase) (hash string, size int64, contentRef string, contentChunks []string, err error) {
 	if meta.ContentHash != "" {
-		exists, err := bm.store.Exists(ctx, "content/"+meta.ContentHash)
+		contentRef = meta.ContentRef
+		if contentRef == "" {
+			if len(bm.hmacKey) > 0 {
+				contentRef = crypto.ComputeHMAC(bm.hmacKey, []byte(meta.ContentHash))
+			} else {
+				contentRef = meta.ContentHash
+			}
+		}
+
+		exists, err := bm.store.Exists(ctx, "content/"+contentRef)
 		if err == nil && exists {
 			if bm.cfg.verbose {
 				phase.Log(fmt.Sprintf("Deduplicated: %s", meta.Name))
 			}
-			return meta.ContentHash, meta.Size, "", nil, nil
+			return meta.ContentHash, meta.Size, contentRef, nil, nil
 		}
 	}
 
@@ -165,11 +173,11 @@ func (bm *BackupManager) uploadContent(ctx context.Context, meta core.FileMeta, 
 		return "", 0, "", nil, fmt.Errorf("chunking %s: %w", meta.Name, err)
 	}
 
-	ref, err := bm.chunker.CreateContentObject(chunkRefs, size, hash)
+	contentRef, err = bm.chunker.CreateContentObject(chunkRefs, size, hash)
 	if err != nil {
 		return "", 0, "", nil, fmt.Errorf("create content for %s: %w", meta.Name, err)
 	}
-	return hash, size, ref, chunkRefs, nil
+	return hash, size, contentRef, chunkRefs, nil
 }
 
 // uploadInline reads the entire file into memory and stores it directly inside
@@ -189,12 +197,18 @@ func (bm *BackupManager) uploadInline(ctx context.Context, r io.Reader, meta cor
 	phase.Increment(size)
 	hash = core.ComputeHash(data)
 
-	contentKey := "content/" + hash
+	if len(bm.hmacKey) > 0 {
+		contentRef = crypto.ComputeHMAC(bm.hmacKey, []byte(hash))
+	} else {
+		contentRef = hash
+	}
+
+	contentKey := "content/" + contentRef
 	if exists, _ := bm.store.Exists(ctx, contentKey); exists {
 		if bm.cfg.verbose {
 			phase.Log(fmt.Sprintf("Deduplicated: %s", meta.Name))
 		}
-		return hash, size, "", nil, nil
+		return hash, size, contentRef, nil, nil
 	}
 
 	// Manually construct JSON to avoid json.Marshal allocating a huge string for the base64 data
@@ -210,5 +224,5 @@ func (bm *BackupManager) uploadInline(ctx context.Context, r io.Reader, meta cor
 	if err := bm.store.Put(ctx, contentKey, contentData); err != nil {
 		return "", 0, "", nil, err
 	}
-	return hash, size, contentKey, nil, nil
+	return hash, size, contentRef, nil, nil
 }

--- a/internal/engine/check.go
+++ b/internal/engine/check.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cloudstic/cli/internal/core"
 	"github.com/cloudstic/cli/internal/hamt"
 	"github.com/cloudstic/cli/internal/ui"
+	"github.com/cloudstic/cli/pkg/crypto"
 	"github.com/cloudstic/cli/pkg/store"
 )
 
@@ -62,14 +63,16 @@ type CheckManager struct {
 	tree     *hamt.Tree
 	reporter ui.Reporter
 	verified map[string]bool
+	hmacKey  []byte
 }
 
 // NewCheckManager creates a CheckManager.
-func NewCheckManager(s store.ObjectStore, reporter ui.Reporter) *CheckManager {
+func NewCheckManager(s store.ObjectStore, reporter ui.Reporter, hmacKey []byte) *CheckManager {
 	return &CheckManager{
 		store:    s,
 		tree:     hamt.NewTree(hamt.NewTransactionalStore(s)),
 		reporter: reporter,
+		hmacKey:  hmacKey,
 	}
 }
 
@@ -236,7 +239,12 @@ func (cm *CheckManager) checkFileMeta(ctx context.Context, ref string, result *C
 		return nil // folder or file with no content
 	}
 
-	return cm.checkContent(ctx, "content/"+meta.ContentHash, result, cfg, phase)
+	contentKey := meta.ContentRef
+	if contentKey == "" {
+		contentKey = meta.ContentHash
+	}
+
+	return cm.checkContent(ctx, "content/"+contentKey, result, cfg, phase)
 }
 
 // checkContent verifies a content object and its referenced chunks.
@@ -297,7 +305,12 @@ func (cm *CheckManager) checkChunk(ctx context.Context, ref string, result *Chec
 		// The key is "chunk/<hash>". Verify the data hashes to the expected value.
 		parts := strings.SplitN(ref, "/", 2)
 		if len(parts) == 2 {
-			actual := core.ComputeHash(data)
+			var actual string
+			if len(cm.hmacKey) > 0 {
+				actual = crypto.ComputeHMAC(cm.hmacKey, data)
+			} else {
+				actual = core.ComputeHash(data)
+			}
 			if actual != parts[1] {
 				result.Errors = append(result.Errors, CheckError{
 					Key:     ref,

--- a/internal/engine/check_test.go
+++ b/internal/engine/check_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cloudstic/cli/internal/core"
 	"github.com/cloudstic/cli/internal/hamt"
 	"github.com/cloudstic/cli/internal/ui"
+	"github.com/cloudstic/cli/pkg/crypto"
 )
 
 // buildTestRepo sets up a minimal valid repository in the mock store and
@@ -65,7 +66,7 @@ func TestCheckManager_HealthyRepo(t *testing.T) {
 	mockStore := NewMockStore()
 	buildTestRepo(t, mockStore)
 
-	cm := NewCheckManager(mockStore, ui.NewNoOpReporter())
+	cm := NewCheckManager(mockStore, ui.NewNoOpReporter(), nil)
 	result, err := cm.Run(ctx)
 	if err != nil {
 		t.Fatalf("Check failed: %v", err)
@@ -86,7 +87,7 @@ func TestCheckManager_HealthyRepoWithReadData(t *testing.T) {
 	mockStore := NewMockStore()
 	buildTestRepo(t, mockStore)
 
-	cm := NewCheckManager(mockStore, ui.NewNoOpReporter())
+	cm := NewCheckManager(mockStore, ui.NewNoOpReporter(), nil)
 	result, err := cm.Run(ctx, WithReadData())
 	if err != nil {
 		t.Fatalf("Check failed: %v", err)
@@ -104,7 +105,7 @@ func TestCheckManager_MissingChunk(t *testing.T) {
 	// Delete the chunk
 	_ = mockStore.Delete(ctx, chunkRef)
 
-	cm := NewCheckManager(mockStore, ui.NewNoOpReporter())
+	cm := NewCheckManager(mockStore, ui.NewNoOpReporter(), nil)
 	result, err := cm.Run(ctx)
 	if err != nil {
 		t.Fatalf("Check failed: %v", err)
@@ -127,7 +128,7 @@ func TestCheckManager_MissingContent(t *testing.T) {
 
 	_ = mockStore.Delete(ctx, contentRef)
 
-	cm := NewCheckManager(mockStore, ui.NewNoOpReporter())
+	cm := NewCheckManager(mockStore, ui.NewNoOpReporter(), nil)
 	result, err := cm.Run(ctx)
 	if err != nil {
 		t.Fatalf("Check failed: %v", err)
@@ -150,7 +151,7 @@ func TestCheckManager_MissingFileMeta(t *testing.T) {
 
 	_ = mockStore.Delete(ctx, metaRef)
 
-	cm := NewCheckManager(mockStore, ui.NewNoOpReporter())
+	cm := NewCheckManager(mockStore, ui.NewNoOpReporter(), nil)
 	result, err := cm.Run(ctx)
 	if err != nil {
 		t.Fatalf("Check failed: %v", err)
@@ -170,7 +171,7 @@ func TestCheckManager_MissingHAMTNode(t *testing.T) {
 
 	_ = mockStore.Delete(ctx, rootRef)
 
-	cm := NewCheckManager(mockStore, ui.NewNoOpReporter())
+	cm := NewCheckManager(mockStore, ui.NewNoOpReporter(), nil)
 	result, err := cm.Run(ctx)
 	if err != nil {
 		t.Fatalf("Check failed: %v", err)
@@ -200,7 +201,7 @@ func TestCheckManager_CorruptChunk_ReadData(t *testing.T) {
 	// Corrupt the chunk data
 	_ = mockStore.Put(ctx, chunkRef, []byte("corrupted data"))
 
-	cm := NewCheckManager(mockStore, ui.NewNoOpReporter())
+	cm := NewCheckManager(mockStore, ui.NewNoOpReporter(), nil)
 	result, err := cm.Run(ctx, WithReadData())
 	if err != nil {
 		t.Fatalf("Check failed: %v", err)
@@ -224,7 +225,7 @@ func TestCheckManager_CorruptChunk_WithoutReadData(t *testing.T) {
 	// Corrupt the chunk data — should NOT be detected without --read-data
 	_ = mockStore.Put(ctx, chunkRef, []byte("corrupted data"))
 
-	cm := NewCheckManager(mockStore, ui.NewNoOpReporter())
+	cm := NewCheckManager(mockStore, ui.NewNoOpReporter(), nil)
 	result, err := cm.Run(ctx)
 	if err != nil {
 		t.Fatalf("Check failed: %v", err)
@@ -239,7 +240,7 @@ func TestCheckManager_SingleSnapshot(t *testing.T) {
 	mockStore := NewMockStore()
 	snapRef, _, _, _, _ := buildTestRepo(t, mockStore)
 
-	cm := NewCheckManager(mockStore, ui.NewNoOpReporter())
+	cm := NewCheckManager(mockStore, ui.NewNoOpReporter(), nil)
 	result, err := cm.Run(ctx, WithSnapshotRef(snapRef))
 	if err != nil {
 		t.Fatalf("Check failed: %v", err)
@@ -257,7 +258,7 @@ func TestCheckManager_SnapshotLatestAlias(t *testing.T) {
 	mockStore := NewMockStore()
 	buildTestRepo(t, mockStore)
 
-	cm := NewCheckManager(mockStore, ui.NewNoOpReporter())
+	cm := NewCheckManager(mockStore, ui.NewNoOpReporter(), nil)
 	result, err := cm.Run(ctx, WithSnapshotRef("latest"))
 	if err != nil {
 		t.Fatalf("Check failed: %v", err)
@@ -267,5 +268,123 @@ func TestCheckManager_SnapshotLatestAlias(t *testing.T) {
 	}
 	if len(result.Errors) != 0 {
 		t.Errorf("Expected 0 errors, got %d: %v", len(result.Errors), result.Errors)
+	}
+}
+
+// TestCheckManager_ContentRef_HMACPath verifies CheckManager follows meta.ContentRef (not ContentHash) to locate content objects.
+func TestCheckManager_ContentRef_HMACPath(t *testing.T) {
+	ctx := context.Background()
+	mockStore := NewMockStore()
+	hmacKey := []byte("test-hmac-key-32-bytes-long!!!!!")
+
+	// Build a chunk
+	chunkData := []byte("hello hmac world")
+	chunkHash := core.ComputeHash(chunkData)
+	chunkRef := "chunk/" + chunkHash
+	_ = mockStore.Put(ctx, chunkRef, chunkData)
+
+	// Build a content object stored under the HMAC ref
+	contentHash := "plain-content-hash-abc"
+	contentRef := crypto.ComputeHMAC(hmacKey, []byte(contentHash))
+	content := core.Content{Chunks: []string{chunkRef}}
+	_, contentData, _ := core.ComputeJSONHash(&content)
+	_ = mockStore.Put(ctx, "content/"+contentRef, contentData)
+
+	// FileMeta uses ContentHash + ContentRef (HMAC variant)
+	meta := core.FileMeta{
+		Name:        "hmac-file.txt",
+		Type:        core.FileTypeFile,
+		ContentHash: contentHash,
+		ContentRef:  contentRef,
+		FileID:      "hmac-file",
+	}
+	metaHash, metaData, _ := core.ComputeJSONHash(&meta)
+	metaRef := "filemeta/" + metaHash
+	_ = mockStore.Put(ctx, metaRef, metaData)
+
+	// HAMT tree + snapshot
+	directTree := hamt.NewTree(mockStore)
+	rootRef, err := directTree.Insert("", "hmac-file", metaRef)
+	if err != nil {
+		t.Fatalf("Failed to build HAMT: %v", err)
+	}
+	snap := core.Snapshot{Root: rootRef, Seq: 1}
+	snapHash, snapData, _ := core.ComputeJSONHash(&snap)
+	snapRef := "snapshot/" + snapHash
+	_ = mockStore.Put(ctx, snapRef, snapData)
+	idx := core.Index{LatestSnapshot: snapRef, Seq: 1}
+	idxData, _ := json.Marshal(idx)
+	_ = mockStore.Put(ctx, "index/latest", idxData)
+
+	cm := NewCheckManager(mockStore, ui.NewNoOpReporter(), hmacKey)
+	result, err := cm.Run(ctx)
+	if err != nil {
+		t.Fatalf("Check failed: %v", err)
+	}
+	if len(result.Errors) != 0 {
+		t.Errorf("Expected 0 errors, got %d: %v", len(result.Errors), result.Errors)
+	}
+}
+
+// TestCheckManager_CorruptChunk_HMACReadData verifies corruption detection with --read-data when chunks are HMAC-keyed.
+func TestCheckManager_CorruptChunk_HMACReadData(t *testing.T) {
+	ctx := context.Background()
+	mockStore := NewMockStore()
+	hmacKey := []byte("test-hmac-key-32-bytes-long!!!!!")
+
+	// Build a clean chunk stored under HMAC key
+	chunkData := []byte("clean chunk data")
+	chunkHMAC := crypto.ComputeHMAC(hmacKey, chunkData)
+	chunkRef := "chunk/" + chunkHMAC
+	_ = mockStore.Put(ctx, chunkRef, chunkData)
+
+	// Content object
+	content := core.Content{Chunks: []string{chunkRef}}
+	_, contentData, _ := core.ComputeJSONHash(&content)
+	contentHash := "hmac-content-hash"
+	contentRef := crypto.ComputeHMAC(hmacKey, []byte(contentHash))
+	_ = mockStore.Put(ctx, "content/"+contentRef, contentData)
+
+	// FileMeta
+	meta := core.FileMeta{
+		Name:        "corrupt-test.txt",
+		Type:        core.FileTypeFile,
+		ContentHash: contentHash,
+		ContentRef:  contentRef,
+		FileID:      "corrupt-hmac-file",
+	}
+	metaHash, metaData, _ := core.ComputeJSONHash(&meta)
+	metaRef := "filemeta/" + metaHash
+	_ = mockStore.Put(ctx, metaRef, metaData)
+
+	directTree := hamt.NewTree(mockStore)
+	rootRef, err := directTree.Insert("", "corrupt-hmac-file", metaRef)
+	if err != nil {
+		t.Fatalf("Failed to build HAMT: %v", err)
+	}
+	snap := core.Snapshot{Root: rootRef, Seq: 1}
+	snapHash, snapData, _ := core.ComputeJSONHash(&snap)
+	snapRef := "snapshot/" + snapHash
+	_ = mockStore.Put(ctx, snapRef, snapData)
+	idx := core.Index{LatestSnapshot: snapRef, Seq: 1}
+	idxData, _ := json.Marshal(idx)
+	_ = mockStore.Put(ctx, "index/latest", idxData)
+
+	// Now corrupt the chunk
+	_ = mockStore.Put(ctx, chunkRef, []byte("corrupted!"))
+
+	cm := NewCheckManager(mockStore, ui.NewNoOpReporter(), hmacKey)
+	result, err := cm.Run(ctx, WithReadData())
+	if err != nil {
+		t.Fatalf("Check failed: %v", err)
+	}
+	if len(result.Errors) != 1 {
+		t.Fatalf("Expected 1 error for corrupt chunk, got %d: %v", len(result.Errors), result.Errors)
+	}
+	if result.Errors[0].Key != chunkRef {
+		t.Errorf("Expected error for %s, got %s", chunkRef, result.Errors[0].Key)
+	}
+	if result.Errors[0].Type != "corrupt" {
+		t.Errorf("Expected error type 'corrupt', got %q", result.Errors[0].Type)
 	}
 }

--- a/internal/engine/chunker.go
+++ b/internal/engine/chunker.go
@@ -142,8 +142,9 @@ func (c *Chunker) ProcessStream(r io.Reader, onProgress func(int64)) (refs []str
 	return refs, size, hash, nil
 }
 
-// CreateContentObject persists a Content object keyed by contentHash and
-// returns its store ref.
+// CreateContentObject persists a Content object. The object is keyed by an HMAC
+// of the contentHash (if encryption is enabled) to prevent hash leakage, or the
+// plain contentHash otherwise. Returns the secure contentRef (the hex hash used).
 func (c *Chunker) CreateContentObject(chunkRefs []string, size int64, contentHash string) (string, error) {
 	content := core.Content{
 		Type:   core.ObjectTypeContent,
@@ -156,11 +157,18 @@ func (c *Chunker) CreateContentObject(chunkRefs []string, size int64, contentHas
 		return "", err
 	}
 
-	ref := "content/" + contentHash
+	var contentRef string
+	if len(c.hmacKey) > 0 {
+		contentRef = crypto.ComputeHMAC(c.hmacKey, []byte(contentHash))
+	} else {
+		contentRef = contentHash
+	}
+
+	ref := "content/" + contentRef
 	if err := c.store.Put(context.Background(), ref, data); err != nil {
 		return "", err
 	}
-	return ref, nil
+	return contentRef, nil
 }
 
 func (c *Chunker) storeChunk(ctx context.Context, data []byte) (string, error) {

--- a/internal/engine/chunker_test.go
+++ b/internal/engine/chunker_test.go
@@ -66,20 +66,53 @@ func TestChunker_CreateContentObject(t *testing.T) {
 		t.Fatalf("CreateContentObject failed: %v", err)
 	}
 
-	expectedRef := "content/" + contentHash
-	if ref != expectedRef {
-		t.Errorf("Expected ref %s, got %s", expectedRef, ref)
+	if ref != contentHash {
+		t.Errorf("Expected ref %s, got %s", contentHash, ref)
 	}
 
-	data, _ := store.Get(ctx, ref)
+	data, _ := store.Get(ctx, "content/"+ref)
 	if !strings.Contains(string(data), "chunk/1") {
 		t.Error("Content object missing chunk/1")
 	}
 }
 
-// TestChunker_HMAC_ChunkRefsUseHMAC verifies that providing an HMAC key
-// produces different chunk refs than without one, while the content hash
-// (stream SHA-256) remains identical.
+// TestChunker_HMAC_CreateContentObject verifies HMAC path: ref differs from hash and object is stored under content/<contentRef>.
+func TestChunker_HMAC_CreateContentObject(t *testing.T) {
+	ctx := context.Background()
+	hmacKey := []byte("test-hmac-key-32-bytes-long!!!!!")
+	store := NewMockStore()
+	chunker := NewChunker(store, hmacKey)
+
+	chunks := []string{"chunk/1", "chunk/2"}
+	contentHash := "plain-content-hash"
+
+	contentRef, err := chunker.CreateContentObject(chunks, 100, contentHash)
+	if err != nil {
+		t.Fatalf("CreateContentObject failed: %v", err)
+	}
+
+	// contentRef must differ from contentHash (it should be the HMAC)
+	if contentRef == contentHash {
+		t.Error("contentRef should differ from contentHash when HMAC key is set")
+	}
+
+	// Object must be stored under content/<contentRef>, NOT content/<contentHash>
+	hmacData, _ := store.Get(ctx, "content/"+contentRef)
+	if hmacData == nil {
+		t.Errorf("Content object not found under content/%s", contentRef)
+	}
+	if !strings.Contains(string(hmacData), "chunk/1") {
+		t.Error("Content object missing chunk/1")
+	}
+
+	// Object must NOT be stored under content/<contentHash>
+	plainData, _ := store.Get(ctx, "content/"+contentHash)
+	if plainData != nil {
+		t.Error("Content object should not be stored under content/<contentHash>")
+	}
+}
+
+// TestChunker_HMAC_ChunkRefsUseHMAC verifies HMAC key produces different chunk refs but identical content hash.
 func TestChunker_HMAC_ChunkRefsUseHMAC(t *testing.T) {
 	hmacKey := []byte("test-hmac-key-32-bytes-long!!!!!")
 
@@ -115,10 +148,7 @@ func TestChunker_HMAC_ChunkRefsUseHMAC(t *testing.T) {
 	}
 }
 
-// TestChunker_HMAC_ContentHashStable verifies that the content hash returned
-// by ProcessStream is deterministic and independent of the HMAC key. This
-// prevents the regression where HMAC-ing the stream hash caused subsequent
-// backups to detect false changes.
+// TestChunker_HMAC_ContentHashStable verifies content hash is deterministic and independent of HMAC key.
 func TestChunker_HMAC_ContentHashStable(t *testing.T) {
 	hmacKey := []byte("test-hmac-key-32-bytes-long!!!!!")
 	data := "stable content hash test"
@@ -143,8 +173,7 @@ func TestChunker_HMAC_ContentHashStable(t *testing.T) {
 	}
 }
 
-// TestChunker_HMAC_Deduplication verifies that dedup works correctly when
-// an HMAC key is used — identical data produces identical chunk refs.
+// TestChunker_HMAC_Deduplication verifies that dedup works correctly with an HMAC key.
 func TestChunker_HMAC_Deduplication(t *testing.T) {
 	hmacKey := []byte("test-hmac-key-32-bytes-long!!!!!")
 	store := NewMockStore()

--- a/internal/engine/prune.go
+++ b/internal/engine/prune.go
@@ -193,7 +193,11 @@ func (pm *PruneManager) markFileMeta(ctx context.Context, ref string, reachable 
 	}
 
 	if meta.ContentHash != "" {
-		return pm.markContent(ctx, "content/"+meta.ContentHash, reachable)
+		contentKey := meta.ContentRef
+		if contentKey == "" {
+			contentKey = meta.ContentHash
+		}
+		return pm.markContent(ctx, "content/"+contentKey, reachable)
 	}
 	return nil
 }

--- a/internal/engine/restore.go
+++ b/internal/engine/restore.go
@@ -155,7 +155,7 @@ func (rm *RestoreManager) Run(ctx context.Context, w io.Writer, snapshotRef stri
 			continue
 		}
 
-		if err := rm.writeFileContent(ctx, fw, meta.ContentHash); err != nil {
+		if err := rm.writeFileContent(ctx, fw, meta); err != nil {
 			phase.Log(fmt.Sprintf("Failed: %s: %v", p, err))
 			result.Errors++
 			phase.Increment(1)
@@ -205,8 +205,13 @@ func (cw *countingWriter) Write(p []byte) (int, error) {
 	return n, err
 }
 
-func (rm *RestoreManager) writeFileContent(ctx context.Context, w io.Writer, contentHash string) error {
-	content, err := rm.loadContent(ctx, contentHash)
+func (rm *RestoreManager) writeFileContent(ctx context.Context, w io.Writer, meta core.FileMeta) error {
+	contentKey := meta.ContentRef
+	if contentKey == "" {
+		contentKey = meta.ContentHash
+	}
+
+	content, err := rm.loadContent(ctx, contentKey)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
Use HMAC-based `content_ref` values for secure backend lookups.

## What Changes
- Introduce/update content reference derivation to use keyed HMAC semantics rather than plaintext-derived identifiers.