### PR TITLE
fix: canonicalize relative local source paths

### DIFF
--- a/pkg/source/local_source.go
+++ b/pkg/source/local_source.go
@@ -10,9 +10,11 @@ import (
 	"github.com/cloudstic/cli/internal/core"
 )
 
+var filepathAbs = filepath.Abs
+
 func (s *LocalSource) Info() core.SourceInfo {
 	hostname, _ := os.Hostname()
-	absPath, _ := filepath.Abs(s.rootPath)
+	absPath, _ := filepathAbs(s.rootPath)
 
 	// When volume UUID is present, store the path relative to the volume
 	// mount point instead of the absolute path. This makes the path
@@ -24,7 +26,17 @@ func (s *LocalSource) Info() core.SourceInfo {
 		realAbs, errA := filepath.EvalSymlinks(absPath)
 		realMount, errM := filepath.EvalSymlinks(s.volumeMountPoint)
 		if errA == nil && errM == nil {
-			if rel, err := filepath.Rel(realMount, realAbs); err == nil {
+			if pathWithinRoot(realMount, realAbs) {
+				if rel, err := filepath.Rel(realMount, realAbs); err == nil {
+					infoPath = filepath.ToSlash(rel)
+				}
+			} else if pathWithinRoot(s.volumeMountPoint, absPath) {
+				if rel, err := filepath.Rel(s.volumeMountPoint, absPath); err == nil {
+					infoPath = filepath.ToSlash(rel)
+				}
+			}
+		} else if pathWithinRoot(s.volumeMountPoint, absPath) {
+			if rel, err := filepath.Rel(s.volumeMountPoint, absPath); err == nil {
 				infoPath = filepath.ToSlash(rel)
 			}
 		}
@@ -60,6 +72,18 @@ func (s *LocalSource) Info() core.SourceInfo {
 			return hostname
 		}(),
 	}
+}
+
+func pathWithinRoot(root, target string) bool {
+	rootClean := filepath.Clean(root)
+	targetClean := filepath.Clean(target)
+	if rootClean == "." || rootClean == "" {
+		return false
+	}
+	if targetClean == rootClean {
+		return true
+	}
+	return strings.HasPrefix(targetClean, rootClean+string(filepath.Separator))
 }
 
 // localOptions holds configuration for a local filesystem source.

--- a/pkg/source/local_source_info_test.go
+++ b/pkg/source/local_source_info_test.go
@@ -1,0 +1,37 @@
+package source
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestLocalSourceInfo_UsesRelativePathOnlyWithinMount(t *testing.T) {
+	abs := filepath.Join(string(filepath.Separator), "Users", "alice", "workspace", "repo")
+	s := &LocalSource{
+		rootPath:         ".",
+		volumeUUID:       "UUID-123",
+		volumeMountPoint: filepath.Join(string(filepath.Separator), "System", "Volumes", "Data"),
+	}
+
+	oldAbs := filepathAbs
+	defer func() { filepathAbs = oldAbs }()
+	filepathAbs = func(string) (string, error) { return abs, nil }
+
+	info := s.Info()
+	if info.Path != abs {
+		t.Fatalf("Path = %q, want %q", info.Path, abs)
+	}
+	if info.PathID != abs {
+		t.Fatalf("PathID = %q, want %q", info.PathID, abs)
+	}
+}
+
+func TestPathWithinRoot(t *testing.T) {
+	root := filepath.Join(string(filepath.Separator), "Users", "alice")
+	if !pathWithinRoot(root, filepath.Join(root, "workspace")) {
+		t.Fatal("expected child path to be within root")
+	}
+	if pathWithinRoot(root, filepath.Join(string(filepath.Separator), "Users", "bob")) {
+		t.Fatal("unexpected unrelated path within root")
+	}
+}


### PR DESCRIPTION
Closes #145

## Summary
- avoid deriving bogus volume-relative local source paths when the resolved source path is not actually under the detected mount root
- keep `local:./` and similar relative roots persisted as canonical absolute paths when no safe relative path exists
- add regression coverage for the broken relative-root case and the root-containment helper

## Testing
- `go test ./pkg/source ./cmd/cloudstic`