### PR TITLE
Model TUI actions in dashboard state

### DIFF
--- a/cmd/cloudstic/cmd_tui_input.go
+++ b/cmd/cloudstic/cmd_tui_input.go
@@ -142,6 +142,9 @@ func runSelectedTUIAction(ctx context.Context, r *runner, profilesFile string, d
 	if !ok {
 		return fmt.Errorf("no profile selected")
 	}
+	if action, ok := profileAction(profile, "b"); !ok || !action.Enabled {
+		return fmt.Errorf("backup action is not available")
+	}
 	return tuiRunProfileAction(ctx, r, profilesFile, profile, log)
 }
 
@@ -149,6 +152,9 @@ func runSelectedTUICheck(ctx context.Context, r *runner, profilesFile string, da
 	profile, ok := selectedTUIProfile(dashboard)
 	if !ok {
 		return fmt.Errorf("no profile selected")
+	}
+	if action, ok := profileAction(profile, "c"); !ok || !action.Enabled {
+		return fmt.Errorf("check action is not available")
 	}
 	return tuiRunProfileCheck(ctx, r, profilesFile, profile, log)
 }
@@ -167,4 +173,13 @@ func selectedTUIProfile(d tui.Dashboard) (tui.ProfileCard, bool) {
 
 func profileNeedsInit(profile tui.ProfileCard) bool {
 	return profile.StoreHealth == tui.StoreHealthNotInitialized
+}
+
+func profileAction(profile tui.ProfileCard, key string) (tui.ProfileAction, bool) {
+	for _, action := range profile.Actions {
+		if action.Key == key {
+			return action, true
+		}
+	}
+	return tui.ProfileAction{}, false
 }

--- a/cmd/cloudstic/cmd_tui_test.go
+++ b/cmd/cloudstic/cmd_tui_test.go
@@ -242,7 +242,17 @@ func TestRunTUI_BackupActionRunsSelectedProfileAction(t *testing.T) {
 			StoreCount:      1,
 			SelectedProfile: "documents",
 			Profiles: []tui.ProfileCard{
-				{Name: "documents", Source: "local:/tmp/Documents", StoreRef: "remote", Enabled: true, Status: tui.ProfileStatusReady},
+				{
+					Name:     "documents",
+					Source:   "local:/tmp/Documents",
+					StoreRef: "remote",
+					Enabled:  true,
+					Status:   tui.ProfileStatusReady,
+					Actions: []tui.ProfileAction{
+						{Kind: tui.ActionKindBackup, Key: "b", Label: "Press b to run backup", Enabled: true},
+						{Kind: tui.ActionKindCheck, Key: "c", Label: "Press c to run repository check", Enabled: true},
+					},
+				},
 			},
 		}, nil
 	}
@@ -308,7 +318,18 @@ func TestRunTUI_CheckActionRunsSelectedProfileCheck(t *testing.T) {
 			StoreCount:      1,
 			SelectedProfile: "documents",
 			Profiles: []tui.ProfileCard{
-				{Name: "documents", Source: "local:/tmp/Documents", StoreRef: "remote", Enabled: true, Status: tui.ProfileStatusReady, StoreHealth: tui.StoreHealthReady},
+				{
+					Name:        "documents",
+					Source:      "local:/tmp/Documents",
+					StoreRef:    "remote",
+					Enabled:     true,
+					Status:      tui.ProfileStatusReady,
+					StoreHealth: tui.StoreHealthReady,
+					Actions: []tui.ProfileAction{
+						{Kind: tui.ActionKindBackup, Key: "b", Label: "Press b to run backup", Enabled: true},
+						{Kind: tui.ActionKindCheck, Key: "c", Label: "Press c to run repository check", Enabled: true},
+					},
+				},
 			},
 		}, nil
 	}
