### PR TITLE
refactor(cli): thread signal-aware context through commands

### DIFF
--- a/cmd/cloudstic/cmd_backup.go
+++ b/cmd/cloudstic/cmd_backup.go
@@ -112,7 +112,7 @@ func (r *runner) runBackup(ctx context.Context) int {
 	}
 
 	if a.profile != "" || a.allProfiles {
-		return r.runBackupWithProfiles(a)
+		return r.runBackupWithProfiles(ctx, a)
 	}
 
 	if a.authRef != "" {
@@ -129,10 +129,10 @@ func (r *runner) runBackup(ctx context.Context) int {
 		}
 	}
 
-	return r.runSingleBackup(a)
+	return r.runSingleBackup(ctx, a)
 }
 
-func (r *runner) runSingleBackup(a *backupArgs) int {
+func (r *runner) runSingleBackup(ctx context.Context, a *backupArgs) int {
 	if err := ensureDefaultAuthRefForCloudBackup(a); err != nil {
 		return r.fail("Failed to prepare auth settings: %v", err)
 	}
@@ -141,8 +141,6 @@ func (r *runner) runSingleBackup(a *backupArgs) int {
 	if err != nil {
 		return r.fail("Failed to read exclude file: %v", err)
 	}
-
-	ctx := context.Background()
 
 	src, err := initSource(ctx, initSourceOptions{
 		sourceURI:         a.sourceURI,
@@ -278,7 +276,7 @@ func ensureDefaultAuthRefForCloudBackup(a *backupArgs) error {
 	return nil
 }
 
-func (r *runner) runBackupWithProfiles(base *backupArgs) int {
+func (r *runner) runBackupWithProfiles(ctx context.Context, base *backupArgs) int {
 	cfg, err := cloudstic.LoadProfilesFile(base.profilesFile)
 	if err != nil {
 		return r.fail("Failed to load profiles: %v", err)
@@ -313,7 +311,7 @@ func (r *runner) runBackupWithProfiles(base *backupArgs) int {
 		}
 		_, _ = fmt.Fprintf(r.out, "\n== Running profile %s ==\n", name)
 		r.client = nil // each profile may target a different store
-		if code := r.runSingleBackup(effective); code != 0 {
+		if code := r.runSingleBackup(ctx, effective); code != 0 {
 			failures++
 			if !base.allProfiles {
 				return code

--- a/cmd/cloudstic/cmd_breaklock.go
+++ b/cmd/cloudstic/cmd_breaklock.go
@@ -25,7 +25,7 @@ func (r *runner) runBreakLock(ctx context.Context) int {
 		return r.fail("Failed to init store: %v", err)
 	}
 
-	removed, err := r.client.BreakLock(context.Background())
+	removed, err := r.client.BreakLock(ctx)
 	if err != nil {
 		return r.fail("Failed to break lock: %v", err)
 	}

--- a/cmd/cloudstic/cmd_cat.go
+++ b/cmd/cloudstic/cmd_cat.go
@@ -51,7 +51,7 @@ func (r *runner) runCat(ctx context.Context) int {
 
 	quiet := *a.g.quiet || a.g.jsonEnabled()
 
-	results, err := r.client.Cat(context.Background(), a.keys...)
+	results, err := r.client.Cat(ctx, a.keys...)
 	if err != nil {
 		return r.fail("Failed to fetch objects: %v", err)
 	}

--- a/cmd/cloudstic/cmd_check.go
+++ b/cmd/cloudstic/cmd_check.go
@@ -36,7 +36,7 @@ func (r *runner) runCheck(ctx context.Context) int {
 
 	checkOpts := buildCheckOpts(a)
 
-	result, err := r.client.Check(context.Background(), checkOpts...)
+	result, err := r.client.Check(ctx, checkOpts...)
 	if err != nil {
 		return r.fail("Check failed: %v", err)
 	}

--- a/cmd/cloudstic/cmd_diff.go
+++ b/cmd/cloudstic/cmd_diff.go
@@ -38,7 +38,7 @@ func (r *runner) runDiff(ctx context.Context) int {
 
 	diffOpts := buildDiffOpts(a)
 
-	result, err := r.client.Diff(context.Background(), a.snap1, a.snap2, diffOpts...)
+	result, err := r.client.Diff(ctx, a.snap1, a.snap2, diffOpts...)
 	if err != nil {
 		return r.fail("Diff failed: %v", err)
 	}

--- a/cmd/cloudstic/cmd_forget.go
+++ b/cmd/cloudstic/cmd_forget.go
@@ -161,12 +161,12 @@ func (r *runner) runForget(ctx context.Context) int {
 	}
 
 	if a.hasPolicy {
-		return r.execForgetPolicy(a)
+		return r.execForgetPolicy(ctx, a)
 	}
-	return r.execForgetSingle(a)
+	return r.execForgetSingle(ctx, a)
 }
 
-func (r *runner) execForgetSingle(a *forgetArgs) int {
+func (r *runner) execForgetSingle(ctx context.Context, a *forgetArgs) int {
 	var forgetOpts []cloudstic.ForgetOption
 	if a.prune {
 		forgetOpts = append(forgetOpts, cloudstic.WithPrune())
@@ -174,7 +174,7 @@ func (r *runner) execForgetSingle(a *forgetArgs) int {
 	if *a.g.verbose {
 		forgetOpts = append(forgetOpts, cloudstic.WithForgetVerbose())
 	}
-	result, err := r.client.Forget(context.Background(), a.snapshotID, forgetOpts...)
+	result, err := r.client.Forget(ctx, a.snapshotID, forgetOpts...)
 	if err != nil {
 		return r.fail("Forget failed: %v", err)
 	}
@@ -192,9 +192,9 @@ func (r *runner) execForgetSingle(a *forgetArgs) int {
 	return 0
 }
 
-func (r *runner) execForgetPolicy(a *forgetArgs) int {
+func (r *runner) execForgetPolicy(ctx context.Context, a *forgetArgs) int {
 	opts := r.buildForgetPolicyOpts(a)
-	result, err := r.client.ForgetPolicy(context.Background(), opts...)
+	result, err := r.client.ForgetPolicy(ctx, opts...)
 	if err != nil {
 		return r.fail("Forget failed: %v", err)
 	}

--- a/cmd/cloudstic/cmd_init.go
+++ b/cmd/cloudstic/cmd_init.go
@@ -39,12 +39,12 @@ func (r *runner) runInit(ctx context.Context) int {
 }
 
 func (r *runner) runInitWithArgs(ctx context.Context, a *initArgs) int {
-	raw, err := a.g.openStore()
+	raw, err := a.g.openStore(ctx)
 	if err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
 
-	kc, err := a.g.buildKeychain(context.Background())
+	kc, err := a.g.buildKeychain(ctx)
 	if err != nil {
 		return r.fail("Failed to build keychain: %v", err)
 	}
@@ -57,7 +57,7 @@ func (r *runner) runInitWithArgs(ctx context.Context, a *initArgs) int {
 				return r.fail("Error: %v", err)
 			}
 			*a.g.password = pw
-			kc, _ = a.g.buildKeychain(context.Background())
+			kc, _ = a.g.buildKeychain(ctx)
 		} else {
 			_, _ = fmt.Fprintln(r.errOut, "Error: encryption is required by default.")
 			_, _ = fmt.Fprintln(r.errOut, "Provide --password or --encryption-key to encrypt your repository.")
@@ -68,7 +68,7 @@ func (r *runner) runInitWithArgs(ctx context.Context, a *initArgs) int {
 
 	initOpts := buildInitOpts(a, kc)
 
-	result, err := cloudstic.InitRepo(context.Background(), raw, initOpts...)
+	result, err := cloudstic.InitRepo(ctx, raw, initOpts...)
 	if err != nil {
 		return r.fail("Init failed: %v", err)
 	}

--- a/cmd/cloudstic/cmd_key.go
+++ b/cmd/cloudstic/cmd_key.go
@@ -53,7 +53,7 @@ func parseKeyListArgs() *keyListArgs {
 func (r *runner) runKeyList(ctx context.Context) int {
 	a := parseKeyListArgs()
 
-	raw, err := a.g.openStore()
+	raw, err := a.g.openStore(ctx)
 	if err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
@@ -107,7 +107,7 @@ func parseKeyPasswdArgs() *keyPasswdArgs {
 func (r *runner) runKeyPasswd(ctx context.Context) int {
 	a := parseKeyPasswdArgs()
 
-	raw, err := a.g.openStore()
+	raw, err := a.g.openStore(ctx)
 	if err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
@@ -157,7 +157,7 @@ func parseAddRecoveryKeyArgs() *addRecoveryKeyArgs {
 func (r *runner) runAddRecoveryKey(ctx context.Context) int {
 	a := parseAddRecoveryKeyArgs()
 
-	raw, err := a.g.openStore()
+	raw, err := a.g.openStore(ctx)
 	if err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}

--- a/cmd/cloudstic/cmd_list.go
+++ b/cmd/cloudstic/cmd_list.go
@@ -31,7 +31,7 @@ func (r *runner) runList(ctx context.Context) int {
 
 	listOpts := buildListOpts(a)
 
-	result, err := r.client.List(context.Background(), listOpts...)
+	result, err := r.client.List(ctx, listOpts...)
 	if err != nil {
 		return r.fail("List failed: %v", err)
 	}

--- a/cmd/cloudstic/cmd_ls.go
+++ b/cmd/cloudstic/cmd_ls.go
@@ -39,7 +39,7 @@ func (r *runner) runLsSnapshot(ctx context.Context) int {
 	start := time.Now()
 	lsOpts := buildLsOpts(a)
 
-	result, err := r.client.LsSnapshot(context.Background(), a.snapshotID, lsOpts...)
+	result, err := r.client.LsSnapshot(ctx, a.snapshotID, lsOpts...)
 	if err != nil {
 		return r.fail("Ls failed: %v", err)
 	}

--- a/cmd/cloudstic/cmd_prune.go
+++ b/cmd/cloudstic/cmd_prune.go
@@ -32,7 +32,7 @@ func (r *runner) runPrune(ctx context.Context) int {
 
 	pruneOpts := buildPruneOpts(a)
 
-	result, err := r.client.Prune(context.Background(), pruneOpts...)
+	result, err := r.client.Prune(ctx, pruneOpts...)
 	if err != nil {
 		return r.fail("Prune failed: %v", err)
 	}

--- a/cmd/cloudstic/cmd_restore.go
+++ b/cmd/cloudstic/cmd_restore.go
@@ -55,12 +55,10 @@ func (r *runner) runRestore(ctx context.Context) int {
 
 	restoreOpts := buildRestoreOpts(a)
 
-	return r.execRestore(a, restoreOpts)
+	return r.execRestore(ctx, a, restoreOpts)
 }
 
-func (r *runner) execRestore(a *restoreArgs, opts []cloudstic.RestoreOption) int {
-	ctx := context.Background()
-
+func (r *runner) execRestore(ctx context.Context, a *restoreArgs, opts []cloudstic.RestoreOption) int {
 	if a.dryRun {
 		result, err := r.client.Restore(ctx, io.Discard, a.snapshotRef, opts...)
 		if err != nil {

--- a/cmd/cloudstic/cmd_store.go
+++ b/cmd/cloudstic/cmd_store.go
@@ -350,7 +350,7 @@ func (r *runner) checkOrInitStore(ctx context.Context, cfg *cloudstic.ProfilesCo
 		}
 		return fmt.Errorf("could not resolve store credentials: %w", err)
 	}
-	raw, err := g.initObjectStore()
+	raw, err := g.initObjectStore(ctx)
 	if err != nil {
 		return fmt.Errorf("could not connect to store: %w", err)
 	}

--- a/cmd/cloudstic/cmd_store_test.go
+++ b/cmd/cloudstic/cmd_store_test.go
@@ -313,7 +313,7 @@ func TestCheckOrInitStore_AlreadyInitialized(t *testing.T) {
 	if err != nil {
 		t.Fatalf("globalFlagsFromProfileStore: %v", err)
 	}
-	raw, err := g.initObjectStore()
+	raw, err := g.initObjectStore(context.Background())
 	if err != nil {
 		t.Fatalf("initObjectStore: %v", err)
 	}
@@ -352,7 +352,7 @@ func TestCheckOrInitStore_InitializedEncrypted_ValidCredentials(t *testing.T) {
 	if err != nil {
 		t.Fatalf("globalFlagsFromProfileStore: %v", err)
 	}
-	raw, err := g.initObjectStore()
+	raw, err := g.initObjectStore(context.Background())
 	if err != nil {
 		t.Fatalf("initObjectStore: %v", err)
 	}
@@ -392,7 +392,7 @@ func TestCheckOrInitStore_InitializedEncrypted_InvalidCredentials(t *testing.T) 
 	if err != nil {
 		t.Fatalf("globalFlagsFromProfileStore: %v", err)
 	}
-	raw, err := g.initObjectStore()
+	raw, err := g.initObjectStore(context.Background())
 	if err != nil {
 		t.Fatalf("initObjectStore: %v", err)
 	}

--- a/cmd/cloudstic/main.go
+++ b/cmd/cloudstic/main.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 )
 
 var (
@@ -25,7 +27,13 @@ func main() {
 		defer stop()
 	}
 
-	exitCode := runCmd(os.Args[1])
+	// A single cancellable context rooted here is threaded through every
+	// command; SIGINT/SIGTERM cancels it so in-flight work (backup, restore,
+	// remote store calls) can unwind cleanly instead of being hard-killed.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	exitCode := runCmd(ctx, os.Args[1])
 
 	if memprofile != "" {
 		writeMemProfile(memprofile)
@@ -34,9 +42,8 @@ func main() {
 	os.Exit(exitCode)
 }
 
-func runCmd(cmd string) int {
+func runCmd(ctx context.Context, cmd string) int {
 	r := newRunner()
-	ctx := context.Background()
 	switch cmd {
 	case "version", "--version", "-v":
 		fmt.Printf("cloudstic %s (commit %s, built %s)\n", version, commit, date)

--- a/cmd/cloudstic/store.go
+++ b/cmd/cloudstic/store.go
@@ -21,11 +21,11 @@ import (
 
 // openStore initializes the raw object store with debug wrapping applied.
 // Used by commands that operate on the store directly (init, key).
-func (g *globalFlags) openStore() (store.ObjectStore, error) {
+func (g *globalFlags) openStore(ctx context.Context) (store.ObjectStore, error) {
 	if err := g.applyProfileStoreOverrides(); err != nil {
 		return nil, err
 	}
-	raw, err := g.initObjectStore()
+	raw, err := g.initObjectStore(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func (g *globalFlags) openClientWithReporter(ctx context.Context, reporterOverri
 	if err := g.applyProfileStoreOverrides(); err != nil {
 		return nil, err
 	}
-	raw, err := g.initObjectStore()
+	raw, err := g.initObjectStore(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -266,7 +266,7 @@ func parseStoreURI(raw string) (*storeURIParts, error) {
 	}
 }
 
-func (g *globalFlags) initObjectStore() (store.ObjectStore, error) {
+func (g *globalFlags) initObjectStore(ctx context.Context) (store.ObjectStore, error) {
 	uri, err := parseStoreURI(*g.store)
 	if err != nil {
 		return nil, err
@@ -285,7 +285,7 @@ func (g *globalFlags) initObjectStore() (store.ObjectStore, error) {
 		inner, err = store.NewB2Store(uri.bucket, store.WithCredentials(keyID, appKey), store.WithPrefix(uri.prefix))
 	case "s3":
 		inner, err = store.NewS3Store(
-			context.Background(),
+			ctx,
 			uri.bucket,
 			store.WithS3Endpoint(*g.s3Endpoint),
 			store.WithS3Region(*g.s3Region),

--- a/cmd/cloudstic/tui_runtime.go
+++ b/cmd/cloudstic/tui_runtime.go
@@ -74,7 +74,7 @@ func (b tuiCLIBackend) BackupProfile(ctx context.Context, profilesFile, profileN
 	}
 	b.r.client = client
 	defer func() { b.r.client = nil }()
-	if code := b.r.runSingleBackup(effective); code != 0 {
+	if code := b.r.runSingleBackup(ctx, effective); code != 0 {
 		return fmt.Errorf("backup failed")
 	}
 	return nil


### PR DESCRIPTION
## Summary

- `main` now builds a cancellable context via `signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)` and threads it into `runCmd` and every command, instead of each command re-deriving `context.Background()`.
- Replaced in-command `context.Background()` with the passed `ctx` across `check`, `cat`, `diff`, `list`, `ls`, `prune`, `break-lock`, `init`, `key`.
- Threaded `ctx` into helpers that previously created their own: `runSingleBackup`, `runBackupWithProfiles`, `execRestore`, `execForgetSingle`, `execForgetPolicy`.
- Threaded `ctx` into `openStore` / `initObjectStore` so S3 store construction is cancellable too.
- Left local secret resolution (`profile_secret.go`) and the TUI store form on `context.Background()` on purpose: they are instantaneous local operations, and threading them cascades into the profile-flags plumbing reworked separately (#252).

This makes the context that was already passed to each `runX` actually reach the client/engine layers, so an interrupted backup/restore against a remote store unwinds cleanly (releases the repo lock, writes no partial snapshot) instead of being hard-killed. Complements #158, which propagated context through the engine/client layers.

Closes #250

## Verification

- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./cmd/cloudstic` passes
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./cmd/cloudstic/...` → 0 issues
- Manual: interrupted a real 2.2 GB backup with SIGINT → `Backup failed: chunking file_7.bin: context canceled`, exit code 1, no snapshot created, and a follow-up backup succeeded (lock released cleanly).