### PR TITLE
refactor: group backup source init options

### DIFF
--- a/cmd/cloudstic/cmd_auth.go
+++ b/cmd/cloudstic/cmd_auth.go
@@ -222,7 +222,12 @@ func (r *runner) runAuthLogin() int {
 		if googleCreds == "" {
 			googleCreds = os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
 		}
-		src, err := initSource(ctx, "gdrive:/", false, "", googleCreds, auth.GoogleTokenFile, "", "", false, false, false, "", g, nil)
+		src, err := initSource(ctx, initSourceOptions{
+			sourceURI:       "gdrive:/",
+			googleCreds:     googleCreds,
+			googleTokenFile: auth.GoogleTokenFile,
+			globalFlags:     g,
+		})
 		if err != nil {
 			return r.fail("Failed to initialize Google auth source: %v", err)
 		}
@@ -232,7 +237,12 @@ func (r *runner) runAuthLogin() int {
 		if onedriveClientID == "" {
 			onedriveClientID = os.Getenv("ONEDRIVE_CLIENT_ID")
 		}
-		src, err := initSource(ctx, "onedrive:/", false, "", "", "", onedriveClientID, auth.OneDriveTokenFile, false, false, false, "", g, nil)
+		src, err := initSource(ctx, initSourceOptions{
+			sourceURI:         "onedrive:/",
+			onedriveClientID:  onedriveClientID,
+			onedriveTokenFile: auth.OneDriveTokenFile,
+			globalFlags:       g,
+		})
 		if err != nil {
 			return r.fail("Failed to initialize OneDrive auth source: %v", err)
 		}

--- a/cmd/cloudstic/cmd_backup.go
+++ b/cmd/cloudstic/cmd_backup.go
@@ -128,22 +128,21 @@ func (r *runner) runSingleBackup(a *backupArgs) int {
 
 	ctx := context.Background()
 
-	src, err := initSource(
-		ctx,
-		a.sourceURI,
-		a.skipNativeFiles,
-		a.volumeUUID,
-		a.googleCreds,
-		a.googleTokenFile,
-		a.onedriveClientID,
-		a.onedriveTokenFile,
-		a.skipMode,
-		a.skipFlags,
-		a.skipXattrs,
-		a.xattrNamespaces,
-		a.g,
-		excludePatterns,
-	)
+	src, err := initSource(ctx, initSourceOptions{
+		sourceURI:         a.sourceURI,
+		skipNativeFiles:   a.skipNativeFiles,
+		volumeUUID:        a.volumeUUID,
+		googleCreds:       a.googleCreds,
+		googleTokenFile:   a.googleTokenFile,
+		onedriveClientID:  a.onedriveClientID,
+		onedriveTokenFile: a.onedriveTokenFile,
+		skipMode:          a.skipMode,
+		skipFlags:         a.skipFlags,
+		skipXattrs:        a.skipXattrs,
+		xattrNamespaces:   a.xattrNamespaces,
+		globalFlags:       a.g,
+		excludePatterns:   excludePatterns,
+	})
 	if err != nil {
 		return r.fail("Failed to init source: %v", err)
 	}
@@ -603,93 +602,109 @@ func (r *runner) printBackupSummary(res *engine.RunResult) {
 	}
 }
 
-func initSource(ctx context.Context, sourceURI string, skipNativeFiles bool, volumeUUID, googleCreds, googleTokenFile, onedriveClientID, onedriveTokenFile string, skipMode, skipFlags, skipXattrs bool, xattrNamespaces string, g *globalFlags, excludePatterns []string) (source.Source, error) {
-	uri, err := parseSourceURI(sourceURI)
+type initSourceOptions struct {
+	sourceURI         string
+	skipNativeFiles   bool
+	volumeUUID        string
+	googleCreds       string
+	googleTokenFile   string
+	onedriveClientID  string
+	onedriveTokenFile string
+	skipMode          bool
+	skipFlags         bool
+	skipXattrs        bool
+	xattrNamespaces   string
+	globalFlags       *globalFlags
+	excludePatterns   []string
+}
+
+func initSource(ctx context.Context, opts initSourceOptions) (source.Source, error) {
+	uri, err := parseSourceURI(opts.sourceURI)
 	if err != nil {
 		return nil, err
 	}
 
 	switch uri.scheme {
 	case "local":
-		opts := []source.LocalOption{source.WithLocalExcludePatterns(excludePatterns)}
-		if volumeUUID != "" {
-			opts = append(opts, source.WithVolumeUUID(volumeUUID))
+		localOpts := []source.LocalOption{source.WithLocalExcludePatterns(opts.excludePatterns)}
+		if opts.volumeUUID != "" {
+			localOpts = append(localOpts, source.WithVolumeUUID(opts.volumeUUID))
 		}
-		if skipMode {
-			opts = append(opts, source.WithSkipMode())
+		if opts.skipMode {
+			localOpts = append(localOpts, source.WithSkipMode())
 		}
-		if skipFlags {
-			opts = append(opts, source.WithSkipFlags())
+		if opts.skipFlags {
+			localOpts = append(localOpts, source.WithSkipFlags())
 		}
-		if skipXattrs {
-			opts = append(opts, source.WithSkipXattrs())
+		if opts.skipXattrs {
+			localOpts = append(localOpts, source.WithSkipXattrs())
 		}
-		if xattrNamespaces != "" {
-			prefixes := parseXattrNamespacePrefixes(xattrNamespaces)
+		if opts.xattrNamespaces != "" {
+			prefixes := parseXattrNamespacePrefixes(opts.xattrNamespaces)
 			if len(prefixes) > 0 {
-				opts = append(opts, source.WithXattrNamespaces(prefixes))
+				localOpts = append(localOpts, source.WithXattrNamespaces(prefixes))
 			}
 		}
-		return source.NewLocalSource(uri.path, opts...), nil
+		return source.NewLocalSource(uri.path, localOpts...), nil
 	case "sftp":
-		sftpOpts := g.buildSFTPSourceOpts(uri)
-		sftpOpts = append(sftpOpts, source.WithSFTPExcludePatterns(excludePatterns))
+		sftpOpts := opts.globalFlags.buildSFTPSourceOpts(uri)
+		sftpOpts = append(sftpOpts, source.WithSFTPExcludePatterns(opts.excludePatterns))
 		return source.NewSFTPSource(uri.host, sftpOpts...)
 	case "gdrive":
-		tokenPath, err := resolveTokenPath(googleTokenFile, "google_token.json")
+		tokenPath, err := resolveTokenPath(opts.googleTokenFile, "google_token.json")
 		if err != nil {
 			return nil, err
 		}
 		gdriveOpts := []source.GDriveOption{
-			source.WithCredsPath(googleCreds),
+			source.WithCredsPath(opts.googleCreds),
 			source.WithTokenPath(tokenPath),
 			source.WithDriveName(uri.host),
 			source.WithRootPath(uri.path),
-			source.WithGDriveExcludePatterns(excludePatterns),
+			source.WithGDriveExcludePatterns(opts.excludePatterns),
 		}
-		if skipNativeFiles {
+		if opts.skipNativeFiles {
 			gdriveOpts = append(gdriveOpts, source.WithSkipNativeFiles())
 		}
 		return source.NewGDriveSource(ctx, gdriveOpts...)
 	case "gdrive-changes":
-		tokenPath, err := resolveTokenPath(googleTokenFile, "google_token.json")
+		tokenPath, err := resolveTokenPath(opts.googleTokenFile, "google_token.json")
 		if err != nil {
 			return nil, err
 		}
 		gdriveOpts := []source.GDriveOption{
-			source.WithCredsPath(googleCreds),
+			source.WithCredsPath(opts.googleCreds),
 			source.WithTokenPath(tokenPath),
 			source.WithDriveName(uri.host),
 			source.WithRootPath(uri.path),
-			source.WithGDriveExcludePatterns(excludePatterns),
+			source.WithGDriveExcludePatterns(opts.excludePatterns),
 		}
-		if skipNativeFiles {
+		if opts.skipNativeFiles {
 			gdriveOpts = append(gdriveOpts, source.WithSkipNativeFiles())
 		}
 		return source.NewGDriveChangeSource(ctx, gdriveOpts...)
 	case "onedrive":
-		tokenPath, err := resolveTokenPath(onedriveTokenFile, "onedrive_token.json")
+		tokenPath, err := resolveTokenPath(opts.onedriveTokenFile, "onedrive_token.json")
 		if err != nil {
 			return nil, err
 		}
 		return source.NewOneDriveSource(ctx,
-			source.WithOneDriveClientID(onedriveClientID),
+			source.WithOneDriveClientID(opts.onedriveClientID),
 			source.WithOneDriveTokenPath(tokenPath),
 			source.WithOneDriveDriveName(uri.host),
 			source.WithOneDriveRootPath(uri.path),
-			source.WithOneDriveExcludePatterns(excludePatterns),
+			source.WithOneDriveExcludePatterns(opts.excludePatterns),
 		)
 	case "onedrive-changes":
-		tokenPath, err := resolveTokenPath(onedriveTokenFile, "onedrive_token.json")
+		tokenPath, err := resolveTokenPath(opts.onedriveTokenFile, "onedrive_token.json")
 		if err != nil {
 			return nil, err
 		}
 		return source.NewOneDriveChangeSource(ctx,
-			source.WithOneDriveClientID(onedriveClientID),
+			source.WithOneDriveClientID(opts.onedriveClientID),
 			source.WithOneDriveTokenPath(tokenPath),
 			source.WithOneDriveDriveName(uri.host),
 			source.WithOneDriveRootPath(uri.path),
-			source.WithOneDriveExcludePatterns(excludePatterns),
+			source.WithOneDriveExcludePatterns(opts.excludePatterns),
 		)
 	default:
 		return nil, fmt.Errorf("unsupported source: %s", uri.scheme)

--- a/cmd/cloudstic/cmd_backup_test.go
+++ b/cmd/cloudstic/cmd_backup_test.go
@@ -16,7 +16,7 @@ func TestInitSource_Local_ExtendedOptions(t *testing.T) {
 	}
 	g := &globalFlags{}
 
-	src, err := initSource(context.Background(), "local:"+tmpDir, false, "", "", "", "", "", a.skipMode, a.skipFlags, a.skipXattrs, a.xattrNamespaces, g, nil)
+	src, err := initSource(context.Background(), initSourceOptions{sourceURI: "local:" + tmpDir, skipMode: a.skipMode, skipFlags: a.skipFlags, skipXattrs: a.skipXattrs, xattrNamespaces: a.xattrNamespaces, globalFlags: g})
 	if err != nil {
 		t.Fatalf("initSource failed: %v", err)
 	}
@@ -36,7 +36,7 @@ func TestInitSource_Local_NoExtendedOptions(t *testing.T) {
 	a := &backupArgs{}
 	g := &globalFlags{}
 
-	src, err := initSource(context.Background(), "local:"+tmpDir, false, "", "", "", "", "", a.skipMode, a.skipFlags, a.skipXattrs, a.xattrNamespaces, g, nil)
+	src, err := initSource(context.Background(), initSourceOptions{sourceURI: "local:" + tmpDir, skipMode: a.skipMode, skipFlags: a.skipFlags, skipXattrs: a.skipXattrs, xattrNamespaces: a.xattrNamespaces, globalFlags: g})
 	if err != nil {
 		t.Fatalf("initSource failed: %v", err)
 	}
@@ -50,7 +50,7 @@ func TestInitSource_Local_VolumeUUID(t *testing.T) {
 	a := &backupArgs{}
 	g := &globalFlags{}
 
-	src, err := initSource(context.Background(), "local:"+tmpDir, false, "test-uuid-123", "", "", "", "", a.skipMode, a.skipFlags, a.skipXattrs, a.xattrNamespaces, g, nil)
+	src, err := initSource(context.Background(), initSourceOptions{sourceURI: "local:" + tmpDir, volumeUUID: "test-uuid-123", skipMode: a.skipMode, skipFlags: a.skipFlags, skipXattrs: a.skipXattrs, xattrNamespaces: a.xattrNamespaces, globalFlags: g})
 	if err != nil {
 		t.Fatalf("initSource failed: %v", err)
 	}
@@ -67,7 +67,7 @@ func TestInitSource_Local_XattrNamespacesParsing(t *testing.T) {
 	}
 	g := &globalFlags{}
 
-	src, err := initSource(context.Background(), "local:"+tmpDir, false, "", "", "", "", "", a.skipMode, a.skipFlags, a.skipXattrs, a.xattrNamespaces, g, nil)
+	src, err := initSource(context.Background(), initSourceOptions{sourceURI: "local:" + tmpDir, skipMode: a.skipMode, skipFlags: a.skipFlags, skipXattrs: a.skipXattrs, xattrNamespaces: a.xattrNamespaces, globalFlags: g})
 	if err != nil {
 		t.Fatalf("initSource failed: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestInitSource_UnsupportedType(t *testing.T) {
 	a := &backupArgs{}
 	g := &globalFlags{}
 
-	_, err := initSource(context.Background(), "invalid-source:/", false, "", "", "", "", "", a.skipMode, a.skipFlags, a.skipXattrs, a.xattrNamespaces, g, nil)
+	_, err := initSource(context.Background(), initSourceOptions{sourceURI: "invalid-source:/", skipMode: a.skipMode, skipFlags: a.skipFlags, skipXattrs: a.skipXattrs, xattrNamespaces: a.xattrNamespaces, globalFlags: g})
 	if err == nil {
 		t.Fatal("expected error for unsupported source type")
 	}

--- a/rfcs/0006-direct-to-filesystem-restore.md
+++ b/rfcs/0006-direct-to-filesystem-restore.md
@@ -1,6 +1,6 @@
 # RFC 0006: Direct-to-Filesystem Restore
 
-* **Status:** In Progress
+* **Status:** Implemented
 * **Date:** 2026-03-08
 * **Affects:** `internal/engine/restore.go`, `cmd/cloudstic/cmd_restore.go`, `client.go`, `cmd/cloudstic/client_iface.go`
 * **Depends on:** RFC 0004 (Extended File Attributes)


### PR DESCRIPTION
Closes #155

## Summary
- replace the long positional `initSource(...)` signature with an `initSourceOptions` struct
- update backup and auth call sites to construct source initialization options explicitly
- refresh the source-init tests to exercise the refactored API

## Testing
- `go test ./cmd/cloudstic ./internal/engine ./pkg/source ./pkg/store`
- `golangci-lint run ./cmd/cloudstic/... ./internal/engine/... ./pkg/source/... ./pkg/store/...`