### PR TITLE
feat: backup profiles (RFC 0010)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,26 @@ cloudstic restore
 cloudstic backup -source local:~/Documents -dry-run
 ```
 
+## Profiles
+
+Save your backup configuration once and reuse it:
+
+```bash
+# Create a store (interactive — prompts for encryption setup)
+cloudstic store new -name my-s3 -uri s3:my-bucket/backups -s3-region us-east-1
+
+# Create a profile
+cloudstic profile new -name documents -source local:~/Documents -store-ref my-s3
+
+# Now backups are one command
+cloudstic backup -profile documents
+
+# Or back up all profiles at once
+cloudstic backup -all-profiles
+```
+
+See the [User Guide — Profiles](docs/user-guide.md#profile) for details.
+
 When running interactively, Cloudstic prompts for the repository password if no credential is provided via flags or environment variables. For non-interactive use (scripts, cron), pass `-password` or set `CLOUDSTIC_PASSWORD`:
 
 ```bash

--- a/client.go
+++ b/client.go
@@ -308,6 +308,10 @@ func (c *Client) Store() store.ObjectStore { return c.store }
 
 type BackupOption = engine.BackupOption
 type BackupResult = engine.RunResult
+type ProfilesConfig = engine.ProfilesConfig
+type ProfileStore = engine.ProfileStore
+type ProfileAuth = engine.ProfileAuth
+type BackupProfile = engine.BackupProfile
 
 var (
 	WithVerbose      = engine.WithVerbose
@@ -331,6 +335,16 @@ func (c *Client) Backup(ctx context.Context, src source.Source, opts ...BackupOp
 	result.BytesAddedRaw = rawMeter.BytesWritten()
 	result.BytesAddedStored = c.storedMeter.BytesWritten()
 	return result, nil
+}
+
+// LoadProfilesFile parses a backup profiles YAML file.
+func LoadProfilesFile(path string) (*ProfilesConfig, error) {
+	return engine.LoadProfilesFile(path)
+}
+
+// SaveProfilesFile writes a backup profiles YAML file.
+func SaveProfilesFile(path string, cfg *ProfilesConfig) error {
+	return engine.SaveProfilesFile(path, cfg)
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/cloudstic/cmd_auth.go
+++ b/cmd/cloudstic/cmd_auth.go
@@ -1,0 +1,321 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	cloudstic "github.com/cloudstic/cli"
+	"github.com/cloudstic/cli/internal/paths"
+)
+
+func (r *runner) runAuth() int {
+	if len(os.Args) < 3 {
+		_, _ = fmt.Fprintln(r.errOut, "Usage: cloudstic auth <subcommand> [options]")
+		_, _ = fmt.Fprintln(r.errOut, "")
+		_, _ = fmt.Fprintln(r.errOut, "Available subcommands: list, show, new, login")
+		return 1
+	}
+
+	switch os.Args[2] {
+	case "list":
+		return r.runAuthList()
+	case "show":
+		return r.runAuthShow()
+	case "new":
+		return r.runAuthNew()
+	case "login":
+		return r.runAuthLogin()
+	default:
+		return r.fail("Unknown auth subcommand: %s", os.Args[2])
+	}
+}
+
+func defaultProfilesPathFallback() string {
+	defaultPath, err := defaultProfilesPath()
+	if err != nil {
+		return defaultProfilesFilename
+	}
+	return defaultPath
+}
+
+func (r *runner) runAuthList() int {
+	fs := flag.NewFlagSet("auth list", flag.ExitOnError)
+	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
+	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
+
+	cfg, err := cloudstic.LoadProfilesFile(*profilesFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0
+		}
+		return r.fail("Failed to load profiles: %v", err)
+	}
+
+	names := make([]string, 0, len(cfg.Auth))
+	for name := range cfg.Auth {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	_, _ = fmt.Fprintf(r.out, "%d auth entries\n", len(names))
+	for _, name := range names {
+		auth := cfg.Auth[name]
+		_, _ = fmt.Fprintf(r.out, "- %s", name)
+		if auth.Provider != "" {
+			_, _ = fmt.Fprintf(r.out, "  provider=%s", auth.Provider)
+		}
+		if auth.Provider == "google" && auth.GoogleTokenFile != "" {
+			_, _ = fmt.Fprintf(r.out, "  token=%s", auth.GoogleTokenFile)
+		}
+		if auth.Provider == "onedrive" && auth.OneDriveTokenFile != "" {
+			_, _ = fmt.Fprintf(r.out, "  token=%s", auth.OneDriveTokenFile)
+		}
+		_, _ = fmt.Fprintln(r.out)
+	}
+	return 0
+}
+
+func (r *runner) runAuthShow() int {
+	fs := flag.NewFlagSet("auth show", flag.ExitOnError)
+	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
+	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
+	if fs.NArg() > 1 {
+		return r.fail("usage: cloudstic auth show [-profiles-file <path>] <name>")
+	}
+	name := ""
+	if fs.NArg() == 1 {
+		name = fs.Arg(0)
+	}
+
+	cfg, err := cloudstic.LoadProfilesFile(*profilesFile)
+	if err != nil {
+		return r.fail("Failed to load profiles: %v", err)
+	}
+	if name == "" {
+		if !r.canPrompt() {
+			return r.fail("usage: cloudstic auth show [-profiles-file <path>] <name>")
+		}
+		names := make([]string, 0, len(cfg.Auth))
+		for n := range cfg.Auth {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		picked, pickErr := r.promptSelect("Select auth entry", names)
+		if pickErr != nil {
+			return r.fail("Failed to select auth entry: %v", pickErr)
+		}
+		name = picked
+	}
+
+	auth, ok := cfg.Auth[name]
+	if !ok {
+		return r.fail("Unknown auth %q", name)
+	}
+
+	_, _ = fmt.Fprintf(r.out, "auth: %s\n", name)
+	_, _ = fmt.Fprintf(r.out, "  provider: %s\n", auth.Provider)
+	if auth.GoogleCreds != "" {
+		_, _ = fmt.Fprintf(r.out, "  google_credentials: %s\n", auth.GoogleCreds)
+	}
+	if auth.GoogleTokenFile != "" {
+		_, _ = fmt.Fprintf(r.out, "  google_token_file: %s\n", auth.GoogleTokenFile)
+	}
+	if auth.OneDriveClientID != "" {
+		_, _ = fmt.Fprintf(r.out, "  onedrive_client_id: %s\n", auth.OneDriveClientID)
+	}
+	if auth.OneDriveTokenFile != "" {
+		_, _ = fmt.Fprintf(r.out, "  onedrive_token_file: %s\n", auth.OneDriveTokenFile)
+	}
+	return 0
+}
+
+func (r *runner) runAuthNew() int {
+	fs := flag.NewFlagSet("auth new", flag.ExitOnError)
+	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
+	name := fs.String("name", "", "Auth reference name")
+	provider := fs.String("provider", "", "Auth provider: google|onedrive")
+	googleCreds := fs.String("google-credentials", "", "Path to Google service account credentials JSON file")
+	googleTokenFile := fs.String("google-token-file", "", "Path to Google OAuth token file")
+	onedriveClientID := fs.String("onedrive-client-id", "", "OneDrive OAuth client ID")
+	onedriveTokenFile := fs.String("onedrive-token-file", "", "Path to OneDrive OAuth token file")
+	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
+
+	if *name == "" {
+		if r.canPrompt() {
+			v, err := r.promptLine("Auth reference name", "")
+			if err != nil {
+				return r.fail("Failed to read auth reference name: %v", err)
+			}
+			*name = v
+		}
+		if *name == "" {
+			return r.fail("-name is required")
+		}
+	}
+	if !validRefName.MatchString(*name) {
+		return r.fail("invalid auth name %q: must start with a letter or digit and contain only letters, digits, dots, hyphens, or underscores", *name)
+	}
+	if *provider != "google" && *provider != "onedrive" {
+		if r.canPrompt() {
+			picked, err := r.promptSelect("Select auth provider", []string{"google", "onedrive"})
+			if err != nil {
+				return r.fail("Failed to read auth provider: %v", err)
+			}
+			*provider = picked
+		}
+		if *provider != "google" && *provider != "onedrive" {
+			return r.fail("-provider must be 'google' or 'onedrive'")
+		}
+	}
+
+	auth := cloudstic.ProfileAuth{Provider: *provider}
+	if *provider == "google" {
+		if *googleTokenFile == "" {
+			if r.canPrompt() {
+				def := defaultAuthTokenPath("google", *name)
+				v, err := r.promptLine("Google token file path", def)
+				if err != nil {
+					return r.fail("Failed to read google token file path: %v", err)
+				}
+				*googleTokenFile = v
+			}
+			if *googleTokenFile == "" {
+				*googleTokenFile = defaultAuthTokenPath("google", *name)
+			}
+			if *googleTokenFile == "" {
+				return r.fail("-google-token-file is required for provider=google")
+			}
+		}
+		auth.GoogleCreds = *googleCreds
+		auth.GoogleTokenFile = *googleTokenFile
+	}
+	if *provider == "onedrive" {
+		if *onedriveTokenFile == "" {
+			if r.canPrompt() {
+				def := defaultAuthTokenPath("onedrive", *name)
+				v, err := r.promptLine("OneDrive token file path", def)
+				if err != nil {
+					return r.fail("Failed to read onedrive token file path: %v", err)
+				}
+				*onedriveTokenFile = v
+			}
+			if *onedriveTokenFile == "" {
+				*onedriveTokenFile = defaultAuthTokenPath("onedrive", *name)
+			}
+			if *onedriveTokenFile == "" {
+				return r.fail("-onedrive-token-file is required for provider=onedrive")
+			}
+		}
+		auth.OneDriveClientID = *onedriveClientID
+		auth.OneDriveTokenFile = *onedriveTokenFile
+	}
+
+	cfg, err := cloudstic.LoadProfilesFile(*profilesFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			cfg = &cloudstic.ProfilesConfig{Version: 1}
+		} else {
+			return r.fail("Failed to load profiles: %v", err)
+		}
+	}
+	if cfg.Auth == nil {
+		cfg.Auth = map[string]cloudstic.ProfileAuth{}
+	}
+	cfg.Auth[*name] = auth
+
+	if err := cloudstic.SaveProfilesFile(*profilesFile, cfg); err != nil {
+		return r.fail("Failed to save profiles: %v", err)
+	}
+	_, _ = fmt.Fprintf(r.out, "Auth %q saved in %s\n", *name, *profilesFile)
+	return 0
+}
+
+func (r *runner) runAuthLogin() int {
+	fs := flag.NewFlagSet("auth login", flag.ExitOnError)
+	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
+	name := fs.String("name", "", "Auth reference name")
+	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
+
+	cfg, err := cloudstic.LoadProfilesFile(*profilesFile)
+	if err != nil {
+		return r.fail("Failed to load profiles: %v", err)
+	}
+
+	if *name == "" {
+		if r.canPrompt() {
+			names := make([]string, 0, len(cfg.Auth))
+			for n := range cfg.Auth {
+				names = append(names, n)
+			}
+			sort.Strings(names)
+			picked, pickErr := r.promptSelect("Select auth entry", names)
+			if pickErr != nil {
+				return r.fail("Failed to select auth entry: %v", pickErr)
+			}
+			*name = picked
+		}
+		if *name == "" {
+			return r.fail("-name is required")
+		}
+	}
+
+	auth, ok := cfg.Auth[*name]
+	if !ok {
+		return r.fail("Unknown auth %q", *name)
+	}
+
+	g := newAuthGlobalFlags()
+	ctx := context.Background()
+
+	switch auth.Provider {
+	case "google":
+		googleCreds := auth.GoogleCreds
+		if googleCreds == "" {
+			googleCreds = os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
+		}
+		src, err := initSource(ctx, "gdrive:/", false, "", googleCreds, auth.GoogleTokenFile, "", "", g, nil)
+		if err != nil {
+			return r.fail("Failed to initialize Google auth source: %v", err)
+		}
+		_ = src.Info()
+	case "onedrive":
+		onedriveClientID := auth.OneDriveClientID
+		if onedriveClientID == "" {
+			onedriveClientID = os.Getenv("ONEDRIVE_CLIENT_ID")
+		}
+		src, err := initSource(ctx, "onedrive:/", false, "", "", "", onedriveClientID, auth.OneDriveTokenFile, g, nil)
+		if err != nil {
+			return r.fail("Failed to initialize OneDrive auth source: %v", err)
+		}
+		_ = src.Info()
+	default:
+		return r.fail("Unsupported auth provider %q", auth.Provider)
+	}
+
+	_, _ = fmt.Fprintf(r.out, "Auth %q is ready\n", *name)
+	return 0
+}
+
+func newAuthGlobalFlags() *globalFlags {
+	fs := flag.NewFlagSet("auth-login-flags", flag.ContinueOnError)
+	return addGlobalFlags(fs)
+}
+
+func defaultAuthTokenPath(provider, name string) string {
+	configDir, err := paths.ConfigDir()
+	if err != nil {
+		return ""
+	}
+	safeName := strings.ReplaceAll(strings.TrimSpace(name), " ", "-")
+	if safeName == "" {
+		safeName = "default"
+	}
+	file := fmt.Sprintf("%s-%s_token.json", provider, safeName)
+	return filepath.Join(configDir, "tokens", file)
+}

--- a/cmd/cloudstic/cmd_auth_test.go
+++ b/cmd/cloudstic/cmd_auth_test.go
@@ -1,0 +1,265 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunAuthNewAndListAndShow(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+
+	os.Args = []string{
+		"cloudstic", "auth", "new",
+		"-profiles-file", profilesPath,
+		"-name", "google-work",
+		"-provider", "google",
+		"-google-token-file", "/tmp/google-work.json",
+	}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+	if code := r.runAuth(); code != 0 {
+		t.Fatalf("auth new failed: %s", errOut.String())
+	}
+
+	os.Args = []string{"cloudstic", "auth", "list", "-profiles-file", profilesPath}
+	out.Reset()
+	errOut.Reset()
+	if code := r.runAuth(); code != 0 {
+		t.Fatalf("auth list failed: %s", errOut.String())
+	}
+	if !strings.Contains(out.String(), "1 auth entries") || !strings.Contains(out.String(), "google-work") {
+		t.Fatalf("unexpected auth list output:\n%s", out.String())
+	}
+
+	os.Args = []string{"cloudstic", "auth", "show", "-profiles-file", profilesPath, "google-work"}
+	out.Reset()
+	errOut.Reset()
+	if code := r.runAuth(); code != 0 {
+		t.Fatalf("auth show failed: %s", errOut.String())
+	}
+	if !strings.Contains(out.String(), "provider: google") || !strings.Contains(out.String(), "google_token_file: /tmp/google-work.json") {
+		t.Fatalf("unexpected auth show output:\n%s", out.String())
+	}
+}
+
+func TestRunAuth_NoSubcommand(t *testing.T) {
+	os.Args = []string{"cloudstic", "auth"}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+	if code := r.runAuth(); code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+	if !strings.Contains(errOut.String(), "Available subcommands") {
+		t.Fatalf("unexpected errOut:\n%s", errOut.String())
+	}
+}
+
+func TestRunAuth_UnknownSubcommand(t *testing.T) {
+	os.Args = []string{"cloudstic", "auth", "unknown"}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+	if code := r.runAuth(); code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+	if !strings.Contains(errOut.String(), "Unknown auth subcommand") {
+		t.Fatalf("unexpected errOut:\n%s", errOut.String())
+	}
+}
+
+func TestRunAuthNew_OneDriveProvider(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+
+	os.Args = []string{
+		"cloudstic", "auth", "new",
+		"-profiles-file", profilesPath,
+		"-name", "od-personal",
+		"-provider", "onedrive",
+		"-onedrive-token-file", "/tmp/od-personal.json",
+		"-onedrive-client-id", "my-client-id-123",
+	}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+	if code := r.runAuth(); code != 0 {
+		t.Fatalf("auth new failed: %s", errOut.String())
+	}
+
+	// Verify via show
+	os.Args = []string{"cloudstic", "auth", "show", "-profiles-file", profilesPath, "od-personal"}
+	out.Reset()
+	errOut.Reset()
+	if code := r.runAuth(); code != 0 {
+		t.Fatalf("auth show failed: %s", errOut.String())
+	}
+	got := out.String()
+	for _, want := range []string{"provider: onedrive", "onedrive_token_file: /tmp/od-personal.json", "onedrive_client_id: my-client-id-123"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in show output:\n%s", want, got)
+		}
+	}
+}
+
+func TestRunAuthNew_RequiresName(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+
+	os.Args = []string{"cloudstic", "auth", "new", "-profiles-file", profilesPath, "-provider", "google"}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut, noPrompt: true}
+	if code := r.runAuth(); code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+	if !strings.Contains(errOut.String(), "-name is required") {
+		t.Fatalf("unexpected errOut:\n%s", errOut.String())
+	}
+}
+
+func TestRunAuthNew_RequiresProvider(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+
+	os.Args = []string{"cloudstic", "auth", "new", "-profiles-file", profilesPath, "-name", "foo"}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut, noPrompt: true}
+	if code := r.runAuth(); code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+	if !strings.Contains(errOut.String(), "-provider must be") {
+		t.Fatalf("unexpected errOut:\n%s", errOut.String())
+	}
+}
+
+func TestRunAuthNew_InvalidName(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+
+	os.Args = []string{"cloudstic", "auth", "new", "-profiles-file", profilesPath, "-name", "bad name!", "-provider", "google"}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+	if code := r.runAuth(); code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+	if !strings.Contains(errOut.String(), "invalid auth name") {
+		t.Fatalf("unexpected errOut:\n%s", errOut.String())
+	}
+}
+
+func TestRunAuthShow_UnknownAuth(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+
+	// Create a profiles file with one auth entry so the file exists
+	os.Args = []string{
+		"cloudstic", "auth", "new",
+		"-profiles-file", profilesPath,
+		"-name", "existing",
+		"-provider", "google",
+		"-google-token-file", "/tmp/tok.json",
+	}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+	if code := r.runAuth(); code != 0 {
+		t.Fatalf("setup auth new failed: %s", errOut.String())
+	}
+
+	// Try to show a non-existent auth entry
+	os.Args = []string{"cloudstic", "auth", "show", "-profiles-file", profilesPath, "missing"}
+	out.Reset()
+	errOut.Reset()
+	if code := r.runAuth(); code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+	if !strings.Contains(errOut.String(), "Unknown auth") {
+		t.Fatalf("unexpected errOut:\n%s", errOut.String())
+	}
+}
+
+func TestRunAuthList_MissingFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "nonexistent.yaml")
+
+	os.Args = []string{"cloudstic", "auth", "list", "-profiles-file", profilesPath}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+	if code := r.runAuth(); code != 0 {
+		t.Fatalf("expected exit code 0, got %d; errOut: %s", code, errOut.String())
+	}
+}
+
+func TestDefaultAuthTokenPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("CLOUDSTIC_CONFIG_DIR", tmpDir)
+
+	got := defaultAuthTokenPath("google", "work")
+	want := filepath.Join("tokens", "google-work_token.json")
+	if !strings.HasSuffix(got, want) {
+		t.Fatalf("expected path ending with %q, got %q", want, got)
+	}
+
+	// Empty name should use "default"
+	got = defaultAuthTokenPath("google", "")
+	want = filepath.Join("tokens", "google-default_token.json")
+	if !strings.HasSuffix(got, want) {
+		t.Fatalf("expected path ending with %q, got %q", want, got)
+	}
+}
+
+func TestRunAuthNew_OneDriveDerivesTokenFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	t.Setenv("CLOUDSTIC_CONFIG_DIR", tmpDir)
+
+	os.Args = []string{
+		"cloudstic", "auth", "new",
+		"-profiles-file", profilesPath,
+		"-name", "od-work",
+		"-provider", "onedrive",
+	}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+	if code := r.runAuth(); code != 0 {
+		t.Fatalf("auth new failed: %s", errOut.String())
+	}
+
+	raw, err := os.ReadFile(profilesPath)
+	if err != nil {
+		t.Fatalf("read profiles file: %v", err)
+	}
+	if !strings.Contains(string(raw), "onedrive-od-work_token.json") {
+		t.Fatalf("expected derived onedrive token file path in profiles file:\n%s", string(raw))
+	}
+}
+
+func TestRunAuthNew_DerivesDefaultTokenFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	t.Setenv("CLOUDSTIC_CONFIG_DIR", tmpDir)
+
+	os.Args = []string{"cloudstic", "auth", "new", "-profiles-file", profilesPath, "-name", "g", "-provider", "google"}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+	if code := r.runAuth(); code != 0 {
+		t.Fatalf("auth new failed: %s", errOut.String())
+	}
+	raw, err := os.ReadFile(profilesPath)
+	if err != nil {
+		t.Fatalf("read profiles file: %v", err)
+	}
+	if !strings.Contains(string(raw), "google-g_token.json") {
+		t.Fatalf("expected derived token file path in profiles file:\n%s", string(raw))
+	}
+}

--- a/cmd/cloudstic/cmd_backup.go
+++ b/cmd/cloudstic/cmd_backup.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"flag"
 	"fmt"
