### PR TITLE
feat: integrate profile secret resolver in backup and store flows

### DIFF
--- a/cmd/cloudstic/cmd_backup.go
+++ b/cmd/cloudstic/cmd_backup.go
@@ -15,7 +15,6 @@ import (
 	cloudstic "github.com/cloudstic/cli"
 	"github.com/cloudstic/cli/internal/engine"
 	"github.com/cloudstic/cli/internal/paths"
-	"github.com/cloudstic/cli/internal/secretref"
 	"github.com/cloudstic/cli/pkg/source"
 )
 
@@ -321,7 +320,9 @@ func mergeProfileBackupArgs(base *backupArgs, profileName string, p cloudstic.Ba
 		if !ok {
 			return nil, fmt.Errorf("profile %q references unknown store %q", profileName, p.Store)
 		}
-		applyProfileStoreToGlobalFlags(g, storeCfg, a.flagsSet)
+		if err := applyProfileStoreToGlobalFlags(g, storeCfg, a.flagsSet); err != nil {
+			return nil, fmt.Errorf("profile %q store %q: %w", profileName, p.Store, err)
+		}
 	}
 
 	if p.AuthRef != "" {
@@ -438,23 +439,7 @@ func cloneGlobalFlags(src *globalFlags) *globalFlags {
 	return &clone
 }
 
-func applyProfileStoreToGlobalFlags(g *globalFlags, s cloudstic.ProfileStore, flagsSet map[string]bool) {
-	resolver := secretref.NewDefaultResolver()
-	resolve := func(direct, secretRef, envName string) string {
-		if direct != "" {
-			return direct
-		}
-		if secretRef != "" {
-			if v, err := resolver.Resolve(context.Background(), secretRef); err == nil {
-				return v
-			}
-		}
-		if envName != "" {
-			return os.Getenv(envName)
-		}
-		return ""
-	}
-
+func applyProfileStoreToGlobalFlags(g *globalFlags, s cloudstic.ProfileStore, flagsSet map[string]bool) error {
 	if !flagsSet["store"] && s.URI != "" {
 		*g.store = s.URI
 	}
@@ -465,28 +450,60 @@ func applyProfileStoreToGlobalFlags(g *globalFlags, s cloudstic.ProfileStore, fl
 		*g.s3Region = s.S3Region
 	}
 	if !flagsSet["s3-profile"] {
-		*g.s3Profile = resolve(s.S3Profile, "", s.S3ProfileEnv)
+		v, err := resolveProfileStoreValue("s3_profile", s.S3Profile, "", s.S3ProfileEnv)
+		if err != nil {
+			return err
+		}
+		*g.s3Profile = v
 	}
 	if !flagsSet["s3-access-key"] {
-		*g.s3AccessKey = resolve(s.S3AccessKey, s.S3AccessKeySecret, s.S3AccessKeyEnv)
+		v, err := resolveProfileStoreValue("s3_access_key", s.S3AccessKey, s.S3AccessKeySecret, s.S3AccessKeyEnv)
+		if err != nil {
+			return err
+		}
+		*g.s3AccessKey = v
 	}
 	if !flagsSet["s3-secret-key"] {
-		*g.s3SecretKey = resolve(s.S3SecretKey, s.S3SecretKeySecret, s.S3SecretKeyEnv)
+		v, err := resolveProfileStoreValue("s3_secret_key", s.S3SecretKey, s.S3SecretKeySecret, s.S3SecretKeyEnv)
+		if err != nil {
+			return err
+		}
+		*g.s3SecretKey = v
 	}
 	if !flagsSet["store-sftp-password"] {
-		*g.storeSFTPPassword = resolve(s.StoreSFTPPassword, s.StoreSFTPPasswordSecret, s.StoreSFTPPasswordEnv)
+		v, err := resolveProfileStoreValue("store_sftp_password", s.StoreSFTPPassword, s.StoreSFTPPasswordSecret, s.StoreSFTPPasswordEnv)
+		if err != nil {
+			return err
+		}
+		*g.storeSFTPPassword = v
 	}
 	if !flagsSet["store-sftp-key"] {
-		*g.storeSFTPKey = resolve(s.StoreSFTPKey, s.StoreSFTPKeySecret, s.StoreSFTPKeyEnv)
+		v, err := resolveProfileStoreValue("store_sftp_key", s.StoreSFTPKey, s.StoreSFTPKeySecret, s.StoreSFTPKeyEnv)
+		if err != nil {
+			return err
+		}
+		*g.storeSFTPKey = v
 	}
 	if !flagsSet["password"] {
-		*g.password = resolve("", s.PasswordSecret, s.PasswordEnv)
+		v, err := resolveProfileStoreValue("password", "", s.PasswordSecret, s.PasswordEnv)
+		if err != nil {
+			return err
+		}
+		*g.password = v
 	}
 	if !flagsSet["encryption-key"] {
-		*g.encryptionKey = resolve("", s.EncryptionKeySecret, s.EncryptionKeyEnv)
+		v, err := resolveProfileStoreValue("encryption_key", "", s.EncryptionKeySecret, s.EncryptionKeyEnv)
+		if err != nil {
+			return err
+		}
+		*g.encryptionKey = v
 	}
 	if !flagsSet["recovery-key"] {
-		*g.recoveryKey = resolve("", s.RecoveryKeySecret, s.RecoveryKeyEnv)
+		v, err := resolveProfileStoreValue("recovery_key", "", s.RecoveryKeySecret, s.RecoveryKeyEnv)
+		if err != nil {
+			return err
+		}
+		*g.recoveryKey = v
 	}
 	if !flagsSet["kms-key-arn"] && s.KMSKeyARN != "" {
 		*g.kmsKeyARN = s.KMSKeyARN
@@ -497,6 +514,7 @@ func applyProfileStoreToGlobalFlags(g *globalFlags, s cloudstic.ProfileStore, fl
 	if !flagsSet["kms-endpoint"] && s.KMSEndpoint != "" {
 		*g.kmsEndpoint = s.KMSEndpoint
 	}
+	return nil
 }
 
 func (r *runner) parseExcludePatterns(a *backupArgs) ([]string, error) {

--- a/cmd/cloudstic/cmd_backup_profile_test.go
+++ b/cmd/cloudstic/cmd_backup_profile_test.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	cloudstic "github.com/cloudstic/cli"
@@ -291,23 +292,25 @@ func TestApplyProfileStoreToGlobalFlags_AllFields(t *testing.T) {
 	g := newTestGlobalFlags()
 	flagsSet := map[string]bool{}
 	s := cloudstic.ProfileStore{
-		URI:              "s3:my-bucket/prefix",
-		S3Region:         "us-east-1",
-		S3Endpoint:       "https://s3.example.com",
-		S3Profile:        "prod",
-		S3AccessKey:      "AKIATEST",
-		S3SecretKey:      "SECRETTEST",
+		URI:               "s3:my-bucket/prefix",
+		S3Region:          "us-east-1",
+		S3Endpoint:        "https://s3.example.com",
+		S3Profile:         "prod",
+		S3AccessKey:       "AKIATEST",
+		S3SecretKey:       "SECRETTEST",
 		StoreSFTPPassword: "sftp-pw",
-		StoreSFTPKey:     "/tmp/sftp.key",
-		PasswordEnv:      "TEST_PASSWORD",
-		EncryptionKeyEnv: "TEST_ENC_KEY",
-		RecoveryKeyEnv:   "TEST_REC_KEY",
-		KMSKeyARN:        "arn:aws:kms:us-east-1:123:key/abc",
-		KMSRegion:        "us-east-1",
-		KMSEndpoint:      "https://kms.example.com",
+		StoreSFTPKey:      "/tmp/sftp.key",
+		PasswordEnv:       "TEST_PASSWORD",
+		EncryptionKeyEnv:  "TEST_ENC_KEY",
+		RecoveryKeyEnv:    "TEST_REC_KEY",
+		KMSKeyARN:         "arn:aws:kms:us-east-1:123:key/abc",
+		KMSRegion:         "us-east-1",
+		KMSEndpoint:       "https://kms.example.com",
 	}
 
-	applyProfileStoreToGlobalFlags(g, s, flagsSet)
+	if err := applyProfileStoreToGlobalFlags(g, s, flagsSet); err != nil {
+		t.Fatalf("applyProfileStoreToGlobalFlags: %v", err)
+	}
 
 	if *g.store != "s3:my-bucket/prefix" {
 		t.Fatalf("store=%q want s3:my-bucket/prefix", *g.store)
@@ -359,10 +362,47 @@ func TestApplyProfileStoreToGlobalFlags_CLIFlagOverrides(t *testing.T) {
 	flagsSet := map[string]bool{"store": true}
 	s := cloudstic.ProfileStore{URI: "s3:profile-bucket"}
 
-	applyProfileStoreToGlobalFlags(g, s, flagsSet)
+	if err := applyProfileStoreToGlobalFlags(g, s, flagsSet); err != nil {
+		t.Fatalf("applyProfileStoreToGlobalFlags: %v", err)
+	}
 
 	if *g.store != "local:/cli-store" {
 		t.Fatalf("store=%q want local:/cli-store", *g.store)
+	}
+}
+
+func TestApplyProfileStoreToGlobalFlags_SecretPrecedenceOverLegacyEnv(t *testing.T) {
+	t.Setenv("LEGACY_PW", "legacy")
+	t.Setenv("SECRET_PW", "from-secret-ref")
+
+	g := newTestGlobalFlags()
+	flagsSet := map[string]bool{}
+	s := cloudstic.ProfileStore{
+		PasswordSecret: "env://SECRET_PW",
+		PasswordEnv:    "LEGACY_PW",
+	}
+
+	if err := applyProfileStoreToGlobalFlags(g, s, flagsSet); err != nil {
+		t.Fatalf("applyProfileStoreToGlobalFlags: %v", err)
+	}
+	if *g.password != "from-secret-ref" {
+		t.Fatalf("password=%q want from-secret-ref", *g.password)
+	}
+}
+
+func TestApplyProfileStoreToGlobalFlags_InvalidSecretRef(t *testing.T) {
+	g := newTestGlobalFlags()
+	flagsSet := map[string]bool{}
+	s := cloudstic.ProfileStore{
+		PasswordSecret: "env:/invalid-format",
+	}
+
+	err := applyProfileStoreToGlobalFlags(g, s, flagsSet)
+	if err == nil {
+		t.Fatal("expected error for invalid secret ref")
+	}
+	if !strings.Contains(err.Error(), "password") {
+		t.Fatalf("expected field context in error, got: %v", err)
 	}
 }
 

--- a/cmd/cloudstic/cmd_store.go
+++ b/cmd/cloudstic/cmd_store.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	cloudstic "github.com/cloudstic/cli"
-	"github.com/cloudstic/cli/internal/secretref"
 )
 
 var validRefName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
@@ -313,7 +312,11 @@ func (r *runner) runStoreNew() int {
 // the store config has already been saved.
 func (r *runner) checkOrInitStore(cfg *cloudstic.ProfilesConfig, storeName, profilesFile string) {
 	s := cfg.Stores[storeName]
-	g := globalFlagsFromProfileStore(s)
+	g, err := globalFlagsFromProfileStore(s)
+	if err != nil {
+		_, _ = fmt.Fprintf(r.errOut, "Could not resolve store credentials: %v\n", err)
+		return
+	}
 	raw, err := g.initObjectStore()
 	if err != nil {
 		_, _ = fmt.Fprintf(r.errOut, "Could not connect to store: %v\n", err)
@@ -447,23 +450,7 @@ func (r *runner) promptEncryptionConfig(cfg *cloudstic.ProfilesConfig, storeName
 
 // globalFlagsFromProfileStore builds a globalFlags populated from a ProfileStore,
 // resolving env var indirections for secrets.
-func globalFlagsFromProfileStore(s cloudstic.ProfileStore) *globalFlags {
-	resolver := secretref.NewDefaultResolver()
-	resolve := func(direct, secretRef, envName string) string {
-		if direct != "" {
-			return direct
-		}
-		if secretRef != "" {
-			v, err := resolver.Resolve(context.Background(), secretRef)
-			if err == nil {
-				return v
-			}
-		}
-		if envName != "" {
-			return os.Getenv(envName)
-		}
-		return ""
-	}
+func globalFlagsFromProfileStore(s cloudstic.ProfileStore) (*globalFlags, error) {
 
 	g := &globalFlags{}
 	store := s.URI
@@ -475,21 +462,45 @@ func globalFlagsFromProfileStore(s cloudstic.ProfileStore) *globalFlags {
 		s3Region = "us-east-1"
 	}
 	g.s3Region = &s3Region
-	s3Profile := resolve(s.S3Profile, "", s.S3ProfileEnv)
+	s3Profile, err := resolveProfileStoreValue("s3_profile", s.S3Profile, "", s.S3ProfileEnv)
+	if err != nil {
+		return nil, err
+	}
 	g.s3Profile = &s3Profile
-	s3AccessKey := resolve(s.S3AccessKey, s.S3AccessKeySecret, s.S3AccessKeyEnv)
+	s3AccessKey, err := resolveProfileStoreValue("s3_access_key", s.S3AccessKey, s.S3AccessKeySecret, s.S3AccessKeyEnv)
+	if err != nil {
+		return nil, err
+	}
 	g.s3AccessKey = &s3AccessKey
-	s3SecretKey := resolve(s.S3SecretKey, s.S3SecretKeySecret, s.S3SecretKeyEnv)
+	s3SecretKey, err := resolveProfileStoreValue("s3_secret_key", s.S3SecretKey, s.S3SecretKeySecret, s.S3SecretKeyEnv)
+	if err != nil {
+		return nil, err
+	}
 	g.s3SecretKey = &s3SecretKey
-	storeSFTPPassword := resolve(s.StoreSFTPPassword, s.StoreSFTPPasswordSecret, s.StoreSFTPPasswordEnv)
+	storeSFTPPassword, err := resolveProfileStoreValue("store_sftp_password", s.StoreSFTPPassword, s.StoreSFTPPasswordSecret, s.StoreSFTPPasswordEnv)
+	if err != nil {
+		return nil, err
+	}
 	g.storeSFTPPassword = &storeSFTPPassword
-	storeSFTPKey := resolve(s.StoreSFTPKey, s.StoreSFTPKeySecret, s.StoreSFTPKeyEnv)
+	storeSFTPKey, err := resolveProfileStoreValue("store_sftp_key", s.StoreSFTPKey, s.StoreSFTPKeySecret, s.StoreSFTPKeyEnv)
+	if err != nil {
+		return nil, err
+	}
 	g.storeSFTPKey = &storeSFTPKey
-	password := resolve("", s.PasswordSecret, s.PasswordEnv)
+	password, err := resolveProfileStoreValue("password", "", s.PasswordSecret, s.PasswordEnv)
+	if err != nil {
+		return nil, err
+	}
 	g.password = &password
-	encryptionKey := resolve("", s.EncryptionKeySecret, s.EncryptionKeyEnv)
+	encryptionKey, err := resolveProfileStoreValue("encryption_key", "", s.EncryptionKeySecret, s.EncryptionKeyEnv)
+	if err != nil {
+		return nil, err
+	}
 	g.encryptionKey = &encryptionKey
-	recoveryKey := resolve("", s.RecoveryKeySecret, s.RecoveryKeyEnv)
+	recoveryKey, err := resolveProfileStoreValue("recovery_key", "", s.RecoveryKeySecret, s.RecoveryKeyEnv)
+	if err != nil {
+		return nil, err
+	}
 	g.recoveryKey = &recoveryKey
 	kmsKeyARN := s.KMSKeyARN
 	g.kmsKeyARN = &kmsKeyARN
@@ -511,7 +522,7 @@ func globalFlagsFromProfileStore(s cloudstic.ProfileStore) *globalFlags {
 	g.profile = &empty
 	g.profilesFile = &empty
 
-	return g
+	return g, nil
 }
 
 func envRef(name string) string {

--- a/cmd/cloudstic/cmd_store_test.go
+++ b/cmd/cloudstic/cmd_store_test.go
@@ -225,7 +225,10 @@ func TestCheckOrInitStore_AlreadyInitialized(t *testing.T) {
 
 	// Initialize the store first.
 	s := cloudstic.ProfileStore{URI: "local:" + storePath}
-	g := globalFlagsFromProfileStore(s)
+	g, err := globalFlagsFromProfileStore(s)
+	if err != nil {
+		t.Fatalf("globalFlagsFromProfileStore: %v", err)
+	}
 	raw, err := g.initObjectStore()
 	if err != nil {
 		t.Fatalf("initObjectStore: %v", err)
@@ -268,7 +271,10 @@ func TestGlobalFlagsFromProfileStore_ResolvesEnvVars(t *testing.T) {
 		KMSKeyARN:      "arn:aws:kms:us-east-1:123:key/abc",
 	}
 
-	g := globalFlagsFromProfileStore(s)
+	g, err := globalFlagsFromProfileStore(s)
+	if err != nil {
+		t.Fatalf("globalFlagsFromProfileStore: %v", err)
+	}
 	if *g.store != "s3:bucket/prefix" {
 		t.Fatalf("store=%q", *g.store)
 	}
@@ -286,6 +292,40 @@ func TestGlobalFlagsFromProfileStore_ResolvesEnvVars(t *testing.T) {
 	}
 	if *g.kmsKeyARN != "arn:aws:kms:us-east-1:123:key/abc" {
 		t.Fatalf("kmsKeyARN=%q", *g.kmsKeyARN)
+	}
+}
+
+func TestGlobalFlagsFromProfileStore_SecretPrecedenceOverLegacyEnv(t *testing.T) {
+	t.Setenv("LEGACY_AK", "legacy-ak")
+	t.Setenv("SECRET_AK", "secret-ak")
+
+	s := cloudstic.ProfileStore{
+		URI:               "s3:bucket/prefix",
+		S3AccessKeyEnv:    "LEGACY_AK",
+		S3AccessKeySecret: "env://SECRET_AK",
+	}
+
+	g, err := globalFlagsFromProfileStore(s)
+	if err != nil {
+		t.Fatalf("globalFlagsFromProfileStore: %v", err)
+	}
+	if *g.s3AccessKey != "secret-ak" {
+		t.Fatalf("s3AccessKey=%q want secret-ak", *g.s3AccessKey)
+	}
+}
+
+func TestGlobalFlagsFromProfileStore_InvalidSecretRefReturnsError(t *testing.T) {
+	s := cloudstic.ProfileStore{
+		URI:            "s3:bucket/prefix",
+		PasswordSecret: "env:/bad-format",
+	}
+
+	_, err := globalFlagsFromProfileStore(s)
+	if err == nil {
+		t.Fatal("expected error for invalid secret ref")
+	}
+	if !strings.Contains(err.Error(), "password") {
+		t.Fatalf("expected field context in error, got: %v", err)
 	}
 }
 
@@ -603,7 +643,10 @@ func TestGlobalFlagsFromProfileStore_DefaultRegion(t *testing.T) {
 	s := cloudstic.ProfileStore{
 		URI: "s3:some-bucket",
 	}
-	g := globalFlagsFromProfileStore(s)
+	g, err := globalFlagsFromProfileStore(s)
+	if err != nil {
+		t.Fatalf("globalFlagsFromProfileStore: %v", err)
+	}
 	if *g.s3Region != "us-east-1" {
 		t.Fatalf("expected default region us-east-1, got %q", *g.s3Region)
 	}
@@ -615,7 +658,10 @@ func TestGlobalFlagsFromProfileStore_SFTPFields(t *testing.T) {
 		StoreSFTPPassword: "direct-pw",
 		StoreSFTPKey:      "/path/to/key",
 	}
-	g := globalFlagsFromProfileStore(s)
+	g, err := globalFlagsFromProfileStore(s)
+	if err != nil {
+		t.Fatalf("globalFlagsFromProfileStore: %v", err)
+	}
 	if *g.storeSFTPPassword != "direct-pw" {
 		t.Fatalf("expected storeSFTPPassword=direct-pw, got %q", *g.storeSFTPPassword)
 	}

--- a/cmd/cloudstic/profile_secret.go
+++ b/cmd/cloudstic/profile_secret.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/cloudstic/cli/internal/secretref"
+)
+
+var profileSecretResolver = secretref.NewDefaultResolver()
+
+func resolveProfileStoreValue(fieldName, direct, secretRef, envName string) (string, error) {
+	if direct != "" {
+		return direct, nil
+	}
+	if secretRef != "" {
+		v, err := profileSecretResolver.Resolve(context.Background(), secretRef)
+		if err != nil {
+			return "", fmt.Errorf("resolve profile store field %q from %q: %w", fieldName, secretRef, err)
+		}
+		return v, nil
+	}
+	if envName != "" {
+		return os.Getenv(envName), nil
+	}
+	return "", nil
+}

--- a/cmd/cloudstic/store.go
+++ b/cmd/cloudstic/store.go
@@ -110,7 +110,9 @@ func (g *globalFlags) applyProfileStoreOverrides() error {
 	} {
 		flagsSet[name] = cliFlagProvided(name)
 	}
-	applyProfileStoreToGlobalFlags(g, s, flagsSet)
+	if err := applyProfileStoreToGlobalFlags(g, s, flagsSet); err != nil {
+		return fmt.Errorf("profile %q store %q: %w", *g.profile, p.Store, err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Implement RFC 0011 issue #92 by wiring secret-reference resolution into profile store runtime merge paths.
- Use shared resolver logic for both backup profile merge and store-driven global flag construction.
- Enforce precedence with tests: CLI flag override > `*_secret` > direct field > legacy `*_env`.

## What Changed
- Added shared helper: `cmd/cloudstic/profile_secret.go`
  - `resolveProfileStoreValue(field, direct, secretRef, envName)`
  - returns actionable field-scoped errors on bad refs
- Updated backup profile merge path:
  - `applyProfileStoreToGlobalFlags` now returns errors
  - resolves `*_secret` values (with legacy env fallback)
  - merge path surfaces contextual errors: `profile <name> store <ref>: ...`
- Updated store runtime path:
  - `globalFlagsFromProfileStore` now returns `(*globalFlags, error)`
  - `checkOrInitStore` reports credential resolution errors early
- Updated global profile override path in `store.go` to propagate errors.
- Added precedence and failure tests in:
  - `cmd/cloudstic/cmd_backup_profile_test.go`
  - `cmd/cloudstic/cmd_store_test.go`

## Validation
- `go test ./...`
- `golangci-lint run ./...`

## Tracking
- Closes #92
- Epic: #93
- RFC: `rfcs/0011-profile-credential-storage-backends.md`