### PR TITLE
test: extend profile e2e coverage and backup secret-ref resolution

### DIFF
--- a/cmd/cloudstic/cmd_backup.go
+++ b/cmd/cloudstic/cmd_backup.go
@@ -15,6 +15,7 @@ import (
 	cloudstic "github.com/cloudstic/cli"
 	"github.com/cloudstic/cli/internal/engine"
 	"github.com/cloudstic/cli/internal/paths"
+	"github.com/cloudstic/cli/internal/secretref"
 	"github.com/cloudstic/cli/pkg/source"
 )
 
@@ -438,6 +439,22 @@ func cloneGlobalFlags(src *globalFlags) *globalFlags {
 }
 
 func applyProfileStoreToGlobalFlags(g *globalFlags, s cloudstic.ProfileStore, flagsSet map[string]bool) {
+	resolver := secretref.NewDefaultResolver()
+	resolve := func(direct, secretRef, envName string) string {
+		if direct != "" {
+			return direct
+		}
+		if secretRef != "" {
+			if v, err := resolver.Resolve(context.Background(), secretRef); err == nil {
+				return v
+			}
+		}
+		if envName != "" {
+			return os.Getenv(envName)
+		}
+		return ""
+	}
+
 	if !flagsSet["store"] && s.URI != "" {
 		*g.store = s.URI
 	}
@@ -448,48 +465,28 @@ func applyProfileStoreToGlobalFlags(g *globalFlags, s cloudstic.ProfileStore, fl
 		*g.s3Region = s.S3Region
 	}
 	if !flagsSet["s3-profile"] {
-		if s.S3Profile != "" {
-			*g.s3Profile = s.S3Profile
-		} else if s.S3ProfileEnv != "" {
-			*g.s3Profile = os.Getenv(s.S3ProfileEnv)
-		}
+		*g.s3Profile = resolve(s.S3Profile, "", s.S3ProfileEnv)
 	}
 	if !flagsSet["s3-access-key"] {
-		if s.S3AccessKey != "" {
-			*g.s3AccessKey = s.S3AccessKey
-		} else if s.S3AccessKeyEnv != "" {
-			*g.s3AccessKey = os.Getenv(s.S3AccessKeyEnv)
-		}
+		*g.s3AccessKey = resolve(s.S3AccessKey, s.S3AccessKeySecret, s.S3AccessKeyEnv)
 	}
 	if !flagsSet["s3-secret-key"] {
-		if s.S3SecretKey != "" {
-			*g.s3SecretKey = s.S3SecretKey
-		} else if s.S3SecretKeyEnv != "" {
-			*g.s3SecretKey = os.Getenv(s.S3SecretKeyEnv)
-		}
+		*g.s3SecretKey = resolve(s.S3SecretKey, s.S3SecretKeySecret, s.S3SecretKeyEnv)
 	}
 	if !flagsSet["store-sftp-password"] {
-		if s.StoreSFTPPassword != "" {
-			*g.storeSFTPPassword = s.StoreSFTPPassword
-		} else if s.StoreSFTPPasswordEnv != "" {
-			*g.storeSFTPPassword = os.Getenv(s.StoreSFTPPasswordEnv)
-		}
+		*g.storeSFTPPassword = resolve(s.StoreSFTPPassword, s.StoreSFTPPasswordSecret, s.StoreSFTPPasswordEnv)
 	}
 	if !flagsSet["store-sftp-key"] {
-		if s.StoreSFTPKey != "" {
-			*g.storeSFTPKey = s.StoreSFTPKey
-		} else if s.StoreSFTPKeyEnv != "" {
-			*g.storeSFTPKey = os.Getenv(s.StoreSFTPKeyEnv)
-		}
+		*g.storeSFTPKey = resolve(s.StoreSFTPKey, s.StoreSFTPKeySecret, s.StoreSFTPKeyEnv)
 	}
-	if !flagsSet["password"] && s.PasswordEnv != "" {
-		*g.password = os.Getenv(s.PasswordEnv)
+	if !flagsSet["password"] {
+		*g.password = resolve("", s.PasswordSecret, s.PasswordEnv)
 	}
-	if !flagsSet["encryption-key"] && s.EncryptionKeyEnv != "" {
-		*g.encryptionKey = os.Getenv(s.EncryptionKeyEnv)
+	if !flagsSet["encryption-key"] {
+		*g.encryptionKey = resolve("", s.EncryptionKeySecret, s.EncryptionKeyEnv)
 	}
-	if !flagsSet["recovery-key"] && s.RecoveryKeyEnv != "" {
-		*g.recoveryKey = os.Getenv(s.RecoveryKeyEnv)
+	if !flagsSet["recovery-key"] {
+		*g.recoveryKey = resolve("", s.RecoveryKeySecret, s.RecoveryKeyEnv)
 	}
 	if !flagsSet["kms-key-arn"] && s.KMSKeyARN != "" {
 		*g.kmsKeyARN = s.KMSKeyARN

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -107,6 +107,17 @@ func runExpectFail(t *testing.T, bin string, args ...string) string {
 	return string(out)
 }
 
+func runWithEnv(t *testing.T, bin string, extraEnv []string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command(bin, args...)
+	cmd.Env = append(cleanEnv(), extraEnv...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Command %v failed: %v\n%s", args, err, out)
+	}
+	return string(out)
+}
+
 func writeFile(t *testing.T, dir, name, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(filepath.Join(dir, name)), 0755); err != nil {
@@ -521,6 +532,91 @@ func TestCLI_EndToEnd_Completion(t *testing.T) {
 	out = runExpectFail(t, bin, "completion")
 	if !strings.Contains(out, "Usage:") {
 		t.Errorf("Expected usage message, got: %s", out)
+	}
+}
+
+func TestCLI_EndToEnd_Profiles_LocalStore(t *testing.T) {
+	if !shouldRun(Hermetic) {
+		t.Skip("skipping hermetic test")
+	}
+
+	bin := buildBinary(t)
+	src1 := t.TempDir()
+	src2 := t.TempDir()
+	storeDir := t.TempDir()
+	profilesPath := filepath.Join(t.TempDir(), "profiles.yaml")
+
+	writeFile(t, src1, "alpha.txt", "from profile one")
+	writeFile(t, src2, "beta.txt", "from profile two")
+
+	passwordEnv := "E2E_PROFILE_PASSWORD"
+	password := "e2e-profile-pass"
+
+	// Create store and ensure the new secret-ref format is written.
+	run(t, bin,
+		"store", "new",
+		"-profiles-file", profilesPath,
+		"-name", "main",
+		"-uri", "local:"+storeDir,
+		"-password-env", passwordEnv,
+	)
+
+	raw, err := os.ReadFile(profilesPath)
+	if err != nil {
+		t.Fatalf("read profiles file: %v", err)
+	}
+	profilesYAML := string(raw)
+	if !strings.Contains(profilesYAML, "password_secret: env://"+passwordEnv) {
+		t.Fatalf("expected password_secret env ref in profiles file:\n%s", profilesYAML)
+	}
+	if strings.Contains(profilesYAML, "password_env:") {
+		t.Fatalf("did not expect legacy password_env in profiles file:\n%s", profilesYAML)
+	}
+
+	// Create two local backup profiles using the shared store.
+	run(t, bin,
+		"profile", "new",
+		"-profiles-file", profilesPath,
+		"-name", "p1",
+		"-source", "local:"+src1,
+		"-store-ref", "main",
+	)
+	run(t, bin,
+		"profile", "new",
+		"-profiles-file", profilesPath,
+		"-name", "p2",
+		"-source", "local:"+src2,
+		"-store-ref", "main",
+	)
+
+	// Initialize repository in the referenced store.
+	run(t, bin, "init", "--store", "local:"+storeDir, "--password", password)
+
+	// Run one profile; password is resolved from password_secret -> env://.
+	runWithEnv(t, bin, []string{passwordEnv + "=" + password},
+		"backup",
+		"-profiles-file", profilesPath,
+		"-profile", "p1",
+	)
+
+	out := run(t, bin, "list", "--store", "local:"+storeDir, "--password", password)
+	if !strings.Contains(out, "1 snapshot") {
+		t.Fatalf("expected one snapshot after single-profile backup, got:\n%s", out)
+	}
+	if !strings.Contains(out, src1) {
+		t.Fatalf("expected source path for p1 in list output, got:\n%s", out)
+	}
+
+	// Run all profiles; should cover both profile entries end-to-end.
+	runWithEnv(t, bin, []string{passwordEnv + "=" + password},
+		"backup",
+		"-profiles-file", profilesPath,
+		"-all-profiles",
+	)
+
+	out = run(t, bin, "list", "--store", "local:"+storeDir, "--password", password)
+	if !strings.Contains(out, src1) || !strings.Contains(out, src2) {
+		t.Fatalf("expected both profile sources in list output after -all-profiles, got:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add a hermetic end-to-end profile workflow test that covers `store new`, `profile new`, `backup -profile`, and `backup -all-profiles`.
- Ensure profile-store merge in backup resolves `*_secret` references (`env://...`) with fallback to legacy `*_env` fields.
- Keep existing backward compatibility while validating the new write format works end to end.

## What is covered now
- `store new -password-env ...` writes `password_secret: env://...`.
- `backup -profile <name>` can unlock an encrypted store using `password_secret`.
- `backup -all-profiles` executes multiple profile entries successfully.
- `list` shows snapshots from both profile sources after all-profiles run.

## Files
- `cmd/cloudstic/cmd_backup.go`
- `e2e/e2e_test.go`

## Validation
- `go test ./...`
- `golangci-lint run ./...`

## Tracking
- RFC: `rfcs/0011-profile-credential-storage-backends.md`
- Follow-up integration work: #92