+	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -18,6 +21,10 @@ import (
 type backupArgs struct {
 	g                 *globalFlags
 	sourceURI         string
+	profile           string
+	allProfiles       bool
+	authRef           string
+	profilesFile      string
 	dryRun            bool
 	excludeFile       string
 	skipNativeFiles   bool
@@ -28,6 +35,7 @@ type backupArgs struct {
 	onedriveTokenFile string
 	tags              stringArrayFlags
 	excludes          stringArrayFlags
+	flagsSet          map[string]bool
 }
 
 func parseBackupArgs() *backupArgs {
@@ -35,6 +43,8 @@ func parseBackupArgs() *backupArgs {
 	a := &backupArgs{}
 	a.g = addGlobalFlags(fs)
 	sourceURI := fs.String("source", envDefault("CLOUDSTIC_SOURCE", "gdrive"), "Source URI: local:<path>, sftp://[user@]host[:port]/<path>, gdrive[://<Drive Name>][/<path>], gdrive-changes[://<Drive Name>][/<path>], onedrive[://<Drive Name>][/<path>], onedrive-changes[://<Drive Name>][/<path>]")
+	allProfiles := fs.Bool("all-profiles", false, "Run backup for all enabled profiles from profiles.yaml")
+	authRef := fs.String("auth-ref", "", "Use named auth entry from profiles.yaml for cloud source credentials")
 	dryRun := fs.Bool("dry-run", false, "Scan source and report changes without writing to the store")
 	skipNativeFiles := fs.Bool("skip-native-files", false, "Exclude Google-native files (Docs, Sheets, Slides, etc.) from the backup")
 	excludeFile := fs.String("exclude-file", "", "Path to file with exclude patterns (one per line, gitignore syntax)")
@@ -47,6 +57,10 @@ func parseBackupArgs() *backupArgs {
 	fs.Var(&a.excludes, "exclude", "Exclude pattern (gitignore syntax, repeatable)")
 	mustParse(fs)
 	a.sourceURI = *sourceURI
+	a.profile = *a.g.profile
+	a.allProfiles = *allProfiles
+	a.authRef = *authRef
+	a.profilesFile = *a.g.profilesFile
 	a.dryRun = *dryRun
 	a.skipNativeFiles = *skipNativeFiles
 	a.excludeFile = *excludeFile
@@ -55,11 +69,45 @@ func parseBackupArgs() *backupArgs {
 	a.googleTokenFile = *googleTokenFile
 	a.onedriveClientID = *onedriveClientID
 	a.onedriveTokenFile = *onedriveTokenFile
+	a.flagsSet = map[string]bool{}
+	fs.Visit(func(f *flag.Flag) {
+		a.flagsSet[f.Name] = true
+	})
 	return a
 }
 
 func (r *runner) runBackup() int {
 	a := parseBackupArgs()
+
+	if a.profile != "" && a.allProfiles {
+		return r.fail("-profile and -all-profiles are mutually exclusive")
+	}
+
+	if a.profile != "" || a.allProfiles {
+		return r.runBackupWithProfiles(a)
+	}
+
+	if a.authRef != "" {
+		cfg, err := cloudstic.LoadProfilesFile(a.profilesFile)
+		if err != nil {
+			return r.fail("Failed to load profiles: %v", err)
+		}
+		authCfg, ok := cfg.Auth[a.authRef]
+		if !ok {
+			return r.fail("Unknown auth reference %q", a.authRef)
+		}
+		if err := applyProfileAuthToBackupArgs(a, authCfg); err != nil {
+			return r.fail("Auth reference %q: %v", a.authRef, err)
+		}
+	}
+
+	return r.runSingleBackup(a)
+}
+
+func (r *runner) runSingleBackup(a *backupArgs) int {
+	if err := ensureDefaultAuthRefForCloudBackup(a); err != nil {
+		return r.fail("Failed to prepare auth settings: %v", err)
+	}
 
 	excludePatterns, err := r.parseExcludePatterns(a)
 	if err != nil {
@@ -85,6 +133,373 @@ func (r *runner) runBackup() int {
 	}
 	r.printBackupSummary(result)
 	return 0
+}
+
+func ensureDefaultAuthRefForCloudBackup(a *backupArgs) error {
+	uri, err := parseSourceURI(a.sourceURI)
+	if err != nil {
+		return err
+	}
+
+	var (
+		provider             string
+		defaultAuthRef       string
+		defaultTokenFilename string
+		getToken             func() string
+		setToken             func(string)
+	)
+
+	switch uri.scheme {
+	case "gdrive", "gdrive-changes":
+		provider = "google"
+		defaultAuthRef = "google-default"
+		defaultTokenFilename = "google_token.json"
+		getToken = func() string { return a.googleTokenFile }
+		setToken = func(v string) { a.googleTokenFile = v }
+	case "onedrive", "onedrive-changes":
+		provider = "onedrive"
+		defaultAuthRef = "onedrive-default"
+		defaultTokenFilename = "onedrive_token.json"
+		getToken = func() string { return a.onedriveTokenFile }
+		setToken = func(v string) { a.onedriveTokenFile = v }
+	default:
+		return nil
+	}
+
+	if a.authRef == "" {
+		authRef := defaultAuthRef
+		a.authRef = authRef
+		if a.flagsSet == nil {
+			a.flagsSet = map[string]bool{}
+		}
+
+		cfg, loadErr := cloudstic.LoadProfilesFile(a.profilesFile)
+		if loadErr != nil {
+			if errors.Is(loadErr, os.ErrNotExist) {
+				cfg = &cloudstic.ProfilesConfig{Version: 1}
+			} else {
+				return fmt.Errorf("load profiles for default auth: %w", loadErr)
+			}
+		}
+		if cfg.Auth == nil {
+			cfg.Auth = map[string]cloudstic.ProfileAuth{}
+		}
+
+		tokenPath := getToken()
+		if tokenPath == "" {
+			resolved, resolveErr := resolveTokenPath("", defaultTokenFilename)
+			if resolveErr != nil {
+				return resolveErr
+			}
+			tokenPath = resolved
+			setToken(tokenPath)
+		}
+
+		auth := cfg.Auth[authRef]
+		if auth.Provider != "" && auth.Provider != provider {
+			return fmt.Errorf("default auth %q has provider %q, expected %q", authRef, auth.Provider, provider)
+		}
+		auth.Provider = provider
+		if provider == "google" {
+			if a.googleCreds != "" {
+				auth.GoogleCreds = a.googleCreds
+			}
+			auth.GoogleTokenFile = tokenPath
+		}
+		if provider == "onedrive" {
+			if a.onedriveClientID != "" {
+				auth.OneDriveClientID = a.onedriveClientID
+			}
+			auth.OneDriveTokenFile = tokenPath
+		}
+		cfg.Auth[authRef] = auth
+
+		if saveErr := cloudstic.SaveProfilesFile(a.profilesFile, cfg); saveErr != nil {
+			return fmt.Errorf("save profiles with default auth: %w", saveErr)
+		}
+
+		if err := applyProfileAuthToBackupArgs(a, auth); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *runner) runBackupWithProfiles(base *backupArgs) int {
+	cfg, err := cloudstic.LoadProfilesFile(base.profilesFile)
+	if err != nil {
+		return r.fail("Failed to load profiles: %v", err)
+	}
+
+	var names []string
+	if base.profile != "" {
+		if _, ok := cfg.Profiles[base.profile]; !ok {
+			return r.fail("Unknown profile %q", base.profile)
+		}
+		names = []string{base.profile}
+	} else {
+		for name, p := range cfg.Profiles {
+			if p.IsEnabled() {
+				names = append(names, name)
+			}
+		}
+		if len(names) == 0 {
+			return r.fail("No enabled profiles found")
+		}
+		slices.Sort(names)
+	}
+
+	failures := 0
+	for _, name := range names {
+		p := cfg.Profiles[name]
+		effective, err := mergeProfileBackupArgs(base, name, p, cfg)
+		if err != nil {
+			_, _ = fmt.Fprintf(r.errOut, "[%s] profile merge failed: %v\n", name, err)
+			failures++
+			continue
+		}
+		_, _ = fmt.Fprintf(r.out, "\n== Running profile %s ==\n", name)
+		r.client = nil // each profile may target a different store
+		if code := r.runSingleBackup(effective); code != 0 {
+			failures++
+			if !base.allProfiles {
+				return code
+			}
+		}
+	}
+	if failures > 0 {
+		return r.fail("%d profile backup(s) failed", failures)
+	}
+	return 0
+}
+
+func mergeProfileBackupArgs(base *backupArgs, profileName string, p cloudstic.BackupProfile, cfg *cloudstic.ProfilesConfig) (*backupArgs, error) {
+	g := cloneGlobalFlags(base.g)
+	a := *base
+	a.g = g
+
+	if !a.flagsSet["source"] {
+		a.sourceURI = p.Source
+	}
+	if a.sourceURI == "" {
+		return nil, fmt.Errorf("profile %q has empty source", profileName)
+	}
+
+	if !a.flagsSet["skip-native-files"] {
+		a.skipNativeFiles = p.SkipNativeFiles
+	}
+	if !a.flagsSet["volume-uuid"] && p.VolumeUUID != "" {
+		a.volumeUUID = p.VolumeUUID
+	}
+	if !a.flagsSet["google-credentials"] && p.GoogleCreds != "" {
+		a.googleCreds = p.GoogleCreds
+	}
+	if !a.flagsSet["google-token-file"] && p.GoogleTokenFile != "" {
+		a.googleTokenFile = p.GoogleTokenFile
+	}
+	if !a.flagsSet["onedrive-client-id"] && p.OneDriveClientID != "" {
+		a.onedriveClientID = p.OneDriveClientID
+	}
+	if !a.flagsSet["onedrive-token-file"] && p.OneDriveTokenFile != "" {
+		a.onedriveTokenFile = p.OneDriveTokenFile
+	}
+
+	if len(a.tags) == 0 && len(p.Tags) > 0 {
+		a.tags = append(stringArrayFlags{}, p.Tags...)
+	}
+	if len(a.excludes) == 0 && len(p.Excludes) > 0 {
+		a.excludes = append(stringArrayFlags{}, p.Excludes...)
+	}
+	if !a.flagsSet["exclude-file"] && p.ExcludeFile != "" {
+		a.excludeFile = p.ExcludeFile
+	}
+
+	if p.Store != "" {
+		storeCfg, ok := cfg.Stores[p.Store]
+		if !ok {
+			return nil, fmt.Errorf("profile %q references unknown store %q", profileName, p.Store)
+		}
+		applyProfileStoreToGlobalFlags(g, storeCfg, a.flagsSet)
+	}
+
+	if p.AuthRef != "" {
+		effectiveAuthRef := p.AuthRef
+		if a.flagsSet["auth-ref"] {
+			effectiveAuthRef = a.authRef
+		}
+		authCfg, ok := cfg.Auth[effectiveAuthRef]
+		if !ok {
+			return nil, fmt.Errorf("profile %q references unknown auth %q", profileName, effectiveAuthRef)
+		}
+		if err := applyProfileAuthToBackupArgs(&a, authCfg); err != nil {
+			return nil, fmt.Errorf("profile %q auth %q: %w", profileName, effectiveAuthRef, err)
+		}
+	} else if a.flagsSet["auth-ref"] {
+		authCfg, ok := cfg.Auth[a.authRef]
+		if !ok {
+			return nil, fmt.Errorf("profile %q requested unknown auth %q", profileName, a.authRef)
+		}
+		if err := applyProfileAuthToBackupArgs(&a, authCfg); err != nil {
+			return nil, fmt.Errorf("profile %q auth %q: %w", profileName, a.authRef, err)
+		}
+	}
+
+	return &a, nil
+}
+
+func applyProfileAuthToBackupArgs(a *backupArgs, auth cloudstic.ProfileAuth) error {
+	uri, err := parseSourceURI(a.sourceURI)
+	if err != nil {
+		return fmt.Errorf("parse source URI: %w", err)
+	}
+
+	requiredProvider := ""
+	switch uri.scheme {
+	case "gdrive", "gdrive-changes":
+		requiredProvider = "google"
+	case "onedrive", "onedrive-changes":
+		requiredProvider = "onedrive"
+	default:
+		return fmt.Errorf("auth refs are only valid for Google Drive and OneDrive sources")
+	}
+
+	if auth.Provider != "" && auth.Provider != requiredProvider {
+		return fmt.Errorf("provider mismatch: source requires %q but auth entry is %q", requiredProvider, auth.Provider)
+	}
+
+	if requiredProvider == "google" {
+		if !a.flagsSet["google-credentials"] && auth.GoogleCreds != "" {
+			a.googleCreds = auth.GoogleCreds
+		}
+		if !a.flagsSet["google-token-file"] && auth.GoogleTokenFile != "" {
+			a.googleTokenFile = auth.GoogleTokenFile
+		}
+	}
+
+	if requiredProvider == "onedrive" {
+		if !a.flagsSet["onedrive-client-id"] && auth.OneDriveClientID != "" {
+			a.onedriveClientID = auth.OneDriveClientID
+		}
+		if !a.flagsSet["onedrive-token-file"] && auth.OneDriveTokenFile != "" {
+			a.onedriveTokenFile = auth.OneDriveTokenFile
+		}
+	}
+
+	return nil
+}
+
+func cloneGlobalFlags(src *globalFlags) *globalFlags {
+	clone := *src
+
+	store := *src.store
+	s3Endpoint := *src.s3Endpoint
+	s3Region := *src.s3Region
+	s3AccessKey := *src.s3AccessKey
+	s3SecretKey := *src.s3SecretKey
+	sourceSFTPPassword := *src.sourceSFTPPassword
+	sourceSFTPKey := *src.sourceSFTPKey
+	storeSFTPPassword := *src.storeSFTPPassword
+	storeSFTPKey := *src.storeSFTPKey
+	encryptionKey := *src.encryptionKey
+	password := *src.password
+	recoveryKey := *src.recoveryKey
+	kmsKeyARN := *src.kmsKeyARN
+	kmsRegion := *src.kmsRegion
+	kmsEndpoint := *src.kmsEndpoint
+	disablePackfile := *src.disablePackfile
+	prompt := *src.prompt
+	verbose := *src.verbose
+	quiet := *src.quiet
+	debug := *src.debug
+
+	clone.store = &store
+	clone.s3Endpoint = &s3Endpoint
+	clone.s3Region = &s3Region
+	clone.s3AccessKey = &s3AccessKey
+	clone.s3SecretKey = &s3SecretKey
+	clone.sourceSFTPPassword = &sourceSFTPPassword
+	clone.sourceSFTPKey = &sourceSFTPKey
+	clone.storeSFTPPassword = &storeSFTPPassword
+	clone.storeSFTPKey = &storeSFTPKey
+	clone.encryptionKey = &encryptionKey
+	clone.password = &password
+	clone.recoveryKey = &recoveryKey
+	clone.kmsKeyARN = &kmsKeyARN
+	clone.kmsRegion = &kmsRegion
+	clone.kmsEndpoint = &kmsEndpoint
+	clone.disablePackfile = &disablePackfile
+	clone.prompt = &prompt
+	clone.verbose = &verbose
+	clone.quiet = &quiet
+	clone.debug = &debug
+
+	return &clone
+}
+
+func applyProfileStoreToGlobalFlags(g *globalFlags, s cloudstic.ProfileStore, flagsSet map[string]bool) {
+	if !flagsSet["store"] && s.URI != "" {
+		*g.store = s.URI
+	}
+	if !flagsSet["s3-endpoint"] && s.S3Endpoint != "" {
+		*g.s3Endpoint = s.S3Endpoint
+	}
+	if !flagsSet["s3-region"] && s.S3Region != "" {
+		*g.s3Region = s.S3Region
+	}
+	if !flagsSet["s3-profile"] {
+		if s.S3Profile != "" {
+			*g.s3Profile = s.S3Profile
+		} else if s.S3ProfileEnv != "" {
+			*g.s3Profile = os.Getenv(s.S3ProfileEnv)
+		}
+	}
+	if !flagsSet["s3-access-key"] {
+		if s.S3AccessKey != "" {
+			*g.s3AccessKey = s.S3AccessKey
+		} else if s.S3AccessKeyEnv != "" {
+			*g.s3AccessKey = os.Getenv(s.S3AccessKeyEnv)
+		}
+	}
+	if !flagsSet["s3-secret-key"] {
+		if s.S3SecretKey != "" {
+			*g.s3SecretKey = s.S3SecretKey
+		} else if s.S3SecretKeyEnv != "" {
+			*g.s3SecretKey = os.Getenv(s.S3SecretKeyEnv)
+		}
+	}
+	if !flagsSet["store-sftp-password"] {
+		if s.StoreSFTPPassword != "" {
+			*g.storeSFTPPassword = s.StoreSFTPPassword
+		} else if s.StoreSFTPPasswordEnv != "" {
+			*g.storeSFTPPassword = os.Getenv(s.StoreSFTPPasswordEnv)
+		}
+	}
+	if !flagsSet["store-sftp-key"] {
+		if s.StoreSFTPKey != "" {
+			*g.storeSFTPKey = s.StoreSFTPKey
+		} else if s.StoreSFTPKeyEnv != "" {
+			*g.storeSFTPKey = os.Getenv(s.StoreSFTPKeyEnv)
+		}
+	}
+	if !flagsSet["password"] && s.PasswordEnv != "" {
+		*g.password = os.Getenv(s.PasswordEnv)
+	}
+	if !flagsSet["encryption-key"] && s.EncryptionKeyEnv != "" {
+		*g.encryptionKey = os.Getenv(s.EncryptionKeyEnv)
+	}
+	if !flagsSet["recovery-key"] && s.RecoveryKeyEnv != "" {
+		*g.recoveryKey = os.Getenv(s.RecoveryKeyEnv)
+	}
+	if !flagsSet["kms-key-arn"] && s.KMSKeyARN != "" {
+		*g.kmsKeyARN = s.KMSKeyARN
+	}
+	if !flagsSet["kms-region"] && s.KMSRegion != "" {
+		*g.kmsRegion = s.KMSRegion
+	}
+	if !flagsSet["kms-endpoint"] && s.KMSEndpoint != "" {
+		*g.kmsEndpoint = s.KMSEndpoint
+	}
 }
 
 func (r *runner) parseExcludePatterns(a *backupArgs) ([]string, error) {

--- a/cmd/cloudstic/cmd_backup_profile_test.go
+++ b/cmd/cloudstic/cmd_backup_profile_test.go
@@ -1,0 +1,451 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+
+	cloudstic "github.com/cloudstic/cli"
+)
+
+func TestMergeProfileBackupArgs_AppliesProfileAndStore(t *testing.T) {
+	base := &backupArgs{
+		sourceURI: "gdrive",
+		g:         newTestGlobalFlags(),
+		flagsSet:  map[string]bool{},
+	}
+	cfg := &cloudstic.ProfilesConfig{
+		Stores: map[string]cloudstic.ProfileStore{
+			"s": {
+				URI:             "s3:bucket/prefix",
+				S3Region:        "eu-west-1",
+				S3AccessKey:     "AKIA",
+				S3SecretKey:     "SECRET",
+				StoreSFTPKeyEnv: "DOES_NOT_EXIST",
+			},
+		},
+	}
+	p := cloudstic.BackupProfile{
+		Source:   "local:/data",
+		Store:    "s",
+		Tags:     []string{"daily"},
+		Excludes: []string{"*.tmp"},
+	}
+
+	eff, err := mergeProfileBackupArgs(base, "p", p, cfg)
+	if err != nil {
+		t.Fatalf("mergeProfileBackupArgs: %v", err)
+	}
+	if eff.sourceURI != "local:/data" {
+		t.Fatalf("sourceURI=%q want local:/data", eff.sourceURI)
+	}
+	if *eff.g.store != "s3:bucket/prefix" {
+		t.Fatalf("store=%q want s3:bucket/prefix", *eff.g.store)
+	}
+	if *eff.g.s3Region != "eu-west-1" {
+		t.Fatalf("s3Region=%q want eu-west-1", *eff.g.s3Region)
+	}
+	if len(eff.tags) != 1 || eff.tags[0] != "daily" {
+		t.Fatalf("tags=%v want [daily]", eff.tags)
+	}
+	if len(eff.excludes) != 1 || eff.excludes[0] != "*.tmp" {
+		t.Fatalf("excludes=%v want [*.tmp]", eff.excludes)
+	}
+}
+
+func TestMergeProfileBackupArgs_CLIFlagsWin(t *testing.T) {
+	base := &backupArgs{
+		sourceURI: "local:/cli",
+		g:         newTestGlobalFlags(),
+		flagsSet:  map[string]bool{"source": true, "store": true},
+	}
+	*base.g.store = "local:/cli-store"
+
+	cfg := &cloudstic.ProfilesConfig{
+		Stores: map[string]cloudstic.ProfileStore{"s": {URI: "s3:bucket"}},
+	}
+	p := cloudstic.BackupProfile{Source: "local:/profile", Store: "s"}
+
+	eff, err := mergeProfileBackupArgs(base, "p", p, cfg)
+	if err != nil {
+		t.Fatalf("mergeProfileBackupArgs: %v", err)
+	}
+	if eff.sourceURI != "local:/cli" {
+		t.Fatalf("sourceURI=%q want local:/cli", eff.sourceURI)
+	}
+	if *eff.g.store != "local:/cli-store" {
+		t.Fatalf("store=%q want local:/cli-store", *eff.g.store)
+	}
+}
+
+func TestMergeProfileBackupArgs_AppliesAuthRef(t *testing.T) {
+	base := &backupArgs{
+		sourceURI: "gdrive-changes:/Docs",
+		g:         newTestGlobalFlags(),
+		flagsSet:  map[string]bool{},
+	}
+	cfg := &cloudstic.ProfilesConfig{
+		Auth: map[string]cloudstic.ProfileAuth{
+			"google-work": {
+				Provider:        "google",
+				GoogleCreds:     "/tmp/creds.json",
+				GoogleTokenFile: "/tmp/google-work.json",
+			},
+		},
+	}
+	p := cloudstic.BackupProfile{Source: "gdrive-changes:/Docs", AuthRef: "google-work"}
+
+	eff, err := mergeProfileBackupArgs(base, "p", p, cfg)
+	if err != nil {
+		t.Fatalf("mergeProfileBackupArgs: %v", err)
+	}
+	if eff.googleCreds != "/tmp/creds.json" {
+		t.Fatalf("googleCreds=%q want /tmp/creds.json", eff.googleCreds)
+	}
+	if eff.googleTokenFile != "/tmp/google-work.json" {
+		t.Fatalf("googleTokenFile=%q want /tmp/google-work.json", eff.googleTokenFile)
+	}
+}
+
+func TestMergeProfileBackupArgs_AuthRefUnknownFails(t *testing.T) {
+	base := &backupArgs{
+		sourceURI: "gdrive-changes:/Docs",
+		g:         newTestGlobalFlags(),
+		flagsSet:  map[string]bool{},
+	}
+	cfg := &cloudstic.ProfilesConfig{}
+	p := cloudstic.BackupProfile{Source: "gdrive-changes:/Docs", AuthRef: "missing"}
+
+	_, err := mergeProfileBackupArgs(base, "p", p, cfg)
+	if err == nil {
+		t.Fatal("expected error for unknown auth ref")
+	}
+}
+
+func TestMergeProfileBackupArgs_AuthProviderMismatchFails(t *testing.T) {
+	base := &backupArgs{
+		sourceURI: "gdrive-changes:/Docs",
+		g:         newTestGlobalFlags(),
+		flagsSet:  map[string]bool{},
+	}
+	cfg := &cloudstic.ProfilesConfig{
+		Auth: map[string]cloudstic.ProfileAuth{
+			"ms-work": {Provider: "onedrive", OneDriveTokenFile: "/tmp/ms.json"},
+		},
+	}
+	p := cloudstic.BackupProfile{Source: "gdrive-changes:/Docs", AuthRef: "ms-work"}
+
+	_, err := mergeProfileBackupArgs(base, "p", p, cfg)
+	if err == nil {
+		t.Fatal("expected provider mismatch error")
+	}
+}
+
+func TestMergeProfileBackupArgs_CLIAuthRefOverridesProfile(t *testing.T) {
+	base := &backupArgs{
+		sourceURI: "gdrive-changes:/Docs",
+		authRef:   "google-alt",
+		g:         newTestGlobalFlags(),
+		flagsSet:  map[string]bool{"auth-ref": true},
+	}
+	cfg := &cloudstic.ProfilesConfig{
+		Auth: map[string]cloudstic.ProfileAuth{
+			"google-work": {Provider: "google", GoogleTokenFile: "/tmp/work.json"},
+			"google-alt":  {Provider: "google", GoogleTokenFile: "/tmp/alt.json"},
+		},
+	}
+	p := cloudstic.BackupProfile{Source: "gdrive-changes:/Docs", AuthRef: "google-work"}
+
+	eff, err := mergeProfileBackupArgs(base, "p", p, cfg)
+	if err != nil {
+		t.Fatalf("mergeProfileBackupArgs: %v", err)
+	}
+	if eff.googleTokenFile != "/tmp/alt.json" {
+		t.Fatalf("googleTokenFile=%q want /tmp/alt.json", eff.googleTokenFile)
+	}
+}
+
+func newTestGlobalFlags() *globalFlags {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	return addGlobalFlags(fs)
+}
+
+func TestEnsureDefaultAuthRefForCloudBackup_CreatesDefaultEntry(t *testing.T) {
+	t.Setenv("CLOUDSTIC_CONFIG_DIR", t.TempDir())
+	profilesPath := filepath.Join(t.TempDir(), "profiles.yaml")
+	a := &backupArgs{
+		sourceURI:    "gdrive-changes:/Docs",
+		profilesFile: profilesPath,
+		flagsSet:     map[string]bool{},
+	}
+	if err := ensureDefaultAuthRefForCloudBackup(a); err != nil {
+		t.Fatalf("ensureDefaultAuthRefForCloudBackup: %v", err)
+	}
+	if a.authRef != "google-default" {
+		t.Fatalf("authRef=%q want google-default", a.authRef)
+	}
+	if a.googleTokenFile == "" {
+		t.Fatal("expected googleTokenFile to be set")
+	}
+	if _, err := os.Stat(profilesPath); err != nil {
+		t.Fatalf("expected profiles file to exist: %v", err)
+	}
+	cfg, err := cloudstic.LoadProfilesFile(profilesPath)
+	if err != nil {
+		t.Fatalf("LoadProfilesFile: %v", err)
+	}
+	auth, ok := cfg.Auth["google-default"]
+	if !ok {
+		t.Fatal("missing google-default auth entry")
+	}
+	if auth.Provider != "google" {
+		t.Fatalf("provider=%q want google", auth.Provider)
+	}
+}
+
+func TestEnsureDefaultAuthRefForCloudBackup_NonCloudNoop(t *testing.T) {
+	a := &backupArgs{sourceURI: "local:/tmp", profilesFile: filepath.Join(t.TempDir(), "profiles.yaml"), flagsSet: map[string]bool{}}
+	if err := ensureDefaultAuthRefForCloudBackup(a); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if a.authRef != "" {
+		t.Fatalf("authRef=%q want empty", a.authRef)
+	}
+}
+
+func TestApplyProfileAuthToBackupArgs_OneDrive(t *testing.T) {
+	a := &backupArgs{
+		sourceURI: "onedrive:/Documents",
+		flagsSet:  map[string]bool{},
+	}
+	auth := cloudstic.ProfileAuth{
+		Provider:          "onedrive",
+		OneDriveClientID:  "my-client-id",
+		OneDriveTokenFile: "/tmp/onedrive.json",
+	}
+	if err := applyProfileAuthToBackupArgs(a, auth); err != nil {
+		t.Fatalf("applyProfileAuthToBackupArgs: %v", err)
+	}
+	if a.onedriveClientID != "my-client-id" {
+		t.Fatalf("onedriveClientID=%q want my-client-id", a.onedriveClientID)
+	}
+	if a.onedriveTokenFile != "/tmp/onedrive.json" {
+		t.Fatalf("onedriveTokenFile=%q want /tmp/onedrive.json", a.onedriveTokenFile)
+	}
+}
+
+func TestApplyProfileAuthToBackupArgs_LocalSourceFails(t *testing.T) {
+	a := &backupArgs{
+		sourceURI: "local:/data",
+		flagsSet:  map[string]bool{},
+	}
+	auth := cloudstic.ProfileAuth{Provider: "google"}
+	err := applyProfileAuthToBackupArgs(a, auth)
+	if err == nil {
+		t.Fatal("expected error for local source")
+	}
+	if got := err.Error(); got != "auth refs are only valid for Google Drive and OneDrive sources" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestApplyProfileAuthToBackupArgs_CLIFlagsPreserved(t *testing.T) {
+	a := &backupArgs{
+		sourceURI:       "gdrive:/Docs",
+		googleTokenFile: "cli.json",
+		flagsSet:        map[string]bool{"google-token-file": true},
+	}
+	auth := cloudstic.ProfileAuth{
+		Provider:        "google",
+		GoogleTokenFile: "/tmp/profile.json",
+	}
+	if err := applyProfileAuthToBackupArgs(a, auth); err != nil {
+		t.Fatalf("applyProfileAuthToBackupArgs: %v", err)
+	}
+	if a.googleTokenFile != "cli.json" {
+		t.Fatalf("googleTokenFile=%q want cli.json", a.googleTokenFile)
+	}
+}
+
+func TestCloneGlobalFlags_Independence(t *testing.T) {
+	orig := newTestGlobalFlags()
+	*orig.store = "original-store"
+
+	clone := cloneGlobalFlags(orig)
+	*clone.store = "modified-store"
+
+	if *orig.store != "original-store" {
+		t.Fatalf("original store=%q want original-store", *orig.store)
+	}
+	if *clone.store != "modified-store" {
+		t.Fatalf("clone store=%q want modified-store", *clone.store)
+	}
+}
+
+func TestApplyProfileStoreToGlobalFlags_AllFields(t *testing.T) {
+	t.Setenv("TEST_PASSWORD", "secret-pw")
+	t.Setenv("TEST_ENC_KEY", "enc-key-val")
+	t.Setenv("TEST_REC_KEY", "rec-key-val")
+
+	g := newTestGlobalFlags()
+	flagsSet := map[string]bool{}
+	s := cloudstic.ProfileStore{
+		URI:              "s3:my-bucket/prefix",
+		S3Region:         "us-east-1",
+		S3Endpoint:       "https://s3.example.com",
+		S3Profile:        "prod",
+		S3AccessKey:      "AKIATEST",
+		S3SecretKey:      "SECRETTEST",
+		StoreSFTPPassword: "sftp-pw",
+		StoreSFTPKey:     "/tmp/sftp.key",
+		PasswordEnv:      "TEST_PASSWORD",
+		EncryptionKeyEnv: "TEST_ENC_KEY",
+		RecoveryKeyEnv:   "TEST_REC_KEY",
+		KMSKeyARN:        "arn:aws:kms:us-east-1:123:key/abc",
+		KMSRegion:        "us-east-1",
+		KMSEndpoint:      "https://kms.example.com",
+	}
+
+	applyProfileStoreToGlobalFlags(g, s, flagsSet)
+
+	if *g.store != "s3:my-bucket/prefix" {
+		t.Fatalf("store=%q want s3:my-bucket/prefix", *g.store)
+	}
+	if *g.s3Region != "us-east-1" {
+		t.Fatalf("s3Region=%q want us-east-1", *g.s3Region)
+	}
+	if *g.s3Endpoint != "https://s3.example.com" {
+		t.Fatalf("s3Endpoint=%q want https://s3.example.com", *g.s3Endpoint)
+	}
+	if *g.s3Profile != "prod" {
+		t.Fatalf("s3Profile=%q want prod", *g.s3Profile)
+	}
+	if *g.s3AccessKey != "AKIATEST" {
+		t.Fatalf("s3AccessKey=%q want AKIATEST", *g.s3AccessKey)
+	}
+	if *g.s3SecretKey != "SECRETTEST" {
+		t.Fatalf("s3SecretKey=%q want SECRETTEST", *g.s3SecretKey)
+	}
+	if *g.storeSFTPPassword != "sftp-pw" {
+		t.Fatalf("storeSFTPPassword=%q want sftp-pw", *g.storeSFTPPassword)
+	}
+	if *g.storeSFTPKey != "/tmp/sftp.key" {
+		t.Fatalf("storeSFTPKey=%q want /tmp/sftp.key", *g.storeSFTPKey)
+	}
+	if *g.password != "secret-pw" {
+		t.Fatalf("password=%q want secret-pw", *g.password)
+	}
+	if *g.encryptionKey != "enc-key-val" {
+		t.Fatalf("encryptionKey=%q want enc-key-val", *g.encryptionKey)
+	}
+	if *g.recoveryKey != "rec-key-val" {
+		t.Fatalf("recoveryKey=%q want rec-key-val", *g.recoveryKey)
+	}
+	if *g.kmsKeyARN != "arn:aws:kms:us-east-1:123:key/abc" {
+		t.Fatalf("kmsKeyARN=%q want arn:aws:kms:us-east-1:123:key/abc", *g.kmsKeyARN)
+	}
+	if *g.kmsRegion != "us-east-1" {
+		t.Fatalf("kmsRegion=%q want us-east-1", *g.kmsRegion)
+	}
+	if *g.kmsEndpoint != "https://kms.example.com" {
+		t.Fatalf("kmsEndpoint=%q want https://kms.example.com", *g.kmsEndpoint)
+	}
+}
+
+func TestApplyProfileStoreToGlobalFlags_CLIFlagOverrides(t *testing.T) {
+	g := newTestGlobalFlags()
+	*g.store = "local:/cli-store"
+	flagsSet := map[string]bool{"store": true}
+	s := cloudstic.ProfileStore{URI: "s3:profile-bucket"}
+
+	applyProfileStoreToGlobalFlags(g, s, flagsSet)
+
+	if *g.store != "local:/cli-store" {
+		t.Fatalf("store=%q want local:/cli-store", *g.store)
+	}
+}
+
+func TestMergeProfileBackupArgs_EmptySourceFails(t *testing.T) {
+	base := &backupArgs{
+		sourceURI: "",
+		g:         newTestGlobalFlags(),
+		flagsSet:  map[string]bool{},
+	}
+	cfg := &cloudstic.ProfilesConfig{}
+	p := cloudstic.BackupProfile{Source: ""}
+
+	_, err := mergeProfileBackupArgs(base, "empty", p, cfg)
+	if err == nil {
+		t.Fatal("expected error for empty source")
+	}
+}
+
+func TestMergeProfileBackupArgs_UnknownStoreFails(t *testing.T) {
+	base := &backupArgs{
+		sourceURI: "local:/data",
+		g:         newTestGlobalFlags(),
+		flagsSet:  map[string]bool{},
+	}
+	cfg := &cloudstic.ProfilesConfig{
+		Stores: map[string]cloudstic.ProfileStore{},
+	}
+	p := cloudstic.BackupProfile{Source: "local:/data", Store: "missing"}
+
+	_, err := mergeProfileBackupArgs(base, "p", p, cfg)
+	if err == nil {
+		t.Fatal("expected error for unknown store")
+	}
+}
+
+func TestMergeProfileBackupArgs_SkipNativeFiles(t *testing.T) {
+	base := &backupArgs{
+		sourceURI: "gdrive:/Docs",
+		g:         newTestGlobalFlags(),
+		flagsSet:  map[string]bool{},
+	}
+	cfg := &cloudstic.ProfilesConfig{}
+	p := cloudstic.BackupProfile{Source: "gdrive:/Docs", SkipNativeFiles: true}
+
+	eff, err := mergeProfileBackupArgs(base, "p", p, cfg)
+	if err != nil {
+		t.Fatalf("mergeProfileBackupArgs: %v", err)
+	}
+	if !eff.skipNativeFiles {
+		t.Fatal("expected skipNativeFiles=true")
+	}
+}
+
+func TestMergeProfileBackupArgs_ExcludeFile(t *testing.T) {
+	base := &backupArgs{
+		sourceURI: "local:/data",
+		g:         newTestGlobalFlags(),
+		flagsSet:  map[string]bool{},
+	}
+	cfg := &cloudstic.ProfilesConfig{}
+	p := cloudstic.BackupProfile{Source: "local:/data", ExcludeFile: "/tmp/excludes.txt"}
+
+	eff, err := mergeProfileBackupArgs(base, "p", p, cfg)
+	if err != nil {
+		t.Fatalf("mergeProfileBackupArgs: %v", err)
+	}
+	if eff.excludeFile != "/tmp/excludes.txt" {
+		t.Fatalf("excludeFile=%q want /tmp/excludes.txt", eff.excludeFile)
+	}
+}
+
+func TestEnsureDefaultAuthRefForCloudBackup_OneDrive(t *testing.T) {
+	t.Setenv("CLOUDSTIC_CONFIG_DIR", t.TempDir())
+	profilesPath := filepath.Join(t.TempDir(), "profiles.yaml")
+	a := &backupArgs{
+		sourceURI:    "onedrive:/Documents",
+		profilesFile: profilesPath,
+		flagsSet:     map[string]bool{},
+	}
+	if err := ensureDefaultAuthRefForCloudBackup(a); err != nil {
+		t.Fatalf("ensureDefaultAuthRefForCloudBackup: %v", err)
+	}
+	if a.authRef != "onedrive-default" {
+		t.Fatalf("authRef=%q want onedrive-default", a.authRef)
+	}
+}

--- a/cmd/cloudstic/cmd_init.go
+++ b/cmd/cloudstic/cmd_init.go
@@ -48,7 +48,7 @@ func (r *runner) runInit() int {
 	hasEncryptionCreds := len(kc) > 0
 
 	if !hasEncryptionCreds && !a.noEncryption {
-		if term.IsTerminal(os.Stdin.Fd()) {
+		if !r.noPrompt && term.IsTerminal(os.Stdin.Fd()) {
 			pw, err := ui.PromptPasswordConfirm("Enter new repository password")
 			if err != nil {
 				return r.fail("Error: %v", err)

--- a/cmd/cloudstic/cmd_key.go
+++ b/cmd/cloudstic/cmd_key.go
@@ -119,7 +119,7 @@ func (r *runner) runKeyPasswd() int {
 	newPassword := cloudstic.PasswordProviderFunc(func(ctx context.Context) (string, error) {
 		newPw := a.newPassword
 		if newPw == "" {
-			if !term.IsTerminal(os.Stdin.Fd()) {
+			if r.noPrompt || !term.IsTerminal(os.Stdin.Fd()) {
 				return "", errors.New("provide --new-password or run interactively")
 			}
 			p1, err := ui.PromptPasswordConfirm("Enter new repository password")

--- a/cmd/cloudstic/cmd_profile.go
+++ b/cmd/cloudstic/cmd_profile.go
@@ -1,0 +1,608 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	cloudstic "github.com/cloudstic/cli"
+	"github.com/cloudstic/cli/internal/paths"
+)
+
+const defaultProfilesFilename = "profiles.yaml"
+
+func defaultProfilesPath() (string, error) {
+	configDir, err := paths.ConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve config dir: %w", err)
+	}
+	return filepath.Join(configDir, defaultProfilesFilename), nil
+}
+
+func (r *runner) runProfile() int {
+	if len(os.Args) < 3 {
+		_, _ = fmt.Fprintln(r.errOut, "Usage: cloudstic profile <subcommand> [options]")
+		_, _ = fmt.Fprintln(r.errOut, "")
+		_, _ = fmt.Fprintln(r.errOut, "Available subcommands: list, show, new")
+		return 1
+	}
+
+	switch os.Args[2] {
+	case "list":
+		return r.runProfileList()
+	case "show":
+		return r.runProfileShow()
+	case "new":
+		return r.runProfileNew()
+	default:
+		return r.fail("Unknown profile subcommand: %s", os.Args[2])
+	}
+}
+
+type profileShowArgs struct {
+	profilesFile string
+	name         string
+}
+
+func parseProfileShowArgs() (*profileShowArgs, error) {
+	fs := flag.NewFlagSet("profile show", flag.ExitOnError)
+	a := &profileShowArgs{}
+	defaultPath, err := defaultProfilesPath()
+	if err != nil {
+		defaultPath = defaultProfilesFilename
+	}
+	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultPath), "Path to profiles YAML file")
+	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
+	a.profilesFile = *profilesFile
+	if fs.NArg() > 1 {
+		return nil, fmt.Errorf("usage: cloudstic profile show [-profiles-file <path>] <name>")
+	}
+	if fs.NArg() == 1 {
+		a.name = fs.Arg(0)
+	}
+	return a, nil
+}
+
+func (r *runner) runProfileShow() int {
+	a, err := parseProfileShowArgs()
+	if err != nil {
+		return r.fail("%v", err)
+	}
+	cfg, err := cloudstic.LoadProfilesFile(a.profilesFile)
+	if err != nil {
+		return r.fail("Failed to load profiles: %v", err)
+	}
+	if a.name == "" {
+		if !r.canPrompt() {
+			return r.fail("usage: cloudstic profile show [-profiles-file <path>] <name>")
+		}
+		names := make([]string, 0, len(cfg.Profiles))
+		for name := range cfg.Profiles {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		picked, pickErr := r.promptSelect("Select profile", names)
+		if pickErr != nil {
+			return r.fail("Failed to select profile: %v", pickErr)
+		}
+		a.name = picked
+	}
+	p, ok := cfg.Profiles[a.name]
+	if !ok {
+		return r.fail("Unknown profile %q", a.name)
+	}
+
+	_, _ = fmt.Fprintf(r.out, "profile: %s\n", a.name)
+	_, _ = fmt.Fprintf(r.out, "  source: %s\n", p.Source)
+	if p.Store != "" {
+		_, _ = fmt.Fprintf(r.out, "  store_ref: %s\n", p.Store)
+		if s, ok := cfg.Stores[p.Store]; ok {
+			_, _ = fmt.Fprintf(r.out, "  store_uri: %s\n", s.URI)
+			if uri, parseErr := parseStoreURI(s.URI); parseErr == nil && uri.scheme == "s3" {
+				if s.S3Region != "" {
+					_, _ = fmt.Fprintf(r.out, "  store_s3_region: %s\n", s.S3Region)
+				}
+				if s.S3Profile != "" {
+					_, _ = fmt.Fprintf(r.out, "  store_s3_profile: %s\n", s.S3Profile)
+				}
+				if s.S3Endpoint != "" {
+					_, _ = fmt.Fprintf(r.out, "  store_s3_endpoint: %s\n", s.S3Endpoint)
+				}
+			}
+			_, _ = fmt.Fprintf(r.out, "  store_auth_mode: %s\n", profileStoreAuthMode(s))
+		} else {
+			_, _ = fmt.Fprintf(r.out, "  store_uri: <missing ref>\n")
+		}
+	}
+	if p.AuthRef != "" {
+		_, _ = fmt.Fprintf(r.out, "  auth_ref: %s\n", p.AuthRef)
+		if auth, ok := cfg.Auth[p.AuthRef]; ok {
+			_, _ = fmt.Fprintf(r.out, "  auth_provider: %s\n", auth.Provider)
+			if auth.GoogleTokenFile != "" {
+				_, _ = fmt.Fprintf(r.out, "  google_token_file: %s\n", auth.GoogleTokenFile)
+			}
+			if auth.OneDriveTokenFile != "" {
+				_, _ = fmt.Fprintf(r.out, "  onedrive_token_file: %s\n", auth.OneDriveTokenFile)
+			}
+		} else {
+			_, _ = fmt.Fprintf(r.out, "  auth_provider: <missing ref>\n")
+		}
+	}
+	if len(p.Tags) > 0 {
+		_, _ = fmt.Fprintf(r.out, "  tags: %s\n", strings.Join(p.Tags, ", "))
+	}
+	if len(p.Excludes) > 0 {
+		_, _ = fmt.Fprintf(r.out, "  excludes: %s\n", strings.Join(p.Excludes, ", "))
+	}
+	if p.ExcludeFile != "" {
+		_, _ = fmt.Fprintf(r.out, "  exclude_file: %s\n", p.ExcludeFile)
+	}
+	return 0
+}
+
+func profileStoreAuthMode(s cloudstic.ProfileStore) string {
+	if s.S3AccessKey != "" || s.S3SecretKey != "" || s.S3AccessKeyEnv != "" || s.S3SecretKeyEnv != "" {
+		return "static-keys"
+	}
+	if s.S3Profile != "" || s.S3ProfileEnv != "" {
+		return "aws-shared-profile"
+	}
+	if s.StoreSFTPPassword != "" || s.StoreSFTPKey != "" || s.StoreSFTPPasswordEnv != "" || s.StoreSFTPKeyEnv != "" {
+		return "sftp"
+	}
+	return "default-chain"
+}
+
+type profileListArgs struct {
+	profilesFile string
+}
+
+func parseProfileListArgs() *profileListArgs {
+	fs := flag.NewFlagSet("profile list", flag.ExitOnError)
+	a := &profileListArgs{}
+	defaultPath, err := defaultProfilesPath()
+	if err != nil {
+		defaultPath = defaultProfilesFilename
+	}
+	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultPath), "Path to profiles YAML file")
+	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
+	a.profilesFile = *profilesFile
+	return a
+}
+
+func (r *runner) runProfileList() int {
+	a := parseProfileListArgs()
+	cfg, err := cloudstic.LoadProfilesFile(a.profilesFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0
+		}
+		return r.fail("Failed to load profiles: %v", err)
+	}
+
+	storeNames := make([]string, 0, len(cfg.Stores))
+	for name := range cfg.Stores {
+		storeNames = append(storeNames, name)
+	}
+	sort.Strings(storeNames)
+
+	_, _ = fmt.Fprintf(r.out, "%d stores\n", len(storeNames))
+	for _, name := range storeNames {
+		s := cfg.Stores[name]
+		_, _ = fmt.Fprintf(r.out, "- %s", name)
+		if s.URI != "" {
+			_, _ = fmt.Fprintf(r.out, "  uri=%s", s.URI)
+		}
+		_, _ = fmt.Fprintln(r.out)
+	}
+	_, _ = fmt.Fprintln(r.out)
+
+	authNames := make([]string, 0, len(cfg.Auth))
+	for name := range cfg.Auth {
+		authNames = append(authNames, name)
+	}
+	sort.Strings(authNames)
+
+	_, _ = fmt.Fprintf(r.out, "%d auth entries\n", len(authNames))
+	for _, name := range authNames {
+		a := cfg.Auth[name]
+		_, _ = fmt.Fprintf(r.out, "- %s", name)
+		if a.Provider != "" {
+			_, _ = fmt.Fprintf(r.out, "  provider=%s", a.Provider)
+		}
+		if a.Provider == "google" && a.GoogleTokenFile != "" {
+			_, _ = fmt.Fprintf(r.out, "  token=%s", a.GoogleTokenFile)
+		}
+		if a.Provider == "onedrive" && a.OneDriveTokenFile != "" {
+			_, _ = fmt.Fprintf(r.out, "  token=%s", a.OneDriveTokenFile)
+		}
+		_, _ = fmt.Fprintln(r.out)
+	}
+	_, _ = fmt.Fprintln(r.out)
+
+	names := make([]string, 0, len(cfg.Profiles))
+	for name := range cfg.Profiles {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	_, _ = fmt.Fprintf(r.out, "%d profiles\n", len(names))
+	for _, name := range names {
+		p := cfg.Profiles[name]
+		_, _ = fmt.Fprintf(r.out, "- %s", name)
+		if p.Source != "" {
+			_, _ = fmt.Fprintf(r.out, "  source=%s", p.Source)
+		}
+		if p.Store != "" {
+			_, _ = fmt.Fprintf(r.out, "  store=%s", p.Store)
+		}
+		if p.AuthRef != "" {
+			_, _ = fmt.Fprintf(r.out, "  auth=%s", p.AuthRef)
+		}
+		_, _ = fmt.Fprintln(r.out)
+	}
+
+	return 0
+}
+
+type profileNewArgs struct {
+	profilesFile      string
+	name              string
+	source            string
+	storeRef          string
+	store             string
+	authRef           string
+	tags              stringArrayFlags
+	excludes          stringArrayFlags
+	excludeFile       string
+	skipNativeFiles   bool
+	volumeUUID        string
+	googleCreds       string
+	googleTokenFile   string
+	onedriveClientID  string
+	onedriveTokenFile string
+	flagsSet          map[string]bool
+}
+
+func parseProfileNewArgs() *profileNewArgs {
+	fs := flag.NewFlagSet("profile new", flag.ExitOnError)
+	a := &profileNewArgs{}
+	defaultPath, err := defaultProfilesPath()
+	if err != nil {
+		defaultPath = defaultProfilesFilename
+	}
+	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultPath), "Path to profiles YAML file")
+	name := fs.String("name", "", "Profile name")
+	source := fs.String("source", "", "Source URI")
+	storeRef := fs.String("store-ref", "", "Store reference name from top-level stores map")
+	store := fs.String("store", "", "Store URI to create/update under -store-ref")
+	authRef := fs.String("auth-ref", "", "Auth reference name from top-level auth map")
+	excludeFile := fs.String("exclude-file", "", "Path to file with exclude patterns")
+	skipNativeFiles := fs.Bool("skip-native-files", false, "Exclude Google-native files (Docs, Sheets, Slides, etc.)")
+	volumeUUID := fs.String("volume-uuid", "", "Override volume UUID for local source")
+	googleCreds := fs.String("google-credentials", "", "Path to Google service account credentials JSON file")
+	googleTokenFile := fs.String("google-token-file", "", "Path to Google OAuth token file")
+	onedriveClientID := fs.String("onedrive-client-id", "", "OneDrive OAuth client ID")
+	onedriveTokenFile := fs.String("onedrive-token-file", "", "Path to OneDrive OAuth token file")
+	fs.Var(&a.tags, "tag", "Tag to apply to snapshots (repeatable)")
+	fs.Var(&a.excludes, "exclude", "Exclude pattern (repeatable)")
+	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
+
+	a.flagsSet = map[string]bool{}
+	fs.Visit(func(f *flag.Flag) { a.flagsSet[f.Name] = true })
+
+	a.profilesFile = *profilesFile
+	a.name = *name
+	a.source = *source
+	a.storeRef = *storeRef
+	a.store = *store
+	a.authRef = *authRef
+	a.excludeFile = *excludeFile
+	a.skipNativeFiles = *skipNativeFiles
+	a.volumeUUID = *volumeUUID
+	a.googleCreds = *googleCreds
+	a.googleTokenFile = *googleTokenFile
+	a.onedriveClientID = *onedriveClientID
+	a.onedriveTokenFile = *onedriveTokenFile
+
+	return a
+}
+
+func (r *runner) runProfileNew() int {
+	a := parseProfileNewArgs()
+	if a.name == "" {
+		if r.canPrompt() {
+			v, err := r.promptLine("Profile name", "")
+			if err != nil {
+				return r.fail("Failed to read profile name: %v", err)
+			}
+			a.name = v
+		}
+		if a.name == "" {
+			return r.fail("-name is required")
+		}
+	}
+	if !validRefName.MatchString(a.name) {
+		return r.fail("invalid profile name %q: must start with a letter or digit and contain only letters, digits, dots, hyphens, or underscores", a.name)
+	}
+
+	cfg, err := cloudstic.LoadProfilesFile(a.profilesFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			cfg = &cloudstic.ProfilesConfig{Version: 1}
+		} else {
+			return r.fail("Failed to load profiles: %v", err)
+		}
+	}
+	if cfg.Stores == nil {
+		cfg.Stores = map[string]cloudstic.ProfileStore{}
+	}
+	if cfg.Profiles == nil {
+		cfg.Profiles = map[string]cloudstic.BackupProfile{}
+	}
+	if cfg.Auth == nil {
+		cfg.Auth = map[string]cloudstic.ProfileAuth{}
+	}
+
+	// When editing an existing profile, prefill unset fields with current values.
+	if existing, ok := cfg.Profiles[a.name]; ok {
+		prefillProfileArgs(a, existing)
+	}
+
+	if a.source == "" {
+		if r.canPrompt() {
+			v, err := r.promptLine("Source URI", "")
+			if err != nil {
+				return r.fail("Failed to read source URI: %v", err)
+			}
+			a.source = v
+		}
+		if a.source == "" {
+			return r.fail("-source is required")
+		}
+	}
+	if _, err := parseSourceURI(a.source); err != nil {
+		return r.fail("Invalid source: %v", err)
+	}
+	if a.store != "" && a.storeRef == "" {
+		if r.canPrompt() {
+			v, err := r.promptLine("Store reference name", "default-store")
+			if err != nil {
+				return r.fail("Failed to read store reference: %v", err)
+			}
+			a.storeRef = v
+		}
+		if a.storeRef == "" {
+			return r.fail("-store requires -store-ref")
+		}
+	}
+
+	if a.store != "" {
+		cfg.Stores[a.storeRef] = cloudstic.ProfileStore{URI: a.store}
+	} else if a.storeRef != "" {
+		if _, ok := cfg.Stores[a.storeRef]; !ok {
+			return r.fail("Unknown store reference %q (use -store to create it)", a.storeRef)
+		}
+	} else {
+		// No store provided — prompt or fail.
+		if r.canPrompt() {
+			ref, code := r.promptStoreSelection(cfg)
+			if code != 0 {
+				return code
+			}
+			a.storeRef = ref
+		}
+		if a.storeRef == "" {
+			return r.fail("-store-ref is required (or provide -store to create a new one)")
+		}
+	}
+
+	requiredProvider := profileProviderFromSource(a.source)
+
+	if a.authRef != "" {
+		if requiredProvider == "" {
+			return r.fail("-auth-ref requires a cloud source (gdrive/gdrive-changes/onedrive/onedrive-changes)")
+		}
+		auth, exists := cfg.Auth[a.authRef]
+		if !exists {
+			return r.fail("Unknown auth reference %q (create it with 'cloudstic auth new')", a.authRef)
+		}
+		if auth.Provider != "" && auth.Provider != requiredProvider {
+			return r.fail("Auth reference %q has provider %q, but source requires %q", a.authRef, auth.Provider, requiredProvider)
+		}
+		if auth.Provider == "google" {
+			if a.googleCreds != "" {
+				auth.GoogleCreds = a.googleCreds
+			}
+			if a.googleTokenFile != "" {
+				auth.GoogleTokenFile = a.googleTokenFile
+			}
+		}
+		if auth.Provider == "onedrive" {
+			if a.onedriveClientID != "" {
+				auth.OneDriveClientID = a.onedriveClientID
+			}
+			if a.onedriveTokenFile != "" {
+				auth.OneDriveTokenFile = a.onedriveTokenFile
+			}
+		}
+		cfg.Auth[a.authRef] = auth
+	} else if requiredProvider != "" {
+		// Cloud source without -auth-ref — prompt or fail.
+		if r.canPrompt() {
+			ref, code := r.promptAuthSelection(cfg, requiredProvider, a.name)
+			if code != 0 {
+				return code
+			}
+			a.authRef = ref
+		}
+		if a.authRef == "" {
+			return r.fail("-auth-ref is required for cloud sources (or use 'cloudstic auth new' to create one)")
+		}
+	}
+
+	p := cloudstic.BackupProfile{
+		Source:            a.source,
+		Store:             a.storeRef,
+		AuthRef:           a.authRef,
+		Tags:              []string(a.tags),
+		Excludes:          []string(a.excludes),
+		ExcludeFile:       a.excludeFile,
+		SkipNativeFiles:   a.skipNativeFiles,
+		VolumeUUID:        a.volumeUUID,
+		GoogleCreds:       a.googleCreds,
+		GoogleTokenFile:   a.googleTokenFile,
+		OneDriveClientID:  a.onedriveClientID,
+		OneDriveTokenFile: a.onedriveTokenFile,
+	}
+	cfg.Profiles[a.name] = p
+
+	if err := cloudstic.SaveProfilesFile(a.profilesFile, cfg); err != nil {
+		return r.fail("Failed to save profiles: %v", err)
+	}
+
+	_, _ = fmt.Fprintf(r.out, "Profile %q saved in %s\n", a.name, a.profilesFile)
+	return 0
+}
+
+// promptStoreSelection prompts the user to pick an existing store or create a
+// new one. It returns the chosen store-ref name and exit code 0 on success.
+func (r *runner) promptStoreSelection(cfg *cloudstic.ProfilesConfig) (string, int) {
+	options := []string{"Create new store"}
+	for name := range cfg.Stores {
+		options = append(options, name)
+	}
+	sort.Strings(options[1:])
+
+	picked, err := r.promptSelect("Select a store", options)
+	if err != nil {
+		return "", r.fail("Failed to select store: %v", err)
+	}
+
+	if picked != "Create new store" {
+		return picked, 0
+	}
+
+	// Create a new store inline.
+	refName, err := r.promptLine("Store reference name", "default-store")
+	if err != nil {
+		return "", r.fail("Failed to read store reference name: %v", err)
+	}
+	if refName == "" {
+		return "", r.fail("Store reference name is required")
+	}
+	uri, err := r.promptLine("Store URI (e.g. s3://bucket/path, local:/path, sftp://host/path)", "")
+	if err != nil {
+		return "", r.fail("Failed to read store URI: %v", err)
+	}
+	if uri == "" {
+		return "", r.fail("Store URI is required")
+	}
+	cfg.Stores[refName] = cloudstic.ProfileStore{URI: uri}
+	return refName, 0
+}
+
+// promptAuthSelection prompts the user to pick an existing auth entry (filtered
+// by provider) or create a new one. It returns the chosen auth-ref name and
+// exit code 0 on success. The new entry is added to cfg.Auth in place.
+func (r *runner) promptAuthSelection(cfg *cloudstic.ProfilesConfig, provider, profileName string) (string, int) {
+	options := []string{"Create new auth"}
+	for name, auth := range cfg.Auth {
+		if auth.Provider == provider {
+			options = append(options, name)
+		}
+	}
+	sort.Strings(options[1:])
+
+	picked, err := r.promptSelect(fmt.Sprintf("Select %s auth entry", provider), options)
+	if err != nil {
+		return "", r.fail("Failed to select auth entry: %v", err)
+	}
+	if picked != "Create new auth" {
+		return picked, 0
+	}
+
+	refName, err := r.promptLine("Auth reference name", provider+"-"+profileName)
+	if err != nil {
+		return "", r.fail("Failed to read auth reference name: %v", err)
+	}
+	if refName == "" {
+		return "", r.fail("Auth reference name is required")
+	}
+
+	tokenFile, err := r.promptLine("Token file path", defaultAuthTokenPath(provider, refName))
+	if err != nil {
+		return "", r.fail("Failed to read token file path: %v", err)
+	}
+	if tokenFile == "" {
+		return "", r.fail("Token file path is required")
+	}
+
+	auth := cloudstic.ProfileAuth{Provider: provider}
+	switch provider {
+	case "google":
+		auth.GoogleTokenFile = tokenFile
+	case "onedrive":
+		auth.OneDriveTokenFile = tokenFile
+	}
+	cfg.Auth[refName] = auth
+	return refName, 0
+}
+
+func prefillProfileArgs(a *profileNewArgs, p cloudstic.BackupProfile) {
+	if !a.flagsSet["source"] && p.Source != "" {
+		a.source = p.Source
+	}
+	if !a.flagsSet["store-ref"] && p.Store != "" {
+		a.storeRef = p.Store
+	}
+	if !a.flagsSet["auth-ref"] && p.AuthRef != "" {
+		a.authRef = p.AuthRef
+	}
+	if !a.flagsSet["exclude-file"] && p.ExcludeFile != "" {
+		a.excludeFile = p.ExcludeFile
+	}
+	if !a.flagsSet["skip-native-files"] && p.SkipNativeFiles {
+		a.skipNativeFiles = true
+	}
+	if !a.flagsSet["volume-uuid"] && p.VolumeUUID != "" {
+		a.volumeUUID = p.VolumeUUID
+	}
+	if !a.flagsSet["google-credentials"] && p.GoogleCreds != "" {
+		a.googleCreds = p.GoogleCreds
+	}
+	if !a.flagsSet["google-token-file"] && p.GoogleTokenFile != "" {
+		a.googleTokenFile = p.GoogleTokenFile
+	}
+	if !a.flagsSet["onedrive-client-id"] && p.OneDriveClientID != "" {
+		a.onedriveClientID = p.OneDriveClientID
+	}
+	if !a.flagsSet["onedrive-token-file"] && p.OneDriveTokenFile != "" {
+		a.onedriveTokenFile = p.OneDriveTokenFile
+	}
+	if len(a.tags) == 0 && len(p.Tags) > 0 {
+		a.tags = append(stringArrayFlags{}, p.Tags...)
+	}
+	if len(a.excludes) == 0 && len(p.Excludes) > 0 {
+		a.excludes = append(stringArrayFlags{}, p.Excludes...)
+	}
+}
+
+func profileProviderFromSource(sourceURI string) string {
+	uri, err := parseSourceURI(sourceURI)
+	if err != nil {
+		return ""
+	}
+	switch uri.scheme {
+	case "gdrive", "gdrive-changes":
+		return "google"
+	case "onedrive", "onedrive-changes":
+		return "onedrive"
+	default:
+		return ""
+	}
+}

--- a/cmd/cloudstic/cmd_profile_test.go
+++ b/cmd/cloudstic/cmd_profile_test.go
@@ -1,0 +1,689 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	cloudstic "github.com/cloudstic/cli"
+)
+
+func TestRunProfileList_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	content := `version: 1
+stores:
+  home-s3:
+    uri: s3:my-bucket/cloudstic
+    s3_region: us-east-1
+    s3_profile: prod
+auth:
+  google-work:
+    provider: google
+    google_token_file: /tmp/google-work.json
+profiles:
+  photos:
+    source: local:/Volumes/Photos
+    store: home-s3
+  work-drive:
+    source: gdrive-changes://Company Data/Engineering
+    store: home-s3
+    auth_ref: google-work
+`
+	if err := os.WriteFile(profilesPath, []byte(content), 0600); err != nil {
+		t.Fatalf("write profiles file: %v", err)
+	}
+
+	os.Args = []string{"cloudstic", "profile", "list", "-profiles-file", profilesPath}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+
+	if code := r.runProfile(); code != 0 {
+		t.Fatalf("runProfile() code=%d err=%s", code, errOut.String())
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "1 stores") {
+		t.Fatalf("expected store count, got:\n%s", got)
+	}
+	if !strings.Contains(got, "- home-s3  uri=s3:my-bucket/cloudstic") {
+		t.Fatalf("expected home-s3 store line, got:\n%s", got)
+	}
+	if !strings.Contains(got, "1 auth entries") {
+		t.Fatalf("expected auth count, got:\n%s", got)
+	}
+	if !strings.Contains(got, "- google-work  provider=google  token=/tmp/google-work.json") {
+		t.Fatalf("expected google-work auth line, got:\n%s", got)
+	}
+	if !strings.Contains(got, "2 profiles") {
+		t.Fatalf("expected profile count, got:\n%s", got)
+	}
+	if !strings.Contains(got, "- photos  source=local:/Volumes/Photos  store=home-s3") {
+		t.Fatalf("expected photos profile line, got:\n%s", got)
+	}
+	if !strings.Contains(got, "- work-drive  source=gdrive-changes://Company Data/Engineering  store=home-s3") {
+		t.Fatalf("expected work-drive profile line, got:\n%s", got)
+	}
+	if !strings.Contains(got, "auth=google-work") {
+		t.Fatalf("expected auth reference in profile line, got:\n%s", got)
+	}
+}
+
+func TestRunProfileShow_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	content := `version: 1
+stores:
+  home-s3:
+    uri: s3:my-bucket/cloudstic
+    s3_region: us-east-1
+    s3_profile: prod
+auth:
+  google-work:
+    provider: google
+    google_token_file: /tmp/google-work.json
+profiles:
+  work-drive:
+    source: gdrive-changes://Company Data/Engineering
+    store: home-s3
+    auth_ref: google-work
+`
+	if err := os.WriteFile(profilesPath, []byte(content), 0600); err != nil {
+		t.Fatalf("write profiles file: %v", err)
+	}
+
+	os.Args = []string{"cloudstic", "profile", "show", "-profiles-file", profilesPath, "work-drive"}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+
+	if code := r.runProfile(); code != 0 {
+		t.Fatalf("runProfile() code=%d err=%s", code, errOut.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "profile: work-drive") || !strings.Contains(got, "store_uri: s3:my-bucket/cloudstic") || !strings.Contains(got, "auth_provider: google") {
+		t.Fatalf("unexpected show output:\n%s", got)
+	}
+	if !strings.Contains(got, "store_s3_profile: prod") || !strings.Contains(got, "store_auth_mode: aws-shared-profile") {
+		t.Fatalf("expected store auth details in show output:\n%s", got)
+	}
+}
+
+func TestRunProfileShow_UnknownProfile(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	if err := os.WriteFile(profilesPath, []byte("version: 1\nprofiles: {}\n"), 0600); err != nil {
+		t.Fatalf("write profiles file: %v", err)
+	}
+
+	os.Args = []string{"cloudstic", "profile", "show", "-profiles-file", profilesPath, "missing"}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+
+	if code := r.runProfile(); code == 0 {
+		t.Fatal("expected non-zero exit code")
+	}
+	if !strings.Contains(errOut.String(), "Unknown profile") {
+		t.Fatalf("unexpected error output: %s", errOut.String())
+	}
+}
+
+func TestRunProfileList_MissingFile(t *testing.T) {
+	os.Args = []string{"cloudstic", "profile", "list", "-profiles-file", filepath.Join(t.TempDir(), "missing.yaml")}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+
+	if code := r.runProfile(); code != 0 {
+		t.Fatalf("expected zero exit code, got=%d err=%s", code, errOut.String())
+	}
+	if out.String() != "" {
+		t.Fatalf("expected empty output for missing file, got: %q", out.String())
+	}
+	if errOut.String() != "" {
+		t.Fatalf("expected empty stderr for missing file, got: %q", errOut.String())
+	}
+}
+
+func TestRunProfile_UnknownSubcommand(t *testing.T) {
+	os.Args = []string{"cloudstic", "profile", "unknown"}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+
+	if code := r.runProfile(); code == 0 {
+		t.Fatalf("expected non-zero exit code")
+	}
+	if !strings.Contains(errOut.String(), "Unknown profile subcommand") {
+		t.Fatalf("unexpected error output: %s", errOut.String())
+	}
+}
+
+func TestRunProfileNew_CreatesFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	os.Args = []string{
+		"cloudstic", "profile", "new",
+		"-profiles-file", profilesPath,
+		"-name", "photos",
+		"-source", "local:/Volumes/Photos",
+		"-store-ref", "home-s3",
+		"-store", "s3:my-bucket/cloudstic",
+		"-tag", "daily",
+	}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+
+	if code := r.runProfile(); code != 0 {
+		t.Fatalf("runProfile() code=%d err=%s", code, errOut.String())
+	}
+
+	raw, err := os.ReadFile(profilesPath)
+	if err != nil {
+		t.Fatalf("read profiles file: %v", err)
+	}
+	got := string(raw)
+	if !strings.Contains(got, "photos:") || !strings.Contains(got, "source: local:/Volumes/Photos") {
+		t.Fatalf("profiles file missing profile content:\n%s", got)
+	}
+	if !strings.Contains(got, "home-s3:") || !strings.Contains(got, "uri: s3:my-bucket/cloudstic") {
+		t.Fatalf("profiles file missing store content:\n%s", got)
+	}
+}
+
+func TestRunProfileNew_PrefillsExistingProfile(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+
+	// Create initial profile.
+	os.Args = []string{
+		"cloudstic", "profile", "new",
+		"-profiles-file", profilesPath,
+		"-name", "photos",
+		"-source", "local:/Volumes/Photos",
+		"-store-ref", "main", "-store", "s3:my-bucket/backup",
+		"-tag", "daily",
+		"-exclude", "*.tmp",
+	}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+	if code := r.runProfile(); code != 0 {
+		t.Fatalf("initial create: code=%d err=%s", code, errOut.String())
+	}
+
+	// Re-run with same name, only override source.
+	os.Args = []string{
+		"cloudstic", "profile", "new",
+		"-profiles-file", profilesPath,
+		"-name", "photos",
+		"-source", "local:/Volumes/NewPhotos",
+	}
+	out.Reset()
+	errOut.Reset()
+	if code := r.runProfile(); code != 0 {
+		t.Fatalf("update: code=%d err=%s", code, errOut.String())
+	}
+
+	raw, err := os.ReadFile(profilesPath)
+	if err != nil {
+		t.Fatalf("read profiles: %v", err)
+	}
+	got := string(raw)
+
+	// Source should be updated.
+	if !strings.Contains(got, "source: local:/Volumes/NewPhotos") {
+		t.Fatalf("expected updated source, got:\n%s", got)
+	}
+	// Store should be preserved from original.
+	if !strings.Contains(got, "store: main") {
+		t.Fatalf("expected preserved store ref, got:\n%s", got)
+	}
+	// Tags should be preserved.
+	if !strings.Contains(got, "daily") {
+		t.Fatalf("expected preserved tags, got:\n%s", got)
+	}
+	// Excludes should be preserved.
+	if !strings.Contains(got, "*.tmp") {
+		t.Fatalf("expected preserved excludes, got:\n%s", got)
+	}
+}
+
+func TestRunProfileNew_RequiresNameAndSource(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	os.Args = []string{"cloudstic", "profile", "new", "-profiles-file", profilesPath, "-name", "x"}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+
+	if code := r.runProfile(); code == 0 {
+		t.Fatal("expected non-zero exit code")
+	}
+	if !strings.Contains(errOut.String(), "-source is required") {
+		t.Fatalf("unexpected error output: %s", errOut.String())
+	}
+}
+
+func TestRunProfileNew_RequiresStore(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	os.Args = []string{
+		"cloudstic", "profile", "new",
+		"-profiles-file", profilesPath,
+		"-name", "photos",
+		"-source", "local:/Volumes/Photos",
+	}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+
+	if code := r.runProfile(); code == 0 {
+		t.Fatal("expected non-zero exit code")
+	}
+	if !strings.Contains(errOut.String(), "-store-ref is required") {
+		t.Fatalf("unexpected error output: %s", errOut.String())
+	}
+}
+
+func TestRunProfileNew_RejectsUnknownStoreRef(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	os.Args = []string{
+		"cloudstic", "profile", "new",
+		"-profiles-file", profilesPath,
+		"-name", "google-drive",
+		"-source", "gdrive-changes:/Test Folder 2",
+		"-store-ref", "home-s3",
+	}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+
+	if code := r.runProfile(); code == 0 {
+		t.Fatal("expected non-zero exit code")
+	}
+	if !strings.Contains(errOut.String(), "Unknown store reference") {
+		t.Fatalf("unexpected error output: %s", errOut.String())
+	}
+}
+
+func TestRunProfileNew_CloudSourceRequiresAuthRef(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	os.Args = []string{
+		"cloudstic", "profile", "new",
+		"-profiles-file", profilesPath,
+		"-name", "drive-backup",
+		"-source", "gdrive:/",
+		"-store-ref", "s", "-store", "s3://bucket",
+	}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+
+	if code := r.runProfile(); code == 0 {
+		t.Fatal("expected non-zero exit code")
+	}
+	if !strings.Contains(errOut.String(), "-auth-ref is required for cloud sources") {
+		t.Fatalf("unexpected error output: %s", errOut.String())
+	}
+}
+
+func TestRunProfileNew_RejectsUnknownAuthRef(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	os.Args = []string{
+		"cloudstic", "profile", "new",
+		"-profiles-file", profilesPath,
+		"-name", "work-drive",
+		"-source", "gdrive-changes:/Team",
+		"-store-ref", "s", "-store", "s3://bucket",
+		"-auth-ref", "google-work",
+	}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+
+	if code := r.runProfile(); code == 0 {
+		t.Fatal("expected non-zero exit code")
+	}
+	if !strings.Contains(errOut.String(), "Unknown auth reference") {
+		t.Fatalf("unexpected error output: %s", errOut.String())
+	}
+}
+
+func TestRunProfileNew_AuthRefRequiresCloudSource(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	os.Args = []string{
+		"cloudstic", "profile", "new",
+		"-profiles-file", profilesPath,
+		"-name", "docs",
+		"-source", "local:/Users/me/Documents",
+		"-store-ref", "s", "-store", "local:/backup",
+		"-auth-ref", "google-work",
+	}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+
+	if code := r.runProfile(); code == 0 {
+		t.Fatal("expected non-zero exit code")
+	}
+	if !strings.Contains(errOut.String(), "-auth-ref requires a cloud source") {
+		t.Fatalf("unexpected error output: %s", errOut.String())
+	}
+}
+
+func TestProfileStoreAuthMode(t *testing.T) {
+	tests := []struct {
+		name string
+		s    cloudstic.ProfileStore
+		want string
+	}{
+		{"s3_access_key", cloudstic.ProfileStore{S3AccessKey: "x"}, "static-keys"},
+		{"s3_access_key_env", cloudstic.ProfileStore{S3AccessKeyEnv: "x"}, "static-keys"},
+		{"s3_profile", cloudstic.ProfileStore{S3Profile: "x"}, "aws-shared-profile"},
+		{"s3_profile_env", cloudstic.ProfileStore{S3ProfileEnv: "x"}, "aws-shared-profile"},
+		{"sftp_password", cloudstic.ProfileStore{StoreSFTPPassword: "x"}, "sftp"},
+		{"sftp_key", cloudstic.ProfileStore{StoreSFTPKey: "x"}, "sftp"},
+		{"sftp_password_env", cloudstic.ProfileStore{StoreSFTPPasswordEnv: "x"}, "sftp"},
+		{"sftp_key_env", cloudstic.ProfileStore{StoreSFTPKeyEnv: "x"}, "sftp"},
+		{"empty", cloudstic.ProfileStore{}, "default-chain"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := profileStoreAuthMode(tt.s)
+			if got != tt.want {
+				t.Fatalf("profileStoreAuthMode() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProfileProviderFromSource(t *testing.T) {
+	tests := []struct {
+		source string
+		want   string
+	}{
+		{"gdrive:/Docs", "google"},
+		{"gdrive-changes:/Docs", "google"},
+		{"onedrive:/Files", "onedrive"},
+		{"onedrive-changes:/Files", "onedrive"},
+		{"local:/tmp", ""},
+		{"sftp://host/path", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.source, func(t *testing.T) {
+			got := profileProviderFromSource(tt.source)
+			if got != tt.want {
+				t.Fatalf("profileProviderFromSource(%q) = %q, want %q", tt.source, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunProfileShow_WithOneDriveAuth(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	content := `version: 1
+stores:
+  local-store:
+    uri: local:/backup
+auth:
+  od-work:
+    provider: onedrive
+    onedrive_token_file: /tmp/od-token.json
+profiles:
+  my-onedrive:
+    source: onedrive:/Documents
+    store: local-store
+    auth_ref: od-work
+`
+	if err := os.WriteFile(profilesPath, []byte(content), 0600); err != nil {
+		t.Fatalf("write profiles file: %v", err)
+	}
+
+	os.Args = []string{"cloudstic", "profile", "show", "-profiles-file", profilesPath, "my-onedrive"}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+
+	if code := r.runProfile(); code != 0 {
+		t.Fatalf("runProfile() code=%d err=%s", code, errOut.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "auth_provider: onedrive") {
+		t.Fatalf("expected auth_provider: onedrive in output:\n%s", got)
+	}
+	if !strings.Contains(got, "onedrive_token_file: /tmp/od-token.json") {
+		t.Fatalf("expected onedrive_token_file in output:\n%s", got)
+	}
+}
+
+func TestRunProfileShow_MissingStoreRef(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	content := `version: 1
+stores: {}
+profiles:
+  broken:
+    source: local:/data
+    store: nonexistent-store
+`
+	if err := os.WriteFile(profilesPath, []byte(content), 0600); err != nil {
+		t.Fatalf("write profiles file: %v", err)
+	}
+
+	os.Args = []string{"cloudstic", "profile", "show", "-profiles-file", profilesPath, "broken"}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+
+	if code := r.runProfile(); code != 0 {
+		t.Fatalf("runProfile() code=%d err=%s", code, errOut.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "store_uri: <missing ref>") {
+		t.Fatalf("expected '<missing ref>' for store_uri in output:\n%s", got)
+	}
+}
+
+func TestRunProfileShow_MissingAuthRef(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	content := `version: 1
+stores:
+  s:
+    uri: local:/backup
+auth: {}
+profiles:
+  broken:
+    source: local:/data
+    store: s
+    auth_ref: nonexistent-auth
+`
+	if err := os.WriteFile(profilesPath, []byte(content), 0600); err != nil {
+		t.Fatalf("write profiles file: %v", err)
+	}
+
+	os.Args = []string{"cloudstic", "profile", "show", "-profiles-file", profilesPath, "broken"}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+
+	if code := r.runProfile(); code != 0 {
+		t.Fatalf("runProfile() code=%d err=%s", code, errOut.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "auth_provider: <missing ref>") {
+		t.Fatalf("expected '<missing ref>' for auth_provider in output:\n%s", got)
+	}
+}
+
+func TestRunProfileNew_WithExcludesAndTags(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	os.Args = []string{
+		"cloudstic", "profile", "new",
+		"-profiles-file", profilesPath,
+		"-name", "multi",
+		"-source", "local:/data",
+		"-store-ref", "s", "-store", "local:/backup",
+		"-exclude", "*.log",
+		"-exclude", "*.tmp",
+		"-exclude-file", "/etc/excludes.txt",
+		"-tag", "daily",
+		"-tag", "important",
+	}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+
+	if code := r.runProfile(); code != 0 {
+		t.Fatalf("runProfile() code=%d err=%s", code, errOut.String())
+	}
+
+	raw, err := os.ReadFile(profilesPath)
+	if err != nil {
+		t.Fatalf("read profiles file: %v", err)
+	}
+	got := string(raw)
+	for _, want := range []string{"*.log", "*.tmp", "/etc/excludes.txt", "daily", "important"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in profiles YAML:\n%s", want, got)
+		}
+	}
+}
+
+func TestRunProfileNew_InvalidName(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	os.Args = []string{
+		"cloudstic", "profile", "new",
+		"-profiles-file", profilesPath,
+		"-name", "bad name!",
+		"-source", "local:/data",
+		"-store-ref", "s", "-store", "local:/backup",
+	}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+
+	if code := r.runProfile(); code == 0 {
+		t.Fatal("expected non-zero exit code")
+	}
+	if !strings.Contains(errOut.String(), "invalid profile name") {
+		t.Fatalf("unexpected error output: %s", errOut.String())
+	}
+}
+
+func TestRunProfileNew_InvalidSource(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	os.Args = []string{
+		"cloudstic", "profile", "new",
+		"-profiles-file", profilesPath,
+		"-name", "bad-source",
+		"-source", "garbage-no-scheme",
+		"-store-ref", "s", "-store", "local:/backup",
+	}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+
+	if code := r.runProfile(); code == 0 {
+		t.Fatal("expected non-zero exit code")
+	}
+	if !strings.Contains(errOut.String(), "Invalid source") {
+		t.Fatalf("unexpected error output: %s", errOut.String())
+	}
+}
+
+func TestRunProfileList_WithOneDriveAuth(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	content := `version: 1
+stores:
+  s:
+    uri: local:/backup
+auth:
+  od-personal:
+    provider: onedrive
+    onedrive_token_file: /home/user/.config/od-token.json
+profiles:
+  docs:
+    source: onedrive:/Documents
+    store: s
+    auth_ref: od-personal
+`
+	if err := os.WriteFile(profilesPath, []byte(content), 0600); err != nil {
+		t.Fatalf("write profiles file: %v", err)
+	}
+
+	os.Args = []string{"cloudstic", "profile", "list", "-profiles-file", profilesPath}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+
+	if code := r.runProfile(); code != 0 {
+		t.Fatalf("runProfile() code=%d err=%s", code, errOut.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "provider=onedrive") {
+		t.Fatalf("expected provider=onedrive in list output:\n%s", got)
+	}
+	if !strings.Contains(got, "token=/home/user/.config/od-token.json") {
+		t.Fatalf("expected onedrive token path in list output:\n%s", got)
+	}
+}
+
+func TestRunProfileShow_WithExcludes(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	content := `version: 1
+stores:
+  s:
+    uri: local:/backup
+profiles:
+  full:
+    source: local:/data
+    store: s
+    tags:
+      - daily
+      - critical
+    excludes:
+      - "*.log"
+      - "*.tmp"
+    exclude_file: /etc/my-excludes.txt
+    skip_native_files: true
+    volume_uuid: ABC-123
+`
+	if err := os.WriteFile(profilesPath, []byte(content), 0600); err != nil {
+		t.Fatalf("write profiles file: %v", err)
+	}
+
+	os.Args = []string{"cloudstic", "profile", "show", "-profiles-file", profilesPath, "full"}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+
+	if code := r.runProfile(); code != 0 {
+		t.Fatalf("runProfile() code=%d err=%s", code, errOut.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "tags: daily, critical") {
+		t.Fatalf("expected tags in output:\n%s", got)
+	}
+	if !strings.Contains(got, "excludes: *.log, *.tmp") {
+		t.Fatalf("expected excludes in output:\n%s", got)
+	}
+	if !strings.Contains(got, "exclude_file: /etc/my-excludes.txt") {
+		t.Fatalf("expected exclude_file in output:\n%s", got)
+	}
+}

--- a/cmd/cloudstic/cmd_store.go
+++ b/cmd/cloudstic/cmd_store.go
@@ -1,0 +1,472 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+
+	cloudstic "github.com/cloudstic/cli"
+)
+
+var validRefName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
+
+func (r *runner) runStore() int {
+	if len(os.Args) < 3 {
+		_, _ = fmt.Fprintln(r.errOut, "Usage: cloudstic store <subcommand> [options]")
+		_, _ = fmt.Fprintln(r.errOut, "")
+		_, _ = fmt.Fprintln(r.errOut, "Available subcommands: list, show, new")
+		return 1
+	}
+
+	switch os.Args[2] {
+	case "list":
+		return r.runStoreList()
+	case "show":
+		return r.runStoreShow()
+	case "new":
+		return r.runStoreNew()
+	default:
+		return r.fail("Unknown store subcommand: %s", os.Args[2])
+	}
+}
+
+func (r *runner) runStoreList() int {
+	fs := flag.NewFlagSet("store list", flag.ExitOnError)
+	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
+	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
+
+	cfg, err := cloudstic.LoadProfilesFile(*profilesFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0
+		}
+		return r.fail("Failed to load profiles: %v", err)
+	}
+
+	names := make([]string, 0, len(cfg.Stores))
+	for name := range cfg.Stores {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	_, _ = fmt.Fprintf(r.out, "%d stores\n", len(names))
+	for _, name := range names {
+		s := cfg.Stores[name]
+		_, _ = fmt.Fprintf(r.out, "- %s", name)
+		if s.URI != "" {
+			_, _ = fmt.Fprintf(r.out, "  uri=%s", s.URI)
+		}
+		_, _ = fmt.Fprintln(r.out)
+	}
+	return 0
+}
+
+func (r *runner) runStoreShow() int {
+	fs := flag.NewFlagSet("store show", flag.ExitOnError)
+	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
+	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
+	if fs.NArg() > 1 {
+		return r.fail("usage: cloudstic store show [-profiles-file <path>] <name>")
+	}
+
+	name := ""
+	if fs.NArg() == 1 {
+		name = fs.Arg(0)
+	}
+
+	cfg, err := cloudstic.LoadProfilesFile(*profilesFile)
+	if err != nil {
+		return r.fail("Failed to load profiles: %v", err)
+	}
+	if name == "" {
+		if !r.canPrompt() {
+			return r.fail("usage: cloudstic store show [-profiles-file <path>] <name>")
+		}
+		names := make([]string, 0, len(cfg.Stores))
+		for n := range cfg.Stores {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		picked, pickErr := r.promptSelect("Select store", names)
+		if pickErr != nil {
+			return r.fail("Failed to select store: %v", pickErr)
+		}
+		name = picked
+	}
+
+	s, ok := cfg.Stores[name]
+	if !ok {
+		return r.fail("Unknown store %q", name)
+	}
+
+	_, _ = fmt.Fprintf(r.out, "store: %s\n", name)
+	_, _ = fmt.Fprintf(r.out, "  uri: %s\n", s.URI)
+	_, _ = fmt.Fprintf(r.out, "  auth_mode: %s\n", profileStoreAuthMode(s))
+	if s.S3Region != "" {
+		_, _ = fmt.Fprintf(r.out, "  s3_region: %s\n", s.S3Region)
+	}
+	if s.S3Profile != "" {
+		_, _ = fmt.Fprintf(r.out, "  s3_profile: %s\n", s.S3Profile)
+	}
+	if s.S3Endpoint != "" {
+		_, _ = fmt.Fprintf(r.out, "  s3_endpoint: %s\n", s.S3Endpoint)
+	}
+	if s.S3AccessKeyEnv != "" {
+		_, _ = fmt.Fprintf(r.out, "  s3_access_key_env: %s\n", s.S3AccessKeyEnv)
+	}
+	if s.S3SecretKeyEnv != "" {
+		_, _ = fmt.Fprintf(r.out, "  s3_secret_key_env: %s\n", s.S3SecretKeyEnv)
+	}
+	if s.S3ProfileEnv != "" {
+		_, _ = fmt.Fprintf(r.out, "  s3_profile_env: %s\n", s.S3ProfileEnv)
+	}
+	if s.StoreSFTPPasswordEnv != "" {
+		_, _ = fmt.Fprintf(r.out, "  store_sftp_password_env: %s\n", s.StoreSFTPPasswordEnv)
+	}
+	if s.StoreSFTPKeyEnv != "" {
+		_, _ = fmt.Fprintf(r.out, "  store_sftp_key_env: %s\n", s.StoreSFTPKeyEnv)
+	}
+	if s.PasswordEnv != "" {
+		_, _ = fmt.Fprintf(r.out, "  password_env: %s\n", s.PasswordEnv)
+	}
+	if s.EncryptionKeyEnv != "" {
+		_, _ = fmt.Fprintf(r.out, "  encryption_key_env: %s\n", s.EncryptionKeyEnv)
+	}
+	if s.RecoveryKeyEnv != "" {
+		_, _ = fmt.Fprintf(r.out, "  recovery_key_env: %s\n", s.RecoveryKeyEnv)
+	}
+	if s.KMSKeyARN != "" {
+		_, _ = fmt.Fprintf(r.out, "  kms_key_arn: %s\n", s.KMSKeyARN)
+	}
+	if s.KMSRegion != "" {
+		_, _ = fmt.Fprintf(r.out, "  kms_region: %s\n", s.KMSRegion)
+	}
+	if s.KMSEndpoint != "" {
+		_, _ = fmt.Fprintf(r.out, "  kms_endpoint: %s\n", s.KMSEndpoint)
+	}
+
+	// Show which profiles reference this store.
+	var refs []string
+	for pName, p := range cfg.Profiles {
+		if p.Store == name {
+			refs = append(refs, pName)
+		}
+	}
+	if len(refs) > 0 {
+		sort.Strings(refs)
+		_, _ = fmt.Fprintf(r.out, "  used_by: %v\n", refs)
+	}
+	return 0
+}
+
+func (r *runner) runStoreNew() int {
+	fs := flag.NewFlagSet("store new", flag.ExitOnError)
+	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
+	name := fs.String("name", "", "Store reference name")
+	uri := fs.String("uri", "", "Store URI (e.g. s3:bucket/path, local:/path, sftp://host/path)")
+	s3Region := fs.String("s3-region", "", "S3 region")
+	s3Profile := fs.String("s3-profile", "", "AWS shared config profile")
+	s3Endpoint := fs.String("s3-endpoint", "", "S3-compatible endpoint URL")
+	s3AccessKey := fs.String("s3-access-key", "", "S3 static access key")
+	s3SecretKey := fs.String("s3-secret-key", "", "S3 static secret key")
+	s3AccessKeyEnv := fs.String("s3-access-key-env", "", "Env var name for S3 access key")
+	s3SecretKeyEnv := fs.String("s3-secret-key-env", "", "Env var name for S3 secret key")
+	s3ProfileEnv := fs.String("s3-profile-env", "", "Env var name for AWS profile")
+	sftpPassword := fs.String("store-sftp-password", "", "SFTP password")
+	sftpKey := fs.String("store-sftp-key", "", "Path to SFTP private key")
+	sftpPasswordEnv := fs.String("store-sftp-password-env", "", "Env var name for SFTP password")
+	sftpKeyEnv := fs.String("store-sftp-key-env", "", "Env var name for SFTP key path")
+	passwordEnv := fs.String("password-env", "", "Env var name for repository password")
+	encryptionKeyEnv := fs.String("encryption-key-env", "", "Env var name for platform key (hex)")
+	recoveryKeyEnv := fs.String("recovery-key-env", "", "Env var name for recovery key mnemonic")
+	kmsKeyARN := fs.String("kms-key-arn", "", "AWS KMS key ARN")
+	kmsRegion := fs.String("kms-region", "", "AWS KMS region")
+	kmsEndpoint := fs.String("kms-endpoint", "", "Custom AWS KMS endpoint URL")
+	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
+
+	if *name == "" {
+		if r.canPrompt() {
+			v, err := r.promptLine("Store reference name", "")
+			if err != nil {
+				return r.fail("Failed to read store name: %v", err)
+			}
+			*name = v
+		}
+		if *name == "" {
+			return r.fail("-name is required")
+		}
+	}
+	if !validRefName.MatchString(*name) {
+		return r.fail("invalid store name %q: must start with a letter or digit and contain only letters, digits, dots, hyphens, or underscores", *name)
+	}
+	if *uri == "" {
+		if r.canPrompt() {
+			v, err := r.promptLine("Store URI", "")
+			if err != nil {
+				return r.fail("Failed to read store URI: %v", err)
+			}
+			*uri = v
+		}
+		if *uri == "" {
+			return r.fail("-uri is required")
+		}
+	}
+
+	// Validate the URI before saving.
+	if _, err := parseStoreURI(*uri); err != nil {
+		return r.fail("%v", err)
+	}
+
+	cfg, err := cloudstic.LoadProfilesFile(*profilesFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			cfg = &cloudstic.ProfilesConfig{Version: 1}
+		} else {
+			return r.fail("Failed to load profiles: %v", err)
+		}
+	}
+	if cfg.Stores == nil {
+		cfg.Stores = map[string]cloudstic.ProfileStore{}
+	}
+
+	cfg.Stores[*name] = cloudstic.ProfileStore{
+		URI:                  *uri,
+		S3Region:             *s3Region,
+		S3Profile:            *s3Profile,
+		S3Endpoint:           *s3Endpoint,
+		S3AccessKey:          *s3AccessKey,
+		S3SecretKey:          *s3SecretKey,
+		S3AccessKeyEnv:       *s3AccessKeyEnv,
+		S3SecretKeyEnv:       *s3SecretKeyEnv,
+		S3ProfileEnv:         *s3ProfileEnv,
+		StoreSFTPPassword:    *sftpPassword,
+		StoreSFTPKey:         *sftpKey,
+		StoreSFTPPasswordEnv: *sftpPasswordEnv,
+		StoreSFTPKeyEnv:      *sftpKeyEnv,
+		PasswordEnv:          *passwordEnv,
+		EncryptionKeyEnv:     *encryptionKeyEnv,
+		RecoveryKeyEnv:       *recoveryKeyEnv,
+		KMSKeyARN:            *kmsKeyARN,
+		KMSRegion:            *kmsRegion,
+		KMSEndpoint:          *kmsEndpoint,
+	}
+
+	if err := cloudstic.SaveProfilesFile(*profilesFile, cfg); err != nil {
+		return r.fail("Failed to save profiles: %v", err)
+	}
+	_, _ = fmt.Fprintf(r.out, "Store %q saved in %s\n", *name, *profilesFile)
+
+	if r.canPrompt() {
+		// If no encryption flags were provided, prompt for encryption config.
+		s := cfg.Stores[*name]
+		hasExplicitEncryption := s.PasswordEnv != "" || s.EncryptionKeyEnv != "" ||
+			s.RecoveryKeyEnv != "" || s.KMSKeyARN != ""
+		if !hasExplicitEncryption {
+			r.promptEncryptionConfig(cfg, *name, *profilesFile)
+		}
+		r.checkOrInitStore(cfg, *name, *profilesFile)
+	}
+
+	return 0
+}
+
+// checkOrInitStore connects to a store and checks if it is initialized.
+// If already initialized, it confirms connectivity. If not, it offers to
+// initialize it. Encryption config should already be saved in profiles.yaml
+// before calling this. Errors are printed but never cause a non-zero exit—
+// the store config has already been saved.
+func (r *runner) checkOrInitStore(cfg *cloudstic.ProfilesConfig, storeName, profilesFile string) {
+	s := cfg.Stores[storeName]
+	g := globalFlagsFromProfileStore(s)
+	raw, err := g.initObjectStore()
+	if err != nil {
+		_, _ = fmt.Fprintf(r.errOut, "Could not connect to store: %v\n", err)
+		return
+	}
+
+	ctx := context.Background()
+
+	// Check if already initialized by looking for the config marker.
+	cfgData, err := raw.Get(ctx, "config")
+	if err == nil && cfgData != nil {
+		_, _ = fmt.Fprintln(r.out, "Store is already initialized and accessible.")
+		return
+	}
+
+	_, _ = fmt.Fprintln(r.out, "Store is accessible but not yet initialized.")
+	yes, promptErr := r.promptConfirm("Initialize it now?", true)
+	if promptErr != nil || !yes {
+		return
+	}
+
+	// Check if the store has encryption config.
+	hasEncryption := s.PasswordEnv != "" || s.EncryptionKeyEnv != "" ||
+		s.RecoveryKeyEnv != "" || s.KMSKeyARN != ""
+
+	if !hasEncryption {
+		// No encryption configured — init without encryption.
+		result, initErr := cloudstic.InitRepo(ctx, raw, cloudstic.WithInitNoEncryption())
+		if initErr != nil {
+			_, _ = fmt.Fprintf(r.errOut, "Init failed: %v\n", initErr)
+			return
+		}
+		r.printInitResult(result)
+		return
+	}
+
+	// Build keychain from the store's encryption settings.
+	// For password-based encryption, the env var must be set for init.
+	// If not set, prompt for the password interactively.
+	kc, err := g.buildKeychain(ctx)
+	if err != nil {
+		_, _ = fmt.Fprintf(r.errOut, "Failed to build keychain: %v\n", err)
+		return
+	}
+
+	var initOpts []cloudstic.InitOption
+	initOpts = append(initOpts, cloudstic.WithInitCredentials(kc))
+	result, err := cloudstic.InitRepo(ctx, raw, initOpts...)
+	if err != nil {
+		_, _ = fmt.Fprintf(r.errOut, "Init failed: %v\n", err)
+		return
+	}
+	r.printInitResult(result)
+}
+
+// promptEncryptionConfig guides the user through encryption configuration
+// and saves the chosen settings to profiles.yaml. It does not build a keychain
+// or prompt for the actual password — that happens later during init.
+func (r *runner) promptEncryptionConfig(cfg *cloudstic.ProfilesConfig, storeName, profilesFile string) {
+	_, _ = fmt.Fprintln(r.out)
+	_, _ = fmt.Fprintln(r.out, "No encryption is configured for this store.")
+
+	options := []string{
+		"Password (recommended for interactive use)",
+		"Platform key (recommended for automation/CI)",
+		"AWS KMS key (enterprise)",
+		"No encryption (not recommended)",
+	}
+	picked, err := r.promptSelect("Select encryption method", options)
+	if err != nil {
+		_, _ = fmt.Fprintf(r.errOut, "Failed to select encryption method: %v\n", err)
+		return
+	}
+
+	s := cfg.Stores[storeName]
+
+	switch picked {
+	case options[0]: // Password
+		envName, envErr := r.promptLine("Env var name for the repository password", "CLOUDSTIC_PASSWORD")
+		if envErr != nil {
+			_, _ = fmt.Fprintf(r.errOut, "Failed to read env var name: %v\n", envErr)
+			return
+		}
+		if envName == "" {
+			envName = "CLOUDSTIC_PASSWORD"
+		}
+		s.PasswordEnv = envName
+		_, _ = fmt.Fprintf(r.out, "Encryption: password via $%s\n", envName)
+
+	case options[1]: // Platform key
+		envName, envErr := r.promptLine("Env var name for the platform key (64-char hex)", "CLOUDSTIC_ENCRYPTION_KEY")
+		if envErr != nil {
+			_, _ = fmt.Fprintf(r.errOut, "Failed to read env var name: %v\n", envErr)
+			return
+		}
+		if envName == "" {
+			envName = "CLOUDSTIC_ENCRYPTION_KEY"
+		}
+		s.EncryptionKeyEnv = envName
+		_, _ = fmt.Fprintf(r.out, "Encryption: platform key via $%s\n", envName)
+
+	case options[2]: // KMS
+		arn, arnErr := r.promptLine("KMS key ARN", "")
+		if arnErr != nil || arn == "" {
+			_, _ = fmt.Fprintln(r.errOut, "KMS key ARN is required.")
+			return
+		}
+		s.KMSKeyARN = arn
+
+		region, _ := r.promptLine("KMS region", "us-east-1")
+		if region != "" {
+			s.KMSRegion = region
+		}
+		_, _ = fmt.Fprintf(r.out, "Encryption: AWS KMS (%s)\n", arn)
+
+	case options[3]: // No encryption
+		_, _ = fmt.Fprintln(r.out, "Encryption: none (not recommended)")
+		return
+	}
+
+	// Save updated store config.
+	cfg.Stores[storeName] = s
+	if saveErr := cloudstic.SaveProfilesFile(profilesFile, cfg); saveErr != nil {
+		_, _ = fmt.Fprintf(r.errOut, "Warning: could not save encryption settings: %v\n", saveErr)
+	}
+}
+
+// globalFlagsFromProfileStore builds a globalFlags populated from a ProfileStore,
+// resolving env var indirections for secrets.
+func globalFlagsFromProfileStore(s cloudstic.ProfileStore) *globalFlags {
+	resolve := func(direct, envName string) string {
+		if direct != "" {
+			return direct
+		}
+		if envName != "" {
+			return os.Getenv(envName)
+		}
+		return ""
+	}
+
+	g := &globalFlags{}
+	store := s.URI
+	g.store = &store
+	s3Endpoint := s.S3Endpoint
+	g.s3Endpoint = &s3Endpoint
+	s3Region := s.S3Region
+	if s3Region == "" {
+		s3Region = "us-east-1"
+	}
+	g.s3Region = &s3Region
+	s3Profile := resolve(s.S3Profile, s.S3ProfileEnv)
+	g.s3Profile = &s3Profile
+	s3AccessKey := resolve(s.S3AccessKey, s.S3AccessKeyEnv)
+	g.s3AccessKey = &s3AccessKey
+	s3SecretKey := resolve(s.S3SecretKey, s.S3SecretKeyEnv)
+	g.s3SecretKey = &s3SecretKey
+	storeSFTPPassword := resolve(s.StoreSFTPPassword, s.StoreSFTPPasswordEnv)
+	g.storeSFTPPassword = &storeSFTPPassword
+	storeSFTPKey := resolve(s.StoreSFTPKey, s.StoreSFTPKeyEnv)
+	g.storeSFTPKey = &storeSFTPKey
+	password := resolve("", s.PasswordEnv)
+	g.password = &password
+	encryptionKey := resolve("", s.EncryptionKeyEnv)
+	g.encryptionKey = &encryptionKey
+	recoveryKey := resolve("", s.RecoveryKeyEnv)
+	g.recoveryKey = &recoveryKey
+	kmsKeyARN := s.KMSKeyARN
+	g.kmsKeyARN = &kmsKeyARN
+	kmsRegion := s.KMSRegion
+	g.kmsRegion = &kmsRegion
+	kmsEndpoint := s.KMSEndpoint
+	g.kmsEndpoint = &kmsEndpoint
+
+	// Non-store fields with safe defaults.
+	empty := ""
+	g.sourceSFTPPassword = &empty
+	g.sourceSFTPKey = &empty
+	falseVal := false
+	g.disablePackfile = &falseVal
+	g.prompt = &falseVal
+	g.verbose = &falseVal
+	g.quiet = &falseVal
+	g.debug = &falseVal
+	g.profile = &empty
+	g.profilesFile = &empty
+
+	return g
+}

--- a/cmd/cloudstic/cmd_store_test.go
+++ b/cmd/cloudstic/cmd_store_test.go
@@ -1,0 +1,625 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	cloudstic "github.com/cloudstic/cli"
+)
+
+func TestRunStoreNewAndListAndShow(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+
+	// Create a store.
+	os.Args = []string{
+		"cloudstic", "store", "new",
+		"-profiles-file", profilesPath,
+		"-name", "prod-s3",
+		"-uri", "s3:my-bucket/backups",
+		"-s3-region", "eu-west-1",
+		"-s3-profile", "prod",
+	}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+	if code := r.runStore(); code != 0 {
+		t.Fatalf("store new failed: %s", errOut.String())
+	}
+	if !strings.Contains(out.String(), `"prod-s3" saved`) {
+		t.Fatalf("unexpected store new output: %s", out.String())
+	}
+
+	// List stores.
+	os.Args = []string{"cloudstic", "store", "list", "-profiles-file", profilesPath}
+	out.Reset()
+	errOut.Reset()
+	if code := r.runStore(); code != 0 {
+		t.Fatalf("store list failed: %s", errOut.String())
+	}
+	if !strings.Contains(out.String(), "1 stores") || !strings.Contains(out.String(), "prod-s3") {
+		t.Fatalf("unexpected store list output:\n%s", out.String())
+	}
+
+	// Show store.
+	os.Args = []string{"cloudstic", "store", "show", "-profiles-file", profilesPath, "prod-s3"}
+	out.Reset()
+	errOut.Reset()
+	if code := r.runStore(); code != 0 {
+		t.Fatalf("store show failed: %s", errOut.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "store: prod-s3") {
+		t.Fatalf("expected store name in show output:\n%s", got)
+	}
+	if !strings.Contains(got, "uri: s3:my-bucket/backups") {
+		t.Fatalf("expected URI in show output:\n%s", got)
+	}
+	if !strings.Contains(got, "s3_region: eu-west-1") {
+		t.Fatalf("expected region in show output:\n%s", got)
+	}
+	if !strings.Contains(got, "s3_profile: prod") {
+		t.Fatalf("expected profile in show output:\n%s", got)
+	}
+}
+
+func TestRunStoreNew_RequiresNameAndURI(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+
+	// Missing URI.
+	os.Args = []string{"cloudstic", "store", "new", "-profiles-file", profilesPath, "-name", "x"}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+	if code := r.runStore(); code == 0 {
+		t.Fatal("expected non-zero exit code")
+	}
+	if !strings.Contains(errOut.String(), "-uri is required") {
+		t.Fatalf("unexpected error: %s", errOut.String())
+	}
+}
+
+func TestNoPromptDisablesInteractivity(t *testing.T) {
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut, noPrompt: true}
+	if r.canPrompt() {
+		t.Fatal("canPrompt() should return false when noPrompt is true")
+	}
+}
+
+func TestHasGlobalFlag(t *testing.T) {
+	orig := os.Args
+	defer func() { os.Args = orig }()
+
+	os.Args = []string{"cloudstic", "store", "new", "--no-prompt", "-name", "x"}
+	if !hasGlobalFlag("no-prompt") {
+		t.Fatal("expected hasGlobalFlag to find --no-prompt")
+	}
+
+	os.Args = []string{"cloudstic", "store", "new", "-name", "x"}
+	if hasGlobalFlag("no-prompt") {
+		t.Fatal("expected hasGlobalFlag to not find --no-prompt")
+	}
+}
+
+func TestRunStoreShow_UnknownStore(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	if err := os.WriteFile(profilesPath, []byte("version: 1\nstores: {}\n"), 0600); err != nil {
+		t.Fatalf("write profiles: %v", err)
+	}
+
+	os.Args = []string{"cloudstic", "store", "show", "-profiles-file", profilesPath, "missing"}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+	if code := r.runStore(); code == 0 {
+		t.Fatal("expected non-zero exit code")
+	}
+	if !strings.Contains(errOut.String(), "Unknown store") {
+		t.Fatalf("unexpected error: %s", errOut.String())
+	}
+}
+
+func TestRunStoreShow_UsedBy(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	content := `version: 1
+stores:
+  main:
+    uri: s3:bucket/path
+profiles:
+  photos:
+    source: local:/photos
+    store: main
+  docs:
+    source: local:/docs
+    store: main
+`
+	if err := os.WriteFile(profilesPath, []byte(content), 0600); err != nil {
+		t.Fatalf("write profiles: %v", err)
+	}
+
+	os.Args = []string{"cloudstic", "store", "show", "-profiles-file", profilesPath, "main"}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+	if code := r.runStore(); code != 0 {
+		t.Fatalf("store show failed: %s", errOut.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "used_by:") || !strings.Contains(got, "docs") || !strings.Contains(got, "photos") {
+		t.Fatalf("expected used_by with both profiles:\n%s", got)
+	}
+}
+
+func TestRunStoreList_MissingFile(t *testing.T) {
+	os.Args = []string{"cloudstic", "store", "list", "-profiles-file", filepath.Join(t.TempDir(), "missing.yaml")}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+	if code := r.runStore(); code != 0 {
+		t.Fatalf("expected zero exit code, got err=%s", errOut.String())
+	}
+}
+
+func TestRunStoreNew_WithEncryption(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+
+	os.Args = []string{
+		"cloudstic", "store", "new",
+		"-profiles-file", profilesPath,
+		"-name", "encrypted-s3",
+		"-uri", "s3:secure-bucket/backups",
+		"-password-env", "MY_BACKUP_PASSWORD",
+		"-kms-key-arn", "arn:aws:kms:us-east-1:123456:key/abcd",
+		"-kms-region", "us-east-1",
+	}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+	if code := r.runStore(); code != 0 {
+		t.Fatalf("store new failed: %s", errOut.String())
+	}
+
+	// Verify show displays encryption fields.
+	os.Args = []string{"cloudstic", "store", "show", "-profiles-file", profilesPath, "encrypted-s3"}
+	out.Reset()
+	errOut.Reset()
+	if code := r.runStore(); code != 0 {
+		t.Fatalf("store show failed: %s", errOut.String())
+	}
+	got := out.String()
+	for _, want := range []string{
+		"password_env: MY_BACKUP_PASSWORD",
+		"kms_key_arn: arn:aws:kms:us-east-1:123456:key/abcd",
+		"kms_region: us-east-1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in show output:\n%s", want, got)
+		}
+	}
+
+	// Verify YAML persistence.
+	raw, err := os.ReadFile(profilesPath)
+	if err != nil {
+		t.Fatalf("read profiles: %v", err)
+	}
+	yaml := string(raw)
+	if !strings.Contains(yaml, "password_env: MY_BACKUP_PASSWORD") {
+		t.Fatalf("expected password_env in YAML:\n%s", yaml)
+	}
+	if !strings.Contains(yaml, "kms_key_arn:") {
+		t.Fatalf("expected kms_key_arn in YAML:\n%s", yaml)
+	}
+}
+
+func TestCheckOrInitStore_AlreadyInitialized(t *testing.T) {
+	tmpDir := t.TempDir()
+	storePath := filepath.Join(tmpDir, "store")
+
+	// Initialize the store first.
+	s := cloudstic.ProfileStore{URI: "local:" + storePath}
+	g := globalFlagsFromProfileStore(s)
+	raw, err := g.initObjectStore()
+	if err != nil {
+		t.Fatalf("initObjectStore: %v", err)
+	}
+	_, err = cloudstic.InitRepo(t.Context(), raw, cloudstic.WithInitNoEncryption())
+	if err != nil {
+		t.Fatalf("InitRepo: %v", err)
+	}
+
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	cfg := &cloudstic.ProfilesConfig{
+		Version: 1,
+		Stores:  map[string]cloudstic.ProfileStore{"test": s},
+	}
+	if err := cloudstic.SaveProfilesFile(profilesPath, cfg); err != nil {
+		t.Fatalf("SaveProfilesFile: %v", err)
+	}
+
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+	r.checkOrInitStore(cfg, "test", profilesPath)
+
+	if !strings.Contains(out.String(), "already initialized") {
+		t.Fatalf("expected 'already initialized' in output, got:\n%s", out.String())
+	}
+}
+
+func TestGlobalFlagsFromProfileStore_ResolvesEnvVars(t *testing.T) {
+	t.Setenv("TEST_AK", "my-access-key")
+	t.Setenv("TEST_SK", "my-secret-key")
+	t.Setenv("TEST_PW", "s3cret")
+
+	s := cloudstic.ProfileStore{
+		URI:            "s3:bucket/prefix",
+		S3Region:       "eu-west-1",
+		S3AccessKeyEnv: "TEST_AK",
+		S3SecretKeyEnv: "TEST_SK",
+		PasswordEnv:    "TEST_PW",
+		KMSKeyARN:      "arn:aws:kms:us-east-1:123:key/abc",
+	}
+
+	g := globalFlagsFromProfileStore(s)
+	if *g.store != "s3:bucket/prefix" {
+		t.Fatalf("store=%q", *g.store)
+	}
+	if *g.s3Region != "eu-west-1" {
+		t.Fatalf("s3Region=%q", *g.s3Region)
+	}
+	if *g.s3AccessKey != "my-access-key" {
+		t.Fatalf("s3AccessKey=%q", *g.s3AccessKey)
+	}
+	if *g.s3SecretKey != "my-secret-key" {
+		t.Fatalf("s3SecretKey=%q", *g.s3SecretKey)
+	}
+	if *g.password != "s3cret" {
+		t.Fatalf("password=%q", *g.password)
+	}
+	if *g.kmsKeyARN != "arn:aws:kms:us-east-1:123:key/abc" {
+		t.Fatalf("kmsKeyARN=%q", *g.kmsKeyARN)
+	}
+}
+
+func TestRunStoreNew_InvalidURI(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+
+	os.Args = []string{"cloudstic", "store", "new", "-profiles-file", profilesPath, "-name", "bad", "-uri", "garbage-no-scheme"}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+	if code := r.runStore(); code == 0 {
+		t.Fatal("expected non-zero exit code for invalid URI")
+	}
+	if !strings.Contains(errOut.String(), "invalid store URI") {
+		t.Fatalf("unexpected error: %s", errOut.String())
+	}
+}
+
+func TestRunStoreNew_InvalidName(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+
+	os.Args = []string{"cloudstic", "store", "new", "-profiles-file", profilesPath, "-name", "bad name!", "-uri", "local:/tmp/store"}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+	if code := r.runStore(); code == 0 {
+		t.Fatal("expected non-zero exit code for invalid name")
+	}
+	if !strings.Contains(errOut.String(), "invalid store name") {
+		t.Fatalf("unexpected error: %s", errOut.String())
+	}
+}
+
+func TestRunStore_UnknownSubcommand(t *testing.T) {
+	os.Args = []string{"cloudstic", "store", "unknown"}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+	if code := r.runStore(); code == 0 {
+		t.Fatal("expected non-zero exit code")
+	}
+	if !strings.Contains(errOut.String(), "Unknown store subcommand") {
+		t.Fatalf("unexpected error: %s", errOut.String())
+	}
+}
+
+func TestRunStoreShow_WithEncryption(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	content := `version: 1
+stores:
+  enc-store:
+    uri: s3:enc-bucket/path
+    password_env: MY_PW
+    encryption_key_env: MY_EK
+    recovery_key_env: MY_RK
+    kms_key_arn: arn:aws:kms:us-east-1:111:key/xyz
+    kms_region: us-west-2
+    kms_endpoint: https://kms.custom.endpoint
+`
+	if err := os.WriteFile(profilesPath, []byte(content), 0600); err != nil {
+		t.Fatalf("write profiles: %v", err)
+	}
+
+	os.Args = []string{"cloudstic", "store", "show", "-profiles-file", profilesPath, "enc-store"}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+	if code := r.runStore(); code != 0 {
+		t.Fatalf("store show failed: %s", errOut.String())
+	}
+	got := out.String()
+	for _, want := range []string{
+		"password_env: MY_PW",
+		"encryption_key_env: MY_EK",
+		"recovery_key_env: MY_RK",
+		"kms_key_arn: arn:aws:kms:us-east-1:111:key/xyz",
+		"kms_region: us-west-2",
+		"kms_endpoint: https://kms.custom.endpoint",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in show output:\n%s", want, got)
+		}
+	}
+}
+
+func TestRunStoreShow_WithSFTP(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	content := `version: 1
+stores:
+  sftp-store:
+    uri: sftp://user@host/path
+    store_sftp_password_env: SFTP_PW_ENV
+    store_sftp_key_env: SFTP_KEY_ENV
+`
+	if err := os.WriteFile(profilesPath, []byte(content), 0600); err != nil {
+		t.Fatalf("write profiles: %v", err)
+	}
+
+	os.Args = []string{"cloudstic", "store", "show", "-profiles-file", profilesPath, "sftp-store"}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+	if code := r.runStore(); code != 0 {
+		t.Fatalf("store show failed: %s", errOut.String())
+	}
+	got := out.String()
+	for _, want := range []string{
+		"store_sftp_password_env: SFTP_PW_ENV",
+		"store_sftp_key_env: SFTP_KEY_ENV",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in show output:\n%s", want, got)
+		}
+	}
+}
+
+func TestRunStoreShow_WithS3Env(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	content := `version: 1
+stores:
+  s3env-store:
+    uri: s3:env-bucket/path
+    s3_access_key_env: AK_ENV
+    s3_secret_key_env: SK_ENV
+    s3_profile_env: PROF_ENV
+`
+	if err := os.WriteFile(profilesPath, []byte(content), 0600); err != nil {
+		t.Fatalf("write profiles: %v", err)
+	}
+
+	os.Args = []string{"cloudstic", "store", "show", "-profiles-file", profilesPath, "s3env-store"}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+	if code := r.runStore(); code != 0 {
+		t.Fatalf("store show failed: %s", errOut.String())
+	}
+	got := out.String()
+	for _, want := range []string{
+		"s3_access_key_env: AK_ENV",
+		"s3_secret_key_env: SK_ENV",
+		"s3_profile_env: PROF_ENV",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in show output:\n%s", want, got)
+		}
+	}
+}
+
+func TestRunStoreNew_WithSFTPOptions(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+
+	os.Args = []string{
+		"cloudstic", "store", "new",
+		"-profiles-file", profilesPath,
+		"-name", "sftp-new",
+		"-uri", "sftp://user@host/path",
+		"-store-sftp-password-env", "SFTP_PW",
+		"-store-sftp-key-env", "SFTP_KEY",
+	}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+	if code := r.runStore(); code != 0 {
+		t.Fatalf("store new failed: %s", errOut.String())
+	}
+
+	// Verify via show.
+	os.Args = []string{"cloudstic", "store", "show", "-profiles-file", profilesPath, "sftp-new"}
+	out.Reset()
+	errOut.Reset()
+	if code := r.runStore(); code != 0 {
+		t.Fatalf("store show failed: %s", errOut.String())
+	}
+	got := out.String()
+	for _, want := range []string{
+		"store_sftp_password_env: SFTP_PW",
+		"store_sftp_key_env: SFTP_KEY",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in show output:\n%s", want, got)
+		}
+	}
+}
+
+func TestRunStoreNew_WithAllS3Options(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+
+	os.Args = []string{
+		"cloudstic", "store", "new",
+		"-profiles-file", profilesPath,
+		"-name", "full-s3",
+		"-uri", "s3:bucket",
+		"-s3-region", "eu-west-1",
+		"-s3-endpoint", "https://custom.endpoint",
+		"-s3-profile", "prod",
+		"-s3-access-key-env", "AK",
+		"-s3-secret-key-env", "SK",
+		"-s3-profile-env", "PROFILE",
+	}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+	if code := r.runStore(); code != 0 {
+		t.Fatalf("store new failed: %s", errOut.String())
+	}
+
+	raw, err := os.ReadFile(profilesPath)
+	if err != nil {
+		t.Fatalf("read profiles: %v", err)
+	}
+	yaml := string(raw)
+	for _, want := range []string{
+		"s3_region: eu-west-1",
+		"s3_endpoint: https://custom.endpoint",
+		"s3_profile: prod",
+		"s3_access_key_env: AK",
+		"s3_secret_key_env: SK",
+		"s3_profile_env: PROFILE",
+	} {
+		if !strings.Contains(yaml, want) {
+			t.Fatalf("expected %q in YAML:\n%s", want, yaml)
+		}
+	}
+}
+
+func TestValidRefName(t *testing.T) {
+	valid := []string{"abc", "a-b", "a.b", "a_b", "A1", "test-store.v2"}
+	for _, name := range valid {
+		if !validRefName.MatchString(name) {
+			t.Errorf("expected %q to be valid", name)
+		}
+	}
+
+	invalid := []string{"", "-abc", ".abc", "_abc", "a b", "a!b", "a@b"}
+	for _, name := range invalid {
+		if validRefName.MatchString(name) {
+			t.Errorf("expected %q to be invalid", name)
+		}
+	}
+}
+
+func TestRunStoreList_MultipleStores(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	content := `version: 1
+stores:
+  alpha:
+    uri: local:/tmp/alpha
+  beta:
+    uri: s3:beta-bucket
+  gamma:
+    uri: sftp://user@host/gamma
+`
+	if err := os.WriteFile(profilesPath, []byte(content), 0600); err != nil {
+		t.Fatalf("write profiles: %v", err)
+	}
+
+	os.Args = []string{"cloudstic", "store", "list", "-profiles-file", profilesPath}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+	if code := r.runStore(); code != 0 {
+		t.Fatalf("store list failed: %s", errOut.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "3 stores") {
+		t.Fatalf("expected '3 stores' in output:\n%s", got)
+	}
+	for _, name := range []string{"alpha", "beta", "gamma"} {
+		if !strings.Contains(got, name) {
+			t.Fatalf("expected %q in list output:\n%s", name, got)
+		}
+	}
+}
+
+func TestRunStoreNew_LocalStore(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+
+	os.Args = []string{
+		"cloudstic", "store", "new",
+		"-profiles-file", profilesPath,
+		"-name", "local-bk",
+		"-uri", "local:/tmp/backup",
+	}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+	if code := r.runStore(); code != 0 {
+		t.Fatalf("store new failed: %s", errOut.String())
+	}
+	if !strings.Contains(out.String(), `"local-bk" saved`) {
+		t.Fatalf("unexpected store new output: %s", out.String())
+	}
+
+	// Verify YAML has the correct URI.
+	raw, err := os.ReadFile(profilesPath)
+	if err != nil {
+		t.Fatalf("read profiles: %v", err)
+	}
+	if !strings.Contains(string(raw), "uri: local:/tmp/backup") {
+		t.Fatalf("expected URI in YAML:\n%s", string(raw))
+	}
+}
+
+func TestGlobalFlagsFromProfileStore_DefaultRegion(t *testing.T) {
+	s := cloudstic.ProfileStore{
+		URI: "s3:some-bucket",
+	}
+	g := globalFlagsFromProfileStore(s)
+	if *g.s3Region != "us-east-1" {
+		t.Fatalf("expected default region us-east-1, got %q", *g.s3Region)
+	}
+}
+
+func TestGlobalFlagsFromProfileStore_SFTPFields(t *testing.T) {
+	s := cloudstic.ProfileStore{
+		URI:               "sftp://user@host/path",
+		StoreSFTPPassword: "direct-pw",
+		StoreSFTPKey:      "/path/to/key",
+	}
+	g := globalFlagsFromProfileStore(s)
+	if *g.storeSFTPPassword != "direct-pw" {
+		t.Fatalf("expected storeSFTPPassword=direct-pw, got %q", *g.storeSFTPPassword)
+	}
+	if *g.storeSFTPKey != "/path/to/key" {
+		t.Fatalf("expected storeSFTPKey=/path/to/key, got %q", *g.storeSFTPKey)
+	}
+}

--- a/cmd/cloudstic/completion.go
+++ b/cmd/cloudstic/completion.go
@@ -41,9 +41,9 @@ _cloudstic() {
     local cur prev words cword
     _init_completion || return
 
-    local commands="init backup restore list ls prune forget diff break-lock key cat completion version help"
+    local commands="init backup auth profile store restore list ls prune forget diff break-lock key cat completion version help"
 
-    local global_flags="-store -s3-endpoint -s3-region -s3-access-key -s3-secret-key -source-sftp-password -source-sftp-key -store-sftp-password -store-sftp-key -encryption-key -password -recovery-key -kms-key-arn -kms-region -kms-endpoint -disable-packfile -prompt -verbose -quiet -debug"
+    local global_flags="-store -profile -profiles-file -s3-endpoint -s3-region -s3-profile -s3-access-key -s3-secret-key -source-sftp-password -source-sftp-key -store-sftp-password -store-sftp-key -encryption-key -password -recovery-key -kms-key-arn -kms-region -kms-endpoint -disable-packfile -prompt -no-prompt -verbose -quiet -debug"
 
     # Identify the subcommand
     local cmd=""
@@ -53,7 +53,7 @@ _cloudstic() {
             -*)
                 # skip flags and their values
                 case "${words[i]}" in
-                    -store|-s3-endpoint|-s3-region|-s3-access-key|-s3-secret-key|-source-sftp-password|-source-sftp-key|-store-sftp-password|-store-sftp-key|-encryption-key|-password|-recovery-key|-kms-key-arn|-kms-region|-kms-endpoint|-source|-google-credentials|-google-token-file|-onedrive-client-id|-onedrive-token-file|-tag|-output|-keep-last|-keep-hourly|-keep-daily|-keep-weekly|-keep-monthly|-keep-yearly|-group-by|-account|-json)
+                    -store|-profile|-profiles-file|-s3-endpoint|-s3-region|-s3-profile|-s3-access-key|-s3-secret-key|-source-sftp-password|-source-sftp-key|-store-sftp-password|-store-sftp-key|-encryption-key|-password|-recovery-key|-kms-key-arn|-kms-region|-kms-endpoint|-source|-all-profiles|-auth-ref|-google-credentials|-google-token-file|-onedrive-client-id|-onedrive-token-file|-tag|-output|-keep-last|-keep-hourly|-keep-daily|-keep-weekly|-keep-monthly|-keep-yearly|-group-by|-account|-json)
                         ((i++)) ;;
                 esac
                 ;;
@@ -76,7 +76,7 @@ _cloudstic() {
         init)
             cmd_flags="-add-recovery-key -no-encryption -adopt-slots" ;;
         backup)
-            cmd_flags="-source -skip-native-files -google-credentials -google-token-file -onedrive-client-id -onedrive-token-file -tag -dry-run" ;;
+            cmd_flags="-source -profile -all-profiles -auth-ref -profiles-file -skip-native-files -google-credentials -google-token-file -onedrive-client-id -onedrive-token-file -tag -dry-run" ;;
         restore)
             cmd_flags="-output -dry-run" ;;
         prune)
@@ -111,6 +111,80 @@ _cloudstic() {
             ;;
         list)
             cmd_flags="-group" ;;
+        profile)
+            local profile_sub=""
+            local j
+            for ((j=i+1; j < cword; j++)); do
+                case "${words[j]}" in
+                    -*) ;;
+                    *) profile_sub="${words[j]}"; break ;;
+                esac
+            done
+            if [[ -z "$profile_sub" ]]; then
+                COMPREPLY=($(compgen -W "list show new" -- "$cur"))
+                return
+            fi
+            case "$profile_sub" in
+                list)
+                    cmd_flags="-profiles-file" ;;
+                show)
+                    cmd_flags="-profiles-file" ;;
+                new)
+                    cmd_flags="-profiles-file -name -source -store-ref -store -auth-ref -tag -exclude -exclude-file -skip-native-files -volume-uuid -google-credentials -google-token-file -onedrive-client-id -onedrive-token-file" ;;
+                *)
+                    cmd_flags="" ;;
+            esac
+            ;;
+        auth)
+            local auth_sub=""
+            local j
+            for ((j=i+1; j < cword; j++)); do
+                case "${words[j]}" in
+                    -*) ;;
+                    *) auth_sub="${words[j]}"; break ;;
+                esac
+            done
+            if [[ -z "$auth_sub" ]]; then
+                COMPREPLY=($(compgen -W "list show new login" -- "$cur"))
+                return
+            fi
+            case "$auth_sub" in
+                list)
+                    cmd_flags="-profiles-file" ;;
+                show)
+                    cmd_flags="-profiles-file" ;;
+                new)
+                    cmd_flags="-profiles-file -name -provider -google-credentials -google-token-file -onedrive-client-id -onedrive-token-file" ;;
+                login)
+                    cmd_flags="-profiles-file -name" ;;
+                *)
+                    cmd_flags="" ;;
+            esac
+            ;;
+        store)
+            local store_sub=""
+            local j
+            for ((j=i+1; j < cword; j++)); do
+                case "${words[j]}" in
+                    -*) ;;
+                    *) store_sub="${words[j]}"; break ;;
+                esac
+            done
+            if [[ -z "$store_sub" ]]; then
+                COMPREPLY=($(compgen -W "list show new" -- "$cur"))
+                return
+            fi
+            case "$store_sub" in
+                list)
+                    cmd_flags="-profiles-file" ;;
+                show)
+                    cmd_flags="-profiles-file" ;;
+                new)
+                    cmd_flags="-profiles-file -name -uri -s3-region -s3-profile -s3-endpoint -s3-access-key -s3-secret-key -s3-access-key-env -s3-secret-key-env -s3-profile-env -store-sftp-password -store-sftp-key -store-sftp-password-env -store-sftp-key-env -password-env -encryption-key-env -recovery-key-env -kms-key-arn -kms-region -kms-endpoint" ;;
+                *)
+                    cmd_flags="" ;;
+            esac
+            ;;
         check)
             cmd_flags="-read-data" ;;
         ls|diff|break-lock|version|help)
