### PR TITLE
fix: stabilize SFTP known_hosts generation in tests

### DIFF
--- a/e2e/sftp.go
+++ b/e2e/sftp.go
@@ -194,25 +194,23 @@ func writeKnownHosts(t *testing.T, ctx context.Context, container testcontainers
 				if pubKeyLine == "" {
 					continue
 				}
-				parts := strings.Fields(pubKeyLine)
-				if len(parts) < 2 {
+				pubKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(pubKeyLine))
+				if err != nil {
 					continue
 				}
-				keyTypeAndKey := parts[0] + " " + parts[1]
 
-				// known_hosts format: host1,host2,... keytype key
-				// We include host, 127.0.0.1, and ::1 to be safe against resolution differences.
-				hosts := fmt.Sprintf("[%s]:%s", host, port)
+				// Include common loopback aliases to tolerate host resolution differences in CI.
+				hosts := []string{fmt.Sprintf("[%s]:%s", host, port)}
 				if host != "127.0.0.1" {
-					hosts += fmt.Sprintf(",[127.0.0.1]:%s", port)
+					hosts = append(hosts, fmt.Sprintf("[127.0.0.1]:%s", port))
 				}
 				if host != "::1" {
-					hosts += fmt.Sprintf(",[::1]:%s", port)
+					hosts = append(hosts, fmt.Sprintf("[::1]:%s", port))
 				}
 				if host != "localhost" {
-					hosts += fmt.Sprintf(",[localhost]:%s", port)
+					hosts = append(hosts, fmt.Sprintf("[localhost]:%s", port))
 				}
-				lines = append(lines, fmt.Sprintf("%s %s", hosts, keyTypeAndKey))
+				lines = append(lines, knownhosts.Line(hosts, pubKey))
 			}
 		}
 	}

--- a/pkg/source/sftp_test.go
+++ b/pkg/source/sftp_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pkg/sftp"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
+	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
 )
 
@@ -87,25 +88,22 @@ func writeKnownHosts(t *testing.T, ctx context.Context, container testcontainers
 				if pubKeyLine == "" {
 					continue
 				}
-				parts := strings.Fields(pubKeyLine)
-				if len(parts) < 2 {
+				pubKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(pubKeyLine))
+				if err != nil {
 					continue
 				}
-				keyTypeAndKey := parts[0] + " " + parts[1]
 
-				// known_hosts format: host1,host2,... keytype key
-				// We include host, 127.0.0.1, and ::1 to be safe against resolution differences.
-				hosts := fmt.Sprintf("[%s]:%s", host, port)
+				hosts := []string{fmt.Sprintf("[%s]:%s", host, port)}
 				if host != "127.0.0.1" {
-					hosts += fmt.Sprintf(",[127.0.0.1]:%s", port)
+					hosts = append(hosts, fmt.Sprintf("[127.0.0.1]:%s", port))
 				}
 				if host != "::1" {
-					hosts += fmt.Sprintf(",[::1]:%s", port)
+					hosts = append(hosts, fmt.Sprintf("[::1]:%s", port))
 				}
 				if host != "localhost" {
-					hosts += fmt.Sprintf(",[localhost]:%s", port)
+					hosts = append(hosts, fmt.Sprintf("[localhost]:%s", port))
 				}
-				lines = append(lines, fmt.Sprintf("%s %s", hosts, keyTypeAndKey))
+				lines = append(lines, knownhosts.Line(hosts, pubKey))
 			}
 		}
 	}

--- a/pkg/store/sftp_test.go
+++ b/pkg/store/sftp_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
 )
 
 // startSFTPContainer spins up an OpenSSH SFTP server using the atmoz/sftp
@@ -62,25 +64,22 @@ func writeKnownHosts(t *testing.T, ctx context.Context, container testcontainers
 				if pubKeyLine == "" {
 					continue
 				}
-				parts := strings.Fields(pubKeyLine)
-				if len(parts) < 2 {
+				pubKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(pubKeyLine))
+				if err != nil {
 					continue
 				}
-				keyTypeAndKey := parts[0] + " " + parts[1]
 
-				// known_hosts format: host1,host2,... keytype key
-				// We include host, 127.0.0.1, and ::1 to be safe against resolution differences.
-				hosts := fmt.Sprintf("[%s]:%s", host, port)
+				hosts := []string{fmt.Sprintf("[%s]:%s", host, port)}
 				if host != "127.0.0.1" {
-					hosts += fmt.Sprintf(",[127.0.0.1]:%s", port)
+					hosts = append(hosts, fmt.Sprintf("[127.0.0.1]:%s", port))
 				}
 				if host != "::1" {
-					hosts += fmt.Sprintf(",[::1]:%s", port)
+					hosts = append(hosts, fmt.Sprintf("[::1]:%s", port))
 				}
 				if host != "localhost" {
-					hosts += fmt.Sprintf(",[localhost]:%s", port)
+					hosts = append(hosts, fmt.Sprintf("[localhost]:%s", port))
 				}
-				lines = append(lines, fmt.Sprintf("%s %s", hosts, keyTypeAndKey))
+				lines = append(lines, knownhosts.Line(hosts, pubKey))
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- stop hand-building known_hosts lines in SFTP test helpers
- parse container host public keys with ssh.ParseAuthorizedKey
- generate canonical known_hosts entries with knownhosts.Line for e2e and package SFTP tests

## Why
The ubuntu CI failure on main was caused by a malformed known_hosts entry in the SFTP test fixture, which broke the sftp-to-sftp integrity scenario during init.

## Validation
- env GOCACHE=/tmp/cloudstic-gocache GOMODCACHE=/tmp/cloudstic-gomodcache go test -count=1 ./e2e -run 'TestCLI_Feature_IntegrityCheck'
- env GOCACHE=/tmp/cloudstic-gocache GOMODCACHE=/tmp/cloudstic-gomodcache go test -count=1 ./pkg/store ./pkg/source -run 'TestSFTP(Store|Source)'
- env GOCACHE=/tmp/cloudstic-gocache GOMODCACHE=/tmp/cloudstic-gomodcache golangci-lint run ./e2e ./pkg/store ./pkg/source