### PR TITLE
Refresh AGENTS.md and add CLAUDE.md importer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,13 +43,21 @@ Docker-based hermetic tests (MinIO store, SFTP source/store) are automatically s
 ### Package Layout
 
 - `client.go` (root) — Public `Client` API. Re-exports types from internal packages using Go type aliases. This is the library entry point for programmatic use.
-- `cmd/cloudstic/` — CLI entry point. Each subcommand (`init`, `backup`, `restore`, `list`, `ls`, `prune`, `forget`, `diff`, `break-lock`, `add-recovery-key`) is a `run*()` function in `main.go`. Uses Go's `flag` package (no cobra/viper).
+- `cmd/cloudstic/` — CLI entry point (`package main`). `main.go`'s `runCmd()` dispatches each subcommand to a `run*()` function that lives in its own `cmd_*.go` file (e.g. `cmd_backup.go`, `cmd_key.go`). Subcommands: `init`, `backup`, `restore`, `list`, `ls`, `prune`, `forget`, `diff`, `break-lock`, `key` (with `list`/`add-recovery`/`passwd`), `check`, `cat`, `profile`, `auth`, `store`, `source`, `setup`, `tui`, `completion`. Uses Go's `flag` package (no cobra/viper); `reorderArgs()` in `flags.go` allows flags after positional args. The interactive terminal UI lives in `cmd_tui*.go`.
+  - Each command splits into a thin `run*()` entry (parses flags, opens the client, calls `os.Exit`) and a `(r *runner) exec*()` method holding the testable logic. The `runner` struct (`runner.go`) carries `out`/`errOut` writers and the client, so command output is capturable in tests.
+  - `cloudsticClient` (`client_iface.go`) is the interface `runner` depends on — satisfied by the real `*Client` and by `stubClient` (`stub_client_test.go`) in unit tests.
 - `internal/engine/` — Business logic for each operation (backup, restore, prune, forget, diff, list). Each operation has a `*Manager` struct (e.g. `BackupManager`, `RestoreManager`) with a `Run(ctx)` method.
 - `internal/core/` — Domain types: `Snapshot`, `FileMeta`, `Content`, `HAMTNode`, `RepoConfig`, `SourceInfo`. Also contains `ComputeJSONHash` which is the canonical content-addressing function.
 - `internal/hamt/` — Persistent Merkle Hash Array Mapped Trie. Backed by the object store. Used to track file→filemeta mappings across snapshots. `TransactionalStore` buffers writes and flushes only reachable nodes.
 - `pkg/store/` — `ObjectStore` interface and all implementations. Also contains `Source` and `IncrementalSource` interfaces for backup data sources.
 - `pkg/crypto/` — AES-256-GCM encryption/decryption, HKDF key derivation, BIP39 mnemonic recovery keys.
-- `internal/ui/` — Console progress reporting and terminal helpers.
+- `internal/app/` — Orchestration layer shared by the CLI and TUI. `TUIService` sits on top of a `TUIBackend` interface (satisfied by the real client, stubbable in tests) and owns profile listing, health checks, and backup actions.
+- `internal/tui/` — Interactive terminal dashboard built on Bubble Tea (`dashboard.go`, `shell.go`). The `cmd_tui*.go` files in `cmd/cloudstic/` only wire it to `internal/app`; the widget/state logic lives here.
+- `internal/ui/` — Non-interactive console progress reporting and terminal helpers (used by plain CLI commands, distinct from the `internal/tui` dashboard).
+- `internal/secretref/` — Resolves `scheme://path` secret references through pluggable, platform-specific backends (see Secret References below).
+- `pkg/keychain/` — OS keychain integration and encryption key-slot helpers.
+- `internal/paths/` — Config-directory and token-path resolution (`ConfigDir()`), plus `MachineID()`.
+- `internal/logger/`, `internal/retry/`, `internal/sftp/` — Structured logging, retry/backoff helpers, and shared SFTP client used by both the SFTP source and store.
 
 ### Store Layering (Decorator Pattern)
 
@@ -100,6 +108,51 @@ All objects are addressed by `<type>/<sha256>`:
 
 Routes metadata objects to PostgreSQL (with RLS tenant isolation via `SET LOCAL cloudstic.tenant_id`) and chunk data to B2. Metadata is also written through to B2 for disaster recovery.
 
