### PR TITLE
feat: add macOS keychain secret backend for profile refs

### DIFF
--- a/internal/secretref/keychain_backend.go
+++ b/internal/secretref/keychain_backend.go
@@ -1,0 +1,71 @@
+package secretref
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var (
+	errKeychainNotFound    = errors.New("keychain item not found")
+	errKeychainUnavailable = errors.New("keychain backend unavailable")
+)
+
+type keychainLookupFunc func(ctx context.Context, service, account string) (string, error)
+
+// KeychainBackend resolves keychain://service/account references.
+type KeychainBackend struct {
+	lookup keychainLookupFunc
+}
+
+// NewKeychainBackend creates a keychain backend for the current platform.
+func NewKeychainBackend() *KeychainBackend {
+	return &KeychainBackend{lookup: defaultKeychainLookup}
+}
+
+func newKeychainBackendWithLookup(lookup keychainLookupFunc) *KeychainBackend {
+	if lookup == nil {
+		lookup = defaultKeychainLookup
+	}
+	return &KeychainBackend{lookup: lookup}
+}
+
+func parseKeychainPath(path string) (service string, account string, err error) {
+	p := strings.TrimSpace(path)
+	p = strings.TrimPrefix(p, "/")
+	if p == "" {
+		return "", "", errors.New("empty keychain path")
+	}
+	i := strings.LastIndex(p, "/")
+	if i <= 0 || i == len(p)-1 {
+		return "", "", errors.New("expected keychain://<service>/<account>")
+	}
+	service = strings.TrimSpace(p[:i])
+	account = strings.TrimSpace(p[i+1:])
+	if service == "" || account == "" {
+		return "", "", errors.New("expected keychain://<service>/<account>")
+	}
+	return service, account, nil
+}
+
+func (b *KeychainBackend) Resolve(ctx context.Context, ref Ref) (string, error) {
+	service, account, err := parseKeychainPath(ref.Path)
+	if err != nil {
+		return "", errorf(KindInvalidRef, ref.Raw, err.Error(), nil)
+	}
+
+	value, err := b.lookup(ctx, service, account)
+	if err != nil {
+		switch {
+		case errors.Is(err, errKeychainNotFound):
+			return "", errorf(KindNotFound, ref.Raw, fmt.Sprintf("keychain item %q/%q not found", service, account), err)
+		case errors.Is(err, errKeychainUnavailable):
+			return "", errorf(KindBackendUnavailable, ref.Raw, err.Error(), err)
+		default:
+			return "", errorf(KindBackendUnavailable, ref.Raw, err.Error(), err)
+		}
+	}
+
+	return value, nil
+}