@@ -465,7 +486,18 @@ func TestTUISession_HandleActionRunRefreshesDashboard(t *testing.T) {
 			StoreCount:      1,
 			SelectedProfile: "docs",
 			Profiles: []tui.ProfileCard{
-				{Name: "docs", Source: "local:/docs", StoreRef: "remote", Enabled: true, Status: tui.ProfileStatusReady, LastBackup: "2026-04-03 12:00"},
+				{
+					Name:       "docs",
+					Source:     "local:/docs",
+					StoreRef:   "remote",
+					Enabled:    true,
+					Status:     tui.ProfileStatusReady,
+					LastBackup: "2026-04-03 12:00",
+					Actions: []tui.ProfileAction{
+						{Kind: tui.ActionKindBackup, Key: "b", Label: "Press b to run backup", Enabled: true},
+						{Kind: tui.ActionKindCheck, Key: "c", Label: "Press c to run repository check", Enabled: true},
+					},
+				},
 			},
 		}, nil
 	}
@@ -478,7 +510,17 @@ func TestTUISession_HandleActionRunRefreshesDashboard(t *testing.T) {
 	s := newTUISession(&runner{out: &out, stdoutFile: os.Stdout, stdin: os.Stdin}, "profiles.yaml", tui.Dashboard{
 		SelectedProfile: "docs",
 		Profiles: []tui.ProfileCard{
-			{Name: "docs", Source: "local:/docs", StoreRef: "remote", Enabled: true, Status: tui.ProfileStatusReady},
+			{
+				Name:     "docs",
+				Source:   "local:/docs",
+				StoreRef: "remote",
+				Enabled:  true,
+				Status:   tui.ProfileStatusReady,
+				Actions: []tui.ProfileAction{
+					{Kind: tui.ActionKindBackup, Key: "b", Label: "Press b to run backup", Enabled: true},
+					{Kind: tui.ActionKindCheck, Key: "c", Label: "Press c to run repository check", Enabled: true},
+				},
+			},
 		},
 	})
 

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -20,6 +20,22 @@ type Dashboard struct {
 	Profiles        []ProfileCard
 }
 
+type ActionKind string
+
+const (
+	ActionKindInit   ActionKind = "init"
+	ActionKindBackup ActionKind = "backup"
+	ActionKindCheck  ActionKind = "check"
+)
+
+type ProfileAction struct {
+	Kind    ActionKind
+	Key     string
+	Label   string
+	Enabled bool
+	Reason  string
+}
+
 type ProfileStatus string
 
 const (
@@ -64,6 +80,7 @@ type ProfileCard struct {
 	BackupState BackupFreshness
 	LastBackup  string
 	LastRef     string
+	Actions     []ProfileAction
 }
 
 type StoreProbe struct {
@@ -141,9 +158,56 @@ func BuildDashboard(cfg *engine.ProfilesConfig, probes map[string]StoreProbe) Da
 			BackupState: backupState,
 			LastBackup:  lastBackup,
 			LastRef:     lastRef,
+			Actions:     deriveProfileActions(status, storeHealth),
 		})
 	}
 	return d
