### PR TITLE
fix: time-bomb TUI dashboard freshness test

### DIFF
--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -40,8 +40,10 @@ func TestBuildDashboard_SortsProfilesAndCountsSections(t *testing.T) {
 			Status: "ok",
 			Snapshots: []engine.SnapshotEntry{
 				{
-					Ref:     "snapshot/abc",
-					Created: mustTime(t, "2026-04-03T10:30:00Z"),
+					Ref: "snapshot/abc",
+					// Relative to now so the "recent" freshness assertion below
+					// stays valid over time (see deriveBackupState's 7-day window).
+					Created: time.Now().Add(-1 * time.Hour),
 					Snap: core.Snapshot{
 						Source: &core.SourceInfo{Type: "local", Path: "/tmp/alpha"},
 					},


### PR DESCRIPTION
## Summary

- Make `TestBuildDashboard_SortsProfilesAndCountsSections` use a snapshot timestamp relative to `time.Now()` instead of a hardcoded `2026-04-03` date.
- The test asserted `BackupState == recent`, but `deriveBackupState` (`internal/tui/dashboard.go`) only returns `recent` within a 7-day window. Once that window elapsed the test began getting `stale`, failing the Ubuntu `Run Unit Tests` step on every PR (which also cancels the macOS matrix job).

## Verification

- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./internal/tui` passes
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./internal/tui/...` passes