### PR TITLE
fix: gate macOS keychain code behind cgo

### DIFF
--- a/cmd/cloudstic/secret_store_darwin.go
+++ b/cmd/cloudstic/secret_store_darwin.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build darwin && cgo
 
 package main
 

--- a/cmd/cloudstic/secret_store_darwin_test.go
+++ b/cmd/cloudstic/secret_store_darwin_test.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build darwin && cgo
 
 package main
 

--- a/cmd/cloudstic/secret_store_stub.go
+++ b/cmd/cloudstic/secret_store_stub.go
@@ -1,4 +1,4 @@
-//go:build !darwin
+//go:build !darwin || (darwin && !cgo)
 
 package main
 

--- a/internal/secretref/keychain_backend_darwin.go
+++ b/internal/secretref/keychain_backend_darwin.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build darwin && cgo
 
 package secretref
 

--- a/internal/secretref/keychain_backend_darwin_test.go
+++ b/internal/secretref/keychain_backend_darwin_test.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build darwin && cgo
 
 package secretref
 

--- a/internal/secretref/keychain_backend_integration_darwin_test.go
+++ b/internal/secretref/keychain_backend_integration_darwin_test.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build darwin && cgo
 
 package secretref
 

--- a/internal/secretref/keychain_backend_stub.go
+++ b/internal/secretref/keychain_backend_stub.go
@@ -1,4 +1,4 @@
-//go:build !darwin
+//go:build !darwin || (darwin && !cgo)
 
 package secretref
 


### PR DESCRIPTION
## Summary
- restrict macOS keychain implementations and tests to `darwin && cgo`
- use the existing stub implementations for `darwin && !cgo` so GoReleaser can cross-compile macOS targets from Linux
- fix the release failure caused by cross-compiling darwin binaries without the `go-keychain` cgo-backed symbols available

## Verification
- `GOOS=darwin GOARCH=amd64 go build ./cmd/cloudstic`
- `GOOS=darwin GOARCH=arm64 go build ./cmd/cloudstic`
- `go test ./internal/secretref ./cmd/cloudstic`