+}
+
+func deriveProfileActions(status ProfileStatus, storeHealth StoreHealth) []ProfileAction {
+	switch {
+	case status == ProfileStatusDisabled:
+		return []ProfileAction{{
+			Kind:    ActionKindBackup,
+			Key:     "b",
+			Label:   "No actions available for disabled profiles",
+			Enabled: false,
+			Reason:  "profile disabled",
+		}}
+	case status == ProfileStatusError:
+		return []ProfileAction{{
+			Kind:    ActionKindBackup,
+			Key:     "b",
+			Label:   "Fix profile configuration before running actions",
+			Enabled: false,
+			Reason:  "profile configuration error",
+		}}
+	case storeHealth == StoreHealthNotInitialized:
+		return []ProfileAction{{
+			Kind:    ActionKindInit,
+			Key:     "b",
+			Label:   "Press b to initialize the repository",
+			Enabled: true,
+		}, {
+			Kind:    ActionKindCheck,
+			Key:     "c",
+			Label:   "Repository check unavailable until initialization",
+			Enabled: false,
+			Reason:  "repository not initialized",
+		}}
+	default:
+		return []ProfileAction{{
+			Kind:    ActionKindBackup,
+			Key:     "b",
+			Label:   "Press b to run backup",
+			Enabled: true,
+		}, {
+			Kind:    ActionKindCheck,
+			Key:     "c",
+			Label:   "Press c to run repository check",
+			Enabled: true,
+		}}
+	}
 }
 
 func profileStatus(cfg *engine.ProfilesConfig, p engine.BackupProfile, probe StoreProbe) (ProfileStatus, string) {

--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -76,8 +76,14 @@ func TestBuildDashboard_SortsProfilesAndCountsSections(t *testing.T) {
 	if got.Profiles[0].BackupState != BackupFreshnessRecent {
 		t.Fatalf("backup state = %q want recent", got.Profiles[0].BackupState)
 	}
+	if len(got.Profiles[0].Actions) != 2 || got.Profiles[0].Actions[0].Kind != ActionKindBackup || !got.Profiles[0].Actions[0].Enabled {
+		t.Fatalf("unexpected actions: %+v", got.Profiles[0].Actions)
+	}
 	if got.Profiles[1].Status != ProfileStatusDisabled {
 		t.Fatalf("status = %q want disabled", got.Profiles[1].Status)
+	}
+	if len(got.Profiles[1].Actions) != 1 || got.Profiles[1].Actions[0].Enabled {
+		t.Fatalf("unexpected disabled actions: %+v", got.Profiles[1].Actions)
 	}
 }
 
@@ -111,6 +117,12 @@ func TestBuildDashboard_NormalizesStoreProbeErrors(t *testing.T) {
 	}
 	if got.Profiles[0].StoreHealth != StoreHealthNotInitialized {
 		t.Fatalf("store health=%q want repository not initialized", got.Profiles[0].StoreHealth)
+	}
+	if len(got.Profiles[0].Actions) != 2 || got.Profiles[0].Actions[0].Kind != ActionKindInit || !got.Profiles[0].Actions[0].Enabled {
+		t.Fatalf("unexpected actions: %+v", got.Profiles[0].Actions)
+	}
+	if got.Profiles[0].Actions[1].Enabled {
+		t.Fatalf("check should be disabled until init: %+v", got.Profiles[0].Actions)
 	}
 }
 

--- a/internal/tui/shell.go
+++ b/internal/tui/shell.go
@@ -198,8 +198,8 @@ func renderSelectedProfile(d Dashboard) []string {
 		lines = append(lines, profileDetailLine("Status", profile.StatusNote))
 	}
 	lines = append(lines, "")
-	for _, action := range selectedActionLines(profile) {
-		lines = append(lines, fmt.Sprintf("%sAction%s  %s", ui.Dim, ui.Reset, action))
+	for _, action := range profile.Actions {
+		lines = append(lines, fmt.Sprintf("%sAction%s  %s", ui.Dim, ui.Reset, actionLabel(action)))
 	}
 	return lines
 }
@@ -428,17 +428,11 @@ func selectedProfileCard(d Dashboard) (ProfileCard, bool) {
 	return d.Profiles[0], true
 }
 
-func selectedActionLines(profile ProfileCard) []string {
-	if profile.StoreHealth == StoreHealthNotInitialized {
-		return []string{"Press b to initialize the repository"}
+func actionLabel(action ProfileAction) string {
+	if action.Enabled {
+		return action.Label
 	}
-	if profile.Status == ProfileStatusDisabled {
-		return []string{"No actions available for disabled profiles"}
-	}
-	if profile.Status == ProfileStatusError {
-		return []string{"Fix profile configuration before running actions"}
-	}
-	return []string{"Press b to run backup", "Press c to run repository check"}
+	return fmt.Sprintf("%s%s%s", ui.Dim, action.Label, ui.Reset)
 }
 
 func trimSnapshotRef(ref string) string {

--- a/internal/tui/shell_test.go
+++ b/internal/tui/shell_test.go
@@ -22,6 +22,10 @@ func TestRenderDashboard(t *testing.T) {
 				BackupState: BackupFreshnessRecent,
 				LastBackup:  "2026-04-03 11:05",
 				LastRef:     "snapshot/abc123",
+				Actions: []ProfileAction{
+					{Kind: ActionKindBackup, Key: "b", Label: "Press b to run backup", Enabled: true},
+					{Kind: ActionKindCheck, Key: "c", Label: "Press c to run repository check", Enabled: true},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- add explicit TUI profile actions to the dashboard model
- derive init/backup/check availability during dashboard build
- update the renderer and input path to consume typed actions directly

## Testing
- env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./internal/app ./cmd/cloudstic ./internal/tui
- env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./internal/app ./cmd/cloudstic ./internal/tui

Closes #215