@@ -132,7 +206,7 @@ _cloudstic() {
             # URI completion hint: show scheme prefixes and bare keywords
             COMPREPLY=($(compgen -W "local: sftp:// gdrive gdrive-changes onedrive onedrive-changes" -- "$cur"))
             return ;;
-        -source-sftp-key|-store-sftp-key|-output)
+        -source-sftp-key|-store-sftp-key|-output|-profiles-file)
             _filedir
             return ;;
     esac
@@ -153,6 +227,8 @@ _cloudstic() {
     commands=(
         'init:Initialize a new repository'
         'backup:Create a new backup snapshot from a source'
+        'auth:Manage reusable cloud auth entries'
+        'profile:Manage backup profiles'
         'restore:Restore files from a backup snapshot'
         'list:List all backup snapshots in the repository'
         'ls:List files within a specific snapshot'
@@ -170,8 +246,11 @@ _cloudstic() {
     local -a global_flags
     global_flags=(
         '-store[Storage backend URI (local:<path>, s3:<bucket>[/<prefix>], b2:<bucket>[/<prefix>], sftp://[user@]host[:port]/<path>)]:uri:'
+        '-profile[Profile name from profiles.yaml]:name:'
+        '-profiles-file[Path to profiles YAML file]:path:_files'
         '-s3-endpoint[S3 compatible endpoint URL]:url:'
         '-s3-region[S3 region]:region:'
+        '-s3-profile[AWS shared config profile for S3 auth]:name:'
         '-s3-access-key[S3 access key ID]:key:'
         '-s3-secret-key[S3 secret access key]:secret:'
         '-source-sftp-password[SFTP source password]:password:'
@@ -186,6 +265,7 @@ _cloudstic() {
         '-kms-endpoint[Custom AWS KMS endpoint]:url:'
         '-disable-packfile[Disable bundling small objects into packs]'
         '-prompt[Prompt for password interactively]'
+        '-no-prompt[Disable interactive prompts (for scripts and CI)]'
         '-verbose[Log detailed operations]'
         '-quiet[Suppress progress bars]'
         '-debug[Log every store request]'
@@ -199,7 +279,7 @@ _cloudstic() {
             -*)
                 # Skip flags with values
                 case "${words[i]}" in
-                    -store|-s3-endpoint|-s3-region|-s3-access-key|-s3-secret-key|-source-sftp-password|-source-sftp-key|-store-sftp-password|-store-sftp-key|-encryption-key|-password|-recovery-key|-kms-key-arn|-kms-region|-kms-endpoint|-source|-google-credentials|-google-token-file|-onedrive-client-id|-onedrive-token-file|-tag|-output|-keep-last|-keep-hourly|-keep-daily|-keep-weekly|-keep-monthly|-keep-yearly|-group-by|-account)
+                    -store|-profile|-profiles-file|-s3-endpoint|-s3-region|-s3-profile|-s3-access-key|-s3-secret-key|-source-sftp-password|-source-sftp-key|-store-sftp-password|-store-sftp-key|-encryption-key|-password|-recovery-key|-kms-key-arn|-kms-region|-kms-endpoint|-source|-all-profiles|-auth-ref|-google-credentials|-google-token-file|-onedrive-client-id|-onedrive-token-file|-tag|-output|-keep-last|-keep-hourly|-keep-daily|-keep-weekly|-keep-monthly|-keep-yearly|-group-by|-account)
                         (( i++ )) ;;
                 esac
                 ;;
@@ -227,6 +307,10 @@ _cloudstic() {
         backup)
             _arguments $global_flags \
                 '-source[Source URI]:uri:(local: sftp:// gdrive gdrive-changes onedrive onedrive-changes)' \
+                '-profile[Backup profile name]:name:' \
+                '-all-profiles[Run all enabled backup profiles]' \
+                '-auth-ref[Use named auth entry from profiles.yaml]:name:' \
+                '-profiles-file[Path to profiles YAML file]:path:_files' \
                 '-skip-native-files[Exclude Google-native files]' \
                 '-google-credentials[Google service account credentials JSON]:path:_files' \
                 '-google-token-file[Google OAuth token file]:path:_files' \
@@ -234,6 +318,160 @@ _cloudstic() {
                 '-onedrive-token-file[OneDrive OAuth token file]:path:_files' \
                 '*-tag[Tag for the snapshot]:tag:' \
                 '-dry-run[Scan without writing]'
+            ;;
+        profile)
+            local -a profile_commands
+            profile_commands=(
+                'list:List stores, auth entries, and backup profiles'
+                'show:Show one profile and resolved store/auth references'
+                'new:Create or update a backup profile'
+            )
+            local profile_sub
+            local -i pi=$((i+1))
+            while (( pi < CURRENT )); do
+                case "${words[pi]}" in
+                    -*) ;;
+                    *) profile_sub="${words[pi]}"; break ;;
+                esac
+                (( pi++ ))
+            done
+            if [[ -z "$profile_sub" ]]; then
+                _describe -t profile-commands 'profile subcommand' profile_commands
+                return
+            fi
+            case "$profile_sub" in
+                list)
+                    _arguments '-profiles-file[Path to profiles YAML file]:path:_files'
+                    ;;
+                show)
+                    _arguments '-profiles-file[Path to profiles YAML file]:path:_files' ':profile name:'
+                    ;;
+                new)
+                    _arguments \
+                        '-profiles-file[Path to profiles YAML file]:path:_files' \
+                        '-name[Profile name]:name:' \
+                        '-source[Source URI]:uri:(local: sftp:// gdrive gdrive-changes onedrive onedrive-changes)' \
+                        '-store-ref[Store reference name]:name:' \
+                        '-store[Store URI]:uri:' \
+                        '-auth-ref[Auth reference name]:name:' \
+                        '*-tag[Tag for snapshots]:tag:' \
+                        '*-exclude[Exclude pattern]:pattern:' \
+                        '-exclude-file[Path to exclude file]:path:_files' \
+                        '-skip-native-files[Exclude Google-native files]' \
+                        '-volume-uuid[Volume UUID override]:uuid:' \
+                        '-google-credentials[Google service account credentials JSON]:path:_files' \
+                        '-google-token-file[Google OAuth token file]:path:_files' \
+                        '-onedrive-client-id[OneDrive OAuth client ID]:id:' \
+                        '-onedrive-token-file[OneDrive OAuth token file]:path:_files'
+                    ;;
+                *)
+                    _arguments
+                    ;;
+            esac
+            ;;
+        auth)
+            local -a auth_commands
+            auth_commands=(
+                'list:List auth entries from profiles.yaml'
+                'show:Show one auth entry'
+                'new:Create or update a reusable cloud auth entry'
+                'login:Run OAuth login flow for one auth entry'
+            )
+            local auth_sub
+            local -i ai=$((i+1))
+            while (( ai < CURRENT )); do
+                case "${words[ai]}" in
+                    -*) ;;
+                    *) auth_sub="${words[ai]}"; break ;;
+                esac
+                (( ai++ ))
+            done
+            if [[ -z "$auth_sub" ]]; then
+                _describe -t auth-commands 'auth subcommand' auth_commands
+                return
+            fi
+            case "$auth_sub" in
+                list)
+                    _arguments '-profiles-file[Path to profiles YAML file]:path:_files'
+                    ;;
+                show)
+                    _arguments '-profiles-file[Path to profiles YAML file]:path:_files' ':auth name:'
+                    ;;
+                new)
+                    _arguments \
+                        '-profiles-file[Path to profiles YAML file]:path:_files' \
+                        '-name[Auth reference name]:name:' \
+                        '-provider[Auth provider]:provider:(google onedrive)' \
+                        '-google-credentials[Google service account credentials JSON]:path:_files' \
+                        '-google-token-file[Google OAuth token file]:path:_files' \
+                        '-onedrive-client-id[OneDrive OAuth client ID]:id:' \
+                        '-onedrive-token-file[OneDrive OAuth token file]:path:_files'
+                    ;;
+                login)
+                    _arguments \
+                        '-profiles-file[Path to profiles YAML file]:path:_files' \
+                        '-name[Auth reference name]:name:'
+                    ;;
+                *)
+                    _arguments
+                    ;;
+            esac
+            ;;
+        store)
+            local -a store_commands
+            store_commands=(
+                'list:List configured stores'
+                'show:Show one store and its configuration'
+                'new:Create or update a store entry'
+            )
+            local store_sub
+            local -i si=$((i+1))
+            while (( si < CURRENT )); do
+                case "${words[si]}" in
+                    -*) ;;
+                    *) store_sub="${words[si]}"; break ;;
+                esac
+                (( si++ ))
+            done
+            if [[ -z "$store_sub" ]]; then
+                _describe -t store-commands 'store subcommand' store_commands
+                return
+            fi
+            case "$store_sub" in
+                list)
+                    _arguments '-profiles-file[Path to profiles YAML file]:path:_files'
+                    ;;
+                show)
+                    _arguments '-profiles-file[Path to profiles YAML file]:path:_files' ':store name:'
+                    ;;
+                new)
+                    _arguments \
+                        '-profiles-file[Path to profiles YAML file]:path:_files' \
+                        '-name[Store reference name]:name:' \
+                        '-uri[Store URI]:uri:' \
+                        '-s3-region[S3 region]:region:' \
+                        '-s3-profile[AWS shared config profile]:profile:' \
+                        '-s3-endpoint[S3-compatible endpoint URL]:url:' \
+                        '-s3-access-key[S3 static access key]:key:' \
+                        '-s3-secret-key[S3 static secret key]:key:' \
+                        '-s3-access-key-env[Env var for S3 access key]:var:' \
+                        '-s3-secret-key-env[Env var for S3 secret key]:var:' \
+                        '-s3-profile-env[Env var for AWS profile]:var:' \
+                        '-store-sftp-password[SFTP password]:password:' \
+                        '-store-sftp-key[SFTP private key path]:path:_files' \
+                        '-store-sftp-password-env[Env var for SFTP password]:var:' \
+                        '-store-sftp-key-env[Env var for SFTP key path]:var:' \
+                        '-password-env[Env var for repository password]:var:' \
+                        '-encryption-key-env[Env var for platform key]:var:' \
+                        '-recovery-key-env[Env var for recovery key mnemonic]:var:' \
+                        '-kms-key-arn[AWS KMS key ARN]:arn:' \
+                        '-kms-region[AWS KMS region]:region:' \
+                        '-kms-endpoint[Custom KMS endpoint URL]:url:'
+                    ;;
+                *)
+                    _arguments
+                    ;;
+            esac
             ;;
         restore)
             _arguments $global_flags \
