### PR TITLE
Fix zsh store completion definition

### DIFF
--- a/cmd/cloudstic/completion.go
+++ b/cmd/cloudstic/completion.go
@@ -265,6 +265,12 @@ func completionZsh(w io.Writer) {
 
 # zsh completion for cloudstic
 
+_cloudstic_store_prefixes() {
+    local -a values
+    values=('local:' 's3:' 'b2:' 'sftp://')
+    compadd -Q -S '' -X 'store URI prefix' -- "${values[@]}"
+}
+
 _cloudstic() {
     local -a commands
     commands=(
@@ -290,7 +296,7 @@ _cloudstic() {
 
     local -a global_flags
     global_flags=(
-        '-store[Storage backend URI (local:<path>, s3:<bucket>[/<prefix>], b2:<bucket>[/<prefix>], sftp://[user@]host[:port]/<path>)]:uri:'
+        '-store[Storage backend URI]:uri:_cloudstic_store_prefixes'
         '-profile[Profile name from profiles.yaml]:name:'
         '-profiles-file[Path to profiles YAML file]:path:_files'
         '-s3-endpoint[S3 compatible endpoint URL]:url:'
@@ -320,7 +326,6 @@ _cloudstic() {
         '-json[Write command result as JSON to stdout]'
         '-debug[Log every store request]'
     )
-
     # Check if a subcommand has been given
     local cmd
     local -i i=2
@@ -692,7 +697,7 @@ _cloudstic() {
     esac
 }
 
-_cloudstic "$@"
+compdef _cloudstic cloudstic
 `)
 }
 

--- a/cmd/cloudstic/completion_test.go
+++ b/cmd/cloudstic/completion_test.go
@@ -56,7 +56,8 @@ func TestCompletionZsh(t *testing.T) {
 	for _, marker := range []string{
 		"#compdef cloudstic",
 		"_cloudstic()",
-		`_cloudstic "$@"`,
+		"_cloudstic_store_prefixes()",
+		"compdef _cloudstic cloudstic",
 		// Commands with descriptions
 		"init:Initialize a new repository",
 		"backup:Create a new backup snapshot",
@@ -78,7 +79,7 @@ func TestCompletionZsh(t *testing.T) {
 		"passwd:Change the repository password",
 		"-new-password[New repository password]",
 		// Global flags with descriptions
-		"-store[Storage backend URI",
+		"-store[Storage backend URI]:uri:_cloudstic_store_prefixes",
 		"-verbose[Log detailed operations]",
 		// Subcommand-specific flags
 		"-add-recovery-key[Generate a 24-word recovery key]",


### PR DESCRIPTION
## Summary
- fix the released zsh completion bug caused by an invalid -store option definition
- replace the malformed zsh store spec with a valid value completion restricted to local:, s3:, b2:, and sftp://
- update the zsh completion test to lock in the valid store completion spec

## Testing
- go test -count=1 ./cmd/cloudstic -run '^TestCompletionZsh$'
