### PR TITLE
docs: expand onboarding RFC and add FileMeta path normalization RFC

### DIFF
--- a/rfcs/0001-hamt-evolution.md
+++ b/rfcs/0001-hamt-evolution.md
@@ -41,6 +41,8 @@ Bias the HAMT key to group siblings together by incorporating the parent's ident
 
 Strip the `Paths` field and only store the `Filename` and list of `ParentID`s.
 
+Follow-up design and rollout details are specified in [RFC 0015](./0015-filemeta-path-normalization.md).
+
 * **Recovery:** Reconstruct paths dynamically by walking the `Parents` chain.
 * **Compatibility:**
   * **Backup:** Filtering happens source-side using ephemeral paths; `FileMeta.Paths` is not used.

--- a/rfcs/0014-workstation-onboarding-and-profile-scaffolding.md
+++ b/rfcs/0014-workstation-onboarding-and-profile-scaffolding.md
@@ -8,10 +8,15 @@
 
 This RFC proposes a guided onboarding workflow for backing up a workstation.
 The workflow helps users create practical profile sets quickly, with OS-aware
-folder suggestions and portable-drive discovery.
+folder suggestions, portable-drive discovery, and a review-first coverage plan
+for the current machine.
 
 The goal is to make first-time setup reliable and obvious without forcing users
 to manually craft each profile/store/auth entry.
+
+This RFC is explicitly workstation-first: local folders and portable/external
+drives are the primary onboarding target in v1. Cloud roots may be integrated
+later, but they are not the center of the initial experience.
 
 ## Context
 
@@ -25,11 +30,17 @@ users still face setup complexity:
 Users commonly want a "set me up for this machine" flow that creates sensible
 defaults and can be reviewed before writing configuration.
 
+The differentiator is not merely generating YAML faster. The onboarding flow
+should help users reason about workstation coverage: what is protected, what is
+intentionally skipped, and which portable drives can keep stable backup lineage
+across mount-point changes and machine changes.
+
 ## Goals
 
 - Add a guided CLI onboarding path for workstation backup setup.
 - Suggest common folders based on the current OS.
 - Discover available portable drives and offer profile creation for each.
+- Help users review workstation coverage before config is written.
 - Reuse existing store/auth/profile model and commands.
 - Keep generated configuration explicit, reviewable, and editable.
 
@@ -39,6 +50,10 @@ defaults and can be reviewed before writing configuration.
 - No hidden writes of secrets or credentials.
 - No replacement of existing `profile new` or `store new` commands.
 - No daemon/scheduling implementation in this RFC (covered by RFC 0013).
+- No cloud-root onboarding flow in v1 beyond reusing an already configured
+  store.
+- No automatic inclusion of caches, temp directories, or other low-signal
+  system data by default.
 
 ## Proposal
 
@@ -55,6 +70,23 @@ Behavior:
 - interactive by default
 - supports `--dry-run` to preview generated profiles/stores
 - supports `--yes` for non-interactive acceptance of defaults
+- optimized for local workstation coverage in v1
+
+### 1b. Introduce an explicit onboarding plan model
+
+`setup workstation` should build an in-memory plan before any configuration is
+written.
+
+The plan contains:
+
+- candidate workstation folders grouped by category
+- discovered portable drives
+- proposed profile drafts
+- references to existing or newly proposed store entries
+- pending collision decisions (`create`, `update`, `rename`, `skip`)
+- a coverage summary for final review
+
+Nothing is persisted until the user confirms the final plan.
 
 ### 2. Add portable-drive discovery command
 
@@ -75,6 +107,10 @@ Output includes enough metadata for onboarding decisions:
 - source URI candidate (for `local:`)
 - display name / mount point
 - portable identity hints (volume UUID/label)
+- whether the source is considered portable for lineage purposes
+
+`source discover` should support both human-readable output and JSON output so
+the same discovery logic can later power TUI and automation paths.
 
 ### 3. OS-aware profile suggestions
 
@@ -89,16 +125,36 @@ Examples:
 Rules:
 
 - include only directories that exist
+- group suggestions by intent, not just by path
 - allow selecting/deselecting before generation
 - offer custom additional paths
