### PR TITLE
docs: add store init to user guide

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -537,6 +537,20 @@ cloudstic store verify prod-s3
 and encrypted repo unlock). It is different from `cloudstic check`, which verifies
 repository data integrity.
 
+#### store init
+
+Initialize a configured store by reference from `profiles.yaml`.
+
+```bash
+cloudstic store init prod-s3
+
+# Non-interactive (skip confirmation prompt)
+cloudstic store init -yes prod-s3
+```
+
+Use this when a store was created/configured earlier but repository
+initialization was skipped or failed.
+
 #### store new
 
 Create or update a named store entry in `profiles.yaml`. Stores define storage backend, connection credentials, and encryption settings.


### PR DESCRIPTION
## Summary
- document the new `cloudstic store init <name>` command in `docs/user-guide.md`
- add usage examples for interactive and non-interactive (`-yes`) flows
- clarify when to use it (initialization skipped or failed during store/profile setup)

## Validation
- docs-only change