### PR TITLE
feat: portable drive identity (RFC 0005)

### DIFF
--- a/cmd/cloudstic/cmd_backup.go
+++ b/cmd/cloudstic/cmd_backup.go
@@ -25,6 +25,7 @@ type backupArgs struct {
 	dryRun          bool
 	excludeFile     string
 	skipNativeFiles bool
+	volumeUUID      string
 	tags            stringArrayFlags
 	excludes        stringArrayFlags
 }
@@ -40,6 +41,7 @@ func parseBackupArgs() *backupArgs {
 	dryRun := fs.Bool("dry-run", false, "Scan source and report changes without writing to the store")
 	skipNativeFiles := fs.Bool("skip-native-files", false, "Exclude Google-native files (Docs, Sheets, Slides, etc.) from the backup")
 	excludeFile := fs.String("exclude-file", "", "Path to file with exclude patterns (one per line, gitignore syntax)")
+	volumeUUID := fs.String("volume-uuid", envDefault("CLOUDSTIC_VOLUME_UUID", ""), "Override volume UUID for local source (enables cross-machine incremental backup)")
 	fs.Var(&a.tags, "tag", "Tag to apply to the snapshot (can be specified multiple times)")
 	fs.Var(&a.excludes, "exclude", "Exclude pattern (gitignore syntax, repeatable)")
 	mustParse(fs)
@@ -50,6 +52,7 @@ func parseBackupArgs() *backupArgs {
 	a.dryRun = *dryRun
 	a.skipNativeFiles = *skipNativeFiles
 	a.excludeFile = *excludeFile
+	a.volumeUUID = *volumeUUID
 	return a
 }
 
@@ -63,7 +66,7 @@ func (r *runner) runBackup() int {
 
 	ctx := context.Background()
 
-	src, err := initSource(ctx, a.sourceType, a.sourcePath, a.driveID, a.rootFolder, a.skipNativeFiles, a.g, excludePatterns)
+	src, err := initSource(ctx, a.sourceType, a.sourcePath, a.driveID, a.rootFolder, a.skipNativeFiles, a.volumeUUID, a.g, excludePatterns)
 	if err != nil {
 		return r.fail("Failed to init source: %v", err)
 	}
@@ -135,10 +138,14 @@ func (r *runner) printBackupSummary(res *engine.RunResult) {
 	}
 }
 
-func initSource(ctx context.Context, sourceType, sourcePath, driveID, rootFolder string, skipNativeFiles bool, g *globalFlags, excludePatterns []string) (source.Source, error) {
+func initSource(ctx context.Context, sourceType, sourcePath, driveID, rootFolder string, skipNativeFiles bool, volumeUUID string, g *globalFlags, excludePatterns []string) (source.Source, error) {
 	switch sourceType {
 	case "local":
-		return source.NewLocalSource(sourcePath, source.WithLocalExcludePatterns(excludePatterns)), nil
+		opts := []source.LocalOption{source.WithLocalExcludePatterns(excludePatterns)}
+		if volumeUUID != "" {
+			opts = append(opts, source.WithVolumeUUID(volumeUUID))
+		}
+		return source.NewLocalSource(sourcePath, opts...), nil
 	case "sftp":
 		sftpHost, sftpOpts := g.sftpSourceOpts(g.sourceSFTPHost, g.sourceSFTPPort, g.sourceSFTPUser, g.sourceSFTPPassword, g.sourceSFTPKey, &sourcePath)
 		if sftpHost == "" {

--- a/cmd/cloudstic/format.go
+++ b/cmd/cloudstic/format.go
@@ -46,7 +46,11 @@ func (r *runner) renderSnapshotTable(entries []engine.SnapshotEntry, reasons map
 		var source, account, path string
 		if e.Snap.Source != nil {
 			source = e.Snap.Source.Type
-			account = e.Snap.Source.Account
+			if e.Snap.Source.VolumeLabel != "" {
+				account = e.Snap.Source.VolumeLabel
+			} else {
+				account = e.Snap.Source.Account
+			}
 			path = e.Snap.Source.Path
 		} else if e.Snap.Meta != nil {
 			source = e.Snap.Meta["source"]

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -276,6 +276,7 @@ cloudstic backup -source local -source-path ~/Documents -dry-run
 | `-tag` | | Tag to apply to the snapshot (repeatable) |
 | `-exclude` | | Exclude pattern using gitignore syntax (repeatable) |
 | `-exclude-file` | | Path to file containing exclude patterns, one per line |
+| `-volume-uuid` | | Override volume UUID for local source (enables cross-machine incremental backup for portable drives) |
 | `-dry-run` | `false` | Scan source and report changes without writing to the store |
 
 The `gdrive-changes` and `onedrive-changes` source types use their respective change/delta APIs for faster incremental backups after the first full backup.
@@ -841,10 +842,56 @@ cloudstic backup -source local -source-path ~/project -exclude-file .backupignor
 | `-source-path` | `.` | Root directory to back up |
 | `-exclude` | | Exclude pattern, gitignore syntax (repeatable) |
 | `-exclude-file` | | File containing exclude patterns (one per line) |
+| `-volume-uuid` | | Override volume UUID (see [Portable drives](#portable-drives)) |
 
 Cloudstic walks the directory recursively. Symbolic links are not followed. File permissions are not preserved — only name, size, modification time, and content are captured.
 
 See [Exclude patterns](#exclude-patterns) for the full pattern syntax reference.
+
+#### Portable Drives
+
+When backing up a portable or external drive from multiple machines, Cloudstic automatically detects the volume identity (on macOS and Linux) and uses it to find previous snapshots. This enables true incremental backups across machines — only changed files are uploaded, even when the mount point or hostname differs.
+
+```bash
+# Back up a portable drive — UUID is auto-detected
+cloudstic backup -source local -source-path /Volumes/MyDrive
+
+# Override UUID when auto-detection fails or for custom lineage
+cloudstic backup -source local -source-path /mnt/backup -volume-uuid "A1B2C3D4-1234-5678-ABCD-EF0123456789"
+```
+
+The volume UUID can also be set via the `CLOUDSTIC_VOLUME_UUID` environment variable. When provided, the explicit UUID takes precedence over auto-detection.
+
+File paths inside the backup are normalized to forward slashes regardless of the operating system, so a backup started on one OS can be continued incrementally on another.
+
+Retention policies (via `forget`) automatically group all snapshots of the same volume together across machines, so a `--keep-daily 7` policy keeps 7 daily snapshots total regardless of which machine created them.
+
+**Cross-OS compatibility:**
+
+For modern GPT-formatted drives (the default for most drives today), Cloudstic uses the **GPT partition UUID** which is identical across all platforms — cross-OS incremental backups work automatically with no configuration needed.
+
+For older MBR-formatted drives (some FAT32 USB sticks), the auto-detected UUID is platform-specific and will differ between operating systems. In this case, use `-volume-uuid` (or `CLOUDSTIC_VOLUME_UUID`) with a consistent UUID value of your choice.
+
+| Platform | UUID detection | Label detection |
+|----------|---------------|-----------------|
+| macOS | ✓ Automatic (GPT partition UUID via `diskutil`, fallback to `getattrlist`) | ✓ Automatic |
+| Linux | ✓ Automatic (GPT partition UUID via `/dev/disk/by-partuuid/`, fallback to `/dev/disk/by-uuid/`) | ✓ Automatic (`/dev/disk/by-label/`) |
+| Windows | ✓ Automatic (GPT partition UUID via `DeviceIoControl`) | ✓ Automatic (`GetVolumeInformation`) |
+
+**Directories spanning multiple drives:**
+
+The volume UUID is determined from the backup root path only. If your backup directory contains mount points for other volumes (e.g. `/data/external` is a separate partition mounted under `/data`), those files are included in the backup but the volume identity reflects only the root path's filesystem. This is usually fine — the backup works correctly, and incremental detection still functions based on file content. However, for portable drive workflows, back up each volume separately rather than backing up a parent directory that spans multiple drives:
+
+```bash
+# Good: back up each volume independently
+cloudstic backup -source local -source-path /Volumes/MyDrive
+cloudstic backup -source local -source-path /Volumes/OtherDrive
+
+# Avoid: backing up a parent that contains mount points from different volumes
+cloudstic backup -source local -source-path /Volumes
+```
+
+Note that symlinks to other volumes are **not followed** — only direct mount points within the tree are traversed.
 
 ### SFTP Source
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -129,6 +129,7 @@ func TestCLI_EndToEnd_Matrix(t *testing.T) {
 	sources := []func(t *testing.T) TestSource{
 		func(t *testing.T) TestSource { return newLocalSource(t) },
 	}
+	sources = append(sources, portableDriveSources()...)
 	stores := []func(t *testing.T) TestStore{
 		func(t *testing.T) TestStore { return newLocalStore(t) },
 	}

--- a/e2e/portable_darwin.go
+++ b/e2e/portable_darwin.go
@@ -1,0 +1,73 @@
+//go:build darwin
+
+package e2e
+
+import (
+"crypto/rand"
+"fmt"
+"os"
+"os/exec"
+"path/filepath"
+"strings"
+"testing"
+)
+
+// portableDriveSource is a TestSource backed by a real GPT-formatted RAM disk.
+// It exercises the full volume UUID auto-detection pipeline (Statfs → diskutil
+// info -plist → DiskUUID parsing) without any manual -volume-uuid flag.
+type portableDriveSource struct {
+mountPoint string
+rawDev     string
+volName    string
+}
+
+func newPortableDriveSource(_ *testing.T) *portableDriveSource {
+	// Generate a unique volume name so parallel tests don't collide.
+	var b [3]byte
+	_, _ = rand.Read(b[:])
+	name := fmt.Sprintf("CST%X", b)
+	return &portableDriveSource{volName: name}
+}
+
+func (s *portableDriveSource) Name() string { return "portable" }
+func (s *portableDriveSource) Env() TestEnv { return Hermetic }
+
+// Setup creates a GPT-formatted RAM disk. Called inside the subtest, so
+// t.Skip gracefully skips just this matrix entry if RAM disks aren't available.
+func (s *portableDriveSource) Setup(t *testing.T) []string {
+t.Helper()
+
+// Create a 10 MB RAM disk (20480 × 512-byte sectors).
+out, err := exec.Command("hdiutil", "attach", "-nomount", "ram://20480").CombinedOutput()
+if err != nil {
+t.Skipf("cannot create RAM disk (needs disk access): %v\n%s", err, out)
+}
+s.rawDev = strings.TrimSpace(string(out))
+t.Cleanup(func() { _ = exec.Command("diskutil", "eject", s.rawDev).Run() })
+
+// Partition as GPT with ExFAT — this gives us a real GPT partition UUID.
+out, err = exec.Command("diskutil", "partitionDisk", s.rawDev,
+"1", "GPT", "ExFAT", s.volName, "100%").CombinedOutput()
+if err != nil {
+_ = exec.Command("diskutil", "eject", s.rawDev).Run()
+t.Skipf("cannot partition RAM disk: %v\n%s", err, out)
+}
+
+s.mountPoint = "/Volumes/" + s.volName
+if _, err := os.Stat(s.mountPoint); os.IsNotExist(err) {
+t.Fatalf("expected mount point %s after partitioning", s.mountPoint)
+}
+
+return []string{"-source", "local", "-source-path", s.mountPoint}
+}
+
+func (s *portableDriveSource) WriteFile(t *testing.T, relPath, content string) {
+t.Helper()
+fullPath := filepath.Join(s.mountPoint, relPath)
+if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+t.Fatal(err)
+}
+if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+t.Fatal(err)
+}
+}

--- a/e2e/portable_linux.go
+++ b/e2e/portable_linux.go
@@ -1,0 +1,153 @@
+//go:build linux
+
+package e2e
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// portableDriveSource is a TestSource backed by a real GPT-formatted loopback
+// device. It exercises the full volume UUID auto-detection pipeline
+// (/proc/mounts → /dev/disk/by-partuuid/ symlinks) without any manual
+// -volume-uuid flag. Requires sudo for losetup/mkfs/mount.
+type portableDriveSource struct {
+	mountPoint string
+}
+
+func newPortableDriveSource(_ *testing.T) *portableDriveSource {
+	return &portableDriveSource{}
+}
+
+func (s *portableDriveSource) Name() string { return "portable" }
+func (s *portableDriveSource) Env() TestEnv { return Hermetic }
+
+// Setup creates a GPT-formatted loopback device. Called inside the subtest, so
+// t.Skip gracefully skips just this matrix entry if sudo/tools aren't available.
+func (s *portableDriveSource) Setup(t *testing.T) []string {
+	t.Helper()
+
+	// Check that we have the required tools.
+	for _, tool := range []string{"sudo", "sgdisk", "losetup", "mkfs.ext4"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("%s not found, skipping portable drive test", tool)
+		}
+	}
+
+	// Verify passwordless sudo (CI runners have this; local dev may not).
+	if out, err := exec.Command("sudo", "-n", "true").CombinedOutput(); err != nil {
+		t.Skipf("sudo requires password, skipping portable drive test: %s", out)
+	}
+
+	// Create a sparse 20 MB disk image.
+	imgPath := filepath.Join(t.TempDir(), "disk.img")
+	if out, err := exec.Command("dd", "if=/dev/zero", "of="+imgPath,
+		"bs=1M", "count=20").CombinedOutput(); err != nil {
+		t.Fatalf("dd failed: %v\n%s", err, out)
+	}
+
+	// Create GPT partition table with one partition.
+	if out, err := exec.Command("sgdisk", "-n", "1:0:0", imgPath).CombinedOutput(); err != nil {
+		t.Fatalf("sgdisk failed: %v\n%s", err, out)
+	}
+
+	// Attach as loopback device with partition scanning.
+	out, err := exec.Command("sudo", "losetup", "--find", "--show", "--partscan", imgPath).CombinedOutput()
+	if err != nil {
+		t.Skipf("losetup failed (may need privileges): %v\n%s", err, out)
+	}
+	loopDev := strings.TrimSpace(string(out)) // e.g. "/dev/loop0"
+	t.Cleanup(func() {
+		_ = exec.Command("sudo", "umount", s.mountPoint).Run()
+		_ = exec.Command("sudo", "losetup", "-d", loopDev).Run()
+	})
+
+	// Wait briefly for the partition device to appear.
+	partDev := loopDev + "p1"
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(partDev); err == nil {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if _, err := os.Stat(partDev); os.IsNotExist(err) {
+		t.Fatalf("partition device %s did not appear", partDev)
+	}
+
+	// Format as ext4.
+	if out, err := exec.Command("sudo", "mkfs.ext4", "-q", "-F", partDev).CombinedOutput(); err != nil {
+		t.Fatalf("mkfs.ext4 failed: %v\n%s", err, out)
+	}
+
+	// Mount.
+	s.mountPoint = filepath.Join(t.TempDir(), "mnt")
+	if err := os.MkdirAll(s.mountPoint, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command("sudo", "mount", partDev, s.mountPoint).CombinedOutput(); err != nil {
+		t.Fatalf("mount failed: %v\n%s", err, out)
+	}
+
+	// Make the mount point writable by the test user.
+	if out, err := exec.Command("sudo", "chmod", "777", s.mountPoint).CombinedOutput(); err != nil {
+		t.Fatalf("chmod failed: %v\n%s", err, out)
+	}
+
+	// Remove lost+found created by mkfs.ext4 — it's root-owned and causes
+	// permission errors during backup scanning.
+	_ = exec.Command("sudo", "rm", "-rf", filepath.Join(s.mountPoint, "lost+found")).Run()
+
+	// Verify the partition UUID is detectable via /dev/disk/by-partuuid/.
+	found := false
+	byPartUUID := "/dev/disk/by-partuuid"
+	if entries, err := os.ReadDir(byPartUUID); err == nil {
+		for _, e := range entries {
+			link, err := os.Readlink(filepath.Join(byPartUUID, e.Name()))
+			if err != nil {
+				continue
+			}
+			resolved, err := filepath.Abs(filepath.Join(byPartUUID, link))
+			if err != nil {
+				continue
+			}
+			if resolved == partDev {
+				found = true
+				t.Logf("GPT partition UUID detected: %s → %s", e.Name(), resolved)
+				break
+			}
+		}
+	}
+	if !found {
+		// udev may not have created the symlink yet (rare in CI).
+		// Try triggering udev and wait.
+		_ = exec.Command("sudo", "udevadm", "trigger", "--subsystem-match=block").Run()
+		_ = exec.Command("sudo", "udevadm", "settle", "--timeout=5").Run()
+		t.Logf("warning: GPT partition UUID symlink not found for %s; udev triggered", partDev)
+	}
+
+	return []string{"-source", "local", "-source-path", s.mountPoint}
+}
+
+func (s *portableDriveSource) WriteFile(t *testing.T, relPath, content string) {
+	t.Helper()
+	fullPath := filepath.Join(s.mountPoint, relPath)
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+		// Files on ext4 mounted with sudo may need sudo to write.
+		// Try direct write first, fall back to sudo tee.
+		if out, err2 := exec.Command("sudo", "mkdir", "-p", filepath.Dir(fullPath)).CombinedOutput(); err2 != nil {
+			t.Fatalf("mkdir failed: %v\n%s (original: %v)", err2, out, err)
+		}
+	}
+	if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+		// Fall back to sudo tee for permission issues.
+		cmd := exec.Command("sudo", "tee", fullPath)
+		cmd.Stdin = strings.NewReader(content)
+		if out, err2 := cmd.CombinedOutput(); err2 != nil {
+			t.Fatalf("write failed: %v\n%s (original: %v)", err2, out, err)
+		}
+	}
+}

--- a/e2e/portable_stub.go
+++ b/e2e/portable_stub.go
@@ -1,0 +1,16 @@
+//go:build !darwin && !linux
+
+package e2e
+
+import "testing"
+
+// portableDriveSource is a stub for platforms where loopback/RAM disk creation
+// is not implemented.
+type portableDriveSource struct{}
+
+func newPortableDriveSource(_ *testing.T) *portableDriveSource { return nil }
+
+func (s *portableDriveSource) Name() string                                   { return "portable" }
+func (s *portableDriveSource) Env() TestEnv                                   { return Hermetic }
+func (s *portableDriveSource) Setup(t *testing.T) []string                    { t.Skip("portable drive not supported on this platform"); return nil }
+func (s *portableDriveSource) WriteFile(t *testing.T, relPath, content string) {}

--- a/e2e/portable_test.go
+++ b/e2e/portable_test.go
@@ -1,0 +1,20 @@
+package e2e
+
+import (
+	"runtime"
+	"testing"
+)
+
+// portableDriveSources returns factory functions for portable drive test
+// sources. On macOS and Linux, this creates a real GPT-formatted disk
+// (RAM disk or loopback device). On other platforms, it returns nil.
+func portableDriveSources() []func(t *testing.T) TestSource {
+	switch runtime.GOOS {
+	case "darwin", "linux":
+		return []func(t *testing.T) TestSource{
+			func(t *testing.T) TestSource { return newPortableDriveSource(t) },
+		}
+	default:
+		return nil
+	}
+}

--- a/internal/core/models.go
+++ b/internal/core/models.go
@@ -71,9 +71,11 @@ type LeafEntry struct {
 // first-class field on the snapshot so that forget policies can group by
 // source identity (Type + Account + Path).
 type SourceInfo struct {
-	Type    string `json:"type"`              // e.g. "gdrive", "local"
-	Account string `json:"account,omitempty"` // Google account email, hostname, etc.
-	Path    string `json:"path,omitempty"`    // root folder ID, filesystem path, etc.
+	Type        string `json:"type"`                        // e.g. "gdrive", "local"
+	Account     string `json:"account,omitempty"`           // Google account email, hostname, etc.
+	Path        string `json:"path,omitempty"`              // root folder ID, filesystem path, etc.
+	VolumeUUID  string `json:"volume_uuid,omitempty"`       // stable volume identity across mounts/machines
+	VolumeLabel string `json:"volume_label,omitempty"`      // human-readable volume name (e.g. "MyDrive")
 }
 
 // Snapshot represents a backup checkpoint

--- a/internal/engine/backup.go
+++ b/internal/engine/backup.go
@@ -287,13 +287,32 @@ func (bm *BackupManager) loadLatestSeq() int {
 }
 
 // findPreviousSnapshot lists all snapshots and returns the most recent one
-// whose Source matches the given info (Type + Account + Path).
+// whose Source matches the given info. When VolumeUUID is set, it is preferred
+// over the legacy (Type + Account + Path) match to enable cross-machine
+// incremental backup for portable drives.
 // Returns nil when no matching snapshot exists.
 func (bm *BackupManager) findPreviousSnapshot(info core.SourceInfo) *core.Snapshot {
 	entries, err := LoadSnapshotCatalog(bm.store)
 	if err != nil {
 		return nil
 	}
+
+	// Pass 1: UUID + path match (cross-machine, mount-point-agnostic).
+	// Path is relative to the volume root, so different sub-directories
+	// of the same drive are tracked independently.
+	if info.VolumeUUID != "" {
+		for _, e := range entries {
+			if e.Snap.Source != nil &&
+				e.Snap.Source.Type == info.Type &&
+				e.Snap.Source.VolumeUUID == info.VolumeUUID &&
+				e.Snap.Source.Path == info.Path {
+				snap := e.Snap
+				return &snap
+			}
+		}
+	}
+
+	// Pass 2: legacy match (type + account + path)
 	for _, e := range entries {
 		if e.Snap.Source != nil &&
 			e.Snap.Source.Type == info.Type &&

--- a/internal/engine/backup_test.go
+++ b/internal/engine/backup_test.go
@@ -225,3 +225,196 @@ func TestBackupManager_Run(t *testing.T) {
 		t.Error("id2 missing in third snapshot")
 	}
 }
+
+// TestFindPreviousSnapshot_VolumeUUID verifies that findPreviousSnapshot
+// uses VolumeUUID for matching when present, enabling cross-machine
+// incremental backup for portable drives.
+func TestFindPreviousSnapshot_VolumeUUID(t *testing.T) {
+	s := NewMockStore()
+
+	// Create snapshots from two different machines backing up the same drive.
+	macSnap := &core.Snapshot{
+		Seq:     1,
+		Created: "2026-03-01T10:00:00Z",
+		Root:    "node/mac",
+		Source: &core.SourceInfo{
+			Type:       "local",
+			Account:    "mac-studio.local",
+			Path:       ".",
+			VolumeUUID: "A1B2C3D4-1234-5678-ABCD-EF0123456789",
+		},
+	}
+	linuxSnap := &core.Snapshot{
+		Seq:     2,
+		Created: "2026-03-02T10:00:00Z",
+		Root:    "node/linux",
+		Source: &core.SourceInfo{
+			Type:       "local",
+			Account:    "linux-workstation",
+			Path:       ".",
+			VolumeUUID: "A1B2C3D4-1234-5678-ABCD-EF0123456789",
+		},
+	}
+
+	ref1 := putSnapshot(t, s, macSnap)
+	ref2 := putSnapshot(t, s, linuxSnap)
+
+	// Build catalog with newest first.
+	putCatalog(t, s, []core.SnapshotSummary{
+		{Ref: ref2, Created: linuxSnap.Created, Root: linuxSnap.Root, Source: linuxSnap.Source},
+		{Ref: ref1, Created: macSnap.Created, Root: macSnap.Root, Source: macSnap.Source},
+	})
+
+	src := NewMockSource()
+	bm := NewBackupManager(src, s, ui.NewNoOpReporter(), nil)
+
+	// Search from the Mac with same UUID and same volume-relative path.
+	info := core.SourceInfo{
+		Type:       "local",
+		Account:    "mac-studio.local",
+		Path:       ".",
+		VolumeUUID: "A1B2C3D4-1234-5678-ABCD-EF0123456789",
+	}
+	prev := bm.findPreviousSnapshot(info)
+	if prev == nil {
+		t.Fatal("expected to find previous snapshot via UUID match")
+	}
+	// Should return the most recent (Linux) snapshot since catalog is newest-first.
+	if prev.Root != "node/linux" {
+		t.Errorf("expected linux snapshot (newest), got root=%s", prev.Root)
+	}
+}
+
+// TestFindPreviousSnapshot_LegacyFallback verifies that snapshots without
+// VolumeUUID are still found by the traditional account+path match.
+func TestFindPreviousSnapshot_LegacyFallback(t *testing.T) {
+	s := NewMockStore()
+
+	snap := &core.Snapshot{
+		Seq:     1,
+		Created: "2026-03-01T10:00:00Z",
+		Root:    "node/legacy",
+		Source: &core.SourceInfo{
+			Type:    "local",
+			Account: "myhost",
+			Path:    "/data",
+		},
+	}
+
+	ref := putSnapshot(t, s, snap)
+	putCatalog(t, s, []core.SnapshotSummary{
+		{Ref: ref, Created: snap.Created, Root: snap.Root, Source: snap.Source},
+	})
+
+	src := NewMockSource()
+	bm := NewBackupManager(src, s, ui.NewNoOpReporter(), nil)
+
+	// Search without VolumeUUID — should fall back to account+path.
+	info := core.SourceInfo{
+		Type:    "local",
+		Account: "myhost",
+		Path:    "/data",
+	}
+	prev := bm.findPreviousSnapshot(info)
+	if prev == nil {
+		t.Fatal("expected to find previous snapshot via legacy match")
+	}
+	if prev.Root != "node/legacy" {
+		t.Errorf("expected root=node/legacy, got %s", prev.Root)
+	}
+}
+
+// TestFindPreviousSnapshot_UUIDPreferredOverLegacy verifies that the UUID
+// match takes precedence when both UUID and account+path could match
+// different snapshots.
+func TestFindPreviousSnapshot_UUIDPreferredOverLegacy(t *testing.T) {
+	s := NewMockStore()
+
+	// Old snapshot from same machine, same path, no UUID.
+	oldSnap := &core.Snapshot{
+		Seq:     1,
+		Created: "2026-03-01T10:00:00Z",
+		Root:    "node/old",
+		Source: &core.SourceInfo{
+			Type:    "local",
+			Account: "mac-studio.local",
+			Path:    "/Volumes/MyDrive",
+		},
+	}
+	// Newer snapshot from different machine with UUID (volume-relative path).
+	newSnap := &core.Snapshot{
+		Seq:     2,
+		Created: "2026-03-02T10:00:00Z",
+		Root:    "node/new",
+		Source: &core.SourceInfo{
+			Type:       "local",
+			Account:    "linux-workstation",
+			Path:       ".",
+			VolumeUUID: "UUID-1234",
+		},
+	}
+
+	ref1 := putSnapshot(t, s, oldSnap)
+	ref2 := putSnapshot(t, s, newSnap)
+
+	putCatalog(t, s, []core.SnapshotSummary{
+		{Ref: ref2, Created: newSnap.Created, Root: newSnap.Root, Source: newSnap.Source},
+		{Ref: ref1, Created: oldSnap.Created, Root: oldSnap.Root, Source: oldSnap.Source},
+	})
+
+	src := NewMockSource()
+	bm := NewBackupManager(src, s, ui.NewNoOpReporter(), nil)
+
+	// Search with UUID — should find the UUID-matched snapshot first.
+	info := core.SourceInfo{
+		Type:       "local",
+		Account:    "mac-studio.local",
+		Path:       ".",
+		VolumeUUID: "UUID-1234",
+	}
+	prev := bm.findPreviousSnapshot(info)
+	if prev == nil {
+		t.Fatal("expected to find previous snapshot")
+	}
+	if prev.Root != "node/new" {
+		t.Errorf("expected UUID-matched snapshot (node/new), got root=%s", prev.Root)
+	}
+}
+
+// TestFindPreviousSnapshot_UUIDDifferentSubdirs verifies that backups of
+// different sub-directories on the same drive do not match each other.
+func TestFindPreviousSnapshot_UUIDDifferentSubdirs(t *testing.T) {
+	s := NewMockStore()
+
+	photosSnap := &core.Snapshot{
+		Seq:     1,
+		Created: "2026-03-01T10:00:00Z",
+		Root:    "node/photos",
+		Source: &core.SourceInfo{
+			Type:       "local",
+			Account:    "mac-studio.local",
+			Path:       "Photos",
+			VolumeUUID: "UUID-SAME-DRIVE",
+		},
+	}
+
+	ref := putSnapshot(t, s, photosSnap)
+	putCatalog(t, s, []core.SnapshotSummary{
+		{Ref: ref, Created: photosSnap.Created, Root: photosSnap.Root, Source: photosSnap.Source},
+	})
+
+	src := NewMockSource()
+	bm := NewBackupManager(src, s, ui.NewNoOpReporter(), nil)
+
+	// Search for Documents on the same drive — should NOT match Photos.
+	info := core.SourceInfo{
+		Type:       "local",
+		Account:    "mac-studio.local",
+		Path:       "Documents",
+		VolumeUUID: "UUID-SAME-DRIVE",
+	}
+	prev := bm.findPreviousSnapshot(info)
+	if prev != nil {
+		t.Errorf("expected nil (different subdir on same drive), got root=%s", prev.Root)
+	}
+}

--- a/internal/engine/policy.go
+++ b/internal/engine/policy.go
@@ -132,11 +132,22 @@ func makeGroupKey(snap *core.Snapshot, gf groupFields) GroupKey {
 		if gf.source {
 			k.Source = snap.Source.Type
 		}
-		if gf.account {
-			k.Account = snap.Source.Account
-		}
-		if gf.path {
-			k.Path = snap.Source.Path
+		// When VolumeUUID is present, use it as the primary grouping
+		// identity instead of account. Path is kept (it is relative to
+		// the volume root) so that different sub-directories of the same
+		// drive are grouped independently.
+		if snap.Source.VolumeUUID != "" && (gf.account || gf.path) {
+			k.Account = snap.Source.VolumeUUID
+			if gf.path {
+				k.Path = snap.Source.Path
+			}
+		} else {
+			if gf.account {
+				k.Account = snap.Source.Account
+			}
+			if gf.path {
+				k.Path = snap.Source.Path
+			}
 		}
 	}
 	if gf.tags && len(snap.Tags) > 0 {

--- a/internal/engine/policy_test.go
+++ b/internal/engine/policy_test.go
@@ -158,3 +158,107 @@ func TestMatchesFilter(t *testing.T) {
 		t.Error("should not match when a tag is missing")
 	}
 }
+
+// TestGroupSnapshots_VolumeUUID verifies that snapshots from different
+// machines but the same VolumeUUID are grouped together.
+func TestGroupSnapshots_VolumeUUID(t *testing.T) {
+	macSource := &core.SourceInfo{
+		Type:       "local",
+		Account:    "mac-studio.local",
+		Path:       ".",
+		VolumeUUID: "UUID-SHARED",
+	}
+	linuxSource := &core.SourceInfo{
+		Type:       "local",
+		Account:    "linux-workstation",
+		Path:       ".",
+		VolumeUUID: "UUID-SHARED",
+	}
+	otherSource := &core.SourceInfo{
+		Type:       "local",
+		Account:    "mac-studio.local",
+		Path:       ".",
+		VolumeUUID: "UUID-OTHER",
+	}
+
+	entries := []SnapshotEntry{
+		makeEntry("a", "2026-03-03T12:00:00Z", macSource, nil),
+		makeEntry("b", "2026-03-02T12:00:00Z", linuxSource, nil),
+		makeEntry("c", "2026-03-01T12:00:00Z", otherSource, nil),
+	}
+
+	groups := groupSnapshots(entries, defaultGroupFields())
+
+	// macSource and linuxSource should be in the same group (same UUID + path).
+	// otherSource should be separate (different UUID).
+	if len(groups) != 2 {
+		t.Errorf("expected 2 groups (same UUID grouped together), got %d", len(groups))
+		for k, v := range groups {
+			t.Logf("  group %v: %d entries", k, len(v))
+		}
+	}
+
+	// Find the group with 2 entries (the shared UUID group).
+	found := false
+	for _, v := range groups {
+		if len(v) == 2 {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected one group with 2 entries (same VolumeUUID)")
+	}
+}
+
+// TestGroupSnapshots_VolumeUUID_DifferentSubdirs verifies that backups of
+// different sub-directories on the same drive are grouped independently.
+func TestGroupSnapshots_VolumeUUID_DifferentSubdirs(t *testing.T) {
+	photosSource := &core.SourceInfo{
+		Type:       "local",
+		Account:    "mac-studio.local",
+		Path:       "Photos",
+		VolumeUUID: "UUID-SHARED",
+	}
+	docsSource := &core.SourceInfo{
+		Type:       "local",
+		Account:    "mac-studio.local",
+		Path:       "Documents",
+		VolumeUUID: "UUID-SHARED",
+	}
+
+	entries := []SnapshotEntry{
+		makeEntry("a", "2026-03-02T12:00:00Z", photosSource, nil),
+		makeEntry("b", "2026-03-01T12:00:00Z", docsSource, nil),
+	}
+
+	groups := groupSnapshots(entries, defaultGroupFields())
+	if len(groups) != 2 {
+		t.Errorf("expected 2 groups (same UUID, different paths), got %d", len(groups))
+	}
+}
+
+// TestGroupSnapshots_MixedUUIDAndLegacy verifies that snapshots with
+// VolumeUUID group by UUID+path while those without group by account+path.
+func TestGroupSnapshots_MixedUUIDAndLegacy(t *testing.T) {
+	withUUID := &core.SourceInfo{
+		Type:       "local",
+		Account:    "mac-studio.local",
+		Path:       ".",
+		VolumeUUID: "UUID-1234",
+	}
+	withoutUUID := &core.SourceInfo{
+		Type:    "local",
+		Account: "mac-studio.local",
+		Path:    "/data",
+	}
+
+	entries := []SnapshotEntry{
+		makeEntry("a", "2026-03-02T12:00:00Z", withUUID, nil),
+		makeEntry("b", "2026-03-01T12:00:00Z", withoutUUID, nil),
+	}
+
+	groups := groupSnapshots(entries, defaultGroupFields())
+	if len(groups) != 2 {
+		t.Errorf("expected 2 groups (UUID vs legacy), got %d", len(groups))
+	}
+}

--- a/pkg/source/local_source.go
+++ b/pkg/source/local_source.go
@@ -12,16 +12,36 @@ import (
 func (s *LocalSource) Info() core.SourceInfo {
 	hostname, _ := os.Hostname()
 	absPath, _ := filepath.Abs(s.rootPath)
+
+	// When volume UUID is present, store the path relative to the volume
+	// mount point instead of the absolute path. This makes the path
+	// stable across machines where mount points differ.
+	infoPath := absPath
+	if s.volumeUUID != "" && s.volumeMountPoint != "" {
+		// Resolve symlinks so the relative path is correct (e.g. on macOS
+		// /var → /private/var but the mount point is /System/Volumes/Data).
+		realAbs, errA := filepath.EvalSymlinks(absPath)
+		realMount, errM := filepath.EvalSymlinks(s.volumeMountPoint)
+		if errA == nil && errM == nil {
+			if rel, err := filepath.Rel(realMount, realAbs); err == nil {
+				infoPath = filepath.ToSlash(rel)
+			}
+		}
+	}
+
 	return core.SourceInfo{
-		Type:    "local",
-		Account: hostname,
-		Path:    absPath,
+		Type:        "local",
+		Account:     hostname,
+		Path:        infoPath,
+		VolumeUUID:  s.volumeUUID,
+		VolumeLabel: s.volumeLabel,
 	}
 }
 
 // localOptions holds configuration for a local filesystem source.
 type localOptions struct {
 	excludePatterns []string
+	volumeUUID      string // explicit override for volume UUID
 }
 
 // LocalOption configures a local filesystem source.
@@ -34,10 +54,22 @@ func WithLocalExcludePatterns(patterns []string) LocalOption {
 	}
 }
 
+// WithVolumeUUID overrides the auto-detected volume UUID for the source.
+// Use this for filesystems where UUID detection is unsupported or to
+// explicitly tie backups to a specific snapshot lineage.
+func WithVolumeUUID(uuid string) LocalOption {
+	return func(o *localOptions) {
+		o.volumeUUID = uuid
+	}
+}
+
 // LocalSource implements Source for local filesystem.
 type LocalSource struct {
-	rootPath string
-	exclude  *ExcludeMatcher
+	rootPath         string
+	exclude          *ExcludeMatcher
+	volumeUUID       string
+	volumeLabel      string
+	volumeMountPoint string
 }
 
 // NewLocalSource creates a local filesystem source rooted at rootPath.
@@ -46,9 +78,18 @@ func NewLocalSource(rootPath string, opts ...LocalOption) *LocalSource {
 	for _, opt := range opts {
 		opt(&cfg)
 	}
+
+	uuid, label, mountPoint := detectVolumeIdentity(rootPath)
+	if cfg.volumeUUID != "" {
+		uuid = cfg.volumeUUID
+	}
+
 	return &LocalSource{
-		rootPath: rootPath,
-		exclude:  NewExcludeMatcher(cfg.excludePatterns),
+		rootPath:         rootPath,
+		exclude:          NewExcludeMatcher(cfg.excludePatterns),
+		volumeUUID:       uuid,
+		volumeLabel:      label,
+		volumeMountPoint: mountPoint,
 	}
 }
 
@@ -82,17 +123,20 @@ func (s *LocalSource) Walk(ctx context.Context, callback func(core.FileMeta) err
 			fileType = core.FileTypeFile
 		}
 
+		// Normalize to forward slashes so backup trees are portable across OS.
+		normalizedPath := filepath.ToSlash(relPath)
+
 		var parents []string
-		if dir := filepath.Dir(relPath); dir != "." {
+		if dir := filepath.ToSlash(filepath.Dir(relPath)); dir != "." {
 			parents = []string{dir}
 		}
 
 		meta := core.FileMeta{
-			FileID:  relPath,
+			FileID:  normalizedPath,
 			Name:    filepath.Base(path),
 			Type:    fileType,
 			Parents: parents,
-			Paths:   []string{relPath},
+			Paths:   []string{normalizedPath},
 			Size:    info.Size(),
 			Mtime:   info.ModTime().Unix(),
 		}

--- a/pkg/source/local_source_darwin.go
+++ b/pkg/source/local_source_darwin.go
@@ -1,0 +1,217 @@
+//go:build darwin
+
+package source
+
+import (
+	"encoding/xml"
+	"fmt"
+	"os/exec"
+	"strings"
+	"syscall"
+	"unsafe"
+)
+
+// macOS getattrlist constants
+const (
+	attrBitMapCount = 5 // ATTR_BIT_MAP_COUNT
+	attrVolUUID     = 0x00040000
+	attrVolName     = 0x00000001
+)
+
+// attrList mirrors struct attrlist from <sys/attr.h>.
+type attrList struct {
+	bitmapCount uint16
+	reserved    uint16
+	commonAttr  uint32
+	volAttr     uint32
+	dirAttr     uint32
+	fileAttr    uint32
+	forkAttr    uint32
+}
+
+// detectVolumeIdentity returns the volume UUID, label, and mount point for
+// the filesystem containing path on macOS. It prefers the GPT partition UUID
+// (cross-OS stable, obtained via diskutil) over the macOS-specific volume
+// UUID from getattrlist(2).
+func detectVolumeIdentity(path string) (uuid, label, mountPoint string) {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err == nil {
+		mountPoint = cStringToGo(stat.Mntonname[:])
+	}
+
+	// Try GPT partition UUID first (stable across OSes).
+	if partUUID := getPartitionUUID(path); partUUID != "" {
+		uuid = partUUID
+	} else {
+		uuid = getVolumeUUID(path)
+	}
+	label = getVolumeLabel(path)
+	return uuid, label, mountPoint
+}
+
+// getPartitionUUID uses statfs to find the BSD device for path, then
+// parses `diskutil info -plist` output for the GPT partition UUID.
+func getPartitionUUID(path string) string {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err != nil {
+		return ""
+	}
+
+	// f_mntfromname is a null-terminated C string in a fixed byte array.
+	device := cStringToGo(stat.Mntfromname[:])
+	if device == "" || !strings.HasPrefix(device, "/dev/") {
+		return ""
+	}
+
+	return parseDiskutilPartUUID(device)
+}
+
+// parseDiskutilPartUUID runs `diskutil info -plist <device>` and extracts
+// the DiskUUID (GPT partition UUID) from the plist XML output.
+func parseDiskutilPartUUID(device string) string {
+	out, err := exec.Command("diskutil", "info", "-plist", device).Output()
+	if err != nil {
+		return ""
+	}
+	return extractPlistValue(out, "DiskUUID")
+}
+
+// extractPlistValue extracts a string value for a given key from an Apple
+// plist XML. We use a simple state-machine scan to avoid depending on
+// external plist libraries.
+func extractPlistValue(data []byte, key string) string {
+	// Apple plists use: <key>Name</key>\n<string>Value</string>
+	d := xml.NewDecoder(strings.NewReader(string(data)))
+	var foundKey bool
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return ""
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			if t.Name.Local == "key" {
+				var k string
+				if err := d.DecodeElement(&k, &t); err == nil && k == key {
+					foundKey = true
+				}
+			} else if foundKey && t.Name.Local == "string" {
+				var v string
+				if err := d.DecodeElement(&v, &t); err == nil {
+					return strings.ToUpper(v)
+				}
+				return ""
+			} else {
+				foundKey = false
+			}
+		}
+	}
+}
+
+// cStringToGo converts a null-terminated int8 or byte slice to a Go string.
+func cStringToGo(b []int8) string {
+	buf := make([]byte, len(b))
+	for i, c := range b {
+		if c == 0 {
+			return string(buf[:i])
+		}
+		buf[i] = byte(c)
+	}
+	return string(buf)
+}
+
+func getVolumeUUID(path string) string {
+	attrs := attrList{
+		bitmapCount: attrBitMapCount,
+		volAttr:     attrVolUUID,
+	}
+
+	// Response: 4-byte length + 16-byte UUID
+	var buf [4 + 16]byte
+
+	pathBytes, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return ""
+	}
+
+	_, _, errno := syscall.Syscall6(
+		syscall.SYS_GETATTRLIST,
+		uintptr(unsafe.Pointer(pathBytes)),
+		uintptr(unsafe.Pointer(&attrs)),
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(len(buf)),
+		0, // options
+		0,
+	)
+	if errno != 0 {
+		return ""
+	}
+
+	u := buf[4:20]
+	return fmt.Sprintf(
+		"%02X%02X%02X%02X-%02X%02X-%02X%02X-%02X%02X-%02X%02X%02X%02X%02X%02X",
+		u[0], u[1], u[2], u[3],
+		u[4], u[5],
+		u[6], u[7],
+		u[8], u[9],
+		u[10], u[11], u[12], u[13], u[14], u[15],
+	)
+}
+
+func getVolumeLabel(path string) string {
+	attrs := attrList{
+		bitmapCount: attrBitMapCount,
+		volAttr:     attrVolName,
+	}
+
+	// Response: 4-byte length + attrreference (4-byte offset + 4-byte length) + name data
+	var buf [4 + 8 + 256]byte
+
+	pathBytes, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return ""
+	}
+
+	_, _, errno := syscall.Syscall6(
+		syscall.SYS_GETATTRLIST,
+		uintptr(unsafe.Pointer(pathBytes)),
+		uintptr(unsafe.Pointer(&attrs)),
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(len(buf)),
+		0,
+		0,
+	)
+	if errno != 0 {
+		return ""
+	}
+
+	// Parse attrreference: offset from start of attrreference field, then length
+	if buf[0] < 12 {
+		return ""
+	}
+	off := *(*int32)(unsafe.Pointer(&buf[4]))
+	nameLen := *(*uint32)(unsafe.Pointer(&buf[8]))
+
+	nameStart := 4 + int(off) // offset is relative to the attrreference field
+	nameEnd := nameStart + int(nameLen)
+	if nameStart < 0 || nameEnd > len(buf) || nameStart >= nameEnd {
+		return ""
+	}
+
+	// Trim null terminator
+	name := buf[nameStart:nameEnd]
+	for len(name) > 0 && name[len(name)-1] == 0 {
+		name = name[:len(name)-1]
+	}
+	return string(name)
+}
+
+// VolumeUUID returns the detected or overridden volume UUID.
+func (s *LocalSource) VolumeUUID() string {
+	return s.volumeUUID
+}
+
+// VolumeLabel returns the detected volume label.
+func (s *LocalSource) VolumeLabel() string {
+	return s.volumeLabel
+}

--- a/pkg/source/local_source_linux.go
+++ b/pkg/source/local_source_linux.go
@@ -1,0 +1,151 @@
+//go:build linux
+
+package source
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+// detectVolumeIdentity returns the volume UUID, label, and mount point for
+// the filesystem containing path on Linux. It prefers the GPT partition UUID
+// (cross-OS stable) over the filesystem UUID (platform-specific).
+func detectVolumeIdentity(path string) (uuid, label, mountPoint string) {
+	device, mnt, err := deviceForPath(path)
+	if err != nil || device == "" {
+		return "", "", ""
+	}
+	mountPoint = mnt
+
+	// Prefer GPT partition UUID (stable across OSes) over filesystem UUID.
+	uuid = findPartUUIDForDevice(device)
+	if uuid == "" {
+		uuid = findUUIDForDevice(device)
+	}
+	label = findLabelForDevice(device)
+	return uuid, label, mountPoint
+}
+
+// deviceForPath finds the mount device and mount point for a given filesystem
+// path by parsing /proc/mounts and matching on device ID (stat.Dev).
+func deviceForPath(path string) (device, mountPoint string, err error) {
+	var st syscall.Stat_t
+	if err := syscall.Stat(path, &st); err != nil {
+		return "", "", err
+	}
+	targetDev := st.Dev
+
+	f, err := os.Open("/proc/mounts")
+	if err != nil {
+		return "", "", err
+	}
+	defer func() { _ = f.Close() }()
+
+	var bestDevice string
+	var bestMount string
+	var bestMountLen int
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 2 {
+			continue
+		}
+		mnt := fields[1]
+
+		// Check if this mount point is a prefix of our path
+		if !strings.HasPrefix(path, mnt) {
+			continue
+		}
+		// Use the longest matching mount point (most specific)
+		if len(mnt) > bestMountLen {
+			var mountStat syscall.Stat_t
+			if err := syscall.Stat(mnt, &mountStat); err == nil && mountStat.Dev == targetDev {
+				bestDevice = fields[0]
+				bestMount = mnt
+				bestMountLen = len(mnt)
+			}
+		}
+	}
+
+	return bestDevice, bestMount, nil
+}
+
+// findUUIDForDevice scans /dev/disk/by-uuid/ for a symlink pointing to the
+// given device and returns the UUID (the symlink name).
+func findUUIDForDevice(device string) string {
+	entries, err := os.ReadDir("/dev/disk/by-uuid")
+	if err != nil {
+		return ""
+	}
+
+	deviceBase := filepath.Base(device)
+	for _, e := range entries {
+		target, err := os.Readlink("/dev/disk/by-uuid/" + e.Name())
+		if err != nil {
+			continue
+		}
+		if filepath.Base(target) == deviceBase {
+			return e.Name()
+		}
+	}
+	return ""
+}
+
+// findPartUUIDForDevice scans /dev/disk/by-partuuid/ for a symlink pointing
+// to the given device and returns the GPT partition UUID. This UUID is stable
+// across operating systems for the same physical partition.
+func findPartUUIDForDevice(device string) string {
+	entries, err := os.ReadDir("/dev/disk/by-partuuid")
+	if err != nil {
+		return ""
+	}
+
+	deviceBase := filepath.Base(device)
+	for _, e := range entries {
+		target, err := os.Readlink("/dev/disk/by-partuuid/" + e.Name())
+		if err != nil {
+			continue
+		}
+		if filepath.Base(target) == deviceBase {
+			return strings.ToUpper(e.Name())
+		}
+	}
+	return ""
+}
+
+// findLabelForDevice scans /dev/disk/by-label/ for a symlink pointing to the
+// given device and returns the label (the symlink name).
+func findLabelForDevice(device string) string {
+	entries, err := os.ReadDir("/dev/disk/by-label")
+	if err != nil {
+		return ""
+	}
+
+	deviceBase := filepath.Base(device)
+	for _, e := range entries {
+		target, err := os.Readlink("/dev/disk/by-label/" + e.Name())
+		if err != nil {
+			continue
+		}
+		if filepath.Base(target) == deviceBase {
+			return e.Name()
+		}
+	}
+	return ""
+}
+
+// VolumeUUID returns the detected or overridden volume UUID.
+// Exported for testing.
+func (s *LocalSource) VolumeUUID() string {
+	return s.volumeUUID
+}
+
+// VolumeLabel returns the detected volume label.
+// Exported for testing.
+func (s *LocalSource) VolumeLabel() string {
+	return s.volumeLabel
+}

--- a/pkg/source/local_source_plist_test.go
+++ b/pkg/source/local_source_plist_test.go
@@ -1,0 +1,72 @@
+//go:build darwin
+
+package source
+
+import "testing"
+
+func TestExtractPlistValue(t *testing.T) {
+plistXML := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+<key>DeviceIdentifier</key>
+<string>disk2s1</string>
+<key>DiskUUID</key>
+<string>a1b2c3d4-e5f6-7890-abcd-ef0123456789</string>
+<key>VolumeName</key>
+<string>MyDrive</string>
+<key>Ejectable</key>
+<true/>
+</dict>
+</plist>`
+
+tests := []struct {
+key  string
+want string
+}{
+{"DiskUUID", "A1B2C3D4-E5F6-7890-ABCD-EF0123456789"},
+{"VolumeName", "MYDRIVE"},
+{"DeviceIdentifier", "DISK2S1"},
+{"NonExistentKey", ""},
+}
+
+for _, tc := range tests {
+t.Run(tc.key, func(t *testing.T) {
+got := extractPlistValue([]byte(plistXML), tc.key)
+if got != tc.want {
+t.Errorf("extractPlistValue(%q) = %q, want %q", tc.key, got, tc.want)
+}
+})
+}
+}
+
+func TestExtractPlistValue_EmptyInput(t *testing.T) {
+if got := extractPlistValue([]byte(""), "DiskUUID"); got != "" {
+t.Errorf("expected empty for empty input, got %q", got)
+}
+}
+
+func TestExtractPlistValue_MalformedXML(t *testing.T) {
+if got := extractPlistValue([]byte("<broken"), "DiskUUID"); got != "" {
+t.Errorf("expected empty for malformed XML, got %q", got)
+}
+}
+
+func TestCStringToGo(t *testing.T) {
+tests := []struct {
+name string
+in   []int8
+want string
+}{
+{"normal", []int8{'/','d','e','v','/','d','i','s','k','0', 0, 0, 0}, "/dev/disk0"},
+{"empty", []int8{0, 0, 0}, ""},
+{"no null", []int8{'a', 'b', 'c'}, "abc"},
+}
+for _, tc := range tests {
+t.Run(tc.name, func(t *testing.T) {
+if got := cStringToGo(tc.in); got != tc.want {
+t.Errorf("cStringToGo = %q, want %q", got, tc.want)
+}
+})
+}
+}

--- a/pkg/source/local_source_stub.go
+++ b/pkg/source/local_source_stub.go
@@ -1,0 +1,22 @@
+//go:build !darwin && !linux && !windows
+
+package source
+
+// detectVolumeIdentity is a stub for platforms where volume UUID detection
+// is not yet implemented (Windows, plan9, etc.). It returns empty strings,
+// causing the engine to fall back to legacy account+path matching.
+func detectVolumeIdentity(_ string) (uuid, label, mountPoint string) {
+	return "", "", ""
+}
+
+// VolumeUUID returns the detected or overridden volume UUID.
+// Exported for testing.
+func (s *LocalSource) VolumeUUID() string {
+	return s.volumeUUID
+}
+
+// VolumeLabel returns the detected volume label.
+// Exported for testing.
+func (s *LocalSource) VolumeLabel() string {
+	return s.volumeLabel
+}

--- a/pkg/source/local_source_test.go
+++ b/pkg/source/local_source_test.go
@@ -126,8 +126,15 @@ func TestLocalSource(t *testing.T) {
 	if info.Type != "local" {
 		t.Errorf("Expected type 'local', got %s", info.Type)
 	}
-	if info.Path != tmpDir {
-		t.Errorf("Expected Path '%s', got %s", tmpDir, info.Path)
+	if info.VolumeUUID != "" {
+		// Path is volume-relative when UUID is detected.
+		if len(info.Path) > 0 && info.Path[0] == '/' {
+			t.Errorf("Expected volume-relative Path when UUID is set, got absolute: %s", info.Path)
+		}
+	} else {
+		if info.Path != tmpDir {
+			t.Errorf("Expected Path '%s', got %s", tmpDir, info.Path)
+		}
 	}
 
 	// Test Size()

--- a/pkg/source/local_source_volume_test.go
+++ b/pkg/source/local_source_volume_test.go
@@ -1,0 +1,159 @@
+package source
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/cloudstic/cli/internal/core"
+)
+
+func TestDetectVolumeIdentity_TempDir(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "cloudstic-volume-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	uuid, label, mountPoint := detectVolumeIdentity(tmpDir)
+
+	// On macOS and Linux, the temp directory lives on a real filesystem
+	// that should have a volume UUID. On stub platforms, both are empty.
+	t.Logf("UUID=%q, Label=%q, MountPoint=%q for %s", uuid, label, mountPoint, tmpDir)
+
+	if uuid != "" {
+		// Validate UUID format: hex characters with dashes.
+		uuidPattern := regexp.MustCompile(`^[0-9A-Fa-f]{8}(-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12}$`)
+		if !uuidPattern.MatchString(uuid) {
+			t.Errorf("UUID %q does not match expected format", uuid)
+		}
+	}
+}
+
+func TestDetectVolumeIdentity_ReturnsUppercaseUUID(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skip("UUID detection only implemented on darwin and linux")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "cloudstic-case-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	uuid, _, _ := detectVolumeIdentity(tmpDir)
+	if uuid == "" {
+		t.Skip("no UUID detected for temp dir filesystem")
+	}
+
+	// UUIDs should be uppercase for consistent cross-platform matching.
+	for _, c := range uuid {
+		if c >= 'a' && c <= 'f' {
+			t.Errorf("UUID %q contains lowercase hex; expected uppercase for consistency", uuid)
+			break
+		}
+	}
+}
+
+func TestLocalSource_WithVolumeUUID_Override(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "cloudstic-uuid-override-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	explicitUUID := "CUSTOM-UUID-1234-5678-ABCD-EF0123456789"
+	src := NewLocalSource(tmpDir, WithVolumeUUID(explicitUUID))
+
+	info := src.Info()
+	if info.VolumeUUID != explicitUUID {
+		t.Errorf("expected VolumeUUID=%q, got %q", explicitUUID, info.VolumeUUID)
+	}
+}
+
+func TestLocalSource_Info_PopulatesVolumeFields(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "cloudstic-info-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	src := NewLocalSource(tmpDir)
+	info := src.Info()
+
+	if info.Type != "local" {
+		t.Errorf("expected Type=local, got %s", info.Type)
+	}
+	if info.Account == "" {
+		t.Error("expected non-empty Account (hostname)")
+	}
+
+	// VolumeUUID and VolumeLabel are populated via the platform-specific
+	// detectVolumeIdentity. We just verify they're set correctly on the
+	// Info output (they may be empty on stub platforms).
+	if info.VolumeUUID != src.VolumeUUID() {
+		t.Errorf("Info().VolumeUUID=%q != VolumeUUID()=%q", info.VolumeUUID, src.VolumeUUID())
+	}
+	if info.VolumeLabel != src.VolumeLabel() {
+		t.Errorf("Info().VolumeLabel=%q != VolumeLabel()=%q", info.VolumeLabel, src.VolumeLabel())
+	}
+
+	// When VolumeUUID is set, Path should be relative to the volume mount
+	// point (not an absolute path).
+	if info.VolumeUUID != "" && len(info.Path) > 0 && info.Path[0] == '/' {
+		t.Errorf("Path should be volume-relative when VolumeUUID is set, got absolute: %q", info.Path)
+	}
+}
+
+func TestLocalSource_Walk_NormalizesPathSeparators(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "cloudstic-walk-sep-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Create nested structure.
+	writeTestFile(t, tmpDir, "docs/notes/file.txt", "hello")
+
+	src := NewLocalSource(tmpDir)
+	var metas []struct{ id, parent, path string }
+	err = src.Walk(t.Context(), func(fm core.FileMeta) error {
+		var parent string
+		if len(fm.Parents) > 0 {
+			parent = fm.Parents[0]
+		}
+		var p string
+		if len(fm.Paths) > 0 {
+			p = fm.Paths[0]
+		}
+		metas = append(metas, struct{ id, parent, path string }{fm.FileID, parent, p})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Walk failed: %v", err)
+	}
+
+	for _, m := range metas {
+		for _, field := range []struct{ name, val string }{
+			{"FileID", m.id}, {"Parent", m.parent}, {"Path", m.path},
+		} {
+			if strings.Contains(field.val, "\\") {
+				t.Errorf("%s=%q contains backslash; expected forward slashes only", field.name, field.val)
+			}
+		}
+	}
+}
+
+func writeTestFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	p := filepath.Join(dir, filepath.FromSlash(name))
+	if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/source/local_source_windows.go
+++ b/pkg/source/local_source_windows.go
@@ -1,0 +1,140 @@
+//go:build windows
+
+package source
+
+import (
+	"fmt"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	// ioctlDiskGetPartitionInfoEx is IOCTL_DISK_GET_PARTITION_INFO_EX.
+	// Returns PARTITION_INFORMATION_EX containing the GPT partition UUID.
+	ioctlDiskGetPartitionInfoEx = 0x00070048
+
+	partitionStyleGPT = 1
+)
+
+// partitionInfoGPT mirrors the GPT variant of the PARTITION_INFORMATION union.
+type partitionInfoGPT struct {
+	PartitionType windows.GUID
+	PartitionId   windows.GUID
+	Attributes    uint64
+	Name          [36]uint16
+}
+
+// partitionInformationEx mirrors the Windows PARTITION_INFORMATION_EX struct.
+// The union at the end is defined as the GPT variant (the larger of the two).
+type partitionInformationEx struct {
+	PartitionStyle   uint32
+	_                uint32 // padding for int64 alignment
+	StartingOffset   int64
+	PartitionLength  int64
+	PartitionNumber  uint32
+	RewritePartition byte
+	_                [3]byte // padding to align union
+	GPT              partitionInfoGPT
+}
+
+func detectVolumeIdentity(path string) (uuid, label, mountPoint string) {
+	pathUTF16, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return "", "", ""
+	}
+
+	// Get the volume mount point (e.g. "C:\").
+	var volPath [windows.MAX_PATH + 1]uint16
+	if err := windows.GetVolumePathName(pathUTF16, &volPath[0], uint32(len(volPath))); err != nil {
+		return "", "", ""
+	}
+	mountPoint = windows.UTF16ToString(volPath[:])
+
+	label = getVolumeLabel(mountPoint)
+	uuid = getPartitionUUID(mountPoint)
+
+	return uuid, label, mountPoint
+}
+
+// getVolumeLabel returns the volume label via GetVolumeInformation.
+func getVolumeLabel(mountPoint string) string {
+	mountUTF16, err := windows.UTF16PtrFromString(mountPoint)
+	if err != nil {
+		return ""
+	}
+	var volumeName [windows.MAX_PATH + 1]uint16
+	if err := windows.GetVolumeInformation(
+		mountUTF16,
+		&volumeName[0], uint32(len(volumeName)),
+		nil, nil, nil, nil, 0,
+	); err != nil {
+		return ""
+	}
+	return windows.UTF16ToString(volumeName[:])
+}
+
+// getPartitionUUID returns the GPT partition UUID via DeviceIoControl.
+// Returns empty for MBR partitions or on error.
+func getPartitionUUID(mountPoint string) string {
+	// Open the volume: "C:\" → "\\.\C:" (strip trailing backslash).
+	volumePath := `\\.\` + strings.TrimRight(mountPoint, `\`)
+	pathUTF16, err := windows.UTF16PtrFromString(volumePath)
+	if err != nil {
+		return ""
+	}
+
+	handle, err := windows.CreateFile(
+		pathUTF16,
+		0, // no access required for partition info queries
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		nil,
+		windows.OPEN_EXISTING,
+		0,
+		0,
+	)
+	if err != nil {
+		return ""
+	}
+	defer windows.CloseHandle(handle)
+
+	var info partitionInformationEx
+	var bytesReturned uint32
+	if err := windows.DeviceIoControl(
+		handle,
+		ioctlDiskGetPartitionInfoEx,
+		nil, 0,
+		(*byte)(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+		&bytesReturned,
+		nil,
+	); err != nil {
+		return ""
+	}
+
+	if info.PartitionStyle != partitionStyleGPT {
+		return ""
+	}
+
+	return strings.ToUpper(formatGUID(info.GPT.PartitionId))
+}
+
+// formatGUID formats a Windows GUID as a standard UUID string.
+func formatGUID(g windows.GUID) string {
+	return fmt.Sprintf("%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X",
+		g.Data1, g.Data2, g.Data3,
+		g.Data4[0], g.Data4[1],
+		g.Data4[2], g.Data4[3], g.Data4[4], g.Data4[5], g.Data4[6], g.Data4[7],
+	)
+}
+
+// VolumeUUID returns the detected or overridden volume UUID.
+func (s *LocalSource) VolumeUUID() string {
+	return s.volumeUUID
+}
+
+// VolumeLabel returns the detected volume label.
+func (s *LocalSource) VolumeLabel() string {
+	return s.volumeLabel
+}

--- a/rfcs/0005-portable-drive-identity.md
+++ b/rfcs/0005-portable-drive-identity.md
@@ -1,6 +1,6 @@
 # RFC 0005: Portable Drive Identity
 
-* **Status:** Proposed
+* **Status:** Implemented
 * **Date:** 2026-03-07
 * **Affects:** `internal/core/models.go`, `internal/engine/backup.go`, `internal/engine/policy.go`, `pkg/source/local_source.go`, `cmd/cloudstic/main.go`
 
@@ -104,7 +104,7 @@ Day 3 — Mac:   UUID match → S2 found, incremental scan, only changed files
 type SourceInfo struct {
     Type        string `json:"type"`
     Account     string `json:"account,omitempty"`  // hostname (informational)
-    Path        string `json:"path,omitempty"`      // mount point at time of backup (informational)
+    Path        string `json:"path,omitempty"`      // volume-relative path when VolumeUUID is set; absolute otherwise
     VolumeUUID  string `json:"volume_uuid,omitempty"` // stable identity across mounts/machines
     VolumeLabel string `json:"volume_label,omitempty"` // human-readable name (e.g. "MyDrive")
     FsType      string `json:"fs_type,omitempty"`   // proposed in RFC 0004
@@ -117,59 +117,57 @@ These fields are backward-compatible: old snapshots have neither field; the engi
 
 ### 2.2 Obtaining the volume UUID per platform
 
-UUID collection is isolated in `local_source_unix.go` (established by RFC 0004):
+UUID collection is isolated in platform-specific files (`local_source_darwin.go`, `local_source_linux.go`, `local_source_windows.go`, `local_source_stub.go`).
+
+The primary goal is **cross-OS stability**: the same physical drive should produce the same UUID regardless of which operating system performs the backup. To achieve this, the implementation prefers the **GPT partition UUID** over platform-specific volume UUIDs. The GPT partition UUID is a standard UUID stored in the GUID Partition Table and is identical on every OS that reads the same partition table.
+
+**Detection priority (per platform):**
+
+1. GPT partition UUID (cross-OS stable) — preferred
+2. Platform-specific volume/filesystem UUID — fallback
+3. Manual override via `-volume-uuid` — always takes final precedence
 
 #### macOS
 
-Use `getattrlist(2)` with `ATTR_VOL_UUID` on the mount point path. The result is a 16-byte UUID. Additionally, `statfs.F_vol_name` or a second `getattrlist(ATTR_VOL_NAME)` call gives the volume label.
+1. **GPT partition UUID** (preferred): Use `syscall.Statfs` to obtain the BSD device name from `Mntfromname` (e.g. `/dev/disk2s1`), then run `diskutil info -plist <device>` and parse the `DiskUUID` key from the XML plist output. This returns the GPT partition UUID, which is identical to the value Linux reads from the partition table.
 
-```go
-// macOS: getattrlist on the mount root
-type volAttrs struct {
-    length uint32
-    uuid   [16]byte
-    name   [256]byte
-}
-attrList := syscall.AttrList{
-    Bitmapcount: syscall.ATTR_BIT_MAP_COUNT,
-    Volattr:     syscall.ATTR_VOL_UUID | syscall.ATTR_VOL_NAME,
-}
-// syscall.Getattrlist(path, &attrList, unsafe.Pointer(&buf), ...)
-```
+2. **Volume UUID** (fallback): Use `getattrlist(2)` with `ATTR_VOL_UUID`. This returns a macOS-specific 128-bit UUID that differs from what Linux reports for the same drive. Used only when the GPT partition UUID is unavailable (e.g. MBR-formatted drives).
+
+3. **Volume label**: `getattrlist(2)` with `ATTR_VOL_NAME` provides the human-readable volume name.
 
 #### Linux
 
-Linux `statfs(2)` does not expose a UUID. The UUID is stored on-disk and readable from two stable locations:
+1. **GPT partition UUID** (preferred): Find the device via `/proc/mounts` + `syscall.Stat` (matching `st.Dev`), then scan `/dev/disk/by-partuuid/` symlinks for a matching device. The `by-partuuid` directory contains GPT partition UUIDs.
 
-1. **`/dev/disk/by-uuid/`**: a directory of symlinks `{uuid} → ../../sdXN`. Find the device for the path via `statfs.Fsid` or `/proc/mounts`, then look for a matching symlink.
-2. **`/proc/mounts` + `blkid`**: parse `/proc/mounts` to find the device for the mount point, then read the UUID from the kernel via `ioctl(BLKID)` or by reading the filesystem superblock directly (ext4: offset 0x468, 16 bytes; btrfs: different offset).
+2. **Filesystem UUID** (fallback): Scan `/dev/disk/by-uuid/` symlinks. This returns the filesystem-level UUID (e.g. ext4 superblock UUID, FAT32 volume serial). Used when `by-partuuid` has no match (MBR-formatted drives).
 
-**Recommended implementation for Linux**: read from `/dev/disk/by-uuid/`. It requires no additional privileges and is stable on all modern distributions:
+3. **Volume label**: Scan `/dev/disk/by-label/` symlinks.
 
-```go
-// Find mount point for path via statfs → Fsid → /proc/mounts
-// Then scan /dev/disk/by-uuid/ for a symlink pointing to that device
-func findVolumeUUIDLinux(path string) (string, error) {
-    device, err := deviceForPath(path)     // parses /proc/mounts
-    if err != nil {
-        return "", err
-    }
-    entries, _ := os.ReadDir("/dev/disk/by-uuid")
-    for _, e := range entries {
-        target, _ := os.Readlink("/dev/disk/by-uuid/" + e.Name())
-        if filepath.Base(target) == filepath.Base(device) {
-            return e.Name(), nil
-        }
-    }
-    return "", nil
-}
-```
+All UUIDs are normalized to uppercase for consistent matching across platforms.
 
-This approach does not require `blkid`, `libblkid`, or root privileges.
+#### Windows
 
-#### Stub (Windows, plan9)
+1. **GPT partition UUID** (preferred): Use `GetVolumePathName` to determine the volume mount point, then open the volume with `CreateFile` (`\\.\C:`) and call `DeviceIoControl` with `IOCTL_DISK_GET_PARTITION_INFO_EX`. For GPT partitions, `PARTITION_INFORMATION_EX.Gpt.PartitionId` contains the GPT partition UUID — the same UUID that macOS and Linux detect from the partition table. Returns empty for MBR partitions.
 
-Return `"", ""` — UUID and label are left empty, existing matching logic applies.
+2. **Volume label**: `GetVolumeInformation` provides the human-readable volume name.
+
+3. **Mount point**: `GetVolumePathName` returns the drive root (e.g. `C:\`).
+
+No elevation is required — `CreateFile` with zero access rights and `FILE_SHARE_READ | FILE_SHARE_WRITE` is sufficient for partition info queries.
+
+#### Stub (plan9, etc.)
+
+Return `"", "", ""` — UUID, label, and mount point are left empty, existing matching logic applies. Users can use `-volume-uuid` for manual override.
+
+#### Cross-OS compatibility matrix
+
+| Partition table | UUID source | macOS ↔ Linux | macOS/Linux ↔ Windows |
+|---|---|---|---|
+| GPT | Partition UUID (`DiskUUID` / `by-partuuid` / `DeviceIoControl`) | ✓ Identical | ✓ Identical |
+| MBR | Platform-specific (getattrlist / `by-uuid` / none) | ✗ Different | ✗ Different |
+| MBR + `-volume-uuid` | Manual override | ✓ User-controlled | ✓ User-controlled |
+
+Modern portable drives (formatted as exFAT or APFS on GPT) produce matching UUIDs automatically. Older MBR-formatted FAT32 drives require `-volume-uuid` for cross-OS use.
 
 #### When UUID is unavailable
 
@@ -184,12 +182,13 @@ func (bm *BackupManager) findPreviousSnapshot(info core.SourceInfo) *core.Snapsh
         return nil
     }
 
-    // Pass 1: UUID match (cross-machine, mount-point-agnostic)
+    // Pass 1: UUID + path match (cross-machine, mount-point-agnostic)
     if info.VolumeUUID != "" {
         for _, e := range entries {
             if e.Snap.Source != nil &&
                 e.Snap.Source.Type == info.Type &&
-                e.Snap.Source.VolumeUUID == info.VolumeUUID {
+                e.Snap.Source.VolumeUUID == info.VolumeUUID &&
+                e.Snap.Source.Path == info.Path {
                 snap := e.Snap
                 return &snap
             }
@@ -211,7 +210,7 @@ func (bm *BackupManager) findPreviousSnapshot(info core.SourceInfo) *core.Snapsh
 }
 ```
 
-**Pass 1** is tried first whenever `VolumeUUID` is non-empty. It finds the most recent snapshot for this drive regardless of which machine performed it or where it was mounted. The `entries` slice is already sorted newest-first by `LoadSnapshotCatalog`, so the first match is the correct previous snapshot.
+**Pass 1** is tried first whenever `VolumeUUID` is non-empty. It finds the most recent snapshot for the same drive **and the same sub-directory** (by matching `Type + VolumeUUID + Path`). Because `Path` is stored relative to the volume mount point when a UUID is present (e.g. `"."` for the drive root, `"Photos"` for a sub-directory), this match works regardless of which machine performed the backup or where the drive was mounted. Users can independently back up different sub-directories of the same drive, and each sub-directory maintains its own snapshot lineage.
 
 **Pass 2** is the existing logic. It activates when:
 
@@ -259,11 +258,12 @@ When `VolumeLabel` is empty, fall back to the existing `account:path` display.
 ```go
 func NewLocalSource(rootPath string, opts ...LocalOption) *LocalSource {
     // ...
-    uuid, label := detectVolumeIdentity(rootPath) // platform helper
+    uuid, label, mountPoint := detectVolumeIdentity(rootPath) // platform helper
     return &LocalSource{
-        rootPath:    rootPath,
-        volumeUUID:  uuid,
-        volumeLabel: label,
+        rootPath:         rootPath,
+        volumeUUID:       uuid,
+        volumeLabel:      label,
+        volumeMountPoint: mountPoint,
         // ...
     }
 }
@@ -271,10 +271,26 @@ func NewLocalSource(rootPath string, opts ...LocalOption) *LocalSource {
 func (s *LocalSource) Info() core.SourceInfo {
     hostname, _ := os.Hostname()
     absPath, _  := filepath.Abs(s.rootPath)
+
+    // When volume UUID is present, store the path relative to the volume
+    // mount point. This makes path matching work across machines where
+    // mount points differ, and allows independent backups of different
+    // sub-directories on the same drive.
+    infoPath := absPath
+    if s.volumeUUID != "" && s.volumeMountPoint != "" {
+        realAbs, errA := filepath.EvalSymlinks(absPath)
+        realMount, errM := filepath.EvalSymlinks(s.volumeMountPoint)
+        if errA == nil && errM == nil {
+            if rel, err := filepath.Rel(realMount, realAbs); err == nil {
+                infoPath = filepath.ToSlash(rel)
+            }
+        }
+    }
+
     return core.SourceInfo{
         Type:        "local",
         Account:     hostname,
-        Path:        absPath,
+        Path:        infoPath,
         VolumeUUID:  s.volumeUUID,
         VolumeLabel: s.volumeLabel,
         FsType:      s.fsType, // RFC 0004
@@ -282,7 +298,9 @@ func (s *LocalSource) Info() core.SourceInfo {
 }
 ```
 
-`detectVolumeIdentity` is called once at construction, not on every `Info()` call.
+`detectVolumeIdentity` is called once at construction, not on every `Info()` call. It also returns the volume mount point, which is used to compute the relative path.
+
+The `volumeMountPoint` field stores the detected mount point (e.g. `/Volumes/MyDrive` on macOS, `/media/user/MyDrive` on Linux). Symlinks are resolved before computing the relative path (important on macOS where `/var` → `/private/var`).
 
 ### 2.7 Explicit override flag
 
@@ -320,15 +338,13 @@ When an explicit UUID is provided it takes precedence over the detected value.
 3. Populate both fields in `Info()`.
 4. Add `WithVolumeUUID(uuid string) LocalOption` for the explicit override.
 
-### `pkg/source/local_source_unix.go` *(extended from RFC 0004)*
+### `pkg/source/local_source_unix.go` → platform-specific files
 
-1. Add `func detectVolumeIdentity(path string) (uuid, label string)`:
-   * macOS: `getattrlist` with `ATTR_VOL_UUID | ATTR_VOL_NAME`.
-   * Linux: `deviceForPath` + `/dev/disk/by-uuid/` scan.
+Implemented as three separate files (one per platform):
 
-### `pkg/source/local_source_stub.go` *(extended from RFC 0004)*
-
-1. Stub `detectVolumeIdentity` returning `"", ""`.
+1. **`local_source_darwin.go`**: `detectVolumeIdentity` tries GPT partition UUID via `Statfs` + `diskutil info -plist`, falls back to `getattrlist(ATTR_VOL_UUID)`. Includes `extractPlistValue` XML parser.
+2. **`local_source_linux.go`**: `detectVolumeIdentity` tries `/dev/disk/by-partuuid/` (GPT), falls back to `/dev/disk/by-uuid/` (filesystem UUID).
+3. **`local_source_stub.go`**: Returns `"", ""` for unsupported platforms.
 
 ### `cmd/cloudstic/main.go`
 
@@ -337,9 +353,11 @@ When an explicit UUID is provided it takes precedence over the detected value.
 ### Tests
 
 1. `local_source_unix_test.go`: verify `detectVolumeIdentity` returns a non-empty UUID for a temp directory on the test runner's native filesystem; verify it is a valid UUID format.
-2. `backup_test.go`: unit test for `findPreviousSnapshot` UUID-first pass: create two mock snapshots for different machines with the same `VolumeUUID`; verify the most recent one is returned regardless of `Account`/`Path`.
+2. `backup_test.go`: unit test for `findPreviousSnapshot` UUID-first pass: create two mock snapshots for different machines with the same `VolumeUUID` and volume-relative `Path`; verify the most recent one is returned regardless of `Account`.
 3. `backup_test.go`: verify legacy fallback: snapshots without `VolumeUUID` are still found by `account+path`.
-4. `policy_test.go`: verify that two snapshots from different machines but same `VolumeUUID` are grouped together under the same retention key.
+4. `backup_test.go`: verify that two snapshots with the same `VolumeUUID` but different sub-directory paths (e.g. `"Photos"` vs `"Documents"`) do **not** match each other.
+5. `policy_test.go`: verify that two snapshots from different machines but same `VolumeUUID` and `Path` are grouped together under the same retention key.
+6. `policy_test.go`: verify that two snapshots with the same `VolumeUUID` but different `Path` values are in **separate** retention groups.
 
 ---
 
@@ -347,7 +365,9 @@ When an explicit UUID is provided it takes precedence over the detected value.
 
 ### fileID stability across machines
 
-`fileID` in the `local` source is the path relative to `rootPath`. For a portable drive mounted at `/Volumes/MyDrive` on macOS and `/media/user/MyDrive` on Linux, the **relative** paths are identical. A file at `/Volumes/MyDrive/Photos/img.jpg` has `fileID = Photos/img.jpg` on both machines. The HAMT lookup, change detection, and dedup all work correctly without any changes to `fileID` semantics.
+`fileID` in the `local` source is the path relative to `rootPath`, **normalized to forward slashes** (via `filepath.ToSlash`). For a portable drive mounted at `/Volumes/MyDrive` on macOS and `/media/user/MyDrive` on Linux, the relative paths are identical (`Photos/img.jpg`). On Windows, backslashes are converted to forward slashes before storage so the same file produces the same `fileID` regardless of OS. The HAMT lookup, change detection, and dedup all work correctly without any changes to `fileID` semantics.
+
+Similarly, the `Path` field in `SourceInfo` is stored as a **volume-relative path** (normalized to forward slashes) when `VolumeUUID` is set — e.g. `"."` for the drive root, `"Photos"` for a sub-directory. This ensures snapshot matching works across machines regardless of mount point. Without `VolumeUUID`, `Path` retains the absolute path for backward compatibility with non-portable sources.
 
 ### Concurrent access from multiple machines
 
@@ -364,6 +384,12 @@ Grouping all backups of a drive into one retention group means a retention polic
 ### UUID unavailability on non-standard filesystems
 
 `tmpfs`, `ramfs`, `procfs`, `sysfs`, and some network filesystems (NFS, SMB) do not have volume UUIDs. UUID detection returns empty, and the legacy `account+path` matching applies. This is correct: these are not portable drives.
+
+### Directories spanning multiple drives
+
+The volume UUID is determined once at source construction from the backup root path. If the backup directory contains mount points for other filesystems (e.g. `/data/external` is a separate partition mounted under `/data`), `filepath.Walk` crosses into those sub-mounts transparently — the files are included in the backup, but the volume UUID and mount-relative path reflect only the root path's filesystem. This is acceptable because backup and dedup operate on file content, not on volume boundaries. However, users should back up each portable drive as a separate source rather than backing up a parent directory that spans multiple drives, since the volume identity would not accurately represent the sub-mounted volumes.
+
+Symlinks to other volumes are **not followed** by `filepath.Walk` (which uses `os.Lstat`). Only direct mount points within the directory tree are traversed.
 
 ### VM disk images and `dd` copies
 


### PR DESCRIPTION
## Summary
Implement portable drive identity foundations from RFC 0005 across local source handling and policy/grouping paths.

## What Changes
- Local source identity detection improvements (UUID/label/mount context).
- Engine and policy updates to use stable source identity fields.
- E2E and source tests for portability behavior.
- RFC updates to align proposal and implementation.

## Tracking
- Story / epic: #103
- RFC: `rfcs/0005-portable-drive-identity.md`
- Milestone: [RFC 0005: Portable drive identity](https://github.com/Cloudstic/cli/milestone/10)