### PR TITLE
feat: drive identity by name (RFC 0008)

### DIFF
--- a/cmd/cloudstic/cmd_backup.go
+++ b/cmd/cloudstic/cmd_backup.go
@@ -18,8 +18,6 @@ import (
 type backupArgs struct {
 	g                 *globalFlags
 	sourceURI         string
-	driveID           string
-	rootFolder        string
 	dryRun            bool
 	excludeFile       string
 	skipNativeFiles   bool
@@ -36,8 +34,7 @@ func parseBackupArgs() *backupArgs {
 	fs := flag.NewFlagSet("backup", flag.ExitOnError)
 	a := &backupArgs{}
 	a.g = addGlobalFlags(fs)
-	sourceURI := fs.String("source", envDefault("CLOUDSTIC_SOURCE", "gdrive"), "Source URI: local:<path>, sftp://[user@]host[:port]/<path>, gdrive[:<path>], gdrive-changes[:<path>], onedrive[:<path>], onedrive-changes[:<path>]")
-	driveID := fs.String("drive-id", envDefault("CLOUDSTIC_DRIVE_ID", ""), "Shared drive ID for gdrive source (omit for My Drive)")
+	sourceURI := fs.String("source", envDefault("CLOUDSTIC_SOURCE", "gdrive"), "Source URI: local:<path>, sftp://[user@]host[:port]/<path>, gdrive[://<Drive Name>][/<path>], gdrive-changes[://<Drive Name>][/<path>], onedrive[://<Drive Name>][/<path>], onedrive-changes[://<Drive Name>][/<path>]")
 	dryRun := fs.Bool("dry-run", false, "Scan source and report changes without writing to the store")
 	skipNativeFiles := fs.Bool("skip-native-files", false, "Exclude Google-native files (Docs, Sheets, Slides, etc.) from the backup")
 	excludeFile := fs.String("exclude-file", "", "Path to file with exclude patterns (one per line, gitignore syntax)")
@@ -50,8 +47,6 @@ func parseBackupArgs() *backupArgs {
 	fs.Var(&a.excludes, "exclude", "Exclude pattern (gitignore syntax, repeatable)")
 	mustParse(fs)
 	a.sourceURI = *sourceURI
-	a.driveID = *driveID
-	a.rootFolder = ""
 	a.dryRun = *dryRun
 	a.skipNativeFiles = *skipNativeFiles
 	a.excludeFile = *excludeFile
@@ -73,7 +68,7 @@ func (r *runner) runBackup() int {
 
 	ctx := context.Background()
 
-	src, err := initSource(ctx, a.sourceURI, a.driveID, a.rootFolder, a.skipNativeFiles, a.volumeUUID, a.googleCreds, a.googleTokenFile, a.onedriveClientID, a.onedriveTokenFile, a.g, excludePatterns)
+	src, err := initSource(ctx, a.sourceURI, a.skipNativeFiles, a.volumeUUID, a.googleCreds, a.googleTokenFile, a.onedriveClientID, a.onedriveTokenFile, a.g, excludePatterns)
 	if err != nil {
 		return r.fail("Failed to init source: %v", err)
 	}
@@ -145,7 +140,7 @@ func (r *runner) printBackupSummary(res *engine.RunResult) {
 	}
 }
 
-func initSource(ctx context.Context, sourceURI, driveID, rootFolder string, skipNativeFiles bool, volumeUUID, googleCreds, googleTokenFile, onedriveClientID, onedriveTokenFile string, g *globalFlags, excludePatterns []string) (source.Source, error) {
+func initSource(ctx context.Context, sourceURI string, skipNativeFiles bool, volumeUUID, googleCreds, googleTokenFile, onedriveClientID, onedriveTokenFile string, g *globalFlags, excludePatterns []string) (source.Source, error) {
 	uri, err := parseSourceURI(sourceURI)
 	if err != nil {
 		return nil, err
@@ -170,7 +165,7 @@ func initSource(ctx context.Context, sourceURI, driveID, rootFolder string, skip
 		gdriveOpts := []source.GDriveOption{
 			source.WithCredsPath(googleCreds),
 			source.WithTokenPath(tokenPath),
-			source.WithDriveID(driveID),
+			source.WithDriveName(uri.host),
 			source.WithRootPath(uri.path),
 			source.WithGDriveExcludePatterns(excludePatterns),
 		}
@@ -186,7 +181,7 @@ func initSource(ctx context.Context, sourceURI, driveID, rootFolder string, skip
 		gdriveOpts := []source.GDriveOption{
 			source.WithCredsPath(googleCreds),
 			source.WithTokenPath(tokenPath),
-			source.WithDriveID(driveID),
+			source.WithDriveName(uri.host),
 			source.WithRootPath(uri.path),
 			source.WithGDriveExcludePatterns(excludePatterns),
 		}
@@ -202,6 +197,7 @@ func initSource(ctx context.Context, sourceURI, driveID, rootFolder string, skip
 		return source.NewOneDriveSource(ctx,
 			source.WithOneDriveClientID(onedriveClientID),
 			source.WithOneDriveTokenPath(tokenPath),
+			source.WithOneDriveDriveName(uri.host),
 			source.WithOneDriveRootPath(uri.path),
 			source.WithOneDriveExcludePatterns(excludePatterns),
 		)
@@ -213,6 +209,7 @@ func initSource(ctx context.Context, sourceURI, driveID, rootFolder string, skip
 		return source.NewOneDriveChangeSource(ctx,
 			source.WithOneDriveClientID(onedriveClientID),
 			source.WithOneDriveTokenPath(tokenPath),
+			source.WithOneDriveDriveName(uri.host),
 			source.WithOneDriveRootPath(uri.path),
 			source.WithOneDriveExcludePatterns(excludePatterns),
 		)

--- a/cmd/cloudstic/completion.go
+++ b/cmd/cloudstic/completion.go
@@ -53,7 +53,7 @@ _cloudstic() {
             -*)
                 # skip flags and their values
                 case "${words[i]}" in
-                    -store|-s3-endpoint|-s3-region|-s3-access-key|-s3-secret-key|-source-sftp-password|-source-sftp-key|-store-sftp-password|-store-sftp-key|-encryption-key|-password|-recovery-key|-kms-key-arn|-kms-region|-kms-endpoint|-source|-drive-id|-google-credentials|-google-token-file|-onedrive-client-id|-onedrive-token-file|-tag|-output|-keep-last|-keep-hourly|-keep-daily|-keep-weekly|-keep-monthly|-keep-yearly|-group-by|-account|-json)
+                    -store|-s3-endpoint|-s3-region|-s3-access-key|-s3-secret-key|-source-sftp-password|-source-sftp-key|-store-sftp-password|-store-sftp-key|-encryption-key|-password|-recovery-key|-kms-key-arn|-kms-region|-kms-endpoint|-source|-google-credentials|-google-token-file|-onedrive-client-id|-onedrive-token-file|-tag|-output|-keep-last|-keep-hourly|-keep-daily|-keep-weekly|-keep-monthly|-keep-yearly|-group-by|-account|-json)
                         ((i++)) ;;
                 esac
                 ;;
@@ -76,7 +76,7 @@ _cloudstic() {
         init)
             cmd_flags="-add-recovery-key -no-encryption -adopt-slots" ;;
         backup)
-            cmd_flags="-source -drive-id -skip-native-files -google-credentials -google-token-file -onedrive-client-id -onedrive-token-file -tag -dry-run" ;;
+            cmd_flags="-source -skip-native-files -google-credentials -google-token-file -onedrive-client-id -onedrive-token-file -tag -dry-run" ;;
         restore)
             cmd_flags="-output -dry-run" ;;
         prune)
@@ -199,7 +199,7 @@ _cloudstic() {
             -*)
                 # Skip flags with values
                 case "${words[i]}" in
-                    -store|-s3-endpoint|-s3-region|-s3-access-key|-s3-secret-key|-source-sftp-password|-source-sftp-key|-store-sftp-password|-store-sftp-key|-encryption-key|-password|-recovery-key|-kms-key-arn|-kms-region|-kms-endpoint|-source|-drive-id|-google-credentials|-google-token-file|-onedrive-client-id|-onedrive-token-file|-tag|-output|-keep-last|-keep-hourly|-keep-daily|-keep-weekly|-keep-monthly|-keep-yearly|-group-by|-account)
+                    -store|-s3-endpoint|-s3-region|-s3-access-key|-s3-secret-key|-source-sftp-password|-source-sftp-key|-store-sftp-password|-store-sftp-key|-encryption-key|-password|-recovery-key|-kms-key-arn|-kms-region|-kms-endpoint|-source|-google-credentials|-google-token-file|-onedrive-client-id|-onedrive-token-file|-tag|-output|-keep-last|-keep-hourly|-keep-daily|-keep-weekly|-keep-monthly|-keep-yearly|-group-by|-account)
                         (( i++ )) ;;
                 esac
                 ;;
@@ -227,7 +227,6 @@ _cloudstic() {
         backup)
             _arguments $global_flags \
                 '-source[Source URI]:uri:(local: sftp:// gdrive gdrive-changes onedrive onedrive-changes)' \
-                '-drive-id[Shared drive ID]:id:' \
                 '-skip-native-files[Exclude Google-native files]' \
                 '-google-credentials[Google service account credentials JSON]:path:_files' \
                 '-google-token-file[Google OAuth token file]:path:_files' \
@@ -377,7 +376,6 @@ complete -c cloudstic -n '__fish_seen_subcommand_from init' -l adopt-slots -d 'A
 
 # backup
 complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l source -x -a 'local: sftp:// gdrive gdrive-changes onedrive onedrive-changes' -d 'Source URI'
-complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l drive-id -x -d 'Shared drive ID'
 complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l skip-native-files -d 'Exclude Google-native files'
 complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l google-credentials -r -F -d 'Google service account credentials JSON'
 complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l google-token-file -r -F -d 'Google OAuth token file'

--- a/cmd/cloudstic/store.go
+++ b/cmd/cloudstic/store.go
@@ -328,6 +328,20 @@ func parseSourceURI(raw string) (*sourceURIParts, error) {
 			}
 			return &sourceURIParts{scheme: "local", path: rest}, nil
 		case "gdrive", "gdrive-changes", "onedrive", "onedrive-changes":
+			if strings.HasPrefix(rest, "//") {
+				// Format: scheme://Drive Name/path
+				rest = rest[2:]
+				idx := strings.IndexByte(rest, '/')
+				driveName := ""
+				path := "/"
+				if idx >= 0 {
+					driveName = rest[:idx]
+					path = ensureLeadingSlash(rest[idx:])
+				} else {
+					driveName = rest
+				}
+				return &sourceURIParts{scheme: scheme, host: driveName, path: path}, nil
+			}
 			return &sourceURIParts{scheme: scheme, path: ensureLeadingSlash(rest)}, nil
 		default:
 			return nil, fmt.Errorf("unknown source scheme %q in %q: supported URI formats are local:<path> and sftp://[user@]host[:port]/<path>", scheme, raw)

--- a/cmd/cloudstic/store_test.go
+++ b/cmd/cloudstic/store_test.go
@@ -95,6 +95,10 @@ func TestParseSourceURI(t *testing.T) {
 		{raw: "gdrive:/some/path", want: sourceURIParts{scheme: "gdrive", path: "/some/path"}},
 		{raw: "gdrive:some/path", want: sourceURIParts{scheme: "gdrive", path: "/some/path"}},
 		{raw: "onedrive:/documents", want: sourceURIParts{scheme: "onedrive", path: "/documents"}},
+		{raw: "gdrive://My Shared Drive/some/path", want: sourceURIParts{scheme: "gdrive", host: "My Shared Drive", path: "/some/path"}},
+		{raw: "gdrive-changes://Company Data/finance", want: sourceURIParts{scheme: "gdrive-changes", host: "Company Data", path: "/finance"}},
+		{raw: "onedrive://Personal/documents", want: sourceURIParts{scheme: "onedrive", host: "Personal", path: "/documents"}},
+		{raw: "onedrive-changes://Shared/photos", want: sourceURIParts{scheme: "onedrive-changes", host: "Shared", path: "/photos"}},
 
 		// invalid
 		{raw: "sftp", wantErr: true},

--- a/cmd/cloudstic/usage.go
+++ b/cmd/cloudstic/usage.go
@@ -108,8 +108,7 @@ func printUsage() {
 
 	t.Command("backup", "")
 	t.Flags([][2]string{
-		{"-source <uri>", ui.Env("Source URI: local:<path>, sftp://[user@]host[:port]/<path>, gdrive, gdrive-changes, onedrive, onedrive-changes", "CLOUDSTIC_SOURCE")},
-		{"-drive-id <id>", "Shared drive ID for gdrive (omit for My Drive)"},
+		{"-source <uri>", ui.Env("Source URI: local:<path>, sftp://[user@]host[:port]/<path>, gdrive[://<Drive Name>][/<path>], gdrive-changes[://<Drive Name>][/<path>], onedrive[://<Drive Name>][/<path>], onedrive-changes[://<Drive Name>][/<path>]", "CLOUDSTIC_SOURCE")},
 		{"-skip-native-files", "Exclude Google-native files (Docs, Sheets, Slides, etc.)"},
 		{"-google-credentials <path>", ui.Env("Path to Google service account credentials JSON", "GOOGLE_APPLICATION_CREDENTIALS")},
 		{"-google-token-file <path>", ui.Env("Path to Google OAuth token file", "GOOGLE_TOKEN_FILE")},

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -128,7 +128,7 @@ Walks the remote directory tree via SFTP. Supports password, SSH private key, an
 | **SourceInfo.Account** | Google account email |
 | **SourceInfo.Path** | `my-drive://` or `<driveID>://<rootFolderID>` |
 
-Lists all files and folders via `files.list`, then topologically sorts folders so parents are emitted before children. Supports My Drive and Shared Drives (via `-drive-id`), with optional folder scoping (via `gdrive:/path/to/folder`).
+Lists all files and folders via `files.list`, then topologically sorts folders so parents are emitted before children. Supports My Drive and Shared Drives (via `gdrive://<Drive Name>`), with optional folder scoping (via `gdrive://<Drive Name>/path/to/folder`).
 
 ### `gdrive-changes` — Google Drive (Changes API)
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -31,9 +31,9 @@ Cloudstic is a content-addressable backup tool that creates encrypted, deduplica
   - [Local Directory](#local-directory)
   - [SFTP](#sftp-source)
   - [Google Drive](#google-drive)
-  - [Google Drive (Changes API)](#google-drive-changes-api)
+  - [Google Drive (Incremental)](#google-drive-incremental)
   - [OneDrive](#onedrive)
-  - [OneDrive (Changes API)](#onedrive-changes-api)
+  - [OneDrive (Incremental)](#onedrive-incremental)
 - [Storage Backends](#storage-backends)
   - [Local](#local-storage)
   - [Amazon S3](#amazon-s3)
@@ -252,7 +252,7 @@ cloudstic backup -source local:~/Documents
 cloudstic backup -source gdrive
 
 # Back up a specific Google Drive shared drive and folder
-cloudstic backup -source gdrive:/path/to/folder -drive-id <shared-drive-id>
+cloudstic backup -source "gdrive://Company Data/path/to/folder"
 
 # Back up with tags
 cloudstic backup -source local:~/Documents -tag daily -tag important
@@ -268,8 +268,7 @@ cloudstic backup -source local:~/Documents -dry-run
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `-source` | `gdrive` | Source type: `local:<path>`, `sftp://[user@]host[:port]/<path>`, `gdrive[:<path>]`, `gdrive-changes[:<path>]`, `onedrive[:<path>]`, `onedrive-changes[:<path>]` |
-| `-drive-id` | | Shared drive ID for Google Drive (omit for My Drive) |
+| `-source` | `gdrive` | Source type: `local:<path>`, `sftp://[user@]host[:port]/<path>`, `gdrive[://<Drive Name>][/<path>]`, `gdrive-changes[://<Drive Name>][/<path>]`, `onedrive[://<Drive Name>][/<path>]`, `onedrive-changes[://<Drive Name>][/<path>]` |
 | `-tag` | | Tag to apply to the snapshot (repeatable) |
 | `-exclude` | | Exclude pattern using gitignore syntax (repeatable) |
 | `-exclude-file` | | Path to file containing exclude patterns, one per line |
@@ -812,9 +811,9 @@ A **source** is where Cloudstic reads files from during a backup. Each source ty
 | [Local directory](#local-directory) | `local` | Files on your local filesystem | None |
 | [SFTP](#sftp-source) | `sftp` | Files on a remote SFTP server | Password, SSH key, or ssh-agent |
 | [Google Drive](#google-drive) | `gdrive` | Full scan of Google Drive (My Drive or Shared Drive) | Automatic (browser) |
-| [Google Drive (Changes API)](#google-drive-changes-api) | `gdrive-changes` | Incremental changes since last backup (recommended for Google Drive) | Automatic (browser) |
+| [Google Drive (Incremental)](#google-drive-incremental) | `gdrive-changes` | Incremental changes since last backup (recommended for Google Drive) | Automatic (browser) |
 | [OneDrive](#onedrive) | `onedrive` | Full scan of Microsoft OneDrive | Automatic (browser) |
-| [OneDrive (Changes API)](#onedrive-changes-api) | `onedrive-changes` | Incremental changes since last backup (recommended for OneDrive) | Automatic (browser) |
+| [OneDrive (Incremental)](#onedrive-incremental) | `onedrive-changes` | Incremental changes since last backup (recommended for OneDrive) | Automatic (browser) |
 
 All sources produce the same snapshot format. You can back up different sources into the same repository, and snapshots are tagged with source metadata so retention policies can be applied per-source.
 
@@ -917,7 +916,7 @@ The `-exclude` and `-exclude-file` flags work with SFTP sources. See [Exclude pa
 
 Full scan of a Google Drive account. On each backup, Cloudstic lists every file and folder, compares metadata against the previous snapshot, and uploads anything new or changed.
 
-> **Note:** For routine backups, prefer [`gdrive-changes`](#google-drive-changes-api) instead — it is significantly faster and makes far fewer API requests.
+> **Note:** For routine backups, prefer [`gdrive-changes`](#google-drive-incremental) instead — it is significantly faster and makes far fewer API requests.
 
 **When to use:** First backup of a Google Drive, or when you want a guaranteed complete rescan (e.g. after recovering from an error).
 
@@ -930,15 +929,11 @@ No configuration is required — Cloudstic ships with built-in OAuth credentials
 cloudstic backup -source gdrive:/
 
 # Back up a shared drive
-cloudstic backup -source gdrive:/ -drive-id <shared-drive-id>
+cloudstic backup -source "gdrive://Company Data"
 
 # Back up only a specific folder
-cloudstic backup -source gdrive:/path/to/folder
+cloudstic backup -source "gdrive://Company Data/path/to/folder"
 ```
-
-| Flag | Description |
-|------|-------------|
-| `-drive-id` | Shared Drive ID (omit for personal My Drive) |
 
 **Environment variables (optional overrides):**
 
@@ -947,7 +942,7 @@ cloudstic backup -source gdrive:/path/to/folder
 | `GOOGLE_APPLICATION_CREDENTIALS` | Path to your own Google OAuth credentials JSON file (overrides built-in credentials) |
 | `GOOGLE_TOKEN_FILE` | Override token cache path (default: `<config-dir>/google_token.json`) |
 
-### Google Drive (Changes API)
+### Google Drive (Incremental)
 
 **This is the recommended way to back up Google Drive.** Uses the Google Drive Changes API to fetch only files that changed since the last backup, rather than listing every file on the drive. This dramatically reduces both backup duration and the number of API requests — a drive with 100,000 files but 50 daily changes only needs to process those 50 files instead of listing all 100,000.
 
@@ -963,7 +958,7 @@ cloudstic backup -source gdrive-changes
 cloudstic backup -source gdrive-changes
 ```
 
-Uses the same authentication and flags as [Google Drive](#google-drive) (`-drive-id`). No setup required — just run the command and authorize in the browser.
+Uses the same authentication and flags as [Google Drive](#google-drive). No setup required — just run the command and authorize in the browser.
 
 > **Tip:** You can use `-source gdrive-changes` from day one — the first run performs a full scan just like `gdrive`. Only fall back to `-source gdrive` if you need to force a complete rescan.
 
@@ -1002,7 +997,7 @@ No client secret is needed — Cloudstic uses the public client flow with PKCE.
 | `ONEDRIVE_CLIENT_ID` | Azure app client ID (overrides built-in credentials) |
 | `ONEDRIVE_TOKEN_FILE` | Override token cache path (default: `<config-dir>/onedrive_token.json`) |
 
-### OneDrive (Changes API)
+### OneDrive (Incremental)
 
 **This is the recommended way to back up OneDrive.** Uses the Microsoft Graph delta API to fetch only files that changed since the last backup, rather than listing every file on the drive. This dramatically reduces both backup duration and the number of API requests.
 
@@ -1263,10 +1258,9 @@ cloudstic forget -keep-daily 7 -keep-monthly 12 -dry-run
 | `AWS_SECRET_ACCESS_KEY` | `-s3-secret-key` | S3 Secret Access Key |
 | `CLOUDSTIC_STORE_SFTP_PASSWORD` | `-store-sftp-password` | SFTP password for the store |
 | `CLOUDSTIC_STORE_SFTP_KEY` | `-store-sftp-key` | Path to SSH private key for the store |
-| `CLOUDSTIC_SOURCE` | `-source` | Source URI: `local:<path>`, `sftp://[user@]host[:port]/<path>`, `gdrive[:<path>]`, `gdrive-changes[:<path>]`, `onedrive[:<path>]`, `onedrive-changes[:<path>]` |
+| `CLOUDSTIC_SOURCE` | `-source` | Source URI: `local:<path>`, `sftp://[user@]host[:port]/<path>`, `gdrive[://<Drive Name>][/<path>]`, `gdrive-changes[://<Drive Name>][/<path>]`, `onedrive[://<Drive Name>][/<path>]`, `onedrive-changes[://<Drive Name>][/<path>]` |
 | `CLOUDSTIC_SOURCE_SFTP_PASSWORD` | `-source-sftp-password` | SFTP password for the source |
 | `CLOUDSTIC_SOURCE_SFTP_KEY` | `-source-sftp-key` | Path to SSH private key for the source |
-| `CLOUDSTIC_DRIVE_ID` | `-drive-id` | Shared drive ID for Google Drive |
 | `CLOUDSTIC_ENCRYPTION_KEY` | `-encryption-key` | Platform key (hex) |
 | `CLOUDSTIC_PASSWORD` | `-password` | Encryption password |
 | `CLOUDSTIC_RECOVERY_KEY` | `-recovery-key` | Recovery seed phrase |

--- a/pkg/source/gdrive.go
+++ b/pkg/source/gdrive.go
@@ -26,6 +26,7 @@ type gDriveOptions struct {
 	credsPath       string
 	tokenPath       string
 	driveID         string
+	driveName       string
 	rootFolderID    string
 	rootPath        string
 	accountEmail    string
@@ -55,6 +56,15 @@ func WithCredsPath(path string) GDriveOption {
 func WithTokenPath(path string) GDriveOption {
 	return func(o *gDriveOptions) {
 		o.tokenPath = path
+	}
+}
+
+// WithDriveName sets the shared drive name to use. It will be resolved to a Drive ID.
+func WithDriveName(name string) GDriveOption {
+	return func(o *gDriveOptions) {
+		if name != "" {
+			o.driveName = name
+		}
 	}
 }
 
@@ -170,18 +180,43 @@ func NewGDriveSource(ctx context.Context, opts ...GDriveOption) (*GDriveSource, 
 		}
 	}
 
+	if cfg.driveName != "" && cfg.driveID == "" {
+		// Try to see if the provided name is actually an ID
+		if d, err := srv.Drives.Get(cfg.driveName).Fields("id, name").Do(); err == nil {
+			cfg.driveID = d.Id
+			cfg.driveName = d.Name
+		} else {
+			// Search by name
+			query := fmt.Sprintf("name = '%s'", strings.ReplaceAll(cfg.driveName, "'", "\\'"))
+			call := srv.Drives.List().Q(query).Fields("drives(id, name)").Context(ctx)
+			r, err := driveCallWithRetry(ctx, func() (*drive.DriveList, error) { return call.Do() })
+			if err != nil {
+				return nil, fmt.Errorf("resolve drive %q: %w", cfg.driveName, err)
+			}
+			if len(r.Drives) == 0 {
+				return nil, fmt.Errorf("shared drive %q not found", cfg.driveName)
+			}
+			if len(r.Drives) > 1 {
+				return nil, fmt.Errorf("ambiguous shared drive name: multiple drives named %q found", cfg.driveName)
+			}
+			cfg.driveID = r.Drives[0].Id
+			cfg.driveName = r.Drives[0].Name
+		}
+	}
+
 	src := &GDriveSource{
 		service:         srv,
 		driveID:         cfg.driveID,
 		rootFolderID:    cfg.rootFolderID,
 		rootPath:        cfg.rootPath,
 		account:         cfg.accountEmail,
+		driveName:       cfg.driveName,
 		exclude:         NewExcludeMatcher(cfg.excludePatterns),
 		skipNativeFiles: cfg.skipNativeFiles,
 	}
 
-	// Resolve the shared drive name for VolumeLabel.
-	if cfg.driveID != "" {
+	// Resolve the shared drive name for VolumeLabel if driveID was set directly
+	if cfg.driveID != "" && src.driveName == "" {
 		if d, err := srv.Drives.Get(cfg.driveID).Fields("name").Do(); err == nil {
 			src.driveName = d.Name
 		}

--- a/pkg/source/onedrive.go
+++ b/pkg/source/onedrive.go
@@ -20,6 +20,7 @@ import (
 type oneDriveOptions struct {
 	clientID        string
 	tokenPath       string
+	driveName       string
 	rootPath        string
 	excludePatterns []string
 }
@@ -31,6 +32,13 @@ type OneDriveOption func(*oneDriveOptions)
 func WithOneDriveClientID(id string) OneDriveOption {
 	return func(o *oneDriveOptions) {
 		o.clientID = id
+	}
+}
+
+// WithOneDriveDriveName sets the shared drive name.
+func WithOneDriveDriveName(name string) OneDriveOption {
+	return func(o *oneDriveOptions) {
+		o.driveName = name
 	}
 }
 
@@ -56,10 +64,12 @@ func WithOneDriveExcludePatterns(patterns []string) OneDriveOption {
 }
 
 type OneDriveSource struct {
-	client   *http.Client
-	account  string // cached user principal name; populated lazily by Info()
-	rootPath string // The string path the user specified, or "/"
-	exclude  *ExcludeMatcher
+	client    *http.Client
+	account   string // cached user principal name; populated lazily by Info()
+	driveID   string // The resolved Drive ID
+	driveName string // The Drive Name (from config)
+	rootPath  string // The string path the user specified, or "/"
+	exclude   *ExcludeMatcher
 }
 
 // NewOneDriveSource creates a new OneDriveSource from the given config.
@@ -95,19 +105,109 @@ func NewOneDriveSource(ctx context.Context, opts ...OneDriveOption) (*OneDriveSo
 	if rootPath == "" {
 		rootPath = "/"
 	}
-	return &OneDriveSource{client: client, rootPath: rootPath, exclude: NewExcludeMatcher(cfg.excludePatterns)}, nil
+	src := &OneDriveSource{
+		client:    client,
+		driveName: cfg.driveName,
+		rootPath:  rootPath,
+		exclude:   NewExcludeMatcher(cfg.excludePatterns),
+	}
+
+	if src.driveName != "" {
+		err = src.resolveDriveName(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return src, nil
+}
+
+func (s *OneDriveSource) resolveDriveName(ctx context.Context) error {
+	// Try fetching by ID first
+	req, err := http.NewRequestWithContext(ctx, "GET", "https://graph.microsoft.com/v1.0/drives/"+s.driveName+"?$select=id,name", nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	resp, err := s.client.Do(req)
+	if err == nil {
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode == http.StatusOK {
+			var drive struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			}
+			if err := json.NewDecoder(resp.Body).Decode(&drive); err == nil {
+				s.driveID = drive.ID
+				s.driveName = drive.Name
+				return nil
+			}
+		}
+	}
+
+	// Fetch all drives and find by name
+	req, err = http.NewRequestWithContext(ctx, "GET", "https://graph.microsoft.com/v1.0/me/drives?$select=id,name", nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	resp, err = s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("list drives: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("list drives returned status %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Value []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"value"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("decode drives: %w", err)
+	}
+
+	var matchedID string
+	var matchedName string
+	matches := 0
+	for _, d := range result.Value {
+		if d.Name == s.driveName {
+			matchedID = d.ID
+			matchedName = d.Name
+			matches++
+		}
+	}
+
+	if matches == 0 {
+		return fmt.Errorf("drive %q not found", s.driveName)
+	}
+	if matches > 1 {
+		return fmt.Errorf("ambiguous drive name: multiple drives named %q found", s.driveName)
+	}
+
+	s.driveID = matchedID
+	s.driveName = matchedName
+	return nil
 }
 
 func (s *OneDriveSource) Info() core.SourceInfo {
 	if s.account == "" {
 		s.account = s.fetchAccount()
 	}
-	return core.SourceInfo{
-		Type:        "onedrive",
-		Account:     s.account,
-		Path:        s.rootPath,
-		VolumeLabel: "My Drive",
+	info := core.SourceInfo{
+		Type:    "onedrive",
+		Account: s.account,
+		Path:    s.rootPath,
 	}
+	if s.driveID != "" {
+		info.VolumeUUID = s.driveID
+		info.VolumeLabel = s.driveName
+	} else {
+		info.VolumeLabel = "My Drive"
+	}
+	return info
 }
 
 func (s *OneDriveSource) fetchAccount() string {
@@ -231,13 +331,19 @@ func (s *OneDriveSource) toFileMeta(item graphItem) core.FileMeta {
 	}
 }
 
-func (s *OneDriveSource) Walk(ctx context.Context, callback func(core.FileMeta) error) error {
-	rootURL := "https://graph.microsoft.com/v1.0/me/drive/root"
-	if s.rootPath != "" && s.rootPath != "/" {
-		// Graph API allows addressing items by path relative to root
-		// e.g. /me/drive/root:/path/to/folder
-		rootURL = fmt.Sprintf("https://graph.microsoft.com/v1.0/me/drive/root:%s", s.rootPath)
+func (s *OneDriveSource) getRootURL() string {
+	base := "https://graph.microsoft.com/v1.0/me/drive/root"
+	if s.driveID != "" {
+		base = fmt.Sprintf("https://graph.microsoft.com/v1.0/drives/%s/root", s.driveID)
 	}
+	if s.rootPath != "" && s.rootPath != "/" {
+		return fmt.Sprintf("%s:%s", base, s.rootPath)
+	}
+	return base
+}
+
+func (s *OneDriveSource) Walk(ctx context.Context, callback func(core.FileMeta) error) error {
+	rootURL := s.getRootURL()
 
 	var rootItem graphItem
 	err := retry.Do(ctx, retry.DefaultPolicy(), func() error {

--- a/pkg/source/onedrive_changes.go
+++ b/pkg/source/onedrive_changes.go
@@ -36,9 +36,11 @@ func (s *OneDriveChangeSource) Info() core.SourceInfo {
 // GetStartPageToken returns the current head of the OneDrive delta stream by
 // requesting a "latest" delta token. The returned string is a full deltaLink URL.
 func (s *OneDriveChangeSource) GetStartPageToken() (string, error) {
-	url := "https://graph.microsoft.com/v1.0/me/drive/root/delta?token=latest"
+	url := s.getRootURL()
 	if s.rootPath != "" && s.rootPath != "/" {
-		url = fmt.Sprintf("https://graph.microsoft.com/v1.0/me/drive/root:%s:/delta?token=latest", s.rootPath)
+		url += ":/delta?token=latest"
+	} else {
+		url += "/delta?token=latest"
 	}
 	resp, err := s.fetchDeltaPage(context.Background(), url)
 	if err != nil {

--- a/rfcs/0007-cloud-subdirectory-backup.md
+++ b/rfcs/0007-cloud-subdirectory-backup.md
@@ -1,6 +1,6 @@
 # RFC 0007: Cloud Subdirectory Backup
 
-- **Status:** Adopted
+- **Status:** Implemented
 - **Date:** 2026-03-14
 
 ## Abstract

--- a/rfcs/0008-drive-identity-by-name.md
+++ b/rfcs/0008-drive-identity-by-name.md
@@ -1,0 +1,48 @@
+# RFC 0008: Drive Identity by Name
+
+- **Status:** Implemented
+- **Date:** 2026-03-14
+
+## Abstract
+
+This RFC proposes the removal of the `-drive-id` command-line flag for Google Drive backups in favor of specifying the Shared Drive name directly in the source URI (e.g., `gdrive://<Drive Name>`). This change also aligns OneDrive sources to use the same URI convention for selecting specific drives.
+
+## Context
+
+Previously, users had to supply a `-drive-id` flag alongside their source definition to target a Google Drive Shared Drive (e.g., `cloudstic backup -source gdrive:/folder -drive-id <ID>`).
+
+This approach suffered from several usability issues:
+
+1. **Opaque IDs:** Shared Drive IDs are long, abstract strings that users must manually locate in the web browser URL.
+2. **Inconsistency:** The `--root-folder` option was recently removed in RFC 0007 in favor of path-based URI configuration (`gdrive:/folder`). The `-drive-id` flag remained an outlier.
+3. **No OneDrive Equivalent:** For OneDrive, there was no intuitive way to specify alternate drives via the CLI in a consistent manner.
+
+## Proposal
+
+### 1. URI Syntax Enhancement
+
+We extend the `-source` flag to accept a Drive Name as the host component of the URI for cloud sources.
+
+- `gdrive://Company Data/Finance` (Backs up the `/Finance` folder within the "Company Data" Shared Drive)
+- `onedrive-changes://Personal/Photos` (Backs up the `/Photos` folder within the "Personal" OneDrive drive)
+- `gdrive:/Documents` (If no host/drive name is provided, it continues to default to "My Drive")
+
+### 2. Deprecation of `-drive-id`
+
+The `-drive-id` CLI flag is completely removed from the `backup` command and autocomplete scripts. Internally, the client library options (`WithDriveID` for Google Drive) are retained, but the CLI relies entirely on the newly introduced `WithDriveName` options.
+
+### 3. API Translation
+
+The provided Drive Name is resolved to an internal ID dynamically at initialization:
+
+- **Google Drive**:
+  - The CLI first attempts a direct `Drives.Get` lookup in case the provided string is actually a valid Drive ID.
+  - If that fails, it performs a `Drives.List` query with a filter (`name = 'Drive Name'`) to resolve the ID.
+- **OneDrive**:
+  - The CLI attempts a direct lookup using `https://graph.microsoft.com/v1.0/drives/<Drive Name>`.
+  - If that fails, it fetches all available drives (`/me/drives`) and matches the provided name locally to extract the Drive ID.
+
+## Trade-offs
+
+- **Name Ambiguity**: Unlike IDs, Drive names are not inherently unique. If multiple drives have the identical name, the tool will throw an ambiguity error, forcing the user to rename the drive or (if calling the library programmatically) use the ID directly.
+- **Additional API Calls**: Resolving the drive name requires an extra API call during the initialization phase of the backup. Given this only occurs once per run, the performance impact is negligible.

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -12,6 +12,9 @@ echo "==> Running golangci-lint..."
 # Note: assumes golangci-lint is installed locally
 golangci-lint run ./...
 
+echo "==> Running markdownlint..."
+npx markdownlint-cli2 "**/*.md" 2>/dev/null
+
 echo "==> Running go test..."
 go test -v -race -coverprofile=coverage.out -count=1 ./...
 


### PR DESCRIPTION
## Summary
Implement RFC 0008 by enabling drive selection and identity resolution by name for cloud sources.

## What Changes
- Update backup/source parsing and source initialization paths for drive-name-based selection.
- Improve Google Drive and OneDrive drive resolution behavior.
- Update CLI/help/completion and docs for the new drive identity behavior.
- Add RFC and related docs updates:
  - `rfcs/0008-drive-identity-by-name.md`
  - `docs/user-guide.md`
  - `docs/sources.md`

## Behavior Notes
- Users can target drives by human-readable name where supported.
- Resolution errors are clearer for missing/ambiguous names.

## Testing
- Includes source and CLI test updates covering drive-name handling paths.

## Tracking
- Story / epic: #97
- RFC: `rfcs/0008-drive-identity-by-name.md`
- Milestone: [RFC 0008: Drive identity by name](https://github.com/Cloudstic/cli/milestone/5)