### PR TITLE
chore: extract shared profile builder helpers

### DIFF
--- a/cmd/cloudstic/cmd_auth.go
+++ b/cmd/cloudstic/cmd_auth.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	cloudstic "github.com/cloudstic/cli"
@@ -36,14 +35,6 @@ func (r *runner) runAuth() int {
 	}
 }
 
-func defaultProfilesPathFallback() string {
-	defaultPath, err := defaultProfilesPath()
-	if err != nil {
-		return defaultProfilesFilename
-	}
-	return defaultPath
-}
-
 func (r *runner) runAuthList() int {
 	fs := flag.NewFlagSet("auth list", flag.ExitOnError)
 	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
@@ -57,11 +48,7 @@ func (r *runner) runAuthList() int {
 		return r.fail("Failed to load profiles: %v", err)
 	}
 
-	names := make([]string, 0, len(cfg.Auth))
-	for name := range cfg.Auth {
-		names = append(names, name)
-	}
-	sort.Strings(names)
+	names := sortedKeys(cfg.Auth)
 
 	_, _ = fmt.Fprintf(r.out, "%d auth entries\n", len(names))
 	for _, name := range names {
@@ -101,11 +88,7 @@ func (r *runner) runAuthShow() int {
 		if !r.canPrompt() {
 			return r.fail("usage: cloudstic auth show [-profiles-file <path>] <name>")
 		}
-		names := make([]string, 0, len(cfg.Auth))
-		for n := range cfg.Auth {
-			names = append(names, n)
-		}
-		sort.Strings(names)
+		names := sortedKeys(cfg.Auth)
 		picked, pickErr := r.promptSelect("Select auth entry", names)
 		if pickErr != nil {
 			return r.fail("Failed to select auth entry: %v", pickErr)
@@ -158,8 +141,8 @@ func (r *runner) runAuthNew() int {
 			return r.fail("-name is required")
 		}
 	}
-	if !validRefName.MatchString(*name) {
-		return r.fail("invalid auth name %q: must start with a letter or digit and contain only letters, digits, dots, hyphens, or underscores", *name)
+	if err := validateRefName("auth", *name); err != nil {
+		return r.fail("%v", err)
 	}
 	if *provider != "google" && *provider != "onedrive" {
 		if r.canPrompt() {
@@ -216,17 +199,11 @@ func (r *runner) runAuthNew() int {
 		auth.OneDriveTokenFile = *onedriveTokenFile
 	}
 
-	cfg, err := cloudstic.LoadProfilesFile(*profilesFile)
+	cfg, err := loadProfilesOrInit(*profilesFile)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			cfg = &cloudstic.ProfilesConfig{Version: 1}
-		} else {
-			return r.fail("Failed to load profiles: %v", err)
-		}
+		return r.fail("Failed to load profiles: %v", err)
 	}
-	if cfg.Auth == nil {
-		cfg.Auth = map[string]cloudstic.ProfileAuth{}
-	}
+	ensureProfilesMaps(cfg)
 	cfg.Auth[*name] = auth
 
 	if err := cloudstic.SaveProfilesFile(*profilesFile, cfg); err != nil {
@@ -249,11 +226,7 @@ func (r *runner) runAuthLogin() int {
 
 	if *name == "" {
 		if r.canPrompt() {
-			names := make([]string, 0, len(cfg.Auth))
-			for n := range cfg.Auth {
-				names = append(names, n)
-			}
-			sort.Strings(names)
+			names := sortedKeys(cfg.Auth)
 			picked, pickErr := r.promptSelect("Select auth entry", names)
 			if pickErr != nil {
 				return r.fail("Failed to select auth entry: %v", pickErr)

--- a/cmd/cloudstic/cmd_profile.go
+++ b/cmd/cloudstic/cmd_profile.go
@@ -80,11 +80,7 @@ func (r *runner) runProfileShow() int {
 		if !r.canPrompt() {
 			return r.fail("usage: cloudstic profile show [-profiles-file <path>] <name>")
 		}
-		names := make([]string, 0, len(cfg.Profiles))
-		for name := range cfg.Profiles {
-			names = append(names, name)
-		}
-		sort.Strings(names)
+		names := sortedKeys(cfg.Profiles)
 		picked, pickErr := r.promptSelect("Select profile", names)
 		if pickErr != nil {
 			return r.fail("Failed to select profile: %v", pickErr)
@@ -184,11 +180,7 @@ func (r *runner) runProfileList() int {
 		return r.fail("Failed to load profiles: %v", err)
 	}
 
-	storeNames := make([]string, 0, len(cfg.Stores))
-	for name := range cfg.Stores {
-		storeNames = append(storeNames, name)
-	}
-	sort.Strings(storeNames)
+	storeNames := sortedKeys(cfg.Stores)
 
 	_, _ = fmt.Fprintf(r.out, "%d stores\n", len(storeNames))
 	for _, name := range storeNames {
@@ -201,11 +193,7 @@ func (r *runner) runProfileList() int {
 	}
 	_, _ = fmt.Fprintln(r.out)
 
-	authNames := make([]string, 0, len(cfg.Auth))
-	for name := range cfg.Auth {
-		authNames = append(authNames, name)
-	}
-	sort.Strings(authNames)
+	authNames := sortedKeys(cfg.Auth)
 
 	_, _ = fmt.Fprintf(r.out, "%d auth entries\n", len(authNames))
 	for _, name := range authNames {
@@ -224,11 +212,7 @@ func (r *runner) runProfileList() int {
 	}
 	_, _ = fmt.Fprintln(r.out)
 
-	names := make([]string, 0, len(cfg.Profiles))
-	for name := range cfg.Profiles {
-		names = append(names, name)
-	}
-	sort.Strings(names)
+	names := sortedKeys(cfg.Profiles)
 
 	_, _ = fmt.Fprintf(r.out, "%d profiles\n", len(names))
 	for _, name := range names {
@@ -326,27 +310,15 @@ func (r *runner) runProfileNew() int {
 			return r.fail("-name is required")
 		}
 	}
-	if !validRefName.MatchString(a.name) {
-		return r.fail("invalid profile name %q: must start with a letter or digit and contain only letters, digits, dots, hyphens, or underscores", a.name)
+	if err := validateRefName("profile", a.name); err != nil {
+		return r.fail("%v", err)
 	}
 
-	cfg, err := cloudstic.LoadProfilesFile(a.profilesFile)
+	cfg, err := loadProfilesOrInit(a.profilesFile)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			cfg = &cloudstic.ProfilesConfig{Version: 1}
-		} else {
-			return r.fail("Failed to load profiles: %v", err)
-		}
+		return r.fail("Failed to load profiles: %v", err)
 	}
-	if cfg.Stores == nil {
-		cfg.Stores = map[string]cloudstic.ProfileStore{}
-	}
-	if cfg.Profiles == nil {
-		cfg.Profiles = map[string]cloudstic.BackupProfile{}
-	}
-	if cfg.Auth == nil {
-		cfg.Auth = map[string]cloudstic.ProfileAuth{}
-	}
+	ensureProfilesMaps(cfg)
 
 	// When editing an existing profile, prefill unset fields with current values.
 	if existing, ok := cfg.Profiles[a.name]; ok {

--- a/cmd/cloudstic/cmd_store.go
+++ b/cmd/cloudstic/cmd_store.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"regexp"
 	"runtime"
 	"sort"
 	"strings"
@@ -17,8 +16,6 @@ import (
 	"github.com/cloudstic/cli/internal/ui"
 	"github.com/cloudstic/cli/pkg/store"
 )
-
-var validRefName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
 
 func (r *runner) runStore() int {
 	if len(os.Args) < 3 {
@@ -55,11 +52,7 @@ func (r *runner) runStoreList() int {
 		return r.fail("Failed to load profiles: %v", err)
 	}
 
-	names := make([]string, 0, len(cfg.Stores))
-	for name := range cfg.Stores {
-		names = append(names, name)
-	}
-	sort.Strings(names)
+	names := sortedKeys(cfg.Stores)
 
 	_, _ = fmt.Fprintf(r.out, "%d stores\n", len(names))
 	for _, name := range names {
@@ -94,11 +87,7 @@ func (r *runner) runStoreShow() int {
 		if !r.canPrompt() {
 			return r.fail("usage: cloudstic store show [-profiles-file <path>] <name>")
 		}
-		names := make([]string, 0, len(cfg.Stores))
-		for n := range cfg.Stores {
-			names = append(names, n)
-		}
-		sort.Strings(names)
+		names := sortedKeys(cfg.Stores)
 		picked, pickErr := r.promptSelect("Select store", names)
 		if pickErr != nil {
 			return r.fail("Failed to select store: %v", pickErr)
@@ -226,6 +215,34 @@ func (r *runner) runStoreNew() int {
 
 	flagsSet := map[string]bool{}
 	fs.Visit(func(f *flag.Flag) { flagsSet[f.Name] = true })
+	storeFlags := storeNewFlagPtrs{
+		uri:                 uri,
+		s3Region:            s3Region,
+		s3Profile:           s3Profile,
+		s3Endpoint:          s3Endpoint,
+		s3AccessKey:         s3AccessKey,
+		s3SecretKey:         s3SecretKey,
+		s3AccessKeySecret:   s3AccessKeySecret,
+		s3SecretKeySecret:   s3SecretKeySecret,
+		s3AccessKeyEnv:      s3AccessKeyEnv,
+		s3SecretKeyEnv:      s3SecretKeyEnv,
+		s3ProfileEnv:        s3ProfileEnv,
+		sftpPassword:        sftpPassword,
+		sftpKey:             sftpKey,
+		sftpPasswordSecret:  sftpPasswordSecret,
+		sftpKeySecret:       sftpKeySecret,
+		sftpPasswordEnv:     sftpPasswordEnv,
+		sftpKeyEnv:          sftpKeyEnv,
+		passwordSecret:      passwordSecret,
+		encryptionKeySecret: encryptionKeySecret,
+		recoveryKeySecret:   recoveryKeySecret,
+		passwordEnv:         passwordEnv,
+		encryptionKeyEnv:    encryptionKeyEnv,
+		recoveryKeyEnv:      recoveryKeyEnv,
+		kmsKeyARN:           kmsKeyARN,
+		kmsRegion:           kmsRegion,
+		kmsEndpoint:         kmsEndpoint,
+	}
 
 	if *name == "" {
 		if r.canPrompt() {
@@ -239,83 +256,21 @@ func (r *runner) runStoreNew() int {
 			return r.fail("-name is required")
 		}
 	}
-	if !validRefName.MatchString(*name) {
-		return r.fail("invalid store name %q: must start with a letter or digit and contain only letters, digits, dots, hyphens, or underscores", *name)
+	if err := validateRefName("store", *name); err != nil {
+		return r.fail("%v", err)
 	}
-	cfg, err := cloudstic.LoadProfilesFile(*profilesFile)
+	cfg, err := loadProfilesOrInit(*profilesFile)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			cfg = &cloudstic.ProfilesConfig{Version: 1}
-		} else {
-			return r.fail("Failed to load profiles: %v", err)
-		}
+		return r.fail("Failed to load profiles: %v", err)
 	}
-	if cfg.Stores == nil {
-		cfg.Stores = map[string]cloudstic.ProfileStore{}
-	}
+	ensureProfilesMaps(cfg)
 
 	_, existedBefore := cfg.Stores[*name]
 	forcePromptURI := false
 	forcePromptEncryption := false
 	askKeepEncryption := false
 	if existing, ok := cfg.Stores[*name]; ok {
-		if !flagsSet["uri"] && existing.URI != "" {
-			*uri = existing.URI
-		}
-		if !flagsSet["s3-region"] && existing.S3Region != "" {
-			*s3Region = existing.S3Region
-		}
-		if !flagsSet["s3-profile"] && existing.S3Profile != "" {
-			*s3Profile = existing.S3Profile
-		}
-		if !flagsSet["s3-endpoint"] && existing.S3Endpoint != "" {
-			*s3Endpoint = existing.S3Endpoint
-		}
-		if !flagsSet["s3-access-key"] && existing.S3AccessKey != "" {
-			*s3AccessKey = existing.S3AccessKey
-		}
-		if !flagsSet["s3-secret-key"] && existing.S3SecretKey != "" {
-			*s3SecretKey = existing.S3SecretKey
-		}
-		if !flagsSet["s3-access-key-secret"] && !flagsSet["s3-access-key-env"] {
-			*s3AccessKeySecret = firstNonEmpty(existing.S3AccessKeySecret, envRef(existing.S3AccessKeyEnv))
-		}
-		if !flagsSet["s3-secret-key-secret"] && !flagsSet["s3-secret-key-env"] {
-			*s3SecretKeySecret = firstNonEmpty(existing.S3SecretKeySecret, envRef(existing.S3SecretKeyEnv))
-		}
-		if !flagsSet["s3-profile-env"] && existing.S3ProfileEnv != "" {
-			*s3ProfileEnv = existing.S3ProfileEnv
-		}
-		if !flagsSet["store-sftp-password"] && existing.StoreSFTPPassword != "" {
-			*sftpPassword = existing.StoreSFTPPassword
-		}
-		if !flagsSet["store-sftp-key"] && existing.StoreSFTPKey != "" {
-			*sftpKey = existing.StoreSFTPKey
-		}
-		if !flagsSet["store-sftp-password-secret"] && !flagsSet["store-sftp-password-env"] {
-			*sftpPasswordSecret = firstNonEmpty(existing.StoreSFTPPasswordSecret, envRef(existing.StoreSFTPPasswordEnv))
-		}
-		if !flagsSet["store-sftp-key-secret"] && !flagsSet["store-sftp-key-env"] {
-			*sftpKeySecret = firstNonEmpty(existing.StoreSFTPKeySecret, envRef(existing.StoreSFTPKeyEnv))
-		}
-		if !flagsSet["password-secret"] && !flagsSet["password-env"] {
-			*passwordSecret = firstNonEmpty(existing.PasswordSecret, envRef(existing.PasswordEnv))
-		}
-		if !flagsSet["encryption-key-secret"] && !flagsSet["encryption-key-env"] {
-			*encryptionKeySecret = firstNonEmpty(existing.EncryptionKeySecret, envRef(existing.EncryptionKeyEnv))
-		}
-		if !flagsSet["recovery-key-secret"] && !flagsSet["recovery-key-env"] {
-			*recoveryKeySecret = firstNonEmpty(existing.RecoveryKeySecret, envRef(existing.RecoveryKeyEnv))
-		}
-		if !flagsSet["kms-key-arn"] && existing.KMSKeyARN != "" {
-			*kmsKeyARN = existing.KMSKeyARN
-		}
-		if !flagsSet["kms-region"] && existing.KMSRegion != "" {
-			*kmsRegion = existing.KMSRegion
-		}
-		if !flagsSet["kms-endpoint"] && existing.KMSEndpoint != "" {
-			*kmsEndpoint = existing.KMSEndpoint
-		}
+		applyExistingStoreDefaults(flagsSet, existing, storeFlags)
 		if promptURI, askKeep := existingStoreInteractivePlan(r.canPrompt(), hasStoreNewOverrideFlags(flagsSet), storeHasExplicitEncryption(existing)); promptURI {
 			forcePromptURI = true
 			askKeepEncryption = askKeep
@@ -340,34 +295,7 @@ func (r *runner) runStoreNew() int {
 		return r.fail("%v", err)
 	}
 
-	cfg.Stores[*name] = cloudstic.ProfileStore{
-		URI:                     *uri,
-		S3Region:                *s3Region,
-		S3Profile:               *s3Profile,
-		S3Endpoint:              *s3Endpoint,
-		S3AccessKey:             *s3AccessKey,
-		S3SecretKey:             *s3SecretKey,
-		S3AccessKeyEnv:          "",
-		S3SecretKeyEnv:          "",
-		S3AccessKeySecret:       firstNonEmpty(*s3AccessKeySecret, envRef(*s3AccessKeyEnv)),
-		S3SecretKeySecret:       firstNonEmpty(*s3SecretKeySecret, envRef(*s3SecretKeyEnv)),
-		S3ProfileEnv:            *s3ProfileEnv,
-		StoreSFTPPassword:       *sftpPassword,
-		StoreSFTPKey:            *sftpKey,
-		StoreSFTPPasswordEnv:    "",
-		StoreSFTPKeyEnv:         "",
-		StoreSFTPPasswordSecret: firstNonEmpty(*sftpPasswordSecret, envRef(*sftpPasswordEnv)),
-		StoreSFTPKeySecret:      firstNonEmpty(*sftpKeySecret, envRef(*sftpKeyEnv)),
-		PasswordEnv:             "",
-		EncryptionKeyEnv:        "",
-		RecoveryKeyEnv:          "",
-		PasswordSecret:          firstNonEmpty(*passwordSecret, envRef(*passwordEnv)),
-		EncryptionKeySecret:     firstNonEmpty(*encryptionKeySecret, envRef(*encryptionKeyEnv)),
-		RecoveryKeySecret:       firstNonEmpty(*recoveryKeySecret, envRef(*recoveryKeyEnv)),
-		KMSKeyARN:               *kmsKeyARN,
-		KMSRegion:               *kmsRegion,
-		KMSEndpoint:             *kmsEndpoint,
-	}
+	cfg.Stores[*name] = buildProfileStoreFromFlags(storeFlags)
 
 	if err := cloudstic.SaveProfilesFile(*profilesFile, cfg); err != nil {
 		return r.fail("Failed to save profiles: %v", err)
@@ -425,11 +353,7 @@ func (r *runner) runStoreVerify() int {
 		if !r.canPrompt() {
 			return r.fail("usage: cloudstic store verify [-profiles-file <path>] <name>")
 		}
-		names := make([]string, 0, len(cfg.Stores))
-		for n := range cfg.Stores {
-			names = append(names, n)
-		}
-		sort.Strings(names)
+		names := sortedKeys(cfg.Stores)
 		picked, pickErr := r.promptSelect("Select store", names)
 		if pickErr != nil {
 			return r.fail("Failed to select store: %v", pickErr)

--- a/cmd/cloudstic/profile_builder_helpers.go
+++ b/cmd/cloudstic/profile_builder_helpers.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+
+	cloudstic "github.com/cloudstic/cli"
+)
+
+var validRefName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
+
+func validateRefName(kind, name string) error {
+	if !validRefName.MatchString(name) {
+		return fmt.Errorf("invalid %s name %q: must start with a letter or digit and contain only letters, digits, dots, hyphens, or underscores", kind, name)
+	}
+	return nil
+}
+
+func defaultProfilesPathFallback() string {
+	defaultPath, err := defaultProfilesPath()
+	if err != nil {
+		return defaultProfilesFilename
+	}
+	return defaultPath
+}
+
+func loadProfilesOrInit(path string) (*cloudstic.ProfilesConfig, error) {
+	cfg, err := cloudstic.LoadProfilesFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &cloudstic.ProfilesConfig{Version: 1}, nil
+		}
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func ensureProfilesMaps(cfg *cloudstic.ProfilesConfig) {
+	if cfg.Stores == nil {
+		cfg.Stores = map[string]cloudstic.ProfileStore{}
+	}
+	if cfg.Profiles == nil {
+		cfg.Profiles = map[string]cloudstic.BackupProfile{}
+	}
+	if cfg.Auth == nil {
+		cfg.Auth = map[string]cloudstic.ProfileAuth{}
+	}
+}
+
+func sortedKeys[T any](m map[string]T) []string {
+	names := make([]string, 0, len(m))
+	for name := range m {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/cmd/cloudstic/store_builder_helpers.go
+++ b/cmd/cloudstic/store_builder_helpers.go
@@ -1,0 +1,123 @@
+package main
+
+import cloudstic "github.com/cloudstic/cli"
+
+type storeNewFlagPtrs struct {
+	uri                 *string
+	s3Region            *string
+	s3Profile           *string
+	s3Endpoint          *string
+	s3AccessKey         *string
+	s3SecretKey         *string
+	s3AccessKeySecret   *string
+	s3SecretKeySecret   *string
+	s3AccessKeyEnv      *string
+	s3SecretKeyEnv      *string
+	s3ProfileEnv        *string
+	sftpPassword        *string
+	sftpKey             *string
+	sftpPasswordSecret  *string
+	sftpKeySecret       *string
+	sftpPasswordEnv     *string
+	sftpKeyEnv          *string
+	passwordSecret      *string
+	encryptionKeySecret *string
+	recoveryKeySecret   *string
+	passwordEnv         *string
+	encryptionKeyEnv    *string
+	recoveryKeyEnv      *string
+	kmsKeyARN           *string
+	kmsRegion           *string
+	kmsEndpoint         *string
+}
+
+func applyExistingStoreDefaults(flagsSet map[string]bool, existing cloudstic.ProfileStore, f storeNewFlagPtrs) {
+	if !flagsSet["uri"] && existing.URI != "" {
+		*f.uri = existing.URI
+	}
+	if !flagsSet["s3-region"] && existing.S3Region != "" {
+		*f.s3Region = existing.S3Region
+	}
+	if !flagsSet["s3-profile"] && existing.S3Profile != "" {
+		*f.s3Profile = existing.S3Profile
+	}
+	if !flagsSet["s3-endpoint"] && existing.S3Endpoint != "" {
+		*f.s3Endpoint = existing.S3Endpoint
+	}
+	if !flagsSet["s3-access-key"] && existing.S3AccessKey != "" {
+		*f.s3AccessKey = existing.S3AccessKey
+	}
+	if !flagsSet["s3-secret-key"] && existing.S3SecretKey != "" {
+		*f.s3SecretKey = existing.S3SecretKey
+	}
+	if !flagsSet["s3-access-key-secret"] && !flagsSet["s3-access-key-env"] {
+		*f.s3AccessKeySecret = firstNonEmpty(existing.S3AccessKeySecret, envRef(existing.S3AccessKeyEnv))
+	}
+	if !flagsSet["s3-secret-key-secret"] && !flagsSet["s3-secret-key-env"] {
+		*f.s3SecretKeySecret = firstNonEmpty(existing.S3SecretKeySecret, envRef(existing.S3SecretKeyEnv))
+	}
+	if !flagsSet["s3-profile-env"] && existing.S3ProfileEnv != "" {
+		*f.s3ProfileEnv = existing.S3ProfileEnv
+	}
+	if !flagsSet["store-sftp-password"] && existing.StoreSFTPPassword != "" {
+		*f.sftpPassword = existing.StoreSFTPPassword
+	}
+	if !flagsSet["store-sftp-key"] && existing.StoreSFTPKey != "" {
+		*f.sftpKey = existing.StoreSFTPKey
+	}
+	if !flagsSet["store-sftp-password-secret"] && !flagsSet["store-sftp-password-env"] {
+		*f.sftpPasswordSecret = firstNonEmpty(existing.StoreSFTPPasswordSecret, envRef(existing.StoreSFTPPasswordEnv))
+	}
+	if !flagsSet["store-sftp-key-secret"] && !flagsSet["store-sftp-key-env"] {
+		*f.sftpKeySecret = firstNonEmpty(existing.StoreSFTPKeySecret, envRef(existing.StoreSFTPKeyEnv))
+	}
+	if !flagsSet["password-secret"] && !flagsSet["password-env"] {
+		*f.passwordSecret = firstNonEmpty(existing.PasswordSecret, envRef(existing.PasswordEnv))
+	}
+	if !flagsSet["encryption-key-secret"] && !flagsSet["encryption-key-env"] {
+		*f.encryptionKeySecret = firstNonEmpty(existing.EncryptionKeySecret, envRef(existing.EncryptionKeyEnv))
+	}
+	if !flagsSet["recovery-key-secret"] && !flagsSet["recovery-key-env"] {
+		*f.recoveryKeySecret = firstNonEmpty(existing.RecoveryKeySecret, envRef(existing.RecoveryKeyEnv))
+	}
+	if !flagsSet["kms-key-arn"] && existing.KMSKeyARN != "" {
+		*f.kmsKeyARN = existing.KMSKeyARN
+	}
+	if !flagsSet["kms-region"] && existing.KMSRegion != "" {
+		*f.kmsRegion = existing.KMSRegion
+	}
+	if !flagsSet["kms-endpoint"] && existing.KMSEndpoint != "" {
+		*f.kmsEndpoint = existing.KMSEndpoint
+	}
+}
+
+func buildProfileStoreFromFlags(f storeNewFlagPtrs) cloudstic.ProfileStore {
+	return cloudstic.ProfileStore{
+		URI:                     *f.uri,
+		S3Region:                *f.s3Region,
+		S3Profile:               *f.s3Profile,
+		S3Endpoint:              *f.s3Endpoint,
+		S3AccessKey:             *f.s3AccessKey,
+		S3SecretKey:             *f.s3SecretKey,
+		S3AccessKeyEnv:          "",
+		S3SecretKeyEnv:          "",
+		S3AccessKeySecret:       firstNonEmpty(*f.s3AccessKeySecret, envRef(*f.s3AccessKeyEnv)),
+		S3SecretKeySecret:       firstNonEmpty(*f.s3SecretKeySecret, envRef(*f.s3SecretKeyEnv)),
+		S3ProfileEnv:            *f.s3ProfileEnv,
+		StoreSFTPPassword:       *f.sftpPassword,
+		StoreSFTPKey:            *f.sftpKey,
+		StoreSFTPPasswordEnv:    "",
+		StoreSFTPKeyEnv:         "",
+		StoreSFTPPasswordSecret: firstNonEmpty(*f.sftpPasswordSecret, envRef(*f.sftpPasswordEnv)),
+		StoreSFTPKeySecret:      firstNonEmpty(*f.sftpKeySecret, envRef(*f.sftpKeyEnv)),
+		PasswordEnv:             "",
+		EncryptionKeyEnv:        "",
+		RecoveryKeyEnv:          "",
+		PasswordSecret:          firstNonEmpty(*f.passwordSecret, envRef(*f.passwordEnv)),
+		EncryptionKeySecret:     firstNonEmpty(*f.encryptionKeySecret, envRef(*f.encryptionKeyEnv)),
+		RecoveryKeySecret:       firstNonEmpty(*f.recoveryKeySecret, envRef(*f.recoveryKeyEnv)),
+		KMSKeyARN:               *f.kmsKeyARN,
+		KMSRegion:               *f.kmsRegion,
+		KMSEndpoint:             *f.kmsEndpoint,
+	}
+}


### PR DESCRIPTION
## Summary
- Extract shared profile-builder helpers for ref-name validation, profiles config loading/initialization, and sorted key utilities used by `profile`, `auth`, and `store` flows.
- Refactor `store new` by moving existing-store prefill/default application and profile-store object construction into dedicated helpers to reduce command-level complexity.
- Keep command behavior and CLI surface unchanged while reducing duplication and making future builder UX work safer to evolve.

## Testing
- go test -count=1 ./cmd/cloudstic
- go test -count=1 ./...
- golangci-lint run ./...