### PR TITLE
fix: improve interactive CLI validation and recovery

### DIFF
--- a/cmd/cloudstic/cmd_auth.go
+++ b/cmd/cloudstic/cmd_auth.go
@@ -102,7 +102,12 @@ func (r *runner) runAuthNew(ctx context.Context) int {
 
 	if *name == "" {
 		if r.canPrompt() {
-			v, err := r.promptLine(ctx, "Auth reference name", "")
+			v, err := r.promptValidatedLine(ctx, "Auth reference name", "", func(v string) error {
+				if v == "" {
+					return fmt.Errorf("auth reference name is required")
+				}
+				return validateRefName("auth", v)
+			})
 			if err != nil {
 				return r.fail("Failed to read auth reference name: %v", err)
 			}

--- a/cmd/cloudstic/cmd_profile.go
+++ b/cmd/cloudstic/cmd_profile.go
@@ -212,7 +212,12 @@ func (r *runner) runProfileNew(ctx context.Context) int {
 	a := parseProfileNewArgs()
 	if a.name == "" {
 		if r.canPrompt() {
-			v, err := r.promptLine(ctx, "Profile name", "")
+			v, err := r.promptValidatedLine(ctx, "Profile name", "", func(v string) error {
+				if v == "" {
+					return fmt.Errorf("profile name is required")
+				}
+				return validateRefName("profile", v)
+			})
 			if err != nil {
 				return r.fail("Failed to read profile name: %v", err)
 			}
@@ -239,7 +244,16 @@ func (r *runner) runProfileNew(ctx context.Context) int {
 
 	if a.source == "" {
 		if r.canPrompt() {
-			v, err := r.promptLine(ctx, "Source URI", "")
+			v, err := r.promptValidatedLine(ctx, "Source URI", "", func(v string) error {
+				if v == "" {
+					return fmt.Errorf("source URI is required")
+				}
+				_, err := parseSourceURI(v)
+				if err != nil {
+					return fmt.Errorf("invalid source: %w", err)
+				}
+				return nil
+			})
 			if err != nil {
 				return r.fail("Failed to read source URI: %v", err)
 			}
@@ -297,11 +311,11 @@ func (r *runner) runProfileNew(ctx context.Context) int {
 		if !storeHasExplicitEncryption(s) {
 			r.promptEncryptionConfig(ctx, cfg, a.storeRef, a.profilesFile)
 		}
-		if err := r.checkOrInitStore(ctx, cfg, a.storeRef, a.profilesFile, checkOrInitOptions{
+		if err := r.checkOrInitStoreWithRecovery(ctx, cfg, a.storeRef, a.profilesFile, checkOrInitOptions{
 			allowMissingSecrets:  true,
 			warnOnMissingSecrets: true,
 			offerInit:            true,
-		}); err != nil {
+		}, true); err != nil {
 			_, _ = fmt.Fprintf(r.errOut, "%v\n", err)
 		}
 	}
@@ -394,22 +408,27 @@ func (r *runner) promptStoreSelection(ctx context.Context, cfg *cloudstic.Profil
 	}
 
 	// Create a new store inline.
-	refName, err := r.promptLine(ctx, "Store reference name", "default-store")
+	refName, err := r.promptValidatedLine(ctx, "Store reference name", "default-store", func(v string) error {
+		if v == "" {
+			return fmt.Errorf("store reference name is required")
+		}
+		return validateRefName("store", v)
+	})
 	if err != nil {
 		return "", false, r.fail("Failed to read store reference name: %v", err)
 	}
-	if refName == "" {
-		return "", false, r.fail("Store reference name is required")
-	}
-	uri, err := r.promptLine(ctx, "Store URI (e.g. s3:bucket/path, local:/path, sftp://host/path)", "")
+	uri, err := r.promptValidatedLine(ctx, "Store URI (e.g. s3:bucket/path, local:/path, sftp://host/path)", "", func(v string) error {
+		if v == "" {
+			return fmt.Errorf("store URI is required")
+		}
+		_, err := parseStoreURI(v)
+		if err != nil {
+			return fmt.Errorf("invalid store URI: %w", err)
+		}
+		return nil
+	})
 	if err != nil {
 		return "", false, r.fail("Failed to read store URI: %v", err)
-	}
-	if uri == "" {
-		return "", false, r.fail("Store URI is required")
-	}
-	if _, err := parseStoreURI(uri); err != nil {
-		return "", false, r.fail("Invalid store URI: %v", err)
 	}
 	cfg.Stores[refName] = cloudstic.ProfileStore{URI: uri}
 	return refName, true, 0
@@ -435,15 +454,14 @@ func (r *runner) promptAuthSelection(ctx context.Context, cfg *cloudstic.Profile
 		return picked, 0
 	}
 
-	refName, err := r.promptLine(ctx, "Auth reference name", provider+"-"+profileName)
+	refName, err := r.promptValidatedLine(ctx, "Auth reference name", provider+"-"+profileName, func(v string) error {
+		if v == "" {
+			return fmt.Errorf("auth reference name is required")
+		}
+		return validateRefName("auth", v)
+	})
 	if err != nil {
 		return "", r.fail("Failed to read auth reference name: %v", err)
-	}
-	if refName == "" {
-		return "", r.fail("Auth reference name is required")
-	}
-	if err := validateRefName("auth", refName); err != nil {
-		return "", r.fail("%v", err)
 	}
 
 	defTokenRef := "config-token://" + provider + "/" + refName

--- a/cmd/cloudstic/cmd_store.go
+++ b/cmd/cloudstic/cmd_store.go
@@ -142,7 +142,12 @@ func (r *runner) runStoreNew(ctx context.Context) int {
 
 	if *name == "" {
 		if r.canPrompt() {
-			v, err := r.promptLine(ctx, "Store reference name", "")
+			v, err := r.promptValidatedLine(ctx, "Store reference name", "", func(v string) error {
+				if v == "" {
+					return fmt.Errorf("store reference name is required")
+				}
+				return validateRefName("store", v)
+			})
 			if err != nil {
 				return r.fail("Failed to read store name: %v", err)
 			}
@@ -175,7 +180,13 @@ func (r *runner) runStoreNew(ctx context.Context) int {
 
 	if *uri == "" || forcePromptURI {
 		if r.canPrompt() {
-			v, err := r.promptLine(ctx, "Store URI", *uri)
+			v, err := r.promptValidatedLine(ctx, "Store URI", *uri, func(v string) error {
+				if v == "" {
+					return fmt.Errorf("store URI is required")
+				}
+				_, err := parseStoreURI(v)
+				return err
+			})
 			if err != nil {
 				return r.fail("Failed to read store URI: %v", err)
 			}
@@ -211,11 +222,11 @@ func (r *runner) runStoreNew(ctx context.Context) int {
 		if forcePromptEncryption || !storeHasExplicitEncryption(s) {
 			r.promptEncryptionConfig(ctx, cfg, *name, *profilesFile)
 		}
-		if err := r.checkOrInitStore(ctx, cfg, *name, *profilesFile, checkOrInitOptions{
+		if err := r.checkOrInitStoreWithRecovery(ctx, cfg, *name, *profilesFile, checkOrInitOptions{
 			allowMissingSecrets:  true,
 			warnOnMissingSecrets: !existedBefore,
 			offerInit:            true,
-		}); err != nil {
+		}, true); err != nil {
 			_, _ = fmt.Fprintf(r.errOut, "%v\n", err)
 		}
 	}
@@ -264,9 +275,9 @@ func (r *runner) runStoreVerify(ctx context.Context) int {
 	if _, ok := cfg.Stores[name]; !ok {
 		return r.fail("Unknown store %q", name)
 	}
-	if err := r.checkOrInitStore(ctx, cfg, name, *profilesFile, checkOrInitOptions{
+	if err := r.checkOrInitStoreWithRecovery(ctx, cfg, name, *profilesFile, checkOrInitOptions{
 		warnOnMissingSecrets: true,
-	}); err != nil {
+	}, false); err != nil {
 		return r.fail("%v", err)
 	}
 	return 0
@@ -309,11 +320,11 @@ func (r *runner) runStoreInit(ctx context.Context) int {
 	if _, ok := cfg.Stores[name]; !ok {
 		return r.fail("Unknown store %q", name)
 	}
-	if err := r.checkOrInitStore(ctx, cfg, name, *profilesFile, checkOrInitOptions{
+	if err := r.checkOrInitStoreWithRecovery(ctx, cfg, name, *profilesFile, checkOrInitOptions{
 		warnOnMissingSecrets: true,
 		offerInit:            true,
 		assumeYes:            *yes,
-	}); err != nil {
+	}, false); err != nil {
 		return r.fail("%v", err)
 	}
 	return 0
@@ -402,6 +413,48 @@ func (r *runner) checkOrInitStore(ctx context.Context, cfg *cloudstic.ProfilesCo
 	}
 	r.printInitResult(result)
 	return nil
+}
+
+func (r *runner) checkOrInitStoreWithRecovery(ctx context.Context, cfg *cloudstic.ProfilesConfig, storeName, profilesFile string, opts checkOrInitOptions, allowSkip bool) error {
+	for {
+		err := r.checkOrInitStore(ctx, cfg, storeName, profilesFile, opts)
+		if err == nil || !r.canPrompt() {
+			return err
+		}
+
+		s := cfg.Stores[storeName]
+		options := []string{"Retry"}
+		loginOption := awsSSOLoginOption(s, err)
+		if loginOption != "" {
+			options = append(options, loginOption)
+		}
+		if allowSkip {
+			options = append(options, "Skip for now")
+		} else {
+			options = append(options, "Abort")
+		}
+
+		_, _ = fmt.Fprintf(r.errOut, "%v\n", err)
+		picked, promptErr := r.promptSelect(ctx, "Store verification failed", options)
+		if promptErr != nil {
+			return err
+		}
+
+		switch picked {
+		case "Retry":
+			continue
+		case "Skip for now":
+			return nil
+		case "Abort":
+			return err
+		case loginOption:
+			if runErr := r.runAWSSSOLogin(ctx, s); runErr != nil {
+				_, _ = fmt.Fprintf(r.errOut, "AWS SSO login failed: %v\n", runErr)
+			}
+		default:
+			return err
+		}
+	}
 }
 
 // promptEncryptionConfig guides the user through encryption configuration
@@ -605,6 +658,52 @@ func verifyStoreEncryptionCredentials(ctx context.Context, g *globalFlags, raw s
 		return err
 	}
 	return nil
+}
+
+func awsSSOLoginOption(s cloudstic.ProfileStore, err error) string {
+	if !isAWSExpiredAuthError(err) {
+		return ""
+	}
+	if s.S3Profile != "" {
+		return fmt.Sprintf("Run aws sso login --profile %s", s.S3Profile)
+	}
+	return "Run aws sso login"
+}
+
+func isAWSExpiredAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, needle := range []string{
+		"sso session has expired",
+		"sso session is expired",
+		"sso session is invalid",
+		"ssoproviderinvalidtoken",
+		"token has expired and refresh failed",
+		"the security token included in the request is expired",
+		"expiredtoken",
+		"expired token",
+		"invalid security token",
+	} {
+		if strings.Contains(msg, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *runner) runAWSSSOLogin(ctx context.Context, s cloudstic.ProfileStore) error {
+	args := []string{"sso", "login"}
+	if s.S3Profile != "" {
+		args = append(args, "--profile", s.S3Profile)
+	}
+	_, _ = fmt.Fprintf(r.errOut, "Running: aws %s\n", strings.Join(args, " "))
+	runFn := r.runInteractiveCmd
+	if runFn == nil {
+		runFn = defaultRunInteractiveCmd
+	}
+	return runFn(ctx, r.stdin, r.out, r.errOut, "aws", args...)
 }
 
 func hasStoreNewOverrideFlags(flagsSet map[string]bool) bool {

--- a/cmd/cloudstic/cmd_store_test.go
+++ b/cmd/cloudstic/cmd_store_test.go
@@ -1056,6 +1056,46 @@ func TestStoreHasExplicitEncryption(t *testing.T) {
 	}
 }
 
+func TestIsAWSExpiredAuthError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "generic", err: errors.New("connection refused"), want: false},
+		{name: "expired token", err: errors.New("ExpiredToken: The security token included in the request is expired"), want: true},
+		{name: "sso invalid", err: errors.New("failed to refresh cached credentials, the SSO session has expired or is invalid"), want: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isAWSExpiredAuthError(tc.err); got != tc.want {
+				t.Fatalf("got %v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAWSSSOLoginOption(t *testing.T) {
+	err := errors.New("failed to refresh cached credentials, the SSO session has expired or is invalid")
+
+	got := awsSSOLoginOption(cloudstic.ProfileStore{URI: "s3:bucket", S3Profile: "work"}, err)
+	if got != "Run aws sso login --profile work" {
+		t.Fatalf("got %q", got)
+	}
+
+	got = awsSSOLoginOption(cloudstic.ProfileStore{URI: "s3:bucket"}, err)
+	if got != "Run aws sso login" {
+		t.Fatalf("got %q", got)
+	}
+
+	got = awsSSOLoginOption(cloudstic.ProfileStore{URI: "s3:bucket"}, errors.New("bucket not found"))
+	if got != "" {
+		t.Fatalf("expected empty option, got %q", got)
+	}
+}
+
 func TestHasStoreNewOverrideFlags(t *testing.T) {
 	if hasStoreNewOverrideFlags(map[string]bool{"name": true}) {
 		t.Fatal("name-only should not count as override")

--- a/cmd/cloudstic/interactive.go
+++ b/cmd/cloudstic/interactive.go
@@ -36,6 +36,23 @@ func (r *runner) promptLine(ctx context.Context, label, defaultValue string) (st
 	return line, nil
 }
 
+func (r *runner) promptValidatedLine(ctx context.Context, label, defaultValue string, validate func(string) error) (string, error) {
+	for {
+		value, err := r.promptLine(ctx, label, defaultValue)
+		if err != nil {
+			return "", err
+		}
+		if validate == nil {
+			return value, nil
+		}
+		if err := validate(value); err != nil {
+			_, _ = fmt.Fprintf(r.errOut, "%v\n", err)
+			continue
+		}
+		return value, nil
+	}
+}
+
 func (r *runner) promptConfirm(ctx context.Context, label string, defaultYes bool) (bool, error) {
 	hint := "y/N"
 	dflt := "n"

--- a/cmd/cloudstic/interactive_test.go
+++ b/cmd/cloudstic/interactive_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestPromptValidatedLine_RetriesUntilValid(t *testing.T) {
+	readEnd, writeEnd, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	defer func() { _ = readEnd.Close() }()
+
+	if _, err := writeEnd.WriteString("bad name!\ngood-name\n"); err != nil {
+		t.Fatalf("WriteString: %v", err)
+	}
+	_ = writeEnd.Close()
+
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{
+		out:    &out,
+		errOut: &errOut,
+		stdin:  readEnd,
+		lineIn: bufio.NewReader(readEnd),
+	}
+
+	got, err := r.promptValidatedLine(context.Background(), "Profile name", "", func(v string) error {
+		return validateRefName("profile", v)
+	})
+	if err != nil {
+		t.Fatalf("promptValidatedLine: %v", err)
+	}
+	if got != "good-name" {
+		t.Fatalf("got %q want good-name", got)
+	}
+	if !strings.Contains(errOut.String(), "invalid profile name") {
+		t.Fatalf("expected validation error in stderr, got: %s", errOut.String())
+	}
+}

--- a/cmd/cloudstic/runner.go
+++ b/cmd/cloudstic/runner.go
@@ -6,23 +6,26 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 )
 
 type runner struct {
-	out      io.Writer
-	errOut   io.Writer
-	client   cloudsticClient
-	noPrompt bool
-	stdin    *os.File
-	lineIn   *bufio.Reader
+	out               io.Writer
+	errOut            io.Writer
+	client            cloudsticClient
+	noPrompt          bool
+	stdin             *os.File
+	lineIn            *bufio.Reader
+	runInteractiveCmd func(context.Context, *os.File, io.Writer, io.Writer, string, ...string) error
 }
 
 func newRunner() *runner {
 	return &runner{
-		out:      os.Stdout,
-		errOut:   os.Stderr,
-		noPrompt: hasGlobalFlag("no-prompt"),
-		stdin:    os.Stdin,
+		out:               os.Stdout,
+		errOut:            os.Stderr,
+		noPrompt:          hasGlobalFlag("no-prompt"),
+		stdin:             os.Stdin,
+		runInteractiveCmd: defaultRunInteractiveCmd,
 	}
 }
 
@@ -66,4 +69,15 @@ func (r *runner) openClient(ctx context.Context, g *globalFlags) error {
 	}
 	r.client = client
 	return nil
+}
+
+func defaultRunInteractiveCmd(ctx context.Context, stdin *os.File, stdout, stderr io.Writer, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	if stdin == nil {
+		stdin = os.Stdin
+	}
+	cmd.Stdin = stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	return cmd.Run()
 }


### PR DESCRIPTION
## Summary
- validate interactive profile, auth, store, and source inputs at prompt time
- add store verification recovery options, including AWS SSO login retries
- cover the new prompt validation and recovery helpers with tests

Closes #169