+
+Suggested v1 categories:
+
+- core documents
+- desktop/workspace files
+- media libraries
+- developer projects
+- portable/external drives
+
+Portable drives should be shown separately from built-in workstation folders so
+users can make an intentional decision about larger or intermittently connected
+data sources.
+
+The setup flow should also identify common low-signal paths that are excluded by
+default or at least flagged as poor backup targets, such as caches, temp files,
+dependency/build artifacts, and OS metadata noise.
 
 ### 4. Store/auth integration behavior
 
 Setup flow uses existing references:
 
 - If no store exists, prompt to create one (reusing `store new` patterns).
-- If cloud source selected and auth missing, prompt to create/select auth entry.
 - For local folders and portable drives, auth is not required.
+
+In v1, workstation onboarding should focus on selecting or creating the backup
+store. Cloud source auth flows remain available through existing commands but
+are out of scope for the initial workstation setup path.
 
 ### 5. Naming and tagging conventions
 
@@ -121,7 +177,32 @@ Before saving, show a summary table:
 - auth ref (if any)
 - tags
 
+The review should also show workstation coverage status:
+
+- `protected now`: selected folders and drives that will produce profiles
+- `skipped intentionally`: suggestions the user deselected
+- `not available now`: portable drives seen in previous discovery logic but not
+  currently mounted (future-friendly wording; may be empty in v1)
+- `warnings`: paths that appear noisy, redundant, or risky to back up by default
+
 User confirms once to persist all generated entries.
+
+The write path should apply the reviewed plan as a batch so the user sees one
+coherent onboarding decision rather than a series of independent writes.
+
+### 7. Dry-run semantics
+
+`setup workstation --dry-run` must be side-effect free.
+
+In particular it must not:
+
+- create the config directory
+- create token directories
+- trigger auth login flows
+- resolve or print secret values
+- mutate `profiles.yaml`
+
+Preview output should be deterministic enough for integration testing.
 
 ## Command examples
 
@@ -147,6 +228,8 @@ cloudstic source discover --portable-only
 - Setup flow must never print resolved secret values.
 - Store/auth creation reuses existing secure secret-reference flow.
 - `--dry-run` should redact sensitive fields in preview output.
+- Workstation review output should avoid exposing more path detail than the user
+  already selected when secrets or private mount naming conventions are involved.
 
 ## Testing strategy
 
@@ -160,7 +243,8 @@ cloudstic source discover --portable-only
 1. Add `source discover` with machine-readable and human-readable output.
 2. Add `setup workstation --dry-run` with profile generation preview.
 3. Add interactive confirmations and write path.
-4. Integrate with optional scheduling suggestions once RFC 0013 lands.
+4. Add workstation coverage review and collision handling polish.
+5. Integrate with optional scheduling suggestions once RFC 0013 lands.
 
 ## Relationship to other RFCs
 
@@ -170,7 +254,9 @@ cloudstic source discover --portable-only
 
 ## Open questions
 
-- Should generated names default to host-prefixed or concise names?
-- Should onboarding include an optional "exclude defaults" profile template
-  per OS (cache/build artifacts/system temp)?
-- Should `source discover` support JSON output in v1 for automation use?
+- Should generated names use concise defaults first, adding host prefixes only
+  when needed to disambiguate?
+- Should exclude-default bundles be always on for workstation onboarding, or
+  merely suggested and reviewable?
+- Should future workstation onboarding detect likely developer workspaces (for
+  example `~/src`, `~/code`, `~/Projects`) with platform-specific heuristics?