+### Configuration & Profiles
+
+- **Config directory** — resolved by `internal/paths.ConfigDir()`: `CLOUDSTIC_CONFIG_DIR` if set, else `os.UserConfigDir()/cloudstic` (e.g. `~/.config/cloudstic`), created `0700`. Holds the profiles file, OAuth tokens, etc.
+- **Profiles** — a profile bundles a named source + store (+ secret refs) so users run `cloudstic backup -profile <name>` instead of re-specifying flags. Persisted via `LoadProfilesFile`/`SaveProfilesFile` (root package, implemented in `internal/engine/profiles.go`). Managed from the CLI (`cmd_profile.go`, `cmd_setup.go`) and the TUI. See RFC `rfcs/0010-backup-profiles.md`. The active profile / file come from `CLOUDSTIC_PROFILE` / `CLOUDSTIC_PROFILES_FILE`.
+
+### Secret References
+
+Store and source credentials can be stored as `scheme://path` references rather than inline secrets, resolved by `internal/secretref`. Each scheme is a pluggable, platform-gated backend:
+
+- `env://VAR` — read from an environment variable (read-only).
+- `keychain://…` — macOS Keychain (`*_darwin.go`).
+- `secret-service://…` — Linux Secret Service / libsecret (`*_linux.go`).
+- `wincred://…` — Windows Credential Manager (`*_windows.go`).
+- file-backed refs for a writable, cross-platform fallback.
+
+Backends expose `Load`/`Save`/`Delete`; unsupported operations return a typed `secretref.Error` (`KindInvalidRef`, `KindNotFound`, `KindBackendUnavailable`). Non-native backends compile to `*_stub.go` no-ops on other platforms.
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `CLOUDSTIC_PASSWORD` | Password for the password-based key slot (non-interactive unlock). |
+| `CLOUDSTIC_ENCRYPTION_KEY` | Raw master key (base64), bypassing key slots. |
+| `CLOUDSTIC_RECOVERY_KEY` | BIP39 recovery mnemonic for unlock/recovery. |
+| `CLOUDSTIC_KMS_KEY_ARN` / `CLOUDSTIC_KMS_REGION` / `CLOUDSTIC_KMS_ENDPOINT` | AWS KMS envelope-encryption config for `kms-platform` slots. |
+| `CLOUDSTIC_STORE` / `CLOUDSTIC_SOURCE` | Default store / source URI when no flag is given. |
+| `CLOUDSTIC_PROFILE` / `CLOUDSTIC_PROFILES_FILE` | Active backup profile and override for the profiles file path. |
+| `CLOUDSTIC_CONFIG_DIR` | Override the config/state directory (default `~/.config/cloudstic`). |
+| `CLOUDSTIC_{STORE,SOURCE}_SFTP_{PASSWORD,KEY,KNOWN_HOSTS,INSECURE}` | SFTP auth/host-key config for the store and source backends. |
+| `CLOUDSTIC_DISABLE_PACKFILE` | Disable the `PackStore` small-object bundling layer. |
+| `CLOUDSTIC_E2E_MODE` | E2E test mode: `hermetic` (default), `live`, or `all` (see below). |
+
+`CLOUDSTIC_TEST_*` and `CLOUDSTIC_VOLUME_UUID` are test-only knobs, not user-facing.
+
+## Documentation Map
+
+Deep-dive docs live in `docs/` and design records in `rfcs/`:
+
+- `docs/spec.md` — format/protocol specification.
+- `docs/storage-model.md` — object model and store layering.
+- `docs/encryption.md` — key hierarchy, slots, and the encryption model.
+- `docs/sources.md` — supported data sources and their identity model.
+- `docs/user-guide.md` — end-user command reference.
+- `rfcs/NNNN-*.md` — numbered design proposals; add a new one for substantial features (see RFC 0010 for the profiles design as a template).
+
 ## Development Best Practices
 
 ### When Adding New Features
@@ -124,10 +177,11 @@ When implementing new functionality, always consider the following:
    - Follow the pattern: define types/options, add a `Client.*()` method, implement in `internal/engine/` if complex.
 
 4. **CLI Integration** — For new commands:
-   - Add a `run*()` function in `cmd/cloudstic/main.go`.
-   - Add the command to the switch case in `runCmd()`.
-   - Add command documentation to `printUsage()`.
-   - Use the `reorderArgs()` helper for proper flag parsing.
+   - Add a `cmd_<name>.go` file with a thin `run<Name>()` entry plus a testable `(r *runner) exec<Name>()` method (see existing `cmd_*.go` for the pattern).
+   - Add the command to the switch in `runCmd()` in `main.go`.
+   - Add command documentation to `printUsage()` in `usage.go`.
+   - Use the `reorderArgs()` helper (`flags.go`) so flags may follow positional args.
+   - Write output via `r.out`/`r.errOut` (not `fmt.Print`) so it is capturable, and unit-test against `stubClient`.
 
 5. **Error Handling** — Return descriptive errors:
    - Wrap errors with context using `fmt.Errorf("context: %w", err)`.
@@ -149,3 +203,70 @@ Markdown files are linted with `markdownlint` (rules from `.markdownlint.json`).
 - E2E tests require Docker for Testcontainers (MinIO, SFTP). They skip gracefully if Docker is unavailable.
 - Use `-race` flag during development to catch race conditions.
 - Hermetic tests (default) use local filesystem + containers; no cloud credentials needed.