@@ -334,6 +572,8 @@ complete -c cloudstic -f
 # Subcommands
 complete -c cloudstic -n __fish_use_subcommand -a init -d 'Initialize a new repository'
 complete -c cloudstic -n __fish_use_subcommand -a backup -d 'Create a new backup snapshot'
+complete -c cloudstic -n __fish_use_subcommand -a auth -d 'Manage reusable cloud auth entries'
+complete -c cloudstic -n __fish_use_subcommand -a profile -d 'Manage backup profiles'
 complete -c cloudstic -n __fish_use_subcommand -a restore -d 'Restore files from a snapshot'
 complete -c cloudstic -n __fish_use_subcommand -a list -d 'List all backup snapshots'
 complete -c cloudstic -n __fish_use_subcommand -a ls -d 'List files within a snapshot'
@@ -349,8 +589,11 @@ complete -c cloudstic -n __fish_use_subcommand -a help -d 'Show usage informatio
 
 # Global flags (available for all subcommands)
 complete -c cloudstic -l store -x -d 'Storage backend URI (local:<path>, s3:<bucket>[/<prefix>], b2:<bucket>[/<prefix>], sftp://[user@]host[:port]/<path>)'
+complete -c cloudstic -l profile -x -d 'Profile name from profiles.yaml'
+complete -c cloudstic -l profiles-file -r -F -d 'Path to profiles YAML file'
 complete -c cloudstic -l s3-endpoint -x -d 'S3 compatible endpoint URL'
 complete -c cloudstic -l s3-region -x -d 'S3 region'
