### PR TITLE
test: stabilize local volume UUID coverage

### DIFF
--- a/pkg/source/local_source.go
+++ b/pkg/source/local_source.go
@@ -12,6 +12,10 @@ import (
 
 var filepathAbs = filepath.Abs
 
+func normalizeVolumeUUID(uuid string) string {
+	return strings.ToUpper(strings.TrimSpace(uuid))
+}
+
 func (s *LocalSource) Info() core.SourceInfo {
 	hostname, _ := os.Hostname()
 	absPath, _ := filepathAbs(s.rootPath)

--- a/pkg/source/local_source_darwin.go
+++ b/pkg/source/local_source_darwin.go
@@ -45,6 +45,7 @@ func detectVolumeIdentity(path string) (uuid, label, mountPoint string) {
 	} else {
 		uuid = getVolumeUUID(path)
 	}
+	uuid = normalizeVolumeUUID(uuid)
 	label = getVolumeLabel(path)
 	return uuid, label, mountPoint
 }
@@ -98,7 +99,7 @@ func extractPlistValue(data []byte, key string) string {
 			} else if foundKey && t.Name.Local == "string" {
 				var v string
 				if err := d.DecodeElement(&v, &t); err == nil {
-					return strings.ToUpper(v)
+					return v
 				}
 				return ""
 			} else {

--- a/pkg/source/local_source_darwin.go
+++ b/pkg/source/local_source_darwin.go
@@ -99,7 +99,7 @@ func extractPlistValue(data []byte, key string) string {
 			} else if foundKey && t.Name.Local == "string" {
 				var v string
 				if err := d.DecodeElement(&v, &t); err == nil {
-					return v
+					return strings.ToUpper(v)
 				}
 				return ""
 			} else {

--- a/pkg/source/local_source_linux.go
+++ b/pkg/source/local_source_linux.go
@@ -26,6 +26,7 @@ func detectVolumeIdentity(path string) (uuid, label, mountPoint string) {
 	if uuid == "" {
 		uuid = findUUIDForDevice(device)
 	}
+	uuid = normalizeVolumeUUID(uuid)
 	label = findLabelForDevice(device)
 	return uuid, label, mountPoint
 }
@@ -135,7 +136,7 @@ func findUUIDForDevice(device string) string {
 			continue
 		}
 		if filepath.Base(target) == deviceBase {
-			return strings.ToUpper(e.Name())
+			return e.Name()
 		}
 	}
 	return ""
@@ -157,7 +158,7 @@ func findPartUUIDForDevice(device string) string {
 			continue
 		}
 		if filepath.Base(target) == deviceBase {
-			return strings.ToUpper(e.Name())
+			return e.Name()
 		}
 	}
 	return ""

--- a/pkg/source/local_source_volume_test.go
+++ b/pkg/source/local_source_volume_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -33,28 +32,24 @@ func TestDetectVolumeIdentity_TempDir(t *testing.T) {
 	}
 }
 
-func TestDetectVolumeIdentity_ReturnsUppercaseUUID(t *testing.T) {
-	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" && runtime.GOOS != "windows" {
-		t.Skip("UUID detection only implemented on darwin, linux, and windows")
+func TestNormalizeVolumeUUID(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: ""},
+		{name: "already_upper", in: "ABCDEF12-3456-7890-ABCD-EF1234567890", want: "ABCDEF12-3456-7890-ABCD-EF1234567890"},
+		{name: "lowercase", in: "abcdef12-3456-7890-abcd-ef1234567890", want: "ABCDEF12-3456-7890-ABCD-EF1234567890"},
+		{name: "trim_spaces", in: "  abcdef12-3456-7890-abcd-ef1234567890  ", want: "ABCDEF12-3456-7890-ABCD-EF1234567890"},
 	}
 
-	tmpDir, err := os.MkdirTemp("", "cloudstic-case-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
-
-	uuid, _, _ := detectVolumeIdentity(tmpDir)
-	if uuid == "" {
-		t.Skip("no UUID detected for temp dir filesystem")
-	}
-
-	// UUIDs should be uppercase for consistent cross-platform matching.
-	for _, c := range uuid {
-		if c >= 'a' && c <= 'f' {
-			t.Errorf("UUID %q contains lowercase hex; expected uppercase for consistency", uuid)
-			break
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeVolumeUUID(tt.in); got != tt.want {
+				t.Fatalf("normalizeVolumeUUID(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/pkg/source/local_source_windows.go
+++ b/pkg/source/local_source_windows.go
@@ -54,7 +54,7 @@ func detectVolumeIdentity(path string) (uuid, label, mountPoint string) {
 	mountPoint = windows.UTF16ToString(volPath[:])
 
 	label = getVolumeLabel(mountPoint)
-	uuid = getPartitionUUID(mountPoint)
+	uuid = normalizeVolumeUUID(getPartitionUUID(mountPoint))
 
 	return uuid, label, mountPoint
 }
@@ -124,7 +124,7 @@ func getPartitionUUID(mountPoint string) string {
 		return ""
 	}
 
-	return strings.ToUpper(formatGUID(info.GPT.PartitionId))
+	return formatGUID(info.GPT.PartitionId)
 }
 
 func getVolumeNameForMountPoint(mountPoint string) (string, error) {


### PR DESCRIPTION
Summary
- centralize volume UUID normalization in one helper used by all platform-specific detectors
- replace the temp-filesystem uppercase assertion with a deterministic normalization test
- keep the existing temp-dir detection smoke coverage intact

Testing
- env GOCACHE=/tmp/cloudstic-gocache GOMODCACHE=/tmp/cloudstic-gomodcache go test -count=1 ./pkg/source -run TestDetectVolumeIdentity|TestNormalizeVolumeUUID|TestLocalSource_