--- a/rfcs/0015-filemeta-path-normalization.md
+++ b/rfcs/0015-filemeta-path-normalization.md
@@ -1,0 +1,231 @@
+# RFC 0015: FileMeta Path Normalization
+
+- **Status:** Draft
+- **Date:** 2026-03-17
+- **Affects:** `internal/core`, `internal/engine`, `pkg/source`, docs
+- **Related:** [RFC 0001](./0001-hamt-evolution.md), [RFC 0006](./0006-direct-to-filesystem-restore.md)
+
+## Abstract
+
+RFC 0001 identified `FileMeta.Paths` as redundant metadata that inflates
+`filemeta/` objects and causes avoidable hash churn. This RFC defines a follow-up
+implementation plan: treat full paths as normalized, ephemeral scan-time data,
+but stop persisting them in newly written `FileMeta` objects.
+
+New snapshots continue to store `Name` and `Parents` as the canonical location
+signal. Restore and other path-based workflows reconstruct paths dynamically by
+walking the parent chain. Older snapshots that still contain `Paths` remain
+fully readable.
+
+## Context
+
+`core.FileMeta` currently persists:
+
+- `Name`
+- `Parents`
+- `Paths`
+
+For local, SFTP, Google Drive, and OneDrive sources, `Paths[0]` is typically a
+single slash-separated display path that can already be derived from the first
+parent chain plus `Name`.
+
+This has several costs:
+
+- repeated path prefixes in every descendant object
+- larger JSON payloads for `filemeta/` objects
+- additional metadata hash churn when path strings differ even though parent
+  lineage already captures the same location
+- confusion between scan-time path needs and persisted snapshot schema
+
+The current engine already proves the model is viable: restore can reconstruct a
+path from `Parents` and `Name` when `Paths` is absent.
+
+## Goals
+
+- Stop persisting redundant path strings in newly written `FileMeta` objects.
+- Keep path-based filtering and exclude evaluation working during backup scans.
+- Preserve backward compatibility for existing snapshots containing `Paths`.
+- Define one normalization model for ephemeral relative paths used during scan,
+  diff, and restore logic.
+- Reduce `filemeta/` size and metadata rewrite overhead without introducing a
+  repository format version bump.
+
+## Non-goals
+
+- No change to the HAMT key (`FileID`) in this RFC.
+- No change to source identity or snapshot lineage semantics.
+- No multi-path deduplication or hard-link model in this RFC.
+- No user-visible path aliasing feature.
+
+## Proposal
+
+### 1. Make persisted `FileMeta.Paths` optional and omit it for new writes
+
+`core.FileMeta.Paths` remains in the schema for compatibility, but new backups
+should write it as empty/nil in persisted metadata objects.
+
+Interpretation becomes:
+
+- scan-time/in-memory `Paths`: optional helper data for source filtering,
+  excludes, and UI
+- persisted `Paths`: legacy compatibility field, not required for correctness
+
+This keeps the on-disk JSON schema backward compatible while moving the system
+toward parent-chain-derived paths.
+
+### 2. Define normalized path semantics for ephemeral use
+
+When a path is carried in memory, it must be normalized as follows:
+
+- relative to the selected source root
+- slash-separated (`/`) on all platforms
+- no leading slash in `FileMeta.Paths`
+- no `.` segments
+- no empty segments except the implicit root
+- directories represented by the same path form as files, without trailing `/`
+
+Examples:
+
+- local file `Documents\\notes.txt` on Windows becomes `Documents/notes.txt`
+- source root folder itself is represented as `Project`, not `./Project` or
+  `Project/`
+- OneDrive and Google Drive scoped roots follow the same relative convention
+
+This normalization applies to ephemeral paths used during source traversal and
+change filtering even though those paths are no longer persisted in new
+snapshots.
+
+### 3. Reconstruct persisted paths from `Parents` + `Name`
+
+Path reconstruction becomes the primary model for snapshot consumers.
+
+Rules:
+
+- if `Paths` exists on a loaded `FileMeta`, consumers may use `Paths[0]` as an
+  optimization only
+- if `Paths` is empty, consumers reconstruct from the first parent chain and
+  `Name`
+- reconstruction should use the same normalized slash-separated relative path
+  semantics defined above
+
+This matches existing restore behavior and formalizes it as the default path
+resolution strategy rather than a fallback curiosity.
+
+### 4. Separate scan-time metadata from persisted metadata
+
+The backup pipeline should treat path strings as transient scan context.
+
+Recommended model:
+
+- sources may emit normalized `Paths` in memory for filtering convenience
+- backup scan logic may synthesize a path when incremental sources only emit a
+  partial change set
+- before hashing and persisting `FileMeta`, the engine clears `Paths`
+
+This makes the persisted object reflect only durable identity and metadata,
+while allowing source adapters to keep practical path-aware behavior.
+
+### 5. Update restore, diff, and filter helpers to prefer derived paths
+
+Any engine helper that needs a path should operate through a shared
+reconstruction helper instead of directly assuming `meta.Paths[0]` exists.
+
+That includes:
+
+- restore path building
+- path-filtered restore selection
+- future diff/list formatting helpers that need a display path
+
+The fast path for legacy snapshots may remain, but correctness must not depend
+on stored `Paths`.
+
+## Detailed behavior by source type
+
+### Local and SFTP
+
+- continue to compute normalized relative paths during `Walk()`
+- use those paths for exclude evaluation and user-facing scan output
+- persist only `Name`, `Parents`, and other durable metadata
+
+### Google Drive and OneDrive full scans
+
+- continue to build path maps during traversal for exclusion and subtree scoping
+- emit normalized relative paths in memory where helpful
+- persist metadata without `Paths`
+
+### Incremental cloud sources
+
+- may reconstruct paths from the previous tree when a change event does not
+  include enough ancestry context
+- use reconstructed normalized paths only for scan-time filtering
+- persist final metadata without `Paths`
+
+## Backward compatibility
+
+- Existing snapshots containing `Paths` remain fully readable.
+- New snapshots omit `Paths`, but old binaries that already reconstruct by
+  parent chain for restore should continue to function for common cases.
+- No repository format version bump is required because the JSON field already
+  exists and may legally be empty.
+
+Compatibility caveat:
+
+- codepaths that still assume `Paths[0]` is always populated must be updated
+  before the new write behavior is enabled broadly
+
+## Performance impact
+
+Expected benefits:
+
+- smaller `filemeta/` objects, especially for deep trees
+- less metadata hash churn from redundant path-string changes
+- reduced object-store traffic for metadata-heavy snapshots
+
+Expected costs:
+
+- more parent-chain reconstruction during restore/list/diff paths
+
+The extra reconstruction cost is acceptable because:
+
+- restore already implements it
+- path reconstruction is bounded by directory depth
+- metadata size savings apply to every written entry
+
+## Security considerations
+
+- No new secret handling or credential behavior is introduced.
+- Persisting fewer path strings slightly reduces duplicated sensitive path data
+  in stored metadata objects.
+- Snapshot consumers must continue to sanitize restore output paths against
+  traversal and root escape attacks; this RFC does not weaken those checks.
+
+## Testing strategy
+
+- Unit tests for path normalization rules across local, SFTP, and cloud sources.
+- Unit tests for path reconstruction from parent chains when `Paths` is absent.
+- Regression tests for restore path filtering with snapshots that omit `Paths`.
+- Mixed-compatibility tests covering old snapshots with stored `Paths` and new
+  snapshots without them.
+- Incremental-source tests ensuring exclude filtering still works when paths are
+  reconstructed in memory.
+
+## Rollout plan
+
+1. Add shared helpers for normalized ephemeral path handling and derived-path
+   reconstruction.
+2. Update engine consumers so correctness no longer depends on persisted
+   `Paths`.
+3. Change backup persistence to clear `Paths` before hashing and writing new
+   `FileMeta` objects.
+4. Update docs/spec examples to show `paths` as optional legacy compatibility
+   data.
+5. Validate mixed old/new snapshot behavior in integration tests.
+
+## Open questions
+
+- Should `Paths` remain in the JSON schema indefinitely as a compatibility field,
+  or be removed in a later schema-cleanup RFC?
+- Should the engine cache reconstructed paths during restore/list operations to
+  avoid repeated parent walks in very large trees?
+- Should `FileMeta.Version` advance when new snapshots begin omitting `Paths`,
+  even if the change is backward compatible?

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -14,3 +14,4 @@
 - [RFC 0012: Interactive TUI Mode](0012-interactive-tui-mode.md)
 - [RFC 0013: Daemon Mode and Profile Scheduling](0013-daemon-mode-and-profile-scheduling.md)
 - [RFC 0014: Workstation Onboarding and Profile Scaffolding](0014-workstation-onboarding-and-profile-scaffolding.md)
+- [RFC 0015: FileMeta Path Normalization](0015-filemeta-path-normalization.md)


### PR DESCRIPTION
## Summary
- refine RFC 0014 around a workstation-first onboarding story with explicit coverage review, batch planning, and side-effect-free dry runs
- add RFC 0015 to turn the HAMT evolution note on FileMeta path normalization into a concrete implementation and rollout proposal
- link the new RFC from RFC 0001 and the RFC index so the follow-up path is explicit