--- a/internal/secretref/keychain_backend_darwin.go
+++ b/internal/secretref/keychain_backend_darwin.go
@@ -1,0 +1,37 @@
+//go:build darwin
+
+package secretref
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+func defaultKeychainLookup(ctx context.Context, service, account string) (string, error) {
+	cmd := exec.CommandContext(ctx, "security", "find-generic-password", "-s", service, "-a", account, "-w")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return "", fmt.Errorf("%w: macOS security tool not found", errKeychainUnavailable)
+		}
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = strings.TrimSpace(err.Error())
+		}
+		lower := strings.ToLower(msg)
+		if strings.Contains(lower, "could not be found") || strings.Contains(lower, "item not found") {
+			return "", errKeychainNotFound
+		}
+		if strings.Contains(lower, "user interaction is not allowed") || strings.Contains(lower, "interaction not allowed") {
+			return "", fmt.Errorf("%w: keychain locked or unavailable in this session", errKeychainUnavailable)
+		}
+		return "", fmt.Errorf("security find-generic-password failed: %s", msg)
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/internal/secretref/keychain_backend_integration_darwin_test.go
+++ b/internal/secretref/keychain_backend_integration_darwin_test.go
@@ -1,0 +1,44 @@
+//go:build darwin
+
+package secretref
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestKeychainBackend_Integration(t *testing.T) {
+	if os.Getenv("CLOUDSTIC_TEST_KEYCHAIN") != "1" {
+		t.Skip("set CLOUDSTIC_TEST_KEYCHAIN=1 to run keychain integration test")
+	}
+
+	service := "cloudstic-test-service-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	account := "cloudstic-test-account"
+	secret := "cloudstic-test-secret"
+
+	add := exec.Command("security", "add-generic-password", "-U", "-s", service, "-a", account, "-w", secret)
+	if out, err := add.CombinedOutput(); err != nil {
+		t.Fatalf("add-generic-password failed: %v\n%s", err, out)
+	}
+	t.Cleanup(func() {
+		del := exec.Command("security", "delete-generic-password", "-s", service, "-a", account)
+		_, _ = del.CombinedOutput()
+	})
+
+	b := NewKeychainBackend()
+	got, err := b.Resolve(context.Background(), Ref{
+		Raw:    "keychain://" + service + "/" + account,
+		Scheme: "keychain",
+		Path:   service + "/" + account,
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != secret {
+		t.Fatalf("Resolve: got %q want %q", got, secret)
+	}
+}

--- a/internal/secretref/keychain_backend_stub.go
+++ b/internal/secretref/keychain_backend_stub.go
@@ -1,0 +1,12 @@
+//go:build !darwin
+
+package secretref
+
+import (
+	"context"
+	"fmt"
+)
+
+func defaultKeychainLookup(_ context.Context, _, _ string) (string, error) {
+	return "", fmt.Errorf("%w: keychain backend is only available on macOS", errKeychainUnavailable)
+}

--- a/internal/secretref/keychain_backend_test.go
+++ b/internal/secretref/keychain_backend_test.go
@@ -1,0 +1,107 @@
+package secretref
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestParseKeychainPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		wantErr  bool
+		wantSvc  string
+		wantAcct string
+	}{
+		{name: "basic", path: "cloudstic/prod/password", wantSvc: "cloudstic/prod", wantAcct: "password"},
+		{name: "leading slash", path: "/cloudstic/prod/password", wantSvc: "cloudstic/prod", wantAcct: "password"},
+		{name: "missing separator", path: "cloudstic", wantErr: true},
+		{name: "empty account", path: "cloudstic/", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, acct, err := parseKeychainPath(tc.path)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseKeychainPath(%q): expected error", tc.path)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseKeychainPath(%q): %v", tc.path, err)
+			}
+			if svc != tc.wantSvc || acct != tc.wantAcct {
+				t.Fatalf("parseKeychainPath(%q): service=%q account=%q", tc.path, svc, acct)
+			}
+		})
+	}
+}
+
+func TestKeychainBackend_Resolve(t *testing.T) {
+	b := newKeychainBackendWithLookup(func(_ context.Context, service, account string) (string, error) {
+		if service != "cloudstic/prod" || account != "password" {
+			t.Fatalf("unexpected lookup args: %q/%q", service, account)
+		}
+		return "s3cr3t", nil
+	})
+
+	got, err := b.Resolve(context.Background(), Ref{Raw: "keychain://cloudstic/prod/password", Scheme: "keychain", Path: "cloudstic/prod/password"})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != "s3cr3t" {
+		t.Fatalf("Resolve: got %q want s3cr3t", got)
+	}
+}
+
+func TestKeychainBackend_ResolveErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  Ref
+		err  error
+		kind ErrorKind
+	}{
+		{
+			name: "invalid path",
+			ref:  Ref{Raw: "keychain://cloudstic", Scheme: "keychain", Path: "cloudstic"},
+			kind: KindInvalidRef,
+		},
+		{
+			name: "not found",
+			ref:  Ref{Raw: "keychain://cloudstic/prod/password", Scheme: "keychain", Path: "cloudstic/prod/password"},
+			err:  errKeychainNotFound,
+			kind: KindNotFound,
+		},
+		{
+			name: "unavailable",
+			ref:  Ref{Raw: "keychain://cloudstic/prod/password", Scheme: "keychain", Path: "cloudstic/prod/password"},
+			err:  errKeychainUnavailable,
+			kind: KindBackendUnavailable,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b := newKeychainBackendWithLookup(func(context.Context, string, string) (string, error) {
+				if tc.err == nil {
+					return "", nil
+				}
+				return "", tc.err
+			})
+
+			_, err := b.Resolve(context.Background(), tc.ref)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			var refErr *Error
+			if !errors.As(err, &refErr) {
+				t.Fatalf("expected *Error, got %T", err)
+			}
+			if refErr.Kind != tc.kind {
+				t.Fatalf("kind=%s want=%s", refErr.Kind, tc.kind)
+			}
+		})
+	}
+}