+complete -c cloudstic -l s3-profile -x -d 'AWS shared config profile for S3 auth'
 complete -c cloudstic -l s3-access-key -x -d 'S3 access key ID'
 complete -c cloudstic -l s3-secret-key -x -d 'S3 secret access key'
 complete -c cloudstic -l source-sftp-password -x -d 'SFTP source password'
@@ -365,6 +608,7 @@ complete -c cloudstic -l kms-region -x -d 'AWS KMS region'
 complete -c cloudstic -l kms-endpoint -x -d 'Custom AWS KMS endpoint'
 complete -c cloudstic -l disable-packfile -d 'Disable bundling small objects into packs'
 complete -c cloudstic -l prompt -d 'Prompt for password interactively'
+complete -c cloudstic -l no-prompt -d 'Disable interactive prompts (for scripts and CI)'
 complete -c cloudstic -l verbose -d 'Log detailed operations'
 complete -c cloudstic -l quiet -d 'Suppress progress bars'
 complete -c cloudstic -l debug -d 'Log every store request'
@@ -376,6 +620,10 @@ complete -c cloudstic -n '__fish_seen_subcommand_from init' -l adopt-slots -d 'A
 
 # backup
 complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l source -x -a 'local: sftp:// gdrive gdrive-changes onedrive onedrive-changes' -d 'Source URI'
+complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l profile -x -d 'Backup profile name'
+complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l all-profiles -d 'Run all enabled backup profiles'
+complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l auth-ref -x -d 'Use named auth entry from profiles.yaml'
+complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l profiles-file -r -F -d 'Path to profiles YAML file'
 complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l skip-native-files -d 'Exclude Google-native files'
 complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l google-credentials -r -F -d 'Google service account credentials JSON'
 complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l google-token-file -r -F -d 'Google OAuth token file'
@@ -383,6 +631,45 @@ complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l onedrive-client
 complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l onedrive-token-file -r -F -d 'OneDrive OAuth token file'
 complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l tag -x -d 'Tag for the snapshot'
 complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l dry-run -d 'Scan without writing'
+
+# profile subcommands
+complete -c cloudstic -n '__fish_seen_subcommand_from profile; and not __fish_seen_subcommand_from list show new' -a list -d 'List stores, auth entries, and backup profiles'
+complete -c cloudstic -n '__fish_seen_subcommand_from profile; and not __fish_seen_subcommand_from list show new' -a show -d 'Show one profile and resolved refs'
+complete -c cloudstic -n '__fish_seen_subcommand_from profile; and not __fish_seen_subcommand_from list show new' -a new -d 'Create or update backup profile'
+complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from list' -l profiles-file -r -F -d 'Path to profiles YAML file'
+complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from show' -l profiles-file -r -F -d 'Path to profiles YAML file'
+complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l profiles-file -r -F -d 'Path to profiles YAML file'
+complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l name -x -d 'Profile name'
+complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l source -x -a 'local: sftp:// gdrive gdrive-changes onedrive onedrive-changes' -d 'Source URI'
+complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l store-ref -x -d 'Store reference name'
+complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l store -x -d 'Store URI'
+complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l auth-ref -x -d 'Auth reference name'
+complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l tag -x -d 'Tag for snapshots'
+complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l exclude -x -d 'Exclude pattern'
+complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l exclude-file -r -F -d 'Path to exclude file'
+complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l skip-native-files -d 'Exclude Google-native files'
+complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l volume-uuid -x -d 'Volume UUID override'
+complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l google-credentials -r -F -d 'Google service account credentials JSON'
+complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l google-token-file -r -F -d 'Google OAuth token file'
+complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l onedrive-client-id -x -d 'OneDrive OAuth client ID'
+complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l onedrive-token-file -r -F -d 'OneDrive OAuth token file'
+
+# auth subcommands
+complete -c cloudstic -n '__fish_seen_subcommand_from auth; and not __fish_seen_subcommand_from list show new login' -a list -d 'List auth entries from profiles.yaml'
+complete -c cloudstic -n '__fish_seen_subcommand_from auth; and not __fish_seen_subcommand_from list show new login' -a show -d 'Show one auth entry'
+complete -c cloudstic -n '__fish_seen_subcommand_from auth; and not __fish_seen_subcommand_from list show new login' -a new -d 'Create or update reusable auth entry'
+complete -c cloudstic -n '__fish_seen_subcommand_from auth; and not __fish_seen_subcommand_from list show new login' -a login -d 'Run OAuth login flow for auth entry'
+complete -c cloudstic -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from list' -l profiles-file -r -F -d 'Path to profiles YAML file'
+complete -c cloudstic -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from show' -l profiles-file -r -F -d 'Path to profiles YAML file'
+complete -c cloudstic -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from new' -l profiles-file -r -F -d 'Path to profiles YAML file'
+complete -c cloudstic -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from new' -l name -x -d 'Auth reference name'
+complete -c cloudstic -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from new' -l provider -x -a 'google onedrive' -d 'Auth provider'
+complete -c cloudstic -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from new' -l google-credentials -r -F -d 'Google service account credentials JSON'
+complete -c cloudstic -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from new' -l google-token-file -r -F -d 'Google OAuth token file'
+complete -c cloudstic -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from new' -l onedrive-client-id -x -d 'OneDrive OAuth client ID'
+complete -c cloudstic -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from new' -l onedrive-token-file -r -F -d 'OneDrive OAuth token file'
+complete -c cloudstic -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from login' -l profiles-file -r -F -d 'Path to profiles YAML file'
+complete -c cloudstic -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from login' -l name -x -d 'Auth reference name'
 
 # restore
 complete -c cloudstic -n '__fish_seen_subcommand_from restore' -l output -r -F -d 'Output ZIP file path'