+
+## Creating GitHub Issues
+
+Create issues with `gh issue create` against `Cloudstic/cli`. Match the existing house style (see #155, #250–#253 as references).
+
+**Body structure** — use these four Markdown sections, in order:
+
+```markdown
+## Context
+Current state and why it matters. Reference concrete files (and functions) with
+backtick paths, e.g. `cmd/cloudstic/cmd_backup.go`. Cross-link related issues
+with `#NNN` when relevant.
+
+## Goal
+One or two sentences on the desired end state.
+
+## Scope
+- bullet list of the concrete changes to make
+
+## Acceptance Criteria
+- bullet list of verifiable outcomes
+- always end with the test and lint commands that must pass, scoped to the
+  touched packages, e.g.
+- `go test ./cmd/cloudstic` passes
+- `golangci-lint run ./cmd/cloudstic/...` passes
+```
+
+**Labels** — apply exactly one *type* label plus one or more `area/*` labels:
+
+- Type (pick one): `bug`, `enhancement`, `refactor`, `tech debt`, `chore`, `test`, `documentation`, `rfc`, `tracking`
+- Area: `area/cli`, `area/core`, `area/tui`, `area/completion`, `area/onboarding`, `area/ci`
+
+**Titles** — short, imperative, no trailing period. Prefix with an area word when it aids scanning (e.g. `TUI: ...`); otherwise lead with the verb (`Add ...`, `Convert ...`, `Separate ...`, `Refactor ...`).
+
+Do not invent new labels — reuse what `gh label list` returns.
+
+## Creating Pull Requests
+
+Open PRs with `gh pr create` against `Cloudstic/cli`. Match the existing house style (see #214, #228, #236, #237 as references).
+
+**Branch names** — `<type>/<kebab-slug>`, where the type mirrors the label vocabulary: `feat/`, `refactor/`, `test/`, `chore/`, `fix/`, `docs/` (e.g. `feat/tui-profile-history`, `refactor/tui-profile-modal-state`). Dependabot branches (`dependabot/...`) are machine-generated — leave them alone.
+
+**Titles** — same conventions as issues: short, imperative, no trailing period. Prefix with an area word when it aids scanning (e.g. `TUI: ...`); otherwise lead with the verb (`Add ...`, `Refactor ...`, `Fix ...`). Conventional-commit prefixes (`feat:`, `chore:`) are also acceptable.
+
+**Body structure** — two Markdown sections:
+
+```markdown
+## Summary
+- bullet list of the concrete changes, imperative voice
+
+<link line: `Closes #NNN`, `Part of #NNN`, or `Fixes #NNN`>
+
+## Verification
+- <exact test command run, scoped to the touched packages>
+- <exact lint command run, scoped to the touched packages>
+```
+
+- Keep the `Summary` bullets high-signal — what changed and why, not a file-by-file diff.
+- The link line ties the PR to its issue; omit it only for standalone work.
+- Under `Verification`, paste the **exact commands you ran**, scoped to the packages you touched, using the repo's cache-env prefixes so they reproduce in CI:
+
+```bash
+env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./cmd/cloudstic ./internal/tui
+env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./cmd/cloudstic ./internal/tui
+```
+
+Apply the same *type* + `area/*` labels described above; the type usually matches the branch prefix.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# cloudstic-cli
+
+Guidance for this repo lives in a single source of truth, `AGENTS.md`, so that
+every agent tool (Claude Code, Codex, Cursor, …) reads the same instructions.
+Claude Code loads it via the import below.
+
+@AGENTS.md


### PR DESCRIPTION
## Summary
- fix the stale `cmd/cloudstic` CLI section: commands now live in per-command `cmd_*.go` files dispatched by `runCmd()`, split into thin `run*()` entries and testable `(r *runner) exec*()` methods against the `cloudsticClient` interface; corrected the command list (`add-recovery-key` → `key add-recovery`, added `check`/`cat`/`profile`/`auth`/`store`/`source`/`setup`/`tui`/`completion`)
- document previously-undocumented packages: `internal/app`, `internal/tui`, `internal/secretref`, `pkg/keychain`, `internal/paths`, `internal/logger`, `internal/retry`, `internal/sftp`
- add Configuration & Profiles, Secret References, Environment Variables, and a Documentation Map (`docs/` + `rfcs/`) sections
- add Creating GitHub Issues (moved out of `CLAUDE.md`) and Creating Pull Requests sections capturing the repo's house style
- add `CLAUDE.md` as a thin `@AGENTS.md` importer so Claude Code loads the same single source of truth other agent tools already read

Docs-only change; no code touched.

## Verification
- `npx markdownlint-cli2 "AGENTS.md" "CLAUDE.md"` — 0 issues