--- a/internal/secretref/secretref.go
+++ b/internal/secretref/secretref.go
@@ -101,7 +101,10 @@ func NewResolver(backends map[string]Backend) *Resolver {
 
 // NewDefaultResolver builds the baseline resolver with env:// support.
 func NewDefaultResolver() *Resolver {
-	return NewResolver(map[string]Backend{"env": NewEnvBackend(nil)})
+	return NewResolver(map[string]Backend{
+		"env":      NewEnvBackend(nil),
+		"keychain": NewKeychainBackend(),
+	})
 }
 
 // Resolve parses and resolves a secret reference.

--- a/internal/secretref/secretref_test.go
+++ b/internal/secretref/secretref_test.go
@@ -75,7 +75,7 @@ func TestResolver_Errors(t *testing.T) {
 		kind ErrorKind
 	}{
 		{name: "invalid syntax", ref: "bad-ref", kind: KindInvalidRef},
-		{name: "unsupported scheme", ref: "keychain://service/account", kind: KindBackendUnavailable},
+		{name: "unsupported scheme", ref: "wincred://service/account", kind: KindBackendUnavailable},
 		{name: "not found", ref: "env://MISSING", kind: KindNotFound},
 		{name: "invalid env name", ref: "env://bad-name", kind: KindInvalidRef},
 	}


### PR DESCRIPTION
## Summary
- Implement RFC 0011 issue #88 by adding `keychain://...` secret reference support.
- Wire `keychain` into the default secret resolver next to `env`.
- Add platform-specific backend behavior for macOS with non-macOS stub fallback.

## What Changed
- Added keychain backend implementation:
  - `internal/secretref/keychain_backend.go`
  - `internal/secretref/keychain_backend_darwin.go`
  - `internal/secretref/keychain_backend_stub.go`
- Updated resolver registration:
  - `internal/secretref/secretref.go` now includes `keychain` in `NewDefaultResolver()`
- Added tests:
  - unit tests in `internal/secretref/keychain_backend_test.go`
  - integration test in `internal/secretref/keychain_backend_integration_darwin_test.go`
    - opt-in via `CLOUDSTIC_TEST_KEYCHAIN=1`
- Updated resolver error test to keep unsupported-scheme coverage independent from keychain.

## Notes
- `keychain://<service>/<account>` parsing uses the last path segment as account and the preceding path as service.
- Backend errors are mapped to typed resolver errors (`not_found`, `backend_unavailable`, `invalid_ref`).

## Validation
- `go test ./internal/secretref -count=1`
- `go test ./...`
- `golangci-lint run ./...`
- `go test ./internal/secretref -run TestKeychainBackend_Integration -count=1 -v`
- `CLOUDSTIC_TEST_KEYCHAIN=1 go test ./internal/secretref -run TestKeychainBackend_Integration -count=1 -v`

## Tracking
- Closes #88
- Epic: #93
- RFC: `rfcs/0011-profile-credential-storage-backends.md`