### PR TITLE
fix: normalize object store prefixes

### DIFF
--- a/pkg/store/b2.go
+++ b/pkg/store/b2.go
@@ -26,7 +26,7 @@ type B2Option func(*b2Options)
 // (e.g. "prod/" and "staging/").
 func WithPrefix(prefix string) B2Option {
 	return func(o *b2Options) {
-		o.prefix = prefix
+		o.prefix = normalizeKeyPrefix(prefix)
 	}
 }
 

--- a/pkg/store/b2_test.go
+++ b/pkg/store/b2_test.go
@@ -1,11 +1,11 @@
 package store
 
-import (
-	"testing"
-)
+import "testing"
 
-func TestB2Store_SDK(t *testing.T) {
-	// Similarly, Blazer SDK connects to real B2.
-	// Mocking the entire B2 API for the SDK to consume is complex.
-	t.Skip("Skipping B2 SDK tests as they require real credentials")
+func TestWithPrefix_NormalizesPrefix(t *testing.T) {
+	var opts b2Options
+	WithPrefix("nested/prefix")(&opts)
+	if opts.prefix != "nested/prefix/" {
+		t.Fatalf("prefix = %q", opts.prefix)
+	}
 }

--- a/pkg/store/prefix.go
+++ b/pkg/store/prefix.go
@@ -1,0 +1,12 @@
+package store
+
+import "strings"
+
+func normalizeKeyPrefix(prefix string) string {
+	prefix = strings.TrimSpace(prefix)
+	prefix = strings.Trim(prefix, "/")
+	if prefix == "" {
+		return ""
+	}
+	return prefix + "/"
+}

--- a/pkg/store/prefix_test.go
+++ b/pkg/store/prefix_test.go
@@ -1,0 +1,23 @@
+package store
+
+import "testing"
+
+func TestNormalizeKeyPrefix(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"   ", ""},
+		{"prod", "prod/"},
+		{"prod/", "prod/"},
+		{"/prod", "prod/"},
+		{"/nested/path/", "nested/path/"},
+	}
+
+	for _, tc := range tests {
+		if got := normalizeKeyPrefix(tc.in); got != tc.want {
+			t.Fatalf("normalizeKeyPrefix(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/pkg/store/s3.go
+++ b/pkg/store/s3.go
@@ -76,7 +76,7 @@ func WithS3Credentials(accessKey, secretKey string) S3Option {
 // Use this to isolate multiple repositories within a single bucket.
 func WithS3Prefix(prefix string) S3Option {
 	return func(o *s3Options) {
-		o.prefix = prefix
+		o.prefix = normalizeKeyPrefix(prefix)
 	}
 }
 

--- a/pkg/store/s3_test.go
+++ b/pkg/store/s3_test.go
@@ -159,3 +159,11 @@ func TestS3Store(t *testing.T) {
 		t.Fatalf("Expected key to be deleted")
 	}
 }
+
+func TestWithS3Prefix_NormalizesPrefix(t *testing.T) {
+	var opts s3Options
+	WithS3Prefix("nested/prefix")(&opts)
+	if opts.prefix != "nested/prefix/" {
+		t.Fatalf("prefix = %q", opts.prefix)
+	}
+}


### PR DESCRIPTION
Closes #147

## Summary
- normalize configured object-store prefixes so repository objects stay under the intended prefix even when the store URI omits a trailing slash
- apply the normalization to both S3 and B2 prefix options
- add regression tests for prefix normalization and prefixed key behavior

## Testing
- `go test ./pkg/store ./cmd/cloudstic`