### PR TITLE
fix: do not prompt for password when key material is already provided

### DIFF
--- a/client.go
+++ b/client.go
@@ -112,9 +112,17 @@ func AddRecoveryKey(ctx context.Context, rawStore store.ObjectStore, kc keychain
 // Returns (nil, nil) if the repository has not been initialized yet.
 // Returns an error if the store is unreachable (e.g. invalid credentials).
 func LoadRepoConfig(ctx context.Context, rawStore store.ObjectStore) (*RepoConfig, error) {
+	exists, err := rawStore.Exists(ctx, "config")
+	if err != nil {
+		return nil, fmt.Errorf("check repo config: %w", err)
+	}
+	if !exists {
+		return nil, nil // repository not initialized
+	}
+
 	data, err := rawStore.Get(ctx, "config")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read repo config: %w", err)
 	}
 	if data == nil {
 		return nil, nil

--- a/cmd/cloudstic/flags.go
+++ b/cmd/cloudstic/flags.go
@@ -30,7 +30,7 @@ type globalFlags struct {
 	recoveryKey                                       *string
 	kmsKeyARN, kmsRegion, kmsEndpoint                 *string
 	enablePackfile                                    *bool
-	verbose, quiet, debug                             *bool
+	password, verbose, quiet, debug                   *bool
 	debugLog                                          *ui.SafeLogWriter
 }
 
@@ -67,6 +67,7 @@ func addGlobalFlags(fs *flag.FlagSet) *globalFlags {
 	g.kmsRegion = fs.String("kms-region", envDefault("CLOUDSTIC_KMS_REGION", ""), "AWS KMS region (defaults to us-east-1)")
 	g.kmsEndpoint = fs.String("kms-endpoint", envDefault("CLOUDSTIC_KMS_ENDPOINT", ""), "Custom AWS KMS endpoint URL")
 	g.enablePackfile = fs.Bool("enable-packfile", true, "Bundle small objects into 8MB packs to save S3 PUTs")
+	g.password = fs.Bool("password", false, "Prompt for a password (used alongside --encryption-key or --kms-key-arn to add a password layer)")
 	g.verbose = fs.Bool("verbose", false, "Log detailed file-level operations")
 	g.quiet = fs.Bool("quiet", false, "Suppress progress bars (keeps final summary)")
 	g.debug = fs.Bool("debug", false, "Log every store request (network calls, timing, sizes)")

--- a/cmd/cloudstic/store.go
+++ b/cmd/cloudstic/store.go
@@ -107,8 +107,8 @@ func (g *globalFlags) buildKeychain(ctx context.Context) (keychain.Chain, error)
 	if *g.recoveryKey != "" {
 		chain = append(chain, keychain.WithRecoveryKey(*g.recoveryKey))
 	}
-
-	if term.IsTerminal(os.Stdin.Fd()) {
+	promptRequested := g.password != nil && *g.password
+	if (len(chain) == 0 || promptRequested) && term.IsTerminal(os.Stdin.Fd()) {
 		chain = append(chain, keychain.WithPrompt(
 			func() (string, error) { return ui.PromptPassword("Repository password") },
 			func() (string, error) { return ui.PromptPasswordConfirm("Enter new repository password") },

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -219,12 +219,19 @@ cloudstic init -no-encryption
 
 When no encryption credential is provided and stdin is a terminal, `init` prompts for a new password with confirmation. In non-interactive environments (piped input, cron jobs), you must pass `-encryption-password`, `-encryption-key`, or `-no-encryption` explicitly.
 
+If you are using a platform key or KMS but also want to protect the repository with a password, pass `-password` to explicitly trigger the prompt:
+
+```bash
+cloudstic init -encryption-key <hex> -password
+```
+
 **Flags:**
 
 | Flag | Description |
 |------|-------------|
 | `-encryption-password` | Password for password-based encryption |
 | `-encryption-key` | Platform key (64 hex chars = 32 bytes) |
+| `-password` | Force interactive password prompt (even when other credentials are provided) |
 | `-recovery` | Generate a 24-word recovery key during init |
 | `-no-encryption` | Create an unencrypted repository (not recommended) |
 | `-adopt-slots` | Adopt existing key slots (and add new credentials to them) |
@@ -1072,7 +1079,13 @@ Encryption is **required by default**. All backup data is encrypted with AES-256
 
 ### Interactive password prompt
 
-When running in a terminal, Cloudstic prompts for the repository password if no credential is provided via flags (`-encryption-password`, `-encryption-key`, `-recovery-key`, `-kms-key-arn`) or environment variables (`CLOUDSTIC_ENCRYPTION_PASSWORD`, etc.).
+When running in a terminal, Cloudstic prompts for the repository password **only if no other credential is provided** via flags (`-encryption-password`, `-encryption-key`, `-recovery-key`, `-kms-key-arn`) or environment variables (`CLOUDSTIC_ENCRYPTION_PASSWORD`, etc.).
+
+To explicitly request an interactive password prompt alongside a platform key or KMS key, use the `-password` flag:
+
+```bash
+cloudstic backup -encryption-key <hex> -password  # decrypt with key + password layer
+```
 
 This applies to all commands that access an encrypted repository — `backup`, `restore`, `list`, `ls`, `diff`, `check`, `cat`, `key passwd`, `key add-recovery`, and `init`.
 


### PR DESCRIPTION
## Summary
Avoid interactive password prompts when key material is already available through other inputs.

## What Changes
- Update prompt gating logic so CLI does not request a password unnecessarily when encryption key/recovery key or equivalent input is already set.

## Notes
- Improves non-interactive UX and scripting reliability.