--- a/cmd/cloudstic/completion_test.go
+++ b/cmd/cloudstic/completion_test.go
@@ -20,7 +20,7 @@ func TestCompletionBash(t *testing.T) {
 		"_cloudstic()",
 		"complete -F _cloudstic cloudstic",
 		// All commands are listed
-		"init", "backup", "restore", "list", "ls", "prune", "forget",
+		"init", "backup", "auth", "profile", "restore", "list", "ls", "prune", "forget",
 		"diff", "break-lock", "key", "cat", "completion",
 		// Key subcommands
 		"list add-recovery passwd",
@@ -28,6 +28,10 @@ func TestCompletionBash(t *testing.T) {
 		"-store", "-password", "-verbose",
 		// Command-specific flags
 		"-dry-run", "-add-recovery-key", "-source", "-output",
+		"-profiles-file",
+		"-profile", "-all-profiles",
+		"-auth-ref",
+		"-auth-ref",
 		// Value completions
 		"local: s3: b2: sftp://",
 		"gdrive", "onedrive",
@@ -54,6 +58,12 @@ func TestCompletionZsh(t *testing.T) {
 		// Commands with descriptions
 		"init:Initialize a new repository",
 		"backup:Create a new backup snapshot",
+		"auth:Manage reusable cloud auth entries",
+		"profile:Manage backup profiles",
+		"new:Create or update a backup profile",
+		"show:Show one profile and resolved store/auth references",
+		"new:Create or update a reusable cloud auth entry",
+		"login:Run OAuth login flow for one auth entry",
 		"key:Manage encryption key slots",
 		"completion:Generate shell completion scripts",
 		// Key subcommands
@@ -68,6 +78,10 @@ func TestCompletionZsh(t *testing.T) {
 		"-add-recovery-key[Generate a 24-word recovery key]",
 		"-dry-run[Scan without writing]",
 		"-keep-last[Keep N most recent snapshots]",
+		"list:List stores, auth entries, and backup profiles",
+		"-profile[Backup profile name]",
+		"-all-profiles[Run all enabled backup profiles]",
+		"-auth-ref[Use named auth entry from profiles.yaml]",
 		// Value completions (source type list still present)
 		"(local: sftp:// gdrive gdrive-changes onedrive onedrive-changes)",
 		"(bash zsh fish)",
@@ -92,6 +106,8 @@ func TestCompletionFish(t *testing.T) {
 		// Subcommands
 		"complete -c cloudstic -n __fish_use_subcommand -a init",
 		"complete -c cloudstic -n __fish_use_subcommand -a backup",
+		"complete -c cloudstic -n __fish_use_subcommand -a profile",
+		"complete -c cloudstic -n __fish_use_subcommand -a auth",
 		"complete -c cloudstic -n __fish_use_subcommand -a key",
 		"complete -c cloudstic -n __fish_use_subcommand -a completion",
 		// Key subcommands
@@ -106,8 +122,16 @@ func TestCompletionFish(t *testing.T) {
 		"__fish_seen_subcommand_from init",
 		"__fish_seen_subcommand_from backup",
 		"__fish_seen_subcommand_from forget",
+		"__fish_seen_subcommand_from profile",
 		"-l dry-run",
 		"-l keep-last",
+		"-l profiles-file",
+		"-l profile",
+		"-l all-profiles",
+		"-l auth-ref",
+		"-a show -d 'Show one profile and resolved refs'",
+		"-a new -d 'Create or update backup profile'",
+		"-a login -d 'Run OAuth login flow for auth entry'",
 		"-l add-recovery-key",
 		// Value completions (source type list still present)
 		"'local: sftp:// gdrive gdrive-changes onedrive onedrive-changes'",

--- a/cmd/cloudstic/flags.go
+++ b/cmd/cloudstic/flags.go
@@ -23,7 +23,8 @@ func envBool(key string) bool {
 
 type globalFlags struct {
 	store                             *string
-	s3Endpoint, s3Region              *string
+	profile, profilesFile             *string
+	s3Endpoint, s3Region, s3Profile   *string
 	s3AccessKey, s3SecretKey          *string
 	sourceSFTPPassword, sourceSFTPKey *string
 	storeSFTPPassword, storeSFTPKey   *string
@@ -39,8 +40,15 @@ type globalFlags struct {
 func addGlobalFlags(fs *flag.FlagSet) *globalFlags {
 	g := &globalFlags{}
 	g.store = fs.String("store", envDefault("CLOUDSTIC_STORE", "local:./backup_store"), "Storage backend URI: local:<path>, s3:<bucket>[/<prefix>], b2:<bucket>[/<prefix>], sftp://[user@]host[:port]/<path>")
+	defaultProfilesPath, err := defaultProfilesPath()
+	if err != nil {
+		defaultProfilesPath = defaultProfilesFilename
+	}
+	g.profile = fs.String("profile", envDefault("CLOUDSTIC_PROFILE", ""), "Profile name from profiles.yaml")
+	g.profilesFile = fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPath), "Path to profiles YAML file")
 	g.s3Endpoint = fs.String("s3-endpoint", envDefault("CLOUDSTIC_S3_ENDPOINT", ""), "S3 compatible endpoint URL (for MinIO, R2, etc.)")
 	g.s3Region = fs.String("s3-region", envDefault("CLOUDSTIC_S3_REGION", "us-east-1"), "S3 region")
+	g.s3Profile = fs.String("s3-profile", envDefault("CLOUDSTIC_S3_PROFILE", envDefault("AWS_PROFILE", "")), "AWS shared config profile for S3 credentials")
 	g.s3AccessKey = fs.String("s3-access-key", envDefault("AWS_ACCESS_KEY_ID", ""), "S3 access key ID")
 	g.s3SecretKey = fs.String("s3-secret-key", envDefault("AWS_SECRET_ACCESS_KEY", ""), "S3 secret access key")
 
@@ -62,6 +70,18 @@ func addGlobalFlags(fs *flag.FlagSet) *globalFlags {
 	g.quiet = fs.Bool("quiet", false, "Suppress progress bars (keeps final summary)")
 	g.debug = fs.Bool("debug", false, "Log every store request (network calls, timing, sizes)")
 	return g
+}
+
+func cliFlagProvided(name string) bool {
+	for _, arg := range os.Args[1:] {
+		if arg == "-"+name || arg == "--"+name {
+			return true
+		}
+		if strings.HasPrefix(arg, "-"+name+"=") || strings.HasPrefix(arg, "--"+name+"=") {
+			return true
+		}
+	}
+	return false
 }
 
 // mustParse parses os.Args[2:] into fs, reordering positional arguments after

--- a/cmd/cloudstic/interactive.go
+++ b/cmd/cloudstic/interactive.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/moby/term"
+)
+
+func (r *runner) canPrompt() bool {
+	return !r.noPrompt && term.IsTerminal(os.Stdin.Fd()) && term.IsTerminal(os.Stdout.Fd())
+}
+
+func (r *runner) promptLine(label, defaultValue string) (string, error) {
+	if defaultValue != "" {
+		_, _ = fmt.Fprintf(r.errOut, "%s [%s]: ", label, defaultValue)
+	} else {
+		_, _ = fmt.Fprintf(r.errOut, "%s: ", label)
+	}
+	reader := bufio.NewReader(os.Stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return defaultValue, nil
+	}
+	return line, nil
+}
+
+func (r *runner) promptConfirm(label string, defaultYes bool) (bool, error) {
+	hint := "y/N"
+	dflt := "n"
+	if defaultYes {
+		hint = "Y/n"
+		dflt = "y"
+	}
+	answer, err := r.promptLine(fmt.Sprintf("%s [%s]", label, hint), dflt)
+	if err != nil {
+		return false, err
+	}
+	answer = strings.ToLower(strings.TrimSpace(answer))
+	return answer == "y" || answer == "yes", nil
+}
+
+func (r *runner) promptSelect(label string, options []string) (string, error) {
+	if len(options) == 0 {
+		return "", fmt.Errorf("no options available")
+	}
+	_, _ = fmt.Fprintf(r.errOut, "%s\n", label)
+	for i, opt := range options {
+		_, _ = fmt.Fprintf(r.errOut, "  %d) %s\n", i+1, opt)
+	}
+	for {
+		choice, err := r.promptLine("Select option number", "1")
+		if err != nil {
+			return "", err
+		}
+		n, err := strconv.Atoi(choice)
+		if err != nil || n < 1 || n > len(options) {
+			_, _ = fmt.Fprintln(r.errOut, "Invalid selection. Please choose a valid number.")
+			continue
+		}
+		return options[n-1], nil
+	}
+}

--- a/cmd/cloudstic/main.go
+++ b/cmd/cloudstic/main.go
@@ -63,6 +63,12 @@ func runCmd(cmd string) int {
 		return r.runCheck()
 	case "cat":
 		return r.runCat()
+	case "profile":
+		return r.runProfile()
+	case "auth":
+		return r.runAuth()
+	case "store":
+		return r.runStore()
 	case "completion":
 		runCompletion()
 		return 0

--- a/cmd/cloudstic/runner.go
+++ b/cmd/cloudstic/runner.go
@@ -7,13 +7,30 @@ import (
 )
 
 type runner struct {
-	out    io.Writer
-	errOut io.Writer
-	client cloudsticClient
+	out      io.Writer
+	errOut   io.Writer
+	client   cloudsticClient
+	noPrompt bool
 }
 
 func newRunner() *runner {
-	return &runner{out: os.Stdout, errOut: os.Stderr}
+	return &runner{
+		out:      os.Stdout,
+		errOut:   os.Stderr,
+		noPrompt: hasGlobalFlag("no-prompt"),
+	}
+}
+
+// hasGlobalFlag checks whether a boolean flag appears anywhere in os.Args.
+// This is used for flags that must be parsed before subcommand flag sets.
+func hasGlobalFlag(name string) bool {
+	for _, arg := range os.Args[1:] {
+		if arg == "-"+name || arg == "--"+name ||
+			arg == "-"+name+"=true" || arg == "--"+name+"=true" {
+			return true
+		}
+	}
+	return false
 }
 
 // fail writes a formatted error to r.errOut and returns exit code 1.

--- a/cmd/cloudstic/store.go
+++ b/cmd/cloudstic/store.go
@@ -21,6 +21,9 @@ import (
 // openStore initializes the raw object store with debug wrapping applied.
 // Used by commands that operate on the store directly (init, key).
 func (g *globalFlags) openStore() (store.ObjectStore, error) {
+	if err := g.applyProfileStoreOverrides(); err != nil {
+		return nil, err
+	}
 	raw, err := g.initObjectStore()
 	if err != nil {
 		return nil, err
@@ -42,6 +45,9 @@ func (g *globalFlags) applyDebug(s store.ObjectStore) store.ObjectStore {
 }
 
 func (g *globalFlags) openClient() (*cloudstic.Client, error) {
+	if err := g.applyProfileStoreOverrides(); err != nil {
+		return nil, err
+	}
 	raw, err := g.initObjectStore()
 	if err != nil {
 		return nil, err
@@ -71,6 +77,41 @@ func (g *globalFlags) openClient() (*cloudstic.Client, error) {
 		cloudstic.WithReporter(reporter),
 		cloudstic.WithPackfile(packfileEnabled),
 	)
+}
+
+func (g *globalFlags) applyProfileStoreOverrides() error {
+	if g.profile == nil || *g.profile == "" {
+		return nil
+	}
+	profilesFile := defaultProfilesFilename
+	if g.profilesFile != nil && *g.profilesFile != "" {
+		profilesFile = *g.profilesFile
+	}
+	cfg, err := cloudstic.LoadProfilesFile(profilesFile)
+	if err != nil {
+		return fmt.Errorf("load profiles file %q: %w", profilesFile, err)
+	}
+	p, ok := cfg.Profiles[*g.profile]
+	if !ok {
+		return fmt.Errorf("unknown profile %q", *g.profile)
+	}
+	if p.Store == "" {
+		return nil
+	}
+	s, ok := cfg.Stores[p.Store]
+	if !ok {
+		return fmt.Errorf("profile %q references unknown store %q", *g.profile, p.Store)
+	}
+	flagsSet := map[string]bool{}
+	for _, name := range []string{
+		"store", "s3-endpoint", "s3-region", "s3-profile", "s3-access-key", "s3-secret-key",
+		"store-sftp-password", "store-sftp-key",
+		"password", "encryption-key", "recovery-key", "kms-key-arn", "kms-region", "kms-endpoint",
+	} {
+		flagsSet[name] = cliFlagProvided(name)
+	}
+	applyProfileStoreToGlobalFlags(g, s, flagsSet)
+	return nil
 }
 
 // buildKMSClient creates an AWS KMS client if -kms-key-arn is set, otherwise
@@ -120,7 +161,7 @@ func (g *globalFlags) buildKeychain(ctx context.Context) (keychain.Chain, error)
 		chain = append(chain, keychain.WithRecoveryKey(*g.recoveryKey))
 	}
 	promptRequested := g.prompt != nil && *g.prompt
-	if (len(chain) == 0 || promptRequested) && term.IsTerminal(os.Stdin.Fd()) {
+	if (len(chain) == 0 || promptRequested) && !hasGlobalFlag("no-prompt") && term.IsTerminal(os.Stdin.Fd()) {
 		chain = append(chain, keychain.WithPrompt(
 			func() (string, error) { return ui.PromptPassword("Repository password") },
 			func() (string, error) { return ui.PromptPasswordConfirm("Enter new repository password") },
@@ -239,6 +280,7 @@ func (g *globalFlags) initObjectStore() (store.ObjectStore, error) {
 			uri.bucket,
 			store.WithS3Endpoint(*g.s3Endpoint),
 			store.WithS3Region(*g.s3Region),
+			store.WithS3Profile(*g.s3Profile),
 			store.WithS3Credentials(*g.s3AccessKey, *g.s3SecretKey),
 			store.WithS3Prefix(uri.prefix),
 		)

--- a/cmd/cloudstic/store_profile_test.go
+++ b/cmd/cloudstic/store_profile_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	cloudstic "github.com/cloudstic/cli"
+)
+
+func TestApplyProfileStoreOverrides_AppliesProfileStore(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	err := cloudstic.SaveProfilesFile(profilesPath, &cloudstic.ProfilesConfig{
+		Version: 1,
+		Stores: map[string]cloudstic.ProfileStore{
+			"s": {URI: "s3:bucket/prefix", S3Region: "eu-west-1", S3Profile: "prod"},
+		},
+		Profiles: map[string]cloudstic.BackupProfile{
+			"p": {Source: "local:/data", Store: "s"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SaveProfilesFile: %v", err)
+	}
+
+	os.Args = []string{"cloudstic", "list", "-profile", "p", "-profiles-file", profilesPath}
+	g := newTestGlobalFlags()
+	*g.profile = "p"
+	*g.profilesFile = profilesPath
+
+	if err := g.applyProfileStoreOverrides(); err != nil {
+		t.Fatalf("applyProfileStoreOverrides: %v", err)
+	}
+	if *g.store != "s3:bucket/prefix" {
+		t.Fatalf("store=%q want s3:bucket/prefix", *g.store)
+	}
+	if *g.s3Region != "eu-west-1" {
+		t.Fatalf("s3Region=%q want eu-west-1", *g.s3Region)
+	}
+	if *g.s3Profile != "prod" {
+		t.Fatalf("s3Profile=%q want prod", *g.s3Profile)
+	}
+}
+
+func TestApplyProfileStoreOverrides_EncryptionFields(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+
+	t.Setenv("TEST_BACKUP_PASSWORD", "s3cret")
+	t.Setenv("TEST_ENC_KEY", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	t.Setenv("TEST_RECOVERY_KEY", "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about")
+
+	err := cloudstic.SaveProfilesFile(profilesPath, &cloudstic.ProfilesConfig{
+		Version: 1,
+		Stores: map[string]cloudstic.ProfileStore{
+			"enc": {
+				URI:              "s3:bucket/enc",
+				PasswordEnv:      "TEST_BACKUP_PASSWORD",
+				EncryptionKeyEnv: "TEST_ENC_KEY",
+				RecoveryKeyEnv:   "TEST_RECOVERY_KEY",
+				KMSKeyARN:        "arn:aws:kms:us-east-1:123456:key/abcd",
+				KMSRegion:        "us-east-1",
+				KMSEndpoint:      "https://kms.example.com",
+			},
+		},
+		Profiles: map[string]cloudstic.BackupProfile{
+			"p": {Source: "local:/data", Store: "enc"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SaveProfilesFile: %v", err)
+	}
+
+	os.Args = []string{"cloudstic", "list", "-profile", "p", "-profiles-file", profilesPath}
+	g := newTestGlobalFlags()
+	*g.profile = "p"
+	*g.profilesFile = profilesPath
+
+	if err := g.applyProfileStoreOverrides(); err != nil {
+		t.Fatalf("applyProfileStoreOverrides: %v", err)
+	}
+	if *g.password != "s3cret" {
+		t.Fatalf("password=%q want s3cret", *g.password)
+	}
+	if *g.encryptionKey != "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
+		t.Fatalf("encryptionKey=%q want aaa...", *g.encryptionKey)
+	}
+	if *g.recoveryKey == "" {
+		t.Fatal("expected recoveryKey to be set from env")
+	}
+	if *g.kmsKeyARN != "arn:aws:kms:us-east-1:123456:key/abcd" {
+		t.Fatalf("kmsKeyARN=%q want arn:...", *g.kmsKeyARN)
+	}
+	if *g.kmsRegion != "us-east-1" {
+		t.Fatalf("kmsRegion=%q want us-east-1", *g.kmsRegion)
+	}
+	if *g.kmsEndpoint != "https://kms.example.com" {
+		t.Fatalf("kmsEndpoint=%q want https://kms.example.com", *g.kmsEndpoint)
+	}
+}
+
+func TestApplyProfileStoreOverrides_DoesNotOverrideExplicitStoreFlag(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+	err := cloudstic.SaveProfilesFile(profilesPath, &cloudstic.ProfilesConfig{
+		Version: 1,
+		Stores: map[string]cloudstic.ProfileStore{
+			"s": {URI: "s3:bucket/prefix"},
+		},
+		Profiles: map[string]cloudstic.BackupProfile{
+			"p": {Source: "local:/data", Store: "s"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SaveProfilesFile: %v", err)
+	}
+
+	os.Args = []string{"cloudstic", "list", "-profile", "p", "-profiles-file", profilesPath, "-store", "local:/explicit"}
+	g := newTestGlobalFlags()
+	*g.profile = "p"
+	*g.profilesFile = profilesPath
+	*g.store = "local:/explicit"
+
+	if err := g.applyProfileStoreOverrides(); err != nil {
+		t.Fatalf("applyProfileStoreOverrides: %v", err)
+	}
+	if *g.store != "local:/explicit" {
+		t.Fatalf("store=%q want local:/explicit", *g.store)
+	}
+}

--- a/cmd/cloudstic/usage.go
+++ b/cmd/cloudstic/usage.go
@@ -19,6 +19,16 @@ func printUsage() {
 	t.Commands([][2]string{
 		{"init", "Initialize a new repository (must run before first backup)"},
 		{"backup", "Create a new backup snapshot from a source"},
+		{"auth new", "Create or update a reusable cloud auth entry"},
+		{"auth list", "List auth entries from profiles.yaml"},
+		{"auth show", "Show one auth entry"},
+		{"auth login", "Run OAuth login flow for one auth entry"},
+		{"store new", "Create or update a store entry in profiles.yaml"},
+		{"store list", "List configured stores"},
+		{"store show", "Show one store and its configuration"},
+		{"profile new", "Create or update a backup profile in profiles.yaml"},
+		{"profile list", "List stores, auth entries, and backup profiles"},
+		{"profile show", "Show one profile and resolved store/auth references"},
 		{"restore", "Restore files from a backup snapshot"},
 		{"list", "List all backup snapshots in the repository"},
 		{"ls", "List files within a specific snapshot"},
@@ -37,14 +47,18 @@ func printUsage() {
 	t.HeadingSub("GLOBAL OPTIONS", "(also settable via env vars)")
 	t.Flags([][2]string{
 		{"-store <uri>", ui.Env("Storage backend URI (see formats below)", "CLOUDSTIC_STORE")},
+		{"-profile <name>", ui.Env("Profile name from profiles.yaml", "CLOUDSTIC_PROFILE")},
+		{"-profiles-file <path>", ui.Env("Path to profiles YAML file", "CLOUDSTIC_PROFILES_FILE")},
 		{"-s3-endpoint <url>", ui.Env("S3 compatible endpoint (for MinIO, R2, etc.)", "CLOUDSTIC_S3_ENDPOINT")},
 		{"-s3-region <region>", ui.Env("S3 region", "CLOUDSTIC_S3_REGION")},
+		{"-s3-profile <name>", ui.Env("AWS shared config profile for S3 auth", "CLOUDSTIC_S3_PROFILE / AWS_PROFILE")},
 		{"-s3-access-key <key>", ui.Env("S3 Access Key ID", "AWS_ACCESS_KEY_ID")},
 		{"-s3-secret-key <secret>", ui.Env("S3 Secret Access Key", "AWS_SECRET_ACCESS_KEY")},
 		{"-source-sftp-password <pw>", ui.Env("SFTP source password", "CLOUDSTIC_SOURCE_SFTP_PASSWORD")},
 		{"-source-sftp-key <path>", ui.Env("Path to SSH private key for SFTP source", "CLOUDSTIC_SOURCE_SFTP_KEY")},
 		{"-store-sftp-password <pw>", ui.Env("SFTP store password", "CLOUDSTIC_STORE_SFTP_PASSWORD")},
 		{"-store-sftp-key <path>", ui.Env("Path to SSH private key for SFTP store", "CLOUDSTIC_STORE_SFTP_KEY")},
+		{"-no-prompt", "Disable interactive prompts (for scripts and CI)"},
 		{"-verbose", "Log detailed file-level operations"},
 		{"-quiet", "Suppress progress bars (keeps final summary)"},
 		{"-debug", "Log every store request (network calls, timing, sizes)"},
@@ -109,6 +123,10 @@ func printUsage() {
 	t.Command("backup", "")
 	t.Flags([][2]string{
 		{"-source <uri>", ui.Env("Source URI: local:<path>, sftp://[user@]host[:port]/<path>, gdrive[://<Drive Name>][/<path>], gdrive-changes[://<Drive Name>][/<path>], onedrive[://<Drive Name>][/<path>], onedrive-changes[://<Drive Name>][/<path>]", "CLOUDSTIC_SOURCE")},
+		{"-profile <name>", "Run backup from a named profile"},
+		{"-all-profiles", "Run backup for all enabled profiles"},
+		{"-auth-ref <name>", "Use named auth entry from profiles.yaml for cloud credentials"},
+		{"-profiles-file <path>", ui.Env("Path to profiles YAML file", "CLOUDSTIC_PROFILES_FILE")},
 		{"-skip-native-files", "Exclude Google-native files (Docs, Sheets, Slides, etc.)"},
 		{"-google-credentials <path>", ui.Env("Path to Google service account credentials JSON", "GOOGLE_APPLICATION_CREDENTIALS")},
 		{"-google-token-file <path>", ui.Env("Path to Google OAuth token file", "GOOGLE_TOKEN_FILE")},
@@ -129,6 +147,117 @@ func printUsage() {
 		"  onedrive                           OneDrive (full scan)",
 		"  onedrive-changes                   OneDrive (incremental via delta API)",
 	)
+
+	t.Command("store list", "")
+	t.Flags([][2]string{{"-profiles-file <path>", ui.Env("Path to profiles YAML file", "CLOUDSTIC_PROFILES_FILE")}})
+	t.Note("  List configured stores.")
+	t.Blank()
+
+	t.Command("store show", "<name>")
+	t.Flags([][2]string{{"-profiles-file <path>", ui.Env("Path to profiles YAML file", "CLOUDSTIC_PROFILES_FILE")}})
+	t.Note("  Show one store and its configuration.")
+	t.Blank()
+
+	t.Command("store new", "")
+	t.Flags([][2]string{
+		{"-name <name>", "Store reference name"},
+		{"-uri <uri>", "Store URI (e.g. s3:bucket/path, local:/path, sftp://host/path)"},
+		{"-s3-region <region>", "S3 region"},
+		{"-s3-profile <name>", "AWS shared config profile"},
+		{"-s3-endpoint <url>", "S3-compatible endpoint URL"},
+		{"-s3-access-key <key>", "S3 static access key"},
+		{"-s3-secret-key <key>", "S3 static secret key"},
+		{"-s3-access-key-env <var>", "Env var name for S3 access key"},
+		{"-s3-secret-key-env <var>", "Env var name for S3 secret key"},
+		{"-s3-profile-env <var>", "Env var name for AWS profile"},
+		{"-store-sftp-password <pass>", "SFTP password"},
+		{"-store-sftp-key <path>", "Path to SFTP private key"},
+		{"-store-sftp-password-env <var>", "Env var name for SFTP password"},
+		{"-store-sftp-key-env <var>", "Env var name for SFTP key path"},
+		{"-password-env <var>", "Env var name for repository password"},
+		{"-encryption-key-env <var>", "Env var name for platform key (hex)"},
+		{"-recovery-key-env <var>", "Env var name for recovery key mnemonic"},
+		{"-kms-key-arn <arn>", "AWS KMS key ARN for envelope encryption"},
+		{"-kms-region <region>", "AWS KMS region"},
+		{"-kms-endpoint <url>", "Custom AWS KMS endpoint URL"},
+		{"-profiles-file <path>", ui.Env("Path to profiles YAML file", "CLOUDSTIC_PROFILES_FILE")},
+	})
+	t.Note("  Create or update a store entry in profiles.yaml.",
+		"  Encryption credentials use env var indirection: -password-env, -encryption-key-env.",
+		"  KMS settings are stored directly (ARN is not a secret).",
+	)
+	t.Blank()
+
+	t.Command("profile list", "")
+	t.Flags([][2]string{
+		{"-profiles-file <path>", ui.Env("Path to profiles YAML file", "CLOUDSTIC_PROFILES_FILE")},
+	})
+	t.Note("  List configured stores, auth entries, and backup profiles.")
+	t.Blank()
+
+	t.Command("profile show", "<name>")
+	t.Flags([][2]string{
+		{"-profiles-file <path>", ui.Env("Path to profiles YAML file", "CLOUDSTIC_PROFILES_FILE")},
+	})
+	t.Note("  Show one profile and resolved store/auth references.")
+	t.Blank()
+
+	t.Command("profile new", "")
+	t.Flags([][2]string{
+		{"-name <name>", "Profile name"},
+		{"-source <uri>", "Source URI for this profile"},
+		{"-store-ref <name>", "Store reference name to use from top-level stores"},
+		{"-store <uri>", "Optional store URI to create/update under -store-ref"},
+		{"-auth-ref <name>", "Auth reference name to use from top-level auth"},
+		{"-tag <tag>", "Tag for snapshots (repeatable)"},
+		{"-exclude <pattern>", "Exclude pattern (repeatable)"},
+		{"-exclude-file <path>", "Path to exclude file"},
+		{"-skip-native-files", "Exclude Google-native files"},
+		{"-volume-uuid <uuid>", "Override local source volume UUID"},
+		{"-google-credentials <path>", "Path to Google service account credentials JSON"},
+		{"-google-token-file <path>", "Path to Google OAuth token file"},
+		{"-onedrive-client-id <id>", "OneDrive OAuth client ID"},
+		{"-onedrive-token-file <path>", "Path to OneDrive OAuth token file"},
+		{"-profiles-file <path>", ui.Env("Path to profiles YAML file", "CLOUDSTIC_PROFILES_FILE")},
+	})
+	t.Note(
+		"  Create or update a backup profile in profiles.yaml.",
+		"  Use -store-ref by itself to reference an existing store entry.",
+		"  Add -store to create or update that store entry in the same command.",
+		"  Use -auth-ref to reuse cloud OAuth settings across multiple profiles.",
+	)
+	t.Blank()
+
+	t.Command("auth list", "")
+	t.Flags([][2]string{{"-profiles-file <path>", ui.Env("Path to profiles YAML file", "CLOUDSTIC_PROFILES_FILE")}})
+	t.Note("  List configured auth entries.")
+	t.Blank()
+
+	t.Command("auth show", "<name>")
+	t.Flags([][2]string{{"-profiles-file <path>", ui.Env("Path to profiles YAML file", "CLOUDSTIC_PROFILES_FILE")}})
+	t.Note("  Show one auth entry.")
+	t.Blank()
+
+	t.Command("auth new", "")
+	t.Flags([][2]string{
+		{"-name <name>", "Auth reference name"},
+		{"-provider <google|onedrive>", "Cloud provider for this auth entry"},
+		{"-google-credentials <path>", "Google service account credentials JSON (optional)"},
+		{"-google-token-file <path>", "Google OAuth token file path (required for provider=google)"},
+		{"-onedrive-client-id <id>", "OneDrive OAuth client ID (optional)"},
+		{"-onedrive-token-file <path>", "OneDrive OAuth token file path (required for provider=onedrive)"},
+		{"-profiles-file <path>", ui.Env("Path to profiles YAML file", "CLOUDSTIC_PROFILES_FILE")},
+	})
+	t.Note("  Create or update a reusable cloud auth entry.")
+	t.Blank()
+
+	t.Command("auth login", "")
+	t.Flags([][2]string{
+		{"-name <name>", "Auth reference name"},
+		{"-profiles-file <path>", ui.Env("Path to profiles YAML file", "CLOUDSTIC_PROFILES_FILE")},
+	})
+	t.Note("  Trigger OAuth login for an auth entry and save token to its configured file.")
+	t.Blank()
 
 	t.Command("restore", "[snapshot_id]")
 	t.Flags([][2]string{

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -13,6 +13,9 @@ Cloudstic is a content-addressable backup tool that creates encrypted, deduplica
 - [Commands](#commands)
   - [init](#init)
   - [backup](#backup)
+  - [auth](#auth)
+  - [profile](#profile)
+  - [store](#store)
   - [restore](#restore)
   - [list](#list)
   - [ls](#ls)
@@ -269,11 +272,26 @@ cloudstic backup -source local:~/Documents -dry-run
 | Flag | Default | Description |
 |------|---------|-------------|
 | `-source` | `gdrive` | Source type: `local:<path>`, `sftp://[user@]host[:port]/<path>`, `gdrive[://<Drive Name>][/<path>]`, `gdrive-changes[://<Drive Name>][/<path>]`, `onedrive[://<Drive Name>][/<path>]`, `onedrive-changes[://<Drive Name>][/<path>]` |
+| `-profile` | | Run backup using one named profile from `profiles.yaml` |
+| `-all-profiles` | `false` | Run backup for all enabled profiles from `profiles.yaml` |
+| `-auth-ref` | | Use one named auth entry from `profiles.yaml` for cloud source credentials |
+| `-profiles-file` | `<config-dir>/profiles.yaml` | Override profile YAML location (also `CLOUDSTIC_PROFILES_FILE`) |
 | `-tag` | | Tag to apply to the snapshot (repeatable) |
 | `-exclude` | | Exclude pattern using gitignore syntax (repeatable) |
 | `-exclude-file` | | Path to file containing exclude patterns, one per line |
 | `-volume-uuid` | | Override volume UUID for local source (enables cross-machine incremental backup for portable drives) |
 | `-dry-run` | `false` | Scan source and report changes without writing to the store |
+
+`-profile` and `-all-profiles` are mutually exclusive.
+
+`-auth-ref` can be used with direct `backup -source ...` runs (outside profile
+mode) to reuse a cloud auth entry from `profiles.yaml`.
+
+If you run a cloud backup without `-auth-ref`, Cloudstic automatically records a
+provider default auth entry in `profiles.yaml` so it is discoverable later:
+
+- Google sources -> `google-default`
+- OneDrive sources -> `onedrive-default`
 
 The `gdrive-changes` and `onedrive-changes` source types use their respective change/delta APIs for faster incremental backups after the first full backup.
 
@@ -344,6 +362,202 @@ For cloud sources (Google Drive, OneDrive), exclude patterns are matched against
 > When using incremental sources (`gdrive-changes`, `onedrive-changes`), Cloudstic stores a hash of the active exclude patterns in each snapshot. If the patterns change between runs (added, removed, or reordered), the next backup automatically performs a full rescan instead of an incremental one. This ensures the new patterns are applied comprehensively. The full rescan also captures a fresh change token, so subsequent runs resume incremental mode from that point.
 >
 > No manual intervention is required — just update your `-exclude` / `-exclude-file` flags and run the backup as usual.
+
+---
+
+### profile
+
+Manage backup profiles stored in YAML.
+
+Profiles are stored by default at `<config-dir>/profiles.yaml`.
+
+#### profile list
+
+List configured stores, auth entries, and profiles.
+
+```bash
+cloudstic profile list
+
+# Custom file location
+cloudstic profile list -profiles-file ./profiles.yaml
+```
+
+If the profiles file does not exist yet, `profile list` exits successfully with
+no output.
+
+#### profile show
+
+Show one profile with resolved store and auth references.
+
+```bash
+cloudstic profile show work-drive
+
+# Custom file location
+cloudstic profile show -profiles-file ./profiles.yaml work-drive
+```
+
+#### profile new
+
+Create or update one profile entry.
+
+```bash
+# Create profile and create/update referenced store entry
+cloudstic profile new \
+  -name google-drive \
+  -source gdrive-changes \
+  -store-ref home-s3 \
+  -store s3:my-bucket/cloudstic
+
+# Reuse an existing store reference (no -store needed)
+cloudstic profile new \
+  -name documents \
+  -source local:~/Documents \
+  -store-ref home-s3
+
+# Create auth entry first, then attach it to a profile
+cloudstic auth new \
+  -name google-work \
+  -provider google \
+  -google-token-file ~/.config/cloudstic/tokens/google-work.json
+
+cloudstic profile new \
+  -name work-drive \
+  -source "gdrive-changes:/Team Folder" \
+  -auth-ref google-work
+```
+
+**Important:** `profile new` requires explicit `-name` and `-source`.
+
+If these required flags are omitted and you are in an interactive terminal,
+Cloudstic prompts for the missing values.
+
+It intentionally does **not** read `CLOUDSTIC_SOURCE` for these required fields,
+to avoid accidentally persisting environment-specific defaults into
+`profiles.yaml`.
+
+Use `--no-prompt` to disable all interactive prompts. Missing required fields will cause an error instead.
+
+Use `-store-ref` by itself to reference an existing store entry.
+Add `-store` with `-store-ref` to create or update that store entry in the same
+command.
+
+Use `-auth-ref` to reference reusable cloud OAuth settings under top-level
+`auth:` in `profiles.yaml`.
+
+`-auth-ref` must point to an existing auth entry.
+
+You can also use `-auth-ref` directly with `backup` when not using `-profile`:
+
+```bash
+cloudstic backup \
+  -source "gdrive-changes:/Team Folder" \
+  -auth-ref google-work
+```
+
+`profile new` validates that `-auth-ref` points to an existing auth entry and
+that provider matches the source type.
+
+`-auth-ref` is only valid for cloud sources.
+
+---
+
+### store
+
+Manage named store entries in `profiles.yaml`. Stores define storage backend, connection credentials, and encryption settings.
+
+#### store list
+
+List configured stores.
+
+```bash
+cloudstic store list
+```
+
+#### store show
+
+Show details for a named store.
+
+```bash
+cloudstic store show prod-s3
+```
+
+#### store new
+
+Create or update a named store entry in `profiles.yaml`. Stores define storage backend, connection credentials, and encryption settings.
+
+```bash
+cloudstic store new \
+  -name prod-s3 \
+  -uri s3:my-bucket/backups \
+  -s3-region eu-west-1
+```
+
+Store names must start with a letter or digit and contain only letters, digits, dots, hyphens, or underscores. URIs must use a supported scheme (`local`, `s3`, `b2`, `sftp`).
+
+In interactive mode, `store new` prompts for:
+
+- Missing required fields (name, URI)
+- Encryption configuration (if no encryption flags provided):
+  1. Password — saves env var name (default: `CLOUDSTIC_PASSWORD`) as `password_env`
+  2. Platform key — saves env var name (default: `CLOUDSTIC_ENCRYPTION_KEY`) as `encryption_key_env`
+  3. AWS KMS key — saves ARN and region
+  4. No encryption
+- Store initialization (if the store is accessible but not yet initialized)
+
+Encryption settings use **env var indirection** — only the environment variable name is stored in `profiles.yaml`, never the secret itself.
+
+Use `--no-prompt` to disable all interactive prompts (for scripts/CI).
+
+---
+
+### auth
+
+Manage reusable cloud OAuth entries in `profiles.yaml`.
+
+#### auth new
+
+Create or update an auth entry.
+
+```bash
+# Google auth entry
+cloudstic auth new \
+  -name google-work \
+  -provider google \
+  -google-token-file ~/.config/cloudstic/tokens/google-work.json
+
+# OneDrive auth entry
+cloudstic auth new \
+  -name ms-personal \
+  -provider onedrive \
+  -onedrive-token-file ~/.config/cloudstic/tokens/ms-personal.json
+```
+
+If token file flags are omitted, Cloudstic derives a default token path from
+the auth name under `<config-dir>/tokens/`.
+
+If required flags are omitted and you are in an interactive terminal,
+`auth new` prompts for missing values.
+
+#### auth login
+
+Trigger OAuth login for an auth entry and save token in its configured token
+file.
+
+```bash
+cloudstic auth login -name google-work
+```
+
+This is useful to pre-authorize before first backup.
+
+#### auth list / auth show
+
+```bash
+cloudstic auth list
+cloudstic auth show google-work
+```
+
+`auth list` exits successfully with no output when the profiles file does not
+exist yet.
 
 ---
 
@@ -1099,12 +1313,19 @@ Use a prefix to namespace objects within a bucket:
 cloudstic init -store s3:my-bucket/laptop/ -password "passphrase"
 ```
 
+If you rely on shared AWS config profiles, you can pin one explicitly:
+
+```bash
+cloudstic backup -store s3:my-bucket -s3-profile my-profile -source local:~/Documents
+```
+
 **Environment variables:**
 
 | Variable | Description |
 |----------|-------------|
 | `AWS_ACCESS_KEY_ID` | S3 access key ID |
 | `AWS_SECRET_ACCESS_KEY` | S3 secret access key |
+| `AWS_PROFILE` | Shared AWS config profile name (also `CLOUDSTIC_S3_PROFILE`) |
 | `CLOUDSTIC_S3_ENDPOINT` | Custom endpoint URL (for R2, MinIO, etc.) |
 | `CLOUDSTIC_S3_REGION` | S3 Region |
 
@@ -1256,6 +1477,7 @@ cloudstic forget -keep-daily 7 -keep-monthly 12 -dry-run
 | `CLOUDSTIC_STORE` | `-store` | Storage backend URI: `local:<path>`, `s3:<bucket>[/<prefix>]`, `b2:<bucket>[/<prefix>]`, `sftp://[user@]host[:port]/<path>` |
 | `CLOUDSTIC_S3_ENDPOINT` | `-s3-endpoint` | S3 compatible endpoint (for MinIO, R2, etc.) |
 | `CLOUDSTIC_S3_REGION` | `-s3-region` | S3 Region |
+| `CLOUDSTIC_S3_PROFILE` | `-s3-profile` | AWS shared config profile for S3 auth |
 | `AWS_ACCESS_KEY_ID` | `-s3-access-key` | S3 Access Key ID |
 | `AWS_SECRET_ACCESS_KEY` | `-s3-secret-key` | S3 Secret Access Key |
 | `CLOUDSTIC_STORE_SFTP_PASSWORD` | `-store-sftp-password` | SFTP password for the store |
@@ -1269,6 +1491,7 @@ cloudstic forget -keep-daily 7 -keep-monthly 12 -dry-run
 | `CLOUDSTIC_KMS_KEY_ARN` | `-kms-key-arn` | AWS KMS key ARN for kms-platform slots |
 | `CLOUDSTIC_KMS_REGION` | `-kms-region` | AWS KMS region |
 | `CLOUDSTIC_KMS_ENDPOINT` | `-kms-endpoint` | Custom AWS KMS endpoint URL |
+| `CLOUDSTIC_PROFILES_FILE` | `-profiles-file` | Path to profiles YAML file |
 | `CLOUDSTIC_CONFIG_DIR` | — | Override config directory path |
 | `GOOGLE_APPLICATION_CREDENTIALS` | — | Path to your own Google OAuth credentials file (optional, overrides built-in) |
 | `GOOGLE_TOKEN_FILE` | — | Override Google OAuth token path |

--- a/internal/engine/profiles.go
+++ b/internal/engine/profiles.go
@@ -1,0 +1,131 @@
+package engine
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ProfilesConfig is the top-level YAML document for backup profiles.
+type ProfilesConfig struct {
+	Version  int                      `yaml:"version"`
+	Stores   map[string]ProfileStore  `yaml:"stores"`
+	Auth     map[string]ProfileAuth   `yaml:"auth"`
+	Profiles map[string]BackupProfile `yaml:"profiles"`
+}
+
+// ProfileStore defines reusable backend settings.
+type ProfileStore struct {
+	URI                  string `yaml:"uri"`
+	S3Endpoint           string `yaml:"s3_endpoint,omitempty"`
+	S3Region             string `yaml:"s3_region,omitempty"`
+	S3Profile            string `yaml:"s3_profile,omitempty"`
+	S3AccessKey          string `yaml:"s3_access_key,omitempty"`
+	S3SecretKey          string `yaml:"s3_secret_key,omitempty"`
+	S3AccessKeyEnv       string `yaml:"s3_access_key_env,omitempty"`
+	S3SecretKeyEnv       string `yaml:"s3_secret_key_env,omitempty"`
+	S3ProfileEnv         string `yaml:"s3_profile_env,omitempty"`
+	StoreSFTPPassword    string `yaml:"store_sftp_password,omitempty"`
+	StoreSFTPKey         string `yaml:"store_sftp_key,omitempty"`
+	StoreSFTPPasswordEnv string `yaml:"store_sftp_password_env,omitempty"`
+	StoreSFTPKeyEnv      string `yaml:"store_sftp_key_env,omitempty"`
+
+	// Encryption: env var indirection for secrets, direct values for non-secrets.
+	PasswordEnv      string `yaml:"password_env,omitempty"`
+	EncryptionKeyEnv string `yaml:"encryption_key_env,omitempty"`
+	RecoveryKeyEnv   string `yaml:"recovery_key_env,omitempty"`
+	KMSKeyARN        string `yaml:"kms_key_arn,omitempty"`
+	KMSRegion        string `yaml:"kms_region,omitempty"`
+	KMSEndpoint      string `yaml:"kms_endpoint,omitempty"`
+}
+
+// BackupProfile defines one backup job preset.
+type BackupProfile struct {
+	Source            string   `yaml:"source"`
+	Store             string   `yaml:"store,omitempty"`
+	AuthRef           string   `yaml:"auth_ref,omitempty"`
+	Tags              []string `yaml:"tags,omitempty"`
+	Excludes          []string `yaml:"excludes,omitempty"`
+	ExcludeFile       string   `yaml:"exclude_file,omitempty"`
+	SkipNativeFiles   bool     `yaml:"skip_native_files,omitempty"`
+	VolumeUUID        string   `yaml:"volume_uuid,omitempty"`
+	GoogleCreds       string   `yaml:"google_credentials,omitempty"`
+	GoogleTokenFile   string   `yaml:"google_token_file,omitempty"`
+	OneDriveClientID  string   `yaml:"onedrive_client_id,omitempty"`
+	OneDriveTokenFile string   `yaml:"onedrive_token_file,omitempty"`
+	Enabled           *bool    `yaml:"enabled,omitempty"`
+}
+
+// ProfileAuth defines reusable OAuth settings for cloud providers.
+type ProfileAuth struct {
+	Provider          string `yaml:"provider"` // google | onedrive
+	GoogleCreds       string `yaml:"google_credentials,omitempty"`
+	GoogleTokenFile   string `yaml:"google_token_file,omitempty"`
+	OneDriveClientID  string `yaml:"onedrive_client_id,omitempty"`
+	OneDriveTokenFile string `yaml:"onedrive_token_file,omitempty"`
+}
+
+// IsEnabled reports whether the profile should be included in -all-profiles.
+func (p BackupProfile) IsEnabled() bool {
+	if p.Enabled == nil {
+		return true
+	}
+	return *p.Enabled
+}
+
+func normalizeProfilesConfig(cfg *ProfilesConfig) *ProfilesConfig {
+	if cfg == nil {
+		cfg = &ProfilesConfig{}
+	}
+	if cfg.Version == 0 {
+		cfg.Version = 1
+	}
+	if cfg.Stores == nil {
+		cfg.Stores = map[string]ProfileStore{}
+	}
+	if cfg.Auth == nil {
+		cfg.Auth = map[string]ProfileAuth{}
+	}
+	if cfg.Profiles == nil {
+		cfg.Profiles = map[string]BackupProfile{}
+	}
+	return cfg
+}
+
+// LoadProfilesFile reads and parses a profiles YAML file.
+func LoadProfilesFile(path string) (*ProfilesConfig, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read profiles file %q: %w", path, err)
+	}
+	var cfg ProfilesConfig
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		return nil, fmt.Errorf("parse profiles file %q: %w", path, err)
+	}
+	return normalizeProfilesConfig(&cfg), nil
+}
+
+// SaveProfilesFile writes a profiles YAML file atomically.
+func SaveProfilesFile(path string, cfg *ProfilesConfig) error {
+	cfg = normalizeProfilesConfig(cfg)
+
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("encode profiles yaml: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("create profiles dir %q: %w", filepath.Dir(path), err)
+	}
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return fmt.Errorf("write profiles temp file %q: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("replace profiles file %q: %w", path, err)
+	}
+	return nil
+}

--- a/internal/engine/profiles_test.go
+++ b/internal/engine/profiles_test.go
@@ -1,0 +1,60 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadProfilesFile_NormalizesMapsAndVersion(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "profiles.yaml")
+	if err := os.WriteFile(path, []byte("profiles:\n  a:\n    source: local:/tmp\n"), 0600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	cfg, err := LoadProfilesFile(path)
+	if err != nil {
+		t.Fatalf("LoadProfilesFile: %v", err)
+	}
+	if cfg.Version != 1 {
+		t.Fatalf("Version=%d want=1", cfg.Version)
+	}
+	if cfg.Stores == nil {
+		t.Fatal("Stores map should be initialized")
+	}
+	if cfg.Auth == nil {
+		t.Fatal("Auth map should be initialized")
+	}
+	if cfg.Profiles == nil || len(cfg.Profiles) != 1 {
+		t.Fatalf("Profiles map invalid: %#v", cfg.Profiles)
+	}
+}
+
+func TestSaveProfilesFile_RoundTrip(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "profiles.yaml")
+
+	err := SaveProfilesFile(path, &ProfilesConfig{
+		Stores: map[string]ProfileStore{
+			"s": {URI: "local:./store"},
+		},
+		Profiles: map[string]BackupProfile{
+			"p": {Source: "local:./docs", Store: "s"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SaveProfilesFile: %v", err)
+	}
+
+	cfg, err := LoadProfilesFile(path)
+	if err != nil {
+		t.Fatalf("LoadProfilesFile: %v", err)
+	}
+	if cfg.Profiles["p"].Source != "local:./docs" {
+		t.Fatalf("unexpected source: %q", cfg.Profiles["p"].Source)
+	}
+	if cfg.Stores["s"].URI != "local:./store" {
+		t.Fatalf("unexpected store uri: %q", cfg.Stores["s"].URI)
+	}
+}

--- a/pkg/source/gdrive.go
+++ b/pkg/source/gdrive.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -361,6 +362,9 @@ func tokenFromFile(file string) (*oauth2.Token, error) {
 }
 
 func saveToken(path string, token *oauth2.Token) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("create token directory: %w", err)
+	}
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("create token file: %w", err)

--- a/pkg/source/onedrive.go
+++ b/pkg/source/onedrive.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/cloudstic/cli/internal/core"
@@ -290,6 +291,9 @@ func loadToken(file string) (*oauth2.Token, error) {
 }
 
 func saveTokenJSON(file string, token *oauth2.Token) error {
+	if err := os.MkdirAll(filepath.Dir(file), 0700); err != nil {
+		return fmt.Errorf("create token directory: %w", err)
+	}
 	f, err := os.OpenFile(file, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err

--- a/pkg/store/s3.go
+++ b/pkg/store/s3.go
@@ -28,6 +28,7 @@ type S3Store struct {
 type s3Options struct {
 	endpoint  string
 	region    string
+	profile   string
 	accessKey string
 	secretKey string
 	prefix    string
@@ -50,6 +51,14 @@ func WithS3Endpoint(endpoint string) S3Option {
 func WithS3Region(region string) S3Option {
 	return func(o *s3Options) {
 		o.region = region
+	}
+}
+
+// WithS3Profile sets the AWS shared config profile name used by the SDK
+// default credential chain (e.g. profile from ~/.aws/config).
+func WithS3Profile(profile string) S3Option {
+	return func(o *s3Options) {
+		o.profile = profile
 	}
 }
 
@@ -105,6 +114,10 @@ func NewS3Store(ctx context.Context, bucketName string, opts ...S3Option) (*S3St
 		cfgOpts := []func(*config.LoadOptions) error{
 			config.WithRegion(o.region),
 			config.WithHTTPClient(httpClient),
+		}
+
+		if o.profile != "" {
+			cfgOpts = append(cfgOpts, config.WithSharedConfigProfile(o.profile))
 		}
 
 		if o.accessKey != "" && o.secretKey != "" {

--- a/rfcs/0010-backup-profiles.md
+++ b/rfcs/0010-backup-profiles.md
@@ -1,0 +1,292 @@
+# RFC 0010: Backup Profiles (YAML Presets)
+
+- **Status:** Draft
+- **Date:** 2026-03-14
+- **Affects:** `cmd/cloudstic/backup`, new `cmd/cloudstic/profile`, docs
+
+## Abstract
+
+This RFC introduces backup profiles: reusable YAML presets for backup jobs.
+
+Users can define sources, exclusions, tags, and storage references once, then run:
+
+- a single profile (`cloudstic backup -profile <name>`)
+- all profiles (`cloudstic backup -all-profiles`)
+
+The design separates reusable storage definitions from backup profiles and adds
+an initial profile-creation command.
+
+It also introduces reusable cloud auth entries so multiple Google/OneDrive
+profiles can use independent token files without manual copy/paste.
+
+## Context
+
+`cloudstic backup` currently requires many flags for repeated runs. This is
+error-prone in daily use and hard to maintain in scripts.
+
+Typical pain points:
+
+- repeating long source/store/auth flag sets
+- managing multiple backup jobs targeting the same store
+- keeping local shell scripts in sync with source changes
+
+## Goals
+
+- Define backup jobs in one YAML file.
+- Allow running one profile or all profiles from the CLI.
+- Reuse shared store definitions across multiple profiles.
+- Keep existing flag-based workflows unchanged.
+
+## Non-goals
+
+- No scheduler/orchestrator in this RFC.
+- No breaking changes to existing `backup` flags.
+- No mandatory migration for existing users.
+
+## Proposal
+
+### 1. Profile file and location
+
+Default path:
+
+- `<config-dir>/profiles.yaml`
+
+where `<config-dir>` is resolved by existing `internal/paths.ConfigDir()`.
+
+Optional override:
+
+- `-profiles-file <path>` on profile-related commands.
+
+### 2. YAML schema
+
+```yaml
+version: 1
+
+stores:
+  home-s3:
+    uri: s3:my-bucket/cloudstic
+    s3_region: us-east-1
+    s3_profile: prod
+    s3_endpoint: https://s3.us-east-1.amazonaws.com
+    # Prefer env references for secrets
+    s3_access_key_env: AWS_ACCESS_KEY_ID
+    s3_secret_key_env: AWS_SECRET_ACCESS_KEY
+
+  local-disk:
+    uri: local:/Volumes/BackupStore
+
+auth:
+  google-work:
+    provider: google
+    google_token_file: ~/.config/cloudstic/tokens/google-work.json
+
+  microsoft-personal:
+    provider: onedrive
+    onedrive_client_id: <client-id>
+    onedrive_token_file: ~/.config/cloudstic/tokens/ms-personal.json
+
+profiles:
+  photos:
+    source: local:/Volumes/Photos
+    store: home-s3
+    tags: [photos, daily]
+    excludes:
+      - "*.tmp"
+      - ".DS_Store"
+
+  work-drive:
+    source: gdrive-changes://Company Data/Engineering
+    store: local-disk
+    auth_ref: google-work
+    skip_native_files: true
+```
+
+### 3. Why `stores` is a top-level section
+
+`stores` are reusable infrastructure definitions. Profiles are backup jobs.
+
+Benefits of reference-by-name:
+
+- avoids copy/paste of store settings
+- makes rotation of endpoints/credentials easier
+- keeps backup job intent separate from backend wiring
+
+### 3b. Why `auth` is a top-level section
+
+`auth` defines reusable cloud OAuth contexts (account/session-level settings),
+separate from backup job definitions.
+
+Benefits:
+
+- lets multiple profiles use different Google/OneDrive accounts cleanly
+- supports per-account token files instead of one implicit global token
+- keeps account credentials separate from source path and retention intent
+
+### 4. CLI behavior
+
+#### Profile command
+
+- `cloudstic profile list`
+- `cloudstic profile show <name>`
+- `cloudstic profile new`
+
+`profile new` requires existing `auth_ref` values; it does not implicitly create
+auth entries.
+
+`profile list` prints all configured stores, auth entries, and profiles.
+`profile show` prints one profile with resolved store/auth references.
+`profile new` creates or updates one profile entry and can optionally create or
+update a referenced store entry.
+
+#### Backup command extensions
+
+- `cloudstic backup -profile <name>`
+- `cloudstic backup -all-profiles`
+- `cloudstic backup -profile <name> -profiles-file <path>`
+- `cloudstic backup -source ... -auth-ref <name>`
+
+When backing up a cloud source without `-auth-ref`, Cloudstic attaches the run
+to a provider default auth entry and persists it in `profiles.yaml`:
+
+- Google: `google-default`
+- OneDrive: `onedrive-default`
+
+This makes discovered auth state visible in CLI (`auth list` / `profile list`)
+without requiring profile mode.
+
+#### Auth command
+
+- `cloudstic auth new`
+- `cloudstic auth list`
+- `cloudstic auth show <name>`
+- `cloudstic auth login -name <name>`
+
+`auth login` triggers provider OAuth flow (if needed) and writes/refreshes token
+at the auth entry's configured token file.
+
+When token file flags are omitted on `auth new`, Cloudstic derives a default
+path from auth name under `<config-dir>/tokens/`.
+
+Rules:
+
+- `-profile` and `-all-profiles` are mutually exclusive.
+- Profile mode is opt-in; existing `-source ...` usage continues unchanged.
+- For `-all-profiles`, profiles are run sequentially in stable name order.
+- In `-all-profiles`, the command continues after individual failures and
+  returns non-zero if any profile failed.
+
+#### Profile creation command
+
+Introduce:
+
+- `cloudstic profile new`
+
+Initial scope:
+
+- create/update one profile entry
+- optionally create/update referenced store entry
+- require referenced auth entry to already exist when `auth_ref` is set
+
+Example:
+
+```bash
+cloudstic profile new \
+  -name photos \
+  -source local:/Volumes/Photos \
+  -store-ref home-s3 \
+  -store s3:my-bucket/cloudstic
+
+cloudstic profile new \
+  -name work-drive \
+  -source gdrive-changes:/Engineering \
+  -auth-ref google-work
+```
+
+```bash
+cloudstic auth new \
+  -name google-work \
+  -provider google \
+  -google-token-file ~/.config/cloudstic/tokens/google-work.json
+```
+
+### 5. Flag/profile precedence
+
+When profile mode is used, value precedence is:
+
+1. Explicit CLI flags
+2. Referenced `auth` entry values (`auth_ref`)
+3. Profile file values (legacy per-profile auth fields)
+4. Existing env defaults
+
+This preserves script-level overrides while keeping profiles ergonomic.
+
+### 6. Architecture: engine logic via client
+
+Profile file parsing and serialization live in `internal/engine` and are
+exposed through package-level client functions:
+
+- `cloudstic.LoadProfilesFile(path)`
+- `cloudstic.SaveProfilesFile(path, cfg)`
+
+CLI commands call these APIs instead of parsing YAML directly in
+`cmd/cloudstic`, so profile semantics are reusable for future non-CLI surfaces.
+
+Auth token acquisition itself remains in source/provider codepaths and is reused
+by `backup` and `auth login`.
+
+### 7. Secrets and secure storage
+
+#### Short term (this RFC)
+
+- Support environment-variable references in YAML (`*_env` fields).
+- Avoid storing plaintext secrets directly in `profiles.yaml`.
+- OAuth token files are still created by the existing source auth flows on first
+  backup (interactive login if needed). `auth` entries define which token path
+  to use, not a new token minting workflow.
+
+#### Why not TPM-only right now
+
+TPM/Secure Enclave usage is platform-specific and better introduced behind a
+cross-platform abstraction. This RFC focuses on profile UX and compatibility.
+
+#### Next step (follow-up RFC)
+
+Add a secure secret backend abstraction for profile fields, for example:
+
+- macOS Keychain
+- Windows Credential Manager / DPAPI
+- Linux Secret Service / KWallet
+- optional TPM-backed provider where available
+
+Potential syntax (future):
+
+```yaml
+password_secret: keychain://cloudstic/repo/main
+```
+
+## Compatibility and migration
+
+- Fully backward compatible: profiles are additive.
+- No impact on users who only use flags.
+- Existing automation can migrate incrementally profile-by-profile.
+
+## Error handling
+
+- Unknown profile/store reference: clear error with available names.
+- Unknown `auth_ref`: clear error with available names.
+- `auth_ref` provider mismatch (e.g. OneDrive auth for gdrive source): fail.
+- Cycles are impossible in current schema (single store ref).
+- Invalid YAML schema: include file path + line when possible.
+- `-all-profiles`: print per-profile result summary + final aggregate status.
+
+## Documentation updates (planned)
+
+- `docs/user-guide.md`: add profile setup and examples.
+- `docs/sources.md`: mention profile-driven execution path.
+- shell completion: add new flags and `profile` command.
+
+## Open questions
+
+- Should we add profile inheritance (`extends`) now or later? (proposed: later)
+- Should interactive prompting be globally toggleable (`--no-input`) across all profile/auth commands?
+- Should `-all-profiles` support include/exclude filters by tag? (later)

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -9,3 +9,4 @@
 - [RFC 0007: Cloud Subdirectory Backup](0007-cloud-subdirectory-backup.md)
 - [RFC 0008: Drive Identity by Name](0008-drive-identity-by-name.md)
 - [RFC 0009: Unified Source Identity](0009-unified-source-identity.md)
+- [RFC 0010: Backup Profiles (YAML Presets)](0010-backup-profiles.md)


### PR DESCRIPTION
## Summary
- Implement backup profiles from RFC 0010 with a YAML-driven workflow.
- Add reusable `stores` and `auth` entries and profile-aware backup execution.
- Add new CLI surfaces for profile/auth/store management and documentation.

## What Changes
- Add profile config model + I/O APIs:
  - `internal/engine/profiles.go`
  - exported via `client.go` (`LoadProfilesFile`, `SaveProfilesFile`)
- Add new CLI commands:
  - `cloudstic profile {list,show,new}`
  - `cloudstic auth {new,list,show,login}`
  - `cloudstic store {list,show,new}`
- Extend backup command:
  - `-profile <name>`
  - `-all-profiles`
  - `-auth-ref <name>`
  - `-profiles-file <path>`
  - profile/store/auth merge + precedence behavior in `cmd/cloudstic/cmd_backup.go`
- Add completion/help/docs updates:
  - `cmd/cloudstic/completion.go`
  - `cmd/cloudstic/usage.go`
  - `docs/user-guide.md`, `README.md`
- Add RFC:
  - `rfcs/0010-backup-profiles.md`
  - index update in `rfcs/README.md`

## Behavior Notes
- Existing flag-based workflows remain supported.
- `-profile` and `-all-profiles` are mutually exclusive.
- `-all-profiles` runs enabled profiles sequentially and reports aggregate failure if any profile fails.
- Secrets in profile store config use env-var indirection fields (`*_env`) rather than plaintext by default.

## Testing
- New tests added across profile/auth/store and backup profile behavior:
  - `cmd/cloudstic/cmd_profile_test.go`
  - `cmd/cloudstic/cmd_auth_test.go`
  - `cmd/cloudstic/cmd_store_test.go`
  - `cmd/cloudstic/cmd_backup_profile_test.go`
  - `internal/engine/profiles_test.go`

## Tracking
- RFC: `rfcs/0010-backup-profiles.md`
- Follow-up secure storage work is tracked separately by RFC 0011 / issue #93.