### PR TITLE
refactor(cli): move presentation and command orchestration off runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,8 @@ Docker-based hermetic tests (MinIO store, SFTP source/store) are automatically s
 
 - `client.go` (root) — Public `Client` API. Re-exports types from internal packages using Go type aliases. This is the library entry point for programmatic use.
 - `cmd/cloudstic/` — CLI entry point (`package main`). `main.go`'s `runCmd()` dispatches each subcommand to a `run*()` function that lives in its own `cmd_*.go` file (e.g. `cmd_backup.go`, `cmd_key.go`). Subcommands: `init`, `backup`, `restore`, `list`, `ls`, `prune`, `forget`, `diff`, `break-lock`, `key` (with `list`/`add-recovery`/`passwd`), `check`, `cat`, `profile`, `auth`, `store`, `source`, `setup`, `tui`, `completion`. Uses Go's `flag` package (no cobra/viper); `reorderArgs()` in `flags.go` allows flags after positional args. The interactive terminal UI lives in `cmd_tui*.go`.
-  - Each command splits into a thin `run*()` entry (parses flags, opens the client, calls `os.Exit`) and a `(r *runner) exec*()` method holding the testable logic. The `runner` struct (`runner.go`) carries `out`/`errOut` writers and the client, so command output is capturable in tests.
+  - Commands are free functions taking the dependency container first: `run<Name>(r *runner, ctx, ...)` (and `exec<Name>(r, ctx, ...)` for testable sub-steps). The `runner` struct (`runner.go`) carries `out`/`errOut` writers and the client, so command output is capturable in tests; only I/O primitives (`fail`, `writeJSON`, `openClient`, `prompt*`) remain methods on it.
+  - Presentation is separate from orchestration: `print*`/`render*` helpers are free functions taking an `io.Writer` first (`printBackupSummary(out, res)`), so result formatting cannot reach the client or command flow.
   - `cloudsticClient` (`client_iface.go`) is the interface `runner` depends on — satisfied by the real `*Client` and by `stubClient` (`stub_client_test.go`) in unit tests.
 - `internal/engine/` — Business logic for each operation (backup, restore, prune, forget, diff, list). Each operation has a `*Manager` struct (e.g. `BackupManager`, `RestoreManager`) with a `Run(ctx)` method.
 - `internal/core/` — Domain types: `Snapshot`, `FileMeta`, `Content`, `HAMTNode`, `RepoConfig`, `SourceInfo`. Also contains `ComputeJSONHash` which is the canonical content-addressing function.
@@ -177,11 +178,12 @@ When implementing new functionality, always consider the following:
    - Follow the pattern: define types/options, add a `Client.*()` method, implement in `internal/engine/` if complex.
 
 4. **CLI Integration** — For new commands:
-   - Add a `cmd_<name>.go` file with a thin `run<Name>()` entry plus a testable `(r *runner) exec<Name>()` method (see existing `cmd_*.go` for the pattern).
+   - Add a `cmd_<name>.go` file with a `run<Name>(r *runner, ctx context.Context) int` free function (plus `exec<Name>(r, ctx, ...)` for testable sub-steps — see existing `cmd_*.go` for the pattern).
    - Add the command to the switch in `runCmd()` in `main.go`.
    - Add command documentation to `printUsage()` in `usage.go`.
    - Use the `reorderArgs()` helper (`flags.go`) so flags may follow positional args.
    - Write output via `r.out`/`r.errOut` (not `fmt.Print`) so it is capturable, and unit-test against `stubClient`.
+   - Keep result rendering in `print*`/`render*` free functions that take an `io.Writer` first — never give presentation code access to `runner`.
 
 5. **Error Handling** — Return descriptive errors:
    - Wrap errors with context using `fmt.Errorf("context: %w", err)`.

--- a/cmd/cloudstic/cmd_auth.go
+++ b/cmd/cloudstic/cmd_auth.go
@@ -11,7 +11,7 @@ import (
 	cloudstic "github.com/cloudstic/cli"
 )
 
-func (r *runner) runAuth(ctx context.Context) int {
+func runAuth(r *runner, ctx context.Context) int {
 	if len(os.Args) < 3 {
 		_, _ = fmt.Fprintln(r.errOut, "Usage: cloudstic auth <subcommand> [options]")
 		_, _ = fmt.Fprintln(r.errOut, "")
@@ -21,19 +21,19 @@ func (r *runner) runAuth(ctx context.Context) int {
 
 	switch os.Args[2] {
 	case "list":
-		return r.runAuthList(ctx)
+		return runAuthList(r, ctx)
 	case "show":
-		return r.runAuthShow(ctx)
+		return runAuthShow(r, ctx)
 	case "new":
-		return r.runAuthNew(ctx)
+		return runAuthNew(r, ctx)
 	case "login":
-		return r.runAuthLogin(ctx)
+		return runAuthLogin(r, ctx)
 	default:
 		return r.fail("Unknown auth subcommand: %s", os.Args[2])
 	}
 }
 
-func (r *runner) runAuthList(ctx context.Context) int {
+func runAuthList(r *runner, ctx context.Context) int {
 	fs := flag.NewFlagSet("auth list", flag.ExitOnError)
 	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
 	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
@@ -46,11 +46,11 @@ func (r *runner) runAuthList(ctx context.Context) int {
 		return r.fail("Failed to load profiles: %v", err)
 	}
 
-	r.renderAuthList(cfg)
+	renderAuthList(r.out, cfg)
 	return 0
 }
 
-func (r *runner) runAuthShow(ctx context.Context) int {
+func runAuthShow(r *runner, ctx context.Context) int {
 	fs := flag.NewFlagSet("auth show", flag.ExitOnError)
 	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
 	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
@@ -82,11 +82,11 @@ func (r *runner) runAuthShow(ctx context.Context) int {
 	if !ok {
 		return r.fail("Unknown auth %q", name)
 	}
-	r.renderAuthShow(cfg, name, auth)
+	renderAuthShow(r.out, cfg, name, auth)
 	return 0
 }
 
-func (r *runner) runAuthNew(ctx context.Context) int {
+func runAuthNew(r *runner, ctx context.Context) int {
 	fs := flag.NewFlagSet("auth new", flag.ExitOnError)
 	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
 	name := fs.String("name", "", "Auth reference name")
@@ -194,7 +194,7 @@ func (r *runner) runAuthNew(ctx context.Context) int {
 	return 0
 }
 
-func (r *runner) runAuthLogin(ctx context.Context) int {
+func runAuthLogin(r *runner, ctx context.Context) int {
 	fs := flag.NewFlagSet("auth login", flag.ExitOnError)
 	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
 	name := fs.String("name", "", "Auth reference name")

--- a/cmd/cloudstic/cmd_auth_test.go
+++ b/cmd/cloudstic/cmd_auth_test.go
@@ -25,14 +25,14 @@ func TestRunAuthNewAndListAndShow(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runAuth(context.Background()); code != 0 {
+	if code := runAuth(r, context.Background()); code != 0 {
 		t.Fatalf("auth new failed: %s", errOut.String())
 	}
 
 	os.Args = []string{"cloudstic", "auth", "list", "-profiles-file", profilesPath}
 	out.Reset()
 	errOut.Reset()
-	if code := r.runAuth(context.Background()); code != 0 {
+	if code := runAuth(r, context.Background()); code != 0 {
 		t.Fatalf("auth list failed: %s", errOut.String())
 	}
 	if !strings.Contains(out.String(), "Auth") || !strings.Contains(out.String(), "google-work") || !strings.Contains(out.String(), "PROVIDER") {
@@ -42,7 +42,7 @@ func TestRunAuthNewAndListAndShow(t *testing.T) {
 	os.Args = []string{"cloudstic", "auth", "show", "-profiles-file", profilesPath, "google-work"}
 	out.Reset()
 	errOut.Reset()
-	if code := r.runAuth(context.Background()); code != 0 {
+	if code := runAuth(r, context.Background()); code != 0 {
 		t.Fatalf("auth show failed: %s", errOut.String())
 	}
 	if !strings.Contains(out.String(), "Auth google-work") || !strings.Contains(out.String(), "Provider Details") || !strings.Contains(out.String(), "/tmp/google-work.json") {
@@ -55,7 +55,7 @@ func TestRunAuth_NoSubcommand(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runAuth(context.Background()); code != 1 {
+	if code := runAuth(r, context.Background()); code != 1 {
 		t.Fatalf("expected exit code 1, got %d", code)
 	}
 	if !strings.Contains(errOut.String(), "Available subcommands") {
@@ -68,7 +68,7 @@ func TestRunAuth_UnknownSubcommand(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runAuth(context.Background()); code != 1 {
+	if code := runAuth(r, context.Background()); code != 1 {
 		t.Fatalf("expected exit code 1, got %d", code)
 	}
 	if !strings.Contains(errOut.String(), "Unknown auth subcommand") {
@@ -91,7 +91,7 @@ func TestRunAuthNew_OneDriveProvider(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runAuth(context.Background()); code != 0 {
+	if code := runAuth(r, context.Background()); code != 0 {
 		t.Fatalf("auth new failed: %s", errOut.String())
 	}
 
@@ -99,7 +99,7 @@ func TestRunAuthNew_OneDriveProvider(t *testing.T) {
 	os.Args = []string{"cloudstic", "auth", "show", "-profiles-file", profilesPath, "od-personal"}
 	out.Reset()
 	errOut.Reset()
-	if code := r.runAuth(context.Background()); code != 0 {
+	if code := runAuth(r, context.Background()); code != 0 {
 		t.Fatalf("auth show failed: %s", errOut.String())
 	}
 	got := out.String()
@@ -118,7 +118,7 @@ func TestRunAuthNew_RequiresName(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut, noPrompt: true}
-	if code := r.runAuth(context.Background()); code != 1 {
+	if code := runAuth(r, context.Background()); code != 1 {
 		t.Fatalf("expected exit code 1, got %d", code)
 	}
 	if !strings.Contains(errOut.String(), "-name is required") {
@@ -134,7 +134,7 @@ func TestRunAuthNew_RequiresProvider(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut, noPrompt: true}
-	if code := r.runAuth(context.Background()); code != 1 {
+	if code := runAuth(r, context.Background()); code != 1 {
 		t.Fatalf("expected exit code 1, got %d", code)
 	}
 	if !strings.Contains(errOut.String(), "-provider must be") {
@@ -150,7 +150,7 @@ func TestRunAuthNew_InvalidName(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runAuth(context.Background()); code != 1 {
+	if code := runAuth(r, context.Background()); code != 1 {
 		t.Fatalf("expected exit code 1, got %d", code)
 	}
 	if !strings.Contains(errOut.String(), "invalid auth name") {
@@ -173,7 +173,7 @@ func TestRunAuthShow_UnknownAuth(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runAuth(context.Background()); code != 0 {
+	if code := runAuth(r, context.Background()); code != 0 {
 		t.Fatalf("setup auth new failed: %s", errOut.String())
 	}
 
@@ -181,7 +181,7 @@ func TestRunAuthShow_UnknownAuth(t *testing.T) {
 	os.Args = []string{"cloudstic", "auth", "show", "-profiles-file", profilesPath, "missing"}
 	out.Reset()
 	errOut.Reset()
-	if code := r.runAuth(context.Background()); code != 1 {
+	if code := runAuth(r, context.Background()); code != 1 {
 		t.Fatalf("expected exit code 1, got %d", code)
 	}
 	if !strings.Contains(errOut.String(), "Unknown auth") {
@@ -197,7 +197,7 @@ func TestRunAuthList_MissingFile(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runAuth(context.Background()); code != 0 {
+	if code := runAuth(r, context.Background()); code != 0 {
 		t.Fatalf("expected exit code 0, got %d; errOut: %s", code, errOut.String())
 	}
 }
@@ -224,7 +224,7 @@ func TestRunAuthNew_OneDriveDerivesTokenRef(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut, noPrompt: true}
-	if code := r.runAuth(context.Background()); code != 0 {
+	if code := runAuth(r, context.Background()); code != 0 {
 		t.Fatalf("auth new failed: %s", errOut.String())
 	}
 
@@ -245,7 +245,7 @@ func TestRunAuthNew_DerivesDefaultTokenRef(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut, noPrompt: true}
-	if code := r.runAuth(context.Background()); code != 0 {
+	if code := runAuth(r, context.Background()); code != 0 {
 		t.Fatalf("auth new failed: %s", errOut.String())
 	}
 	raw, err := os.ReadFile(profilesPath)

--- a/cmd/cloudstic/cmd_backup.go
+++ b/cmd/cloudstic/cmd_backup.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"slices"
 	"strings"
@@ -104,7 +105,7 @@ func parseBackupArgs() *backupArgs {
 	return a
 }
 
-func (r *runner) runBackup(ctx context.Context) int {
+func runBackup(r *runner, ctx context.Context) int {
 	a := parseBackupArgs()
 
 	if a.profile != "" && a.allProfiles {
@@ -112,7 +113,7 @@ func (r *runner) runBackup(ctx context.Context) int {
 	}
 
 	if a.profile != "" || a.allProfiles {
-		return r.runBackupWithProfiles(ctx, a)
+		return runBackupWithProfiles(r, ctx, a)
 	}
 
 	if a.authRef != "" {
@@ -129,15 +130,15 @@ func (r *runner) runBackup(ctx context.Context) int {
 		}
 	}
 
-	return r.runSingleBackup(ctx, a)
+	return runSingleBackup(r, ctx, a)
 }
 
-func (r *runner) runSingleBackup(ctx context.Context, a *backupArgs) int {
+func runSingleBackup(r *runner, ctx context.Context, a *backupArgs) int {
 	if err := ensureDefaultAuthRefForCloudBackup(a); err != nil {
 		return r.fail("Failed to prepare auth settings: %v", err)
 	}
 
-	excludePatterns, err := r.parseExcludePatterns(a)
+	excludePatterns, err := parseExcludePatterns(a)
 	if err != nil {
 		return r.fail("Failed to read exclude file: %v", err)
 	}
@@ -178,7 +179,7 @@ func (r *runner) runSingleBackup(ctx context.Context, a *backupArgs) int {
 	if a.g.jsonEnabled() {
 		return r.writeJSON(result)
 	}
-	r.printBackupSummary(result)
+	printBackupSummary(r.out, result)
 	return 0
 }
 
@@ -276,7 +277,7 @@ func ensureDefaultAuthRefForCloudBackup(a *backupArgs) error {
 	return nil
 }
 
-func (r *runner) runBackupWithProfiles(ctx context.Context, base *backupArgs) int {
+func runBackupWithProfiles(r *runner, ctx context.Context, base *backupArgs) int {
 	cfg, err := cloudstic.LoadProfilesFile(base.profilesFile)
 	if err != nil {
 		return r.fail("Failed to load profiles: %v", err)
@@ -311,7 +312,7 @@ func (r *runner) runBackupWithProfiles(ctx context.Context, base *backupArgs) in
 		}
 		_, _ = fmt.Fprintf(r.out, "\n== Running profile %s ==\n", name)
 		r.client = nil // each profile may target a different store
-		if code := r.runSingleBackup(ctx, effective); code != 0 {
+		if code := runSingleBackup(r, ctx, effective); code != 0 {
 			failures++
 			if !base.allProfiles {
 				return code
@@ -600,7 +601,7 @@ func applyProfileStoreToGlobalFlags(g *globalFlags, s cloudstic.ProfileStore, fl
 	return nil
 }
 
-func (r *runner) parseExcludePatterns(a *backupArgs) ([]string, error) {
+func parseExcludePatterns(a *backupArgs) ([]string, error) {
 	excludePatterns := []string(a.excludes)
 	if a.excludeFile != "" {
 		filePatterns, err := source.ParseExcludeFile(a.excludeFile)
@@ -633,28 +634,28 @@ func buildBackupOpts(a *backupArgs, excludePatterns []string) []cloudstic.Backup
 	return opts
 }
 
-func (r *runner) printBackupSummary(res *engine.RunResult) {
+func printBackupSummary(out io.Writer, res *engine.RunResult) {
 	total := res.FilesNew + res.FilesChanged + res.FilesUnmodified +
 		res.DirsNew + res.DirsChanged + res.DirsUnmodified
 	if res.DryRun {
-		_, _ = fmt.Fprintf(r.out, "\nBackup dry run complete.\n")
+		_, _ = fmt.Fprintf(out, "\nBackup dry run complete.\n")
 	} else if res.EmptySnapshotIgnored {
-		_, _ = fmt.Fprintf(r.out, "\nBackup complete. No new snapshot created; nothing changed. Root: %s\n", res.Root)
+		_, _ = fmt.Fprintf(out, "\nBackup complete. No new snapshot created; nothing changed. Root: %s\n", res.Root)
 	} else {
-		_, _ = fmt.Fprintf(r.out, "\nBackup complete. Snapshot: %s, Root: %s\n", res.SnapshotRef, res.Root)
+		_, _ = fmt.Fprintf(out, "\nBackup complete. Snapshot: %s, Root: %s\n", res.SnapshotRef, res.Root)
 	}
-	_, _ = fmt.Fprintf(r.out, "Files:  %d new,  %d changed,  %d unmodified,  %d removed\n",
+	_, _ = fmt.Fprintf(out, "Files:  %d new,  %d changed,  %d unmodified,  %d removed\n",
 		res.FilesNew, res.FilesChanged, res.FilesUnmodified, res.FilesRemoved)
-	_, _ = fmt.Fprintf(r.out, "Dirs:   %d new,  %d changed,  %d unmodified,  %d removed\n",
+	_, _ = fmt.Fprintf(out, "Dirs:   %d new,  %d changed,  %d unmodified,  %d removed\n",
 		res.DirsNew, res.DirsChanged, res.DirsUnmodified, res.DirsRemoved)
 	if !res.DryRun && !res.EmptySnapshotIgnored {
-		_, _ = fmt.Fprintf(r.out, "Added to the repository: %s (%s compressed)\n",
+		_, _ = fmt.Fprintf(out, "Added to the repository: %s (%s compressed)\n",
 			formatBytes(res.BytesAddedRaw), formatBytes(res.BytesAddedStored))
 	}
-	_, _ = fmt.Fprintf(r.out, "Processed %d entries in %s\n",
+	_, _ = fmt.Fprintf(out, "Processed %d entries in %s\n",
 		total, res.Duration.Round(time.Second))
 	if !res.DryRun && !res.EmptySnapshotIgnored {
-		_, _ = fmt.Fprintf(r.out, "Snapshot %s saved\n", res.SnapshotHash)
+		_, _ = fmt.Fprintf(out, "Snapshot %s saved\n", res.SnapshotHash)
 	}
 }
 

--- a/cmd/cloudstic/cmd_backup_test.go
+++ b/cmd/cloudstic/cmd_backup_test.go
@@ -121,7 +121,7 @@ func TestPrintBackupSummary_EmptySnapshotIgnored(t *testing.T) {
 	var out strings.Builder
 	r := &runner{out: &out}
 
-	r.printBackupSummary(&engine.RunResult{
+	printBackupSummary(r.out, &engine.RunResult{
 		Root:                 "node/abc",
 		FilesUnmodified:      1,
 		Duration:             2,

--- a/cmd/cloudstic/cmd_breaklock.go
+++ b/cmd/cloudstic/cmd_breaklock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 
 	cloudstic "github.com/cloudstic/cli"
 )
@@ -19,7 +20,7 @@ func parseBreakLockArgs() *breakLockArgs {
 	return a
 }
 
-func (r *runner) runBreakLock(ctx context.Context) int {
+func runBreakLock(r *runner, ctx context.Context) int {
 	a := parseBreakLockArgs()
 	if err := r.openClient(ctx, a.g); err != nil {
 		return r.fail("Failed to init store: %v", err)
@@ -32,22 +33,22 @@ func (r *runner) runBreakLock(ctx context.Context) int {
 	if a.g.jsonEnabled() {
 		return r.writeJSON(&breakLockJSONResult{Locks: removed})
 	}
-	r.printBreakLockResult(removed)
+	printBreakLockResult(r.errOut, removed)
 	return 0
 }
 
-func (r *runner) printBreakLockResult(removed []*cloudstic.RepoLock) {
+func printBreakLockResult(errOut io.Writer, removed []*cloudstic.RepoLock) {
 	if len(removed) == 0 {
-		_, _ = fmt.Fprintln(r.errOut, "No lock found — repository is not locked.")
+		_, _ = fmt.Fprintln(errOut, "No lock found — repository is not locked.")
 		return
 	}
 
-	_, _ = fmt.Fprintf(r.errOut, "Locks removed:\n")
+	_, _ = fmt.Fprintf(errOut, "Locks removed:\n")
 	for _, lock := range removed {
-		_, _ = fmt.Fprintf(r.errOut, "  Operation:  %s\n", lock.Operation)
-		_, _ = fmt.Fprintf(r.errOut, "  Holder:     %s\n", lock.Holder)
-		_, _ = fmt.Fprintf(r.errOut, "  Acquired:   %s\n", lock.AcquiredAt)
-		_, _ = fmt.Fprintf(r.errOut, "  Expired at: %s\n", lock.ExpiresAt)
-		_, _ = fmt.Fprintf(r.errOut, "  Shared:     %v\n\n", lock.IsShared)
+		_, _ = fmt.Fprintf(errOut, "  Operation:  %s\n", lock.Operation)
+		_, _ = fmt.Fprintf(errOut, "  Holder:     %s\n", lock.Holder)
+		_, _ = fmt.Fprintf(errOut, "  Acquired:   %s\n", lock.AcquiredAt)
+		_, _ = fmt.Fprintf(errOut, "  Expired at: %s\n", lock.ExpiresAt)
+		_, _ = fmt.Fprintf(errOut, "  Shared:     %v\n\n", lock.IsShared)
 	}
 }

--- a/cmd/cloudstic/cmd_breaklock_test.go
+++ b/cmd/cloudstic/cmd_breaklock_test.go
@@ -15,7 +15,7 @@ func TestRunBreakLock_NoLock(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &strings.Builder{}, errOut: &errOut, client: &stubClient{breakLockResult: nil}}
 
-	r.runBreakLock(context.Background())
+	runBreakLock(r, context.Background())
 
 	if !strings.Contains(errOut.String(), "not locked") {
 		t.Errorf("expected 'not locked' message, got:\n%s", errOut.String())
@@ -31,7 +31,7 @@ func TestRunBreakLock_JSON(t *testing.T) {
 		},
 	}}
 
-	if exit := r.runBreakLock(context.Background()); exit != 0 {
+	if exit := runBreakLock(r, context.Background()); exit != 0 {
 		t.Fatalf("runBreakLock() exit = %d, want 0", exit)
 	}
 
@@ -59,7 +59,7 @@ func TestRunBreakLock_LocksRemoved(t *testing.T) {
 		},
 	}}
 
-	r.runBreakLock(context.Background())
+	runBreakLock(r, context.Background())
 
 	got := errOut.String()
 	if !strings.Contains(got, "Locks removed") {
@@ -76,7 +76,7 @@ func TestRunBreakLock_LocksRemoved(t *testing.T) {
 func TestPrintBreakLockResult_NoLock(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &strings.Builder{}, errOut: &errOut}
-	r.printBreakLockResult(nil)
+	printBreakLockResult(r.errOut, nil)
 
 	if !strings.Contains(errOut.String(), "not locked") {
 		t.Errorf("expected 'not locked', got:\n%s", errOut.String())
@@ -86,7 +86,7 @@ func TestPrintBreakLockResult_NoLock(t *testing.T) {
 func TestPrintBreakLockResult_MultipleLocks(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &strings.Builder{}, errOut: &errOut}
-	r.printBreakLockResult([]*cloudstic.RepoLock{
+	printBreakLockResult(r.errOut, []*cloudstic.RepoLock{
 		{Operation: "prune", Holder: "host-a"},
 		{Operation: "backup", Holder: "host-b"},
 	})

--- a/cmd/cloudstic/cmd_cat.go
+++ b/cmd/cloudstic/cmd_cat.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 
 	cloudstic "github.com/cloudstic/cli"
@@ -39,7 +40,7 @@ func parseCatArgs() *catArgs {
 	return a
 }
 
-func (r *runner) runCat(ctx context.Context) int {
+func runCat(r *runner, ctx context.Context) int {
 	a := parseCatArgs()
 	if err := r.openClient(ctx, a.g); err != nil {
 		return r.fail("Failed to init store: %v", err)
@@ -59,31 +60,31 @@ func (r *runner) runCat(ctx context.Context) int {
 	if a.g.jsonEnabled() {
 		return r.writeJSON(makeCatJSONResults(results))
 	}
-	r.printCatResult(results, quiet, a.raw)
+	printCatResult(r.out, r.errOut, results, quiet, a.raw)
 	return 0
 }
 
-func (r *runner) printCatResult(results []*cloudstic.CatResult, quiet, raw bool) {
+func printCatResult(out io.Writer, errOut io.Writer, results []*cloudstic.CatResult, quiet, raw bool) {
 	for i, result := range results {
 		if !quiet && len(results) > 1 {
-			_, _ = fmt.Fprintf(r.errOut, "==> %s <==\n", result.Key)
+			_, _ = fmt.Fprintf(errOut, "==> %s <==\n", result.Key)
 		}
 		if raw {
-			if _, err := r.out.Write(result.Data); err != nil {
-				_, _ = fmt.Fprintf(r.errOut, "Failed to write raw data: %v\n", err)
+			if _, err := out.Write(result.Data); err != nil {
+				_, _ = fmt.Fprintf(errOut, "Failed to write raw data: %v\n", err)
 				return
 			}
 		} else {
 			var indented bytes.Buffer
 			if err := json.Indent(&indented, result.Data, "", "  "); err != nil {
-				_, _ = fmt.Fprint(r.out, string(result.Data))
+				_, _ = fmt.Fprint(out, string(result.Data))
 			} else {
-				_, _ = fmt.Fprintln(r.out, indented.String())
+				_, _ = fmt.Fprintln(out, indented.String())
 			}
 		}
 
 		if !quiet && i < len(results)-1 {
-			_, _ = fmt.Fprintln(r.errOut)
+			_, _ = fmt.Fprintln(errOut)
 		}
 	}
 }

--- a/cmd/cloudstic/cmd_cat_test.go
+++ b/cmd/cloudstic/cmd_cat_test.go
@@ -19,7 +19,7 @@ func TestRunCat_SingleKey_JSON(t *testing.T) {
 		},
 	}}
 
-	r.runCat(context.Background())
+	runCat(r, context.Background())
 
 	got := out.String()
 	if !strings.Contains(got, `"version"`) {
@@ -37,7 +37,7 @@ func TestRunCat_MultipleKeys_HeadersShown(t *testing.T) {
 		},
 	}}
 
-	r.runCat(context.Background())
+	runCat(r, context.Background())
 
 	got := errOut.String()
 	if !strings.Contains(got, "==> config <==") {
@@ -59,7 +59,7 @@ func TestRunCat_JSON_NoHeadersAndStructuredOutput(t *testing.T) {
 		},
 	}}
 
-	if exit := r.runCat(context.Background()); exit != 0 {
+	if exit := runCat(r, context.Background()); exit != 0 {
 		t.Fatalf("runCat() exit = %d, want 0", exit)
 	}
 
@@ -87,7 +87,7 @@ func TestRunCat_RawMode(t *testing.T) {
 		catResults: []*cloudstic.CatResult{{Key: "config", Data: rawData}},
 	}}
 
-	r.runCat(context.Background())
+	runCat(r, context.Background())
 
 	if out.String() != string(rawData) {
 		t.Errorf("raw mode: expected %q, got %q", rawData, out.String())
@@ -101,7 +101,7 @@ func TestRunCat_InvalidJSON_PrintsRaw(t *testing.T) {
 		catResults: []*cloudstic.CatResult{{Key: "config", Data: []byte("not-json")}},
 	}}
 
-	r.runCat(context.Background())
+	runCat(r, context.Background())
 
 	if !strings.Contains(out.String(), "not-json") {
 		t.Errorf("expected raw fallback output, got:\n%s", out.String())
@@ -113,7 +113,7 @@ func TestRunCat_JSONAndRawConflict(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &strings.Builder{}, errOut: &errOut, client: &stubClient{}}
 
-	if exit := r.runCat(context.Background()); exit != 1 {
+	if exit := runCat(r, context.Background()); exit != 1 {
 		t.Fatalf("runCat() exit = %d, want 1", exit)
 	}
 	if !strings.Contains(errOut.String(), "-json cannot be combined with -raw") {

--- a/cmd/cloudstic/cmd_check.go
+++ b/cmd/cloudstic/cmd_check.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 
 	cloudstic "github.com/cloudstic/cli"
 )
@@ -28,7 +29,7 @@ func parseCheckArgs() *checkArgs {
 	return a
 }
 
-func (r *runner) runCheck(ctx context.Context) int {
+func runCheck(r *runner, ctx context.Context) int {
 	a := parseCheckArgs()
 	if err := r.openClient(ctx, a.g); err != nil {
 		return r.fail("Failed to init store: %v", err)
@@ -49,7 +50,7 @@ func (r *runner) runCheck(ctx context.Context) int {
 		}
 		return 0
 	}
-	if r.printCheckResult(result) {
+	if printCheckResult(r.errOut, result) {
 		return 1
 	}
 	return 0
@@ -71,19 +72,19 @@ func buildCheckOpts(a *checkArgs) []cloudstic.CheckOption {
 
 // printCheckResult prints the check summary to r.errOut.
 // Returns true if integrity errors were found.
-func (r *runner) printCheckResult(result *cloudstic.CheckResult) bool {
-	_, _ = fmt.Fprintf(r.errOut, "\nRepository check complete.\n")
-	_, _ = fmt.Fprintf(r.errOut, "  Snapshots checked:  %d\n", result.SnapshotsChecked)
-	_, _ = fmt.Fprintf(r.errOut, "  Objects verified:   %d\n", result.ObjectsVerified)
+func printCheckResult(errOut io.Writer, result *cloudstic.CheckResult) bool {
+	_, _ = fmt.Fprintf(errOut, "\nRepository check complete.\n")
+	_, _ = fmt.Fprintf(errOut, "  Snapshots checked:  %d\n", result.SnapshotsChecked)
+	_, _ = fmt.Fprintf(errOut, "  Objects verified:   %d\n", result.ObjectsVerified)
 	if len(result.Errors) > 0 {
-		_, _ = fmt.Fprintf(r.errOut, "  Errors found:       %d\n\n", len(result.Errors))
+		_, _ = fmt.Fprintf(errOut, "  Errors found:       %d\n\n", len(result.Errors))
 		for _, e := range result.Errors {
-			_, _ = fmt.Fprintf(r.errOut, "  [%s] %s: %s\n", e.Type, e.Key, e.Message)
+			_, _ = fmt.Fprintf(errOut, "  [%s] %s: %s\n", e.Type, e.Key, e.Message)
 		}
-		_, _ = fmt.Fprintln(r.errOut)
+		_, _ = fmt.Fprintln(errOut)
 		return true
 	}
-	_, _ = fmt.Fprintf(r.errOut, "  Errors found:       0\n")
-	_, _ = fmt.Fprintf(r.errOut, "\nNo errors found — repository is healthy.\n")
+	_, _ = fmt.Fprintf(errOut, "  Errors found:       0\n")
+	_, _ = fmt.Fprintf(errOut, "\nNo errors found — repository is healthy.\n")
 	return false
 }

--- a/cmd/cloudstic/cmd_check_test.go
+++ b/cmd/cloudstic/cmd_check_test.go
@@ -22,7 +22,7 @@ func TestRunCheck_Healthy(t *testing.T) {
 		},
 	}}
 
-	r.runCheck(context.Background())
+	runCheck(r, context.Background())
 
 	got := errOut.String()
 	if !strings.Contains(got, "No errors found") {
@@ -46,7 +46,7 @@ func TestRunCheck_JSONWithErrorsReturnsExitOne(t *testing.T) {
 		},
 	}}
 
-	if exit := r.runCheck(context.Background()); exit != 1 {
+	if exit := runCheck(r, context.Background()); exit != 1 {
 		t.Fatalf("runCheck() exit = %d, want 1", exit)
 	}
 
@@ -63,7 +63,7 @@ func TestPrintCheckResult_Healthy(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &strings.Builder{}, errOut: &errOut}
 
-	hasErrors := r.printCheckResult(&cloudstic.CheckResult{
+	hasErrors := printCheckResult(r.errOut, &cloudstic.CheckResult{
 		SnapshotsChecked: 10,
 		ObjectsVerified:  300,
 	})
@@ -81,7 +81,7 @@ func TestPrintCheckResult_WithErrors(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &strings.Builder{}, errOut: &errOut}
 
-	hasErrors := r.printCheckResult(&cloudstic.CheckResult{
+	hasErrors := printCheckResult(r.errOut, &cloudstic.CheckResult{
 		SnapshotsChecked: 2,
 		ObjectsVerified:  40,
 		Errors: []engine.CheckError{

--- a/cmd/cloudstic/cmd_diff.go
+++ b/cmd/cloudstic/cmd_diff.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 
 	cloudstic "github.com/cloudstic/cli"
@@ -30,7 +31,7 @@ func parseDiffArgs() *diffArgs {
 	return a
 }
 
-func (r *runner) runDiff(ctx context.Context) int {
+func runDiff(r *runner, ctx context.Context) int {
 	a := parseDiffArgs()
 	if err := r.openClient(ctx, a.g); err != nil {
 		return r.fail("Failed to init store: %v", err)
@@ -45,7 +46,7 @@ func (r *runner) runDiff(ctx context.Context) int {
 	if a.g.jsonEnabled() {
 		return r.writeJSON(result)
 	}
-	r.printDiffResult(result)
+	printDiffResult(r.out, result)
 	return 0
 }
 
@@ -57,9 +58,9 @@ func buildDiffOpts(a *diffArgs) []cloudstic.DiffOption {
 	return diffOpts
 }
 
-func (r *runner) printDiffResult(result *cloudstic.DiffResult) {
-	_, _ = fmt.Fprintf(r.out, "Diffing %s vs %s\n", result.Ref1, result.Ref2)
+func printDiffResult(out io.Writer, result *cloudstic.DiffResult) {
+	_, _ = fmt.Fprintf(out, "Diffing %s vs %s\n", result.Ref1, result.Ref2)
 	for _, c := range result.Changes {
-		_, _ = fmt.Fprintf(r.out, "%s %s\n", c.Type, c.Path)
+		_, _ = fmt.Fprintf(out, "%s %s\n", c.Type, c.Path)
 	}
 }

--- a/cmd/cloudstic/cmd_diff_test.go
+++ b/cmd/cloudstic/cmd_diff_test.go
@@ -26,7 +26,7 @@ func TestRunDiff_Success(t *testing.T) {
 		},
 	}}
 
-	r.runDiff(context.Background())
+	runDiff(r, context.Background())
 
 	got := out.String()
 	if !strings.Contains(got, "snapshot/aaa") {
@@ -56,7 +56,7 @@ func TestRunDiff_JSON(t *testing.T) {
 		},
 	}}
 
-	if exit := r.runDiff(context.Background()); exit != 0 {
+	if exit := runDiff(r, context.Background()); exit != 0 {
 		t.Fatalf("runDiff() exit = %d, want 0", exit)
 	}
 
@@ -80,7 +80,7 @@ func TestRunDiff_NoChanges(t *testing.T) {
 		},
 	}}
 
-	r.runDiff(context.Background())
+	runDiff(r, context.Background())
 
 	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
 	if len(lines) != 1 {

--- a/cmd/cloudstic/cmd_forget.go
+++ b/cmd/cloudstic/cmd_forget.go
@@ -154,19 +154,19 @@ func validateForgetArgs(a *forgetArgs) error {
 	return nil
 }
 
-func (r *runner) runForget(ctx context.Context) int {
+func runForget(r *runner, ctx context.Context) int {
 	a := parseForgetArgs()
 	if err := r.openClient(ctx, a.g); err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
 
 	if a.hasPolicy {
-		return r.execForgetPolicy(ctx, a)
+		return execForgetPolicy(r, ctx, a)
 	}
-	return r.execForgetSingle(ctx, a)
+	return execForgetSingle(r, ctx, a)
 }
 
-func (r *runner) execForgetSingle(ctx context.Context, a *forgetArgs) int {
+func execForgetSingle(r *runner, ctx context.Context, a *forgetArgs) int {
 	var forgetOpts []cloudstic.ForgetOption
 	if a.prune {
 		forgetOpts = append(forgetOpts, cloudstic.WithPrune())
@@ -187,13 +187,13 @@ func (r *runner) execForgetSingle(ctx context.Context, a *forgetArgs) int {
 	_, _ = fmt.Fprintln(r.out)
 	_, _ = fmt.Fprintln(r.out, "Snapshot removed.")
 	if result.Prune != nil {
-		r.printPruneStats(result.Prune)
+		printPruneStats(r.out, result.Prune)
 	}
 	return 0
 }
 
-func (r *runner) execForgetPolicy(ctx context.Context, a *forgetArgs) int {
-	opts := r.buildForgetPolicyOpts(a)
+func execForgetPolicy(r *runner, ctx context.Context, a *forgetArgs) int {
+	opts := buildForgetPolicyOpts(a)
 	result, err := r.client.ForgetPolicy(ctx, opts...)
 	if err != nil {
 		return r.fail("Forget failed: %v", err)
@@ -201,11 +201,11 @@ func (r *runner) execForgetPolicy(ctx context.Context, a *forgetArgs) int {
 	if a.g.jsonEnabled() {
 		return r.writeJSON(makeForgetPolicyJSONResult(result, a.dryRun))
 	}
-	r.printPolicyResult(result, a.dryRun)
+	printPolicyResult(r.out, result, a.dryRun)
 	return 0
 }
 
-func (r *runner) buildForgetPolicyOpts(a *forgetArgs) []cloudstic.ForgetOption {
+func buildForgetPolicyOpts(a *forgetArgs) []cloudstic.ForgetOption {
 	var opts []cloudstic.ForgetOption
 	if a.prune {
 		opts = append(opts, cloudstic.WithPrune())
@@ -250,19 +250,19 @@ func (r *runner) buildForgetPolicyOpts(a *forgetArgs) []cloudstic.ForgetOption {
 	return opts
 }
 
-func (r *runner) printPolicyResult(result *cloudstic.PolicyResult, dryRun bool) {
+func printPolicyResult(out io.Writer, result *cloudstic.PolicyResult, dryRun bool) {
 	for _, group := range result.Groups {
-		_, _ = fmt.Fprintf(r.out, "\nSnapshots for %s:\n", group.Key)
+		_, _ = fmt.Fprintf(out, "\nSnapshots for %s:\n", group.Key)
 
 		if len(group.Keep) > 0 {
-			_, _ = fmt.Fprintf(r.out, "\nkeep %d snapshots:\n", len(group.Keep))
+			_, _ = fmt.Fprintf(out, "\nkeep %d snapshots:\n", len(group.Keep))
 			reasons := make(map[string]string, len(group.Keep))
 			entries := make([]engine.SnapshotEntry, 0, len(group.Keep))
 			for _, k := range group.Keep {
 				entries = append(entries, k.Entry)
 				reasons[k.Entry.Ref] = strings.Join(k.Reasons, ", ")
 			}
-			r.renderSnapshotTable(entries, reasons)
+			renderSnapshotTable(out, entries, reasons)
 		}
 
 		if len(group.Remove) > 0 {
@@ -270,8 +270,8 @@ func (r *runner) printPolicyResult(result *cloudstic.PolicyResult, dryRun bool) 
 			if dryRun {
 				action = "would remove"
 			}
-			_, _ = fmt.Fprintf(r.out, "\n%s %d snapshots:\n", action, len(group.Remove))
-			r.renderSnapshotTable(group.Remove, nil)
+			_, _ = fmt.Fprintf(out, "\n%s %d snapshots:\n", action, len(group.Remove))
+			renderSnapshotTable(out, group.Remove, nil)
 		}
 	}
 
@@ -280,15 +280,15 @@ func (r *runner) printPolicyResult(result *cloudstic.PolicyResult, dryRun bool) 
 		totalRemoved += len(g.Remove)
 	}
 
-	_, _ = fmt.Fprintln(r.out)
+	_, _ = fmt.Fprintln(out)
 	if dryRun {
-		_, _ = fmt.Fprintf(r.out, "%d snapshots would be removed (dry run)\n", totalRemoved)
+		_, _ = fmt.Fprintf(out, "%d snapshots would be removed (dry run)\n", totalRemoved)
 	} else if totalRemoved > 0 {
-		_, _ = fmt.Fprintf(r.out, "%d snapshots have been removed\n", totalRemoved)
+		_, _ = fmt.Fprintf(out, "%d snapshots have been removed\n", totalRemoved)
 		if result.Prune != nil {
-			r.printPruneStats(result.Prune)
+			printPruneStats(out, result.Prune)
 		}
 	} else {
-		_, _ = fmt.Fprintln(r.out, "No snapshots to remove")
+		_, _ = fmt.Fprintln(out, "No snapshots to remove")
 	}
 }

--- a/cmd/cloudstic/cmd_forget_test.go
+++ b/cmd/cloudstic/cmd_forget_test.go
@@ -18,7 +18,7 @@ func TestRunForget_SingleSnapshot(t *testing.T) {
 		forgetResult: &cloudstic.ForgetResult{Prune: nil},
 	}}
 
-	r.runForget(context.Background())
+	runForget(r, context.Background())
 
 	if !strings.Contains(out.String(), "Snapshot removed.") {
 		t.Errorf("expected 'Snapshot removed.', got:\n%s", out.String())
@@ -38,7 +38,7 @@ func TestRunForget_SingleSnapshot_WithPruneResult(t *testing.T) {
 		},
 	}}
 
-	r.runForget(context.Background())
+	runForget(r, context.Background())
 
 	got := out.String()
 	if !strings.Contains(got, "Snapshot removed.") {
@@ -64,7 +64,7 @@ func TestRunForget_Policy_NoRemove(t *testing.T) {
 		},
 	}}
 
-	r.runForget(context.Background())
+	runForget(r, context.Background())
 
 	got := out.String()
 	if !strings.Contains(got, "No snapshots to remove") {
@@ -87,7 +87,7 @@ func TestRunForget_Policy_WithRemoval(t *testing.T) {
 		},
 	}}
 
-	r.runForget(context.Background())
+	runForget(r, context.Background())
 
 	got := out.String()
 	if !strings.Contains(got, "1 snapshots have been removed") {
@@ -109,7 +109,7 @@ func TestRunForget_Policy_DryRun(t *testing.T) {
 		},
 	}}
 
-	r.runForget(context.Background())
+	runForget(r, context.Background())
 
 	got := out.String()
 	if !strings.Contains(got, "would remove") {

--- a/cmd/cloudstic/cmd_init.go
+++ b/cmd/cloudstic/cmd_init.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 
 	cloudstic "github.com/cloudstic/cli"
@@ -33,12 +34,12 @@ func parseInitArgs() *initArgs {
 	return a
 }
 
-func (r *runner) runInit(ctx context.Context) int {
+func runInit(r *runner, ctx context.Context) int {
 	a := parseInitArgs()
-	return r.runInitWithArgs(ctx, a)
+	return runInitWithArgs(r, ctx, a)
 }
 
-func (r *runner) runInitWithArgs(ctx context.Context, a *initArgs) int {
+func runInitWithArgs(r *runner, ctx context.Context, a *initArgs) int {
 	raw, err := a.g.openStore(ctx)
 	if err != nil {
 		return r.fail("Failed to init store: %v", err)
@@ -76,7 +77,7 @@ func (r *runner) runInitWithArgs(ctx context.Context, a *initArgs) int {
 	if a.g.jsonEnabled() {
 		return r.writeJSON(result)
 	}
-	r.printInitResult(result)
+	printInitResult(r.errOut, result)
 	return 0
 }
 
@@ -97,35 +98,35 @@ func buildInitOpts(a *initArgs, kc keychain.Chain) []cloudstic.InitOption {
 	return initOpts
 }
 
-func (r *runner) printInitResult(result *cloudstic.InitResult) {
+func printInitResult(errOut io.Writer, result *cloudstic.InitResult) {
 	if result.Encrypted {
 		if result.AdoptedSlots {
-			_, _ = fmt.Fprintln(r.errOut, "Adopted existing encryption key slots.")
+			_, _ = fmt.Fprintln(errOut, "Adopted existing encryption key slots.")
 		} else {
-			_, _ = fmt.Fprintln(r.errOut, "Created new encryption key slots.")
+			_, _ = fmt.Fprintln(errOut, "Created new encryption key slots.")
 		}
 		if result.RecoveryKey != "" {
-			r.printRecoveryKey(result.RecoveryKey)
+			printRecoveryKey(errOut, result.RecoveryKey)
 		}
 	} else {
-		_, _ = fmt.Fprintln(r.errOut, "WARNING: creating unencrypted repository. Your backups will NOT be encrypted at rest.")
+		_, _ = fmt.Fprintln(errOut, "WARNING: creating unencrypted repository. Your backups will NOT be encrypted at rest.")
 	}
-	_, _ = fmt.Fprintf(r.errOut, "Repository initialized (encrypted: %v).\n", result.Encrypted)
+	_, _ = fmt.Fprintf(errOut, "Repository initialized (encrypted: %v).\n", result.Encrypted)
 }
 
-func (r *runner) printRecoveryKey(mnemonic string) {
-	_, _ = fmt.Fprintln(r.errOut)
-	_, _ = fmt.Fprintln(r.errOut, "╔══════════════════════════════════════════════════════════════╗")
-	_, _ = fmt.Fprintln(r.errOut, "║                      RECOVERY KEY                           ║")
-	_, _ = fmt.Fprintln(r.errOut, "╠══════════════════════════════════════════════════════════════╣")
-	_, _ = fmt.Fprintln(r.errOut, "║                                                              ║")
-	_, _ = fmt.Fprintf(r.errOut, "║  %s\n", mnemonic)
-	_, _ = fmt.Fprintln(r.errOut, "║                                                              ║")
-	_, _ = fmt.Fprintln(r.errOut, "║  Write down these 24 words and store them in a safe place.   ║")
-	_, _ = fmt.Fprintln(r.errOut, "║  This is the ONLY time the recovery key will be displayed.   ║")
-	_, _ = fmt.Fprintln(r.errOut, "║  If you lose your password, this key is your only way to     ║")
-	_, _ = fmt.Fprintln(r.errOut, "║  recover your encrypted backups.                             ║")
-	_, _ = fmt.Fprintln(r.errOut, "║                                                              ║")
-	_, _ = fmt.Fprintln(r.errOut, "╚══════════════════════════════════════════════════════════════╝")
-	_, _ = fmt.Fprintln(r.errOut)
+func printRecoveryKey(errOut io.Writer, mnemonic string) {
+	_, _ = fmt.Fprintln(errOut)
+	_, _ = fmt.Fprintln(errOut, "╔══════════════════════════════════════════════════════════════╗")
+	_, _ = fmt.Fprintln(errOut, "║                      RECOVERY KEY                           ║")
+	_, _ = fmt.Fprintln(errOut, "╠══════════════════════════════════════════════════════════════╣")
+	_, _ = fmt.Fprintln(errOut, "║                                                              ║")
+	_, _ = fmt.Fprintf(errOut, "║  %s\n", mnemonic)
+	_, _ = fmt.Fprintln(errOut, "║                                                              ║")
+	_, _ = fmt.Fprintln(errOut, "║  Write down these 24 words and store them in a safe place.   ║")
+	_, _ = fmt.Fprintln(errOut, "║  This is the ONLY time the recovery key will be displayed.   ║")
+	_, _ = fmt.Fprintln(errOut, "║  If you lose your password, this key is your only way to     ║")
+	_, _ = fmt.Fprintln(errOut, "║  recover your encrypted backups.                             ║")
+	_, _ = fmt.Fprintln(errOut, "║                                                              ║")
+	_, _ = fmt.Fprintln(errOut, "╚══════════════════════════════════════════════════════════════╝")
+	_, _ = fmt.Fprintln(errOut)
 }

--- a/cmd/cloudstic/cmd_init_test.go
+++ b/cmd/cloudstic/cmd_init_test.go
@@ -10,7 +10,7 @@ import (
 func TestPrintInitResult_Encrypted(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &strings.Builder{}, errOut: &errOut}
-	r.printInitResult(&cloudstic.InitResult{
+	printInitResult(r.errOut, &cloudstic.InitResult{
 		Encrypted:    true,
 		AdoptedSlots: false,
 		RecoveryKey:  "",
@@ -28,7 +28,7 @@ func TestPrintInitResult_Encrypted(t *testing.T) {
 func TestPrintInitResult_AdoptedSlots(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &strings.Builder{}, errOut: &errOut}
-	r.printInitResult(&cloudstic.InitResult{
+	printInitResult(r.errOut, &cloudstic.InitResult{
 		Encrypted:    true,
 		AdoptedSlots: true,
 	})
@@ -42,7 +42,7 @@ func TestPrintInitResult_AdoptedSlots(t *testing.T) {
 func TestPrintInitResult_WithRecoveryKey(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &strings.Builder{}, errOut: &errOut}
-	r.printInitResult(&cloudstic.InitResult{
+	printInitResult(r.errOut, &cloudstic.InitResult{
 		Encrypted:   true,
 		RecoveryKey: "word1 word2 word3",
 	})
@@ -59,7 +59,7 @@ func TestPrintInitResult_WithRecoveryKey(t *testing.T) {
 func TestPrintInitResult_NoEncryption(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &strings.Builder{}, errOut: &errOut}
-	r.printInitResult(&cloudstic.InitResult{Encrypted: false})
+	printInitResult(r.errOut, &cloudstic.InitResult{Encrypted: false})
 
 	got := errOut.String()
 	if !strings.Contains(got, "WARNING") {
@@ -73,7 +73,7 @@ func TestPrintInitResult_NoEncryption(t *testing.T) {
 func TestPrintRecoveryKey(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &strings.Builder{}, errOut: &errOut}
-	r.printRecoveryKey("abandon ability able about above")
+	printRecoveryKey(r.errOut, "abandon ability able about above")
 
 	got := errOut.String()
 	if !strings.Contains(got, "RECOVERY KEY") {

--- a/cmd/cloudstic/cmd_key.go
+++ b/cmd/cloudstic/cmd_key.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 
 	cloudstic "github.com/cloudstic/cli"
@@ -13,7 +14,7 @@ import (
 	"github.com/moby/term"
 )
 
-func (r *runner) runKey(ctx context.Context) int {
+func runKey(r *runner, ctx context.Context) int {
 	if len(os.Args) < 3 {
 		_, _ = fmt.Fprintln(r.errOut, "Usage: cloudstic key <subcommand>")
 		_, _ = fmt.Fprintln(r.errOut)
@@ -29,11 +30,11 @@ func (r *runner) runKey(ctx context.Context) int {
 
 	switch sub {
 	case "list":
-		return r.runKeyList(ctx)
+		return runKeyList(r, ctx)
 	case "add-recovery":
-		return r.runAddRecoveryKey(ctx)
+		return runAddRecoveryKey(r, ctx)
 	case "passwd":
-		return r.runKeyPasswd(ctx)
+		return runKeyPasswd(r, ctx)
 	default:
 		return r.fail("Unknown key subcommand: %s", sub)
 	}
@@ -50,7 +51,7 @@ func parseKeyListArgs() *keyListArgs {
 	return a
 }
 
-func (r *runner) runKeyList(ctx context.Context) int {
+func runKeyList(r *runner, ctx context.Context) int {
 	a := parseKeyListArgs()
 
 	raw, err := a.g.openStore(ctx)
@@ -66,17 +67,17 @@ func (r *runner) runKeyList(ctx context.Context) int {
 	if a.g.jsonEnabled() {
 		return r.writeJSON(slots)
 	}
-	r.printKeySlots(slots)
+	printKeySlots(r.out, r.errOut, slots)
 	return 0
 }
 
-func (r *runner) printKeySlots(slots []cloudstic.KeySlot) {
+func printKeySlots(out io.Writer, errOut io.Writer, slots []cloudstic.KeySlot) {
 	if len(slots) == 0 {
-		_, _ = fmt.Fprintln(r.errOut, "No key slots found.")
+		_, _ = fmt.Fprintln(errOut, "No key slots found.")
 		return
 	}
 	t := table.NewWriter()
-	t.SetOutputMirror(r.out)
+	t.SetOutputMirror(out)
 	t.AppendHeader(table.Row{"Type", "Label", "KDF"})
 	for _, slot := range slots {
 		kdf := "—"
@@ -86,7 +87,7 @@ func (r *runner) printKeySlots(slots []cloudstic.KeySlot) {
 		t.AppendRow(table.Row{slot.SlotType, slot.Label, kdf})
 	}
 	t.Render()
-	_, _ = fmt.Fprintf(r.errOut, "\n%d key slot(s) found.\n", len(slots))
+	_, _ = fmt.Fprintf(errOut, "\n%d key slot(s) found.\n", len(slots))
 }
 
 type keyPasswdArgs struct {
@@ -104,7 +105,7 @@ func parseKeyPasswdArgs() *keyPasswdArgs {
 	return a
 }
 
-func (r *runner) runKeyPasswd(ctx context.Context) int {
+func runKeyPasswd(r *runner, ctx context.Context) int {
 	a := parseKeyPasswdArgs()
 
 	raw, err := a.g.openStore(ctx)
@@ -154,7 +155,7 @@ func parseAddRecoveryKeyArgs() *addRecoveryKeyArgs {
 	return a
 }
 
-func (r *runner) runAddRecoveryKey(ctx context.Context) int {
+func runAddRecoveryKey(r *runner, ctx context.Context) int {
 	a := parseAddRecoveryKeyArgs()
 
 	raw, err := a.g.openStore(ctx)
@@ -175,7 +176,7 @@ func (r *runner) runAddRecoveryKey(ctx context.Context) int {
 	if a.g.jsonEnabled() {
 		return r.writeJSON(&recoveryKeyJSONResult{RecoveryKey: mnemonic})
 	}
-	r.printRecoveryKey(mnemonic)
+	printRecoveryKey(r.errOut, mnemonic)
 	_, _ = fmt.Fprintln(r.errOut, "Recovery key slot has been added to the repository.")
 	return 0
 }

--- a/cmd/cloudstic/cmd_key_test.go
+++ b/cmd/cloudstic/cmd_key_test.go
@@ -11,7 +11,7 @@ import (
 func TestPrintKeySlots_Empty(t *testing.T) {
 	var out, errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	r.printKeySlots(nil)
+	printKeySlots(r.out, r.errOut, nil)
 
 	if !strings.Contains(errOut.String(), "No key slots found") {
 		t.Errorf("expected 'No key slots found', got:\n%s", errOut.String())
@@ -29,7 +29,7 @@ func TestPrintKeySlots_WithSlots(t *testing.T) {
 		{SlotType: "recovery", Label: "backup", KDFParams: nil},
 	}
 
-	r.printKeySlots(slots)
+	printKeySlots(r.out, r.errOut, slots)
 
 	tableOut := out.String()
 	if !strings.Contains(tableOut, "password") {

--- a/cmd/cloudstic/cmd_list.go
+++ b/cmd/cloudstic/cmd_list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 
 	cloudstic "github.com/cloudstic/cli"
 )
@@ -23,7 +24,7 @@ func parseListArgs() *listArgs {
 	return a
 }
 
-func (r *runner) runList(ctx context.Context) int {
+func runList(r *runner, ctx context.Context) int {
 	a := parseListArgs()
 	if err := r.openClient(ctx, a.g); err != nil {
 		return r.fail("Failed to init store: %v", err)
@@ -38,7 +39,7 @@ func (r *runner) runList(ctx context.Context) int {
 	if a.g.jsonEnabled() {
 		return r.writeJSON(result)
 	}
-	r.printListResult(result, *a.group)
+	printListResult(r.out, result, *a.group)
 	return 0
 }
 
@@ -50,11 +51,11 @@ func buildListOpts(a *listArgs) []cloudstic.ListOption {
 	return listOpts
 }
 
-func (r *runner) printListResult(result *cloudstic.ListResult, group bool) {
-	_, _ = fmt.Fprintf(r.out, "%d snapshots\n", len(result.Snapshots))
+func printListResult(out io.Writer, result *cloudstic.ListResult, group bool) {
+	_, _ = fmt.Fprintf(out, "%d snapshots\n", len(result.Snapshots))
 	if group {
-		r.renderGroupedSnapshotTables(result.Snapshots)
+		renderGroupedSnapshotTables(out, result.Snapshots)
 	} else {
-		r.renderSnapshotTable(result.Snapshots, nil)
+		renderSnapshotTable(out, result.Snapshots, nil)
 	}
 }

--- a/cmd/cloudstic/cmd_list_test.go
+++ b/cmd/cloudstic/cmd_list_test.go
@@ -24,7 +24,7 @@ func TestRunList_Success(t *testing.T) {
 		},
 	}}
 
-	r.runList(context.Background())
+	runList(r, context.Background())
 
 	got := out.String()
 	if !strings.Contains(got, "2 snapshots") {
@@ -43,7 +43,7 @@ func TestRunList_JSON(t *testing.T) {
 		},
 	}}
 
-	if exit := r.runList(context.Background()); exit != 0 {
+	if exit := runList(r, context.Background()); exit != 0 {
 		t.Fatalf("runList() exit = %d, want 0", exit)
 	}
 
@@ -63,7 +63,7 @@ func TestRunList_Empty(t *testing.T) {
 		listResult: &cloudstic.ListResult{Snapshots: nil},
 	}}
 
-	r.runList(context.Background())
+	runList(r, context.Background())
 
 	if !strings.Contains(out.String(), "0 snapshots") {
 		t.Errorf("expected '0 snapshots', got: %s", out.String())
@@ -94,7 +94,7 @@ func TestRunList_Group(t *testing.T) {
 		},
 	}}
 
-	r.runList(context.Background())
+	runList(r, context.Background())
 
 	got := out.String()
 	if !strings.Contains(got, "2 snapshots") {

--- a/cmd/cloudstic/cmd_ls.go
+++ b/cmd/cloudstic/cmd_ls.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"sort"
 	"time"
 
@@ -30,7 +31,7 @@ func parseLsArgs() *lsArgs {
 	return a
 }
 
-func (r *runner) runLsSnapshot(ctx context.Context) int {
+func runLsSnapshot(r *runner, ctx context.Context) int {
 	a := parseLsArgs()
 	if err := r.openClient(ctx, a.g); err != nil {
 		return r.fail("Failed to init store: %v", err)
@@ -46,7 +47,7 @@ func (r *runner) runLsSnapshot(ctx context.Context) int {
 	if a.g.jsonEnabled() {
 		return r.writeJSON(result)
 	}
-	r.printLsResult(result, time.Since(start))
+	printLsResult(r.out, result, time.Since(start))
 	return 0
 }
 
@@ -58,15 +59,15 @@ func buildLsOpts(a *lsArgs) []cloudstic.LsSnapshotOption {
 	return lsOpts
 }
 
-func (r *runner) printLsResult(result *engine.LsSnapshotResult, elapsed time.Duration) {
-	_, _ = fmt.Fprintf(r.out, "Listing files for snapshot: %s (Created: %s)\n", result.Ref, result.Snapshot.Created)
-	r.renderSnapshotTree(result)
-	_, _ = fmt.Fprintf(r.out, "\n%d entries listed in %s\n", len(result.RefToMeta), elapsed.Round(time.Millisecond))
+func printLsResult(out io.Writer, result *engine.LsSnapshotResult, elapsed time.Duration) {
+	_, _ = fmt.Fprintf(out, "Listing files for snapshot: %s (Created: %s)\n", result.Ref, result.Snapshot.Created)
+	renderSnapshotTree(out, result)
+	_, _ = fmt.Fprintf(out, "\n%d entries listed in %s\n", len(result.RefToMeta), elapsed.Round(time.Millisecond))
 }
 
-func (r *runner) renderSnapshotTree(result *engine.LsSnapshotResult) {
+func renderSnapshotTree(out io.Writer, result *engine.LsSnapshotResult) {
 	l := list.NewWriter()
-	l.SetOutputMirror(r.out)
+	l.SetOutputMirror(out)
 	for _, rootRef := range result.RootRefs {
 		appendTreeNode(l, rootRef, result.RefToMeta, result.ChildRefs)
 	}

--- a/cmd/cloudstic/cmd_profile.go
+++ b/cmd/cloudstic/cmd_profile.go
@@ -24,7 +24,7 @@ func defaultProfilesPath() (string, error) {
 	return filepath.Join(configDir, defaultProfilesFilename), nil
 }
 
-func (r *runner) runProfile(ctx context.Context) int {
+func runProfile(r *runner, ctx context.Context) int {
 	if len(os.Args) < 3 {
 		_, _ = fmt.Fprintln(r.errOut, "Usage: cloudstic profile <subcommand> [options]")
 		_, _ = fmt.Fprintln(r.errOut, "")
@@ -34,11 +34,11 @@ func (r *runner) runProfile(ctx context.Context) int {
 
 	switch os.Args[2] {
 	case "list":
-		return r.runProfileList(ctx)
+		return runProfileList(r, ctx)
 	case "show":
-		return r.runProfileShow(ctx)
+		return runProfileShow(r, ctx)
 	case "new":
-		return r.runProfileNew(ctx)
+		return runProfileNew(r, ctx)
 	default:
 		return r.fail("Unknown profile subcommand: %s", os.Args[2])
 	}
@@ -68,7 +68,7 @@ func parseProfileShowArgs() (*profileShowArgs, error) {
 	return a, nil
 }
 
-func (r *runner) runProfileShow(ctx context.Context) int {
+func runProfileShow(r *runner, ctx context.Context) int {
 	a, err := parseProfileShowArgs()
 	if err != nil {
 		return r.fail("%v", err)
@@ -92,7 +92,7 @@ func (r *runner) runProfileShow(ctx context.Context) int {
 	if !ok {
 		return r.fail("Unknown profile %q", a.name)
 	}
-	r.renderProfileShow(cfg, a.name, p)
+	renderProfileShow(r.out, cfg, a.name, p)
 	return 0
 }
 
@@ -126,7 +126,7 @@ func parseProfileListArgs() *profileListArgs {
 	return a
 }
 
-func (r *runner) runProfileList(ctx context.Context) int {
+func runProfileList(r *runner, ctx context.Context) int {
 	a := parseProfileListArgs()
 	cfg, err := cloudstic.LoadProfilesFile(a.profilesFile)
 	if err != nil {
@@ -136,11 +136,11 @@ func (r *runner) runProfileList(ctx context.Context) int {
 		return r.fail("Failed to load profiles: %v", err)
 	}
 
-	r.renderStoreList(cfg)
+	renderStoreList(r.out, cfg)
 	_, _ = fmt.Fprintln(r.out)
-	r.renderAuthList(cfg)
+	renderAuthList(r.out, cfg)
 	_, _ = fmt.Fprintln(r.out)
-	r.renderProfileList(cfg)
+	renderProfileList(r.out, cfg)
 
 	return 0
 }
@@ -223,7 +223,7 @@ func parseProfileNewArgs() *profileNewArgs {
 	return a
 }
 
-func (r *runner) runProfileNew(ctx context.Context) int {
+func runProfileNew(r *runner, ctx context.Context) int {
 	a := parseProfileNewArgs()
 	if a.name == "" {
 		if r.canPrompt() {
@@ -326,7 +326,7 @@ func (r *runner) runProfileNew(ctx context.Context) int {
 		if !storeHasExplicitEncryption(s) {
 			r.promptEncryptionConfig(ctx, cfg, a.storeRef, a.profilesFile)
 		}
-		if err := r.checkOrInitStoreWithRecovery(ctx, cfg, a.storeRef, a.profilesFile, checkOrInitOptions{
+		if err := checkOrInitStoreWithRecovery(r, ctx, cfg, a.storeRef, a.profilesFile, checkOrInitOptions{
 			allowMissingSecrets:  true,
 			warnOnMissingSecrets: true,
 			offerInit:            true,

--- a/cmd/cloudstic/cmd_profile_test.go
+++ b/cmd/cloudstic/cmd_profile_test.go
@@ -41,7 +41,7 @@ profiles:
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := r.runProfile(context.Background()); code != 0 {
+	if code := runProfile(r, context.Background()); code != 0 {
 		t.Fatalf("runProfile() code=%d err=%s", code, errOut.String())
 	}
 
@@ -81,7 +81,7 @@ profiles:
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := r.runProfile(context.Background()); code != 0 {
+	if code := runProfile(r, context.Background()); code != 0 {
 		t.Fatalf("runProfile() code=%d err=%s", code, errOut.String())
 	}
 	got := out.String()
@@ -105,7 +105,7 @@ func TestRunProfileShow_UnknownProfile(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := r.runProfile(context.Background()); code == 0 {
+	if code := runProfile(r, context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "Unknown profile") {
@@ -119,7 +119,7 @@ func TestRunProfileList_MissingFile(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := r.runProfile(context.Background()); code != 0 {
+	if code := runProfile(r, context.Background()); code != 0 {
 		t.Fatalf("expected zero exit code, got=%d err=%s", code, errOut.String())
 	}
 	if out.String() != "" {
@@ -136,7 +136,7 @@ func TestRunProfile_UnknownSubcommand(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := r.runProfile(context.Background()); code == 0 {
+	if code := runProfile(r, context.Background()); code == 0 {
 		t.Fatalf("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "Unknown profile subcommand") {
@@ -160,7 +160,7 @@ func TestRunProfileNew_CreatesFile(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := r.runProfile(context.Background()); code != 0 {
+	if code := runProfile(r, context.Background()); code != 0 {
 		t.Fatalf("runProfile() code=%d err=%s", code, errOut.String())
 	}
 
@@ -194,7 +194,7 @@ func TestRunProfileNew_PrefillsExistingProfile(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runProfile(context.Background()); code != 0 {
+	if code := runProfile(r, context.Background()); code != 0 {
 		t.Fatalf("initial create: code=%d err=%s", code, errOut.String())
 	}
 
@@ -207,7 +207,7 @@ func TestRunProfileNew_PrefillsExistingProfile(t *testing.T) {
 	}
 	out.Reset()
 	errOut.Reset()
-	if code := r.runProfile(context.Background()); code != 0 {
+	if code := runProfile(r, context.Background()); code != 0 {
 		t.Fatalf("update: code=%d err=%s", code, errOut.String())
 	}
 
@@ -243,7 +243,7 @@ func TestRunProfileNew_RequiresNameAndSource(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := r.runProfile(context.Background()); code == 0 {
+	if code := runProfile(r, context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "-source is required") {
@@ -264,7 +264,7 @@ func TestRunProfileNew_RequiresStore(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := r.runProfile(context.Background()); code == 0 {
+	if code := runProfile(r, context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "-store-ref is required") {
@@ -286,7 +286,7 @@ func TestRunProfileNew_RejectsUnknownStoreRef(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := r.runProfile(context.Background()); code == 0 {
+	if code := runProfile(r, context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "Unknown store reference") {
@@ -308,7 +308,7 @@ func TestRunProfileNew_CloudSourceRequiresAuthRef(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := r.runProfile(context.Background()); code == 0 {
+	if code := runProfile(r, context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "-auth-ref is required for cloud sources") {
@@ -331,7 +331,7 @@ func TestRunProfileNew_RejectsUnknownAuthRef(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := r.runProfile(context.Background()); code == 0 {
+	if code := runProfile(r, context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "Unknown auth reference") {
@@ -354,7 +354,7 @@ func TestRunProfileNew_AuthRefRequiresCloudSource(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := r.runProfile(context.Background()); code == 0 {
+	if code := runProfile(r, context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "-auth-ref requires a cloud source") {
@@ -432,7 +432,7 @@ profiles:
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := r.runProfile(context.Background()); code != 0 {
+	if code := runProfile(r, context.Background()); code != 0 {
 		t.Fatalf("runProfile() code=%d err=%s", code, errOut.String())
 	}
 	got := out.String()
@@ -463,7 +463,7 @@ profiles:
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := r.runProfile(context.Background()); code != 0 {
+	if code := runProfile(r, context.Background()); code != 0 {
 		t.Fatalf("runProfile() code=%d err=%s", code, errOut.String())
 	}
 	got := out.String()
@@ -495,7 +495,7 @@ profiles:
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := r.runProfile(context.Background()); code != 0 {
+	if code := runProfile(r, context.Background()); code != 0 {
 		t.Fatalf("runProfile() code=%d err=%s", code, errOut.String())
 	}
 	got := out.String()
@@ -523,7 +523,7 @@ func TestRunProfileNew_WithExcludesAndTags(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := r.runProfile(context.Background()); code != 0 {
+	if code := runProfile(r, context.Background()); code != 0 {
 		t.Fatalf("runProfile() code=%d err=%s", code, errOut.String())
 	}
 
@@ -553,7 +553,7 @@ func TestRunProfileNew_InvalidName(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := r.runProfile(context.Background()); code == 0 {
+	if code := runProfile(r, context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "invalid profile name") {
@@ -575,7 +575,7 @@ func TestRunProfileNew_InvalidSource(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := r.runProfile(context.Background()); code == 0 {
+	if code := runProfile(r, context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "Invalid source") {
@@ -597,7 +597,7 @@ func TestRunProfileNew_InvalidStoreURI(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := r.runProfile(context.Background()); code == 0 {
+	if code := runProfile(r, context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "Invalid store URI") {
@@ -631,7 +631,7 @@ profiles:
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := r.runProfile(context.Background()); code != 0 {
+	if code := runProfile(r, context.Background()); code != 0 {
 		t.Fatalf("runProfile() code=%d err=%s", code, errOut.String())
 	}
 	got := out.String()
@@ -673,7 +673,7 @@ profiles:
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := r.runProfile(context.Background()); code != 0 {
+	if code := runProfile(r, context.Background()); code != 0 {
 		t.Fatalf("runProfile() code=%d err=%s", code, errOut.String())
 	}
 	got := out.String()

--- a/cmd/cloudstic/cmd_prune.go
+++ b/cmd/cloudstic/cmd_prune.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 
 	cloudstic "github.com/cloudstic/cli"
 	"github.com/cloudstic/cli/internal/engine"
@@ -24,7 +25,7 @@ func parsePruneArgs() *pruneArgs {
 	return a
 }
 
-func (r *runner) runPrune(ctx context.Context) int {
+func runPrune(r *runner, ctx context.Context) int {
 	a := parsePruneArgs()
 	if err := r.openClient(ctx, a.g); err != nil {
 		return r.fail("Failed to init store: %v", err)
@@ -40,7 +41,7 @@ func (r *runner) runPrune(ctx context.Context) int {
 		return r.writeJSON(result)
 	}
 	_, _ = fmt.Fprintln(r.out)
-	r.printPruneStats(result)
+	printPruneStats(r.out, result)
 	return 0
 }
 
@@ -55,15 +56,15 @@ func buildPruneOpts(a *pruneArgs) []cloudstic.PruneOption {
 	return pruneOpts
 }
 
-func (r *runner) printPruneStats(res *cloudstic.PruneResult) {
+func printPruneStats(out io.Writer, res *cloudstic.PruneResult) {
 	if res.DryRun {
-		_, _ = fmt.Fprintf(r.out, "Prune dry run complete.\n")
-		_, _ = fmt.Fprintf(r.out, "  Objects scanned:       %d\n", res.ObjectsScanned)
-		_, _ = fmt.Fprintf(r.out, "  Objects would delete:  %d\n", res.ObjectsDeleted)
+		_, _ = fmt.Fprintf(out, "Prune dry run complete.\n")
+		_, _ = fmt.Fprintf(out, "  Objects scanned:       %d\n", res.ObjectsScanned)
+		_, _ = fmt.Fprintf(out, "  Objects would delete:  %d\n", res.ObjectsDeleted)
 	} else {
-		_, _ = fmt.Fprintf(r.out, "Prune complete.\n")
-		_, _ = fmt.Fprintf(r.out, "  Objects scanned:  %d\n", res.ObjectsScanned)
-		_, _ = fmt.Fprintf(r.out, "  Objects deleted:  %d\n", res.ObjectsDeleted)
-		_, _ = fmt.Fprintf(r.out, "  Space reclaimed:  %s\n", formatBytes(res.BytesReclaimed))
+		_, _ = fmt.Fprintf(out, "Prune complete.\n")
+		_, _ = fmt.Fprintf(out, "  Objects scanned:  %d\n", res.ObjectsScanned)
+		_, _ = fmt.Fprintf(out, "  Objects deleted:  %d\n", res.ObjectsDeleted)
+		_, _ = fmt.Fprintf(out, "  Space reclaimed:  %s\n", formatBytes(res.BytesReclaimed))
 	}
 }

--- a/cmd/cloudstic/cmd_prune_test.go
+++ b/cmd/cloudstic/cmd_prune_test.go
@@ -21,7 +21,7 @@ func TestRunPrune_Normal(t *testing.T) {
 		},
 	}}
 
-	r.runPrune(context.Background())
+	runPrune(r, context.Background())
 
 	got := out.String()
 	if !strings.Contains(got, "Prune complete.") {
@@ -49,7 +49,7 @@ func TestRunPrune_DryRun(t *testing.T) {
 		},
 	}}
 
-	r.runPrune(context.Background())
+	runPrune(r, context.Background())
 
 	got := out.String()
 	if !strings.Contains(got, "Prune dry run complete.") {
@@ -63,7 +63,7 @@ func TestRunPrune_DryRun(t *testing.T) {
 func TestPrintPruneStats_Normal(t *testing.T) {
 	var out strings.Builder
 	r := &runner{out: &out, errOut: &strings.Builder{}}
-	r.printPruneStats(&cloudstic.PruneResult{
+	printPruneStats(r.out, &cloudstic.PruneResult{
 		ObjectsScanned: 200,
 		ObjectsDeleted: 15,
 		BytesReclaimed: 1024 * 1024,
@@ -81,7 +81,7 @@ func TestPrintPruneStats_Normal(t *testing.T) {
 func TestPrintPruneStats_DryRun(t *testing.T) {
 	var out strings.Builder
 	r := &runner{out: &out, errOut: &strings.Builder{}}
-	r.printPruneStats(&cloudstic.PruneResult{
+	printPruneStats(r.out, &cloudstic.PruneResult{
 		ObjectsScanned: 30,
 		ObjectsDeleted: 3,
 		DryRun:         true,

--- a/cmd/cloudstic/cmd_restore.go
+++ b/cmd/cloudstic/cmd_restore.go
@@ -41,7 +41,7 @@ func parseRestoreArgs() *restoreArgs {
 	return a
 }
 
-func (r *runner) runRestore(ctx context.Context) int {
+func runRestore(r *runner, ctx context.Context) int {
 	a := parseRestoreArgs()
 	format, err := resolveRestoreFormat(a.format, a.output)
 	if err != nil {
@@ -55,10 +55,10 @@ func (r *runner) runRestore(ctx context.Context) int {
 
 	restoreOpts := buildRestoreOpts(a)
 
-	return r.execRestore(ctx, a, restoreOpts)
+	return execRestore(r, ctx, a, restoreOpts)
 }
 
-func (r *runner) execRestore(ctx context.Context, a *restoreArgs, opts []cloudstic.RestoreOption) int {
+func execRestore(r *runner, ctx context.Context, a *restoreArgs, opts []cloudstic.RestoreOption) int {
 	if a.dryRun {
 		result, err := r.client.Restore(ctx, io.Discard, a.snapshotRef, opts...)
 		if err != nil {
@@ -67,7 +67,7 @@ func (r *runner) execRestore(ctx context.Context, a *restoreArgs, opts []cloudst
 		if a.g.jsonEnabled() {
 			return r.writeJSON(result)
 		}
-		r.printRestoreSummary(result, "")
+		printRestoreSummary(r.out, result, "")
 		return 0
 	}
 
@@ -79,7 +79,7 @@ func (r *runner) execRestore(ctx context.Context, a *restoreArgs, opts []cloudst
 		if a.g.jsonEnabled() {
 			return r.writeJSON(result)
 		}
-		r.printRestoreSummary(result, a.output)
+		printRestoreSummary(r.out, result, a.output)
 		return 0
 	}
 
@@ -97,7 +97,7 @@ func (r *runner) execRestore(ctx context.Context, a *restoreArgs, opts []cloudst
 	if a.g.jsonEnabled() {
 		return r.writeJSON(result)
 	}
-	r.printRestoreSummary(result, a.output)
+	printRestoreSummary(r.out, result, a.output)
 	return 0
 }
 
@@ -115,23 +115,23 @@ func buildRestoreOpts(a *restoreArgs) []cloudstic.RestoreOption {
 	return restoreOpts
 }
 
-func (r *runner) printRestoreSummary(result *engine.RestoreResult, output string) {
+func printRestoreSummary(out io.Writer, result *engine.RestoreResult, output string) {
 	if result.DryRun {
-		_, _ = fmt.Fprintf(r.out, "\nRestore dry run complete. Snapshot: %s\n", result.SnapshotRef)
-		_, _ = fmt.Fprintf(r.out, "  Files: %d, Dirs: %d\n", result.FilesWritten, result.DirsWritten)
-		_, _ = fmt.Fprintf(r.out, "  Estimated size: %s\n", formatBytes(result.BytesWritten))
+		_, _ = fmt.Fprintf(out, "\nRestore dry run complete. Snapshot: %s\n", result.SnapshotRef)
+		_, _ = fmt.Fprintf(out, "  Files: %d, Dirs: %d\n", result.FilesWritten, result.DirsWritten)
+		_, _ = fmt.Fprintf(out, "  Estimated size: %s\n", formatBytes(result.BytesWritten))
 		return
 	}
-	_, _ = fmt.Fprintf(r.out, "\nRestore complete. Snapshot: %s\n", result.SnapshotRef)
-	_, _ = fmt.Fprintf(r.out, "  Files: %d, Dirs: %d", result.FilesWritten, result.DirsWritten)
+	_, _ = fmt.Fprintf(out, "\nRestore complete. Snapshot: %s\n", result.SnapshotRef)
+	_, _ = fmt.Fprintf(out, "  Files: %d, Dirs: %d", result.FilesWritten, result.DirsWritten)
 	if result.Warnings > 0 {
-		_, _ = fmt.Fprintf(r.out, ", Warnings: %d", result.Warnings)
+		_, _ = fmt.Fprintf(out, ", Warnings: %d", result.Warnings)
 	}
 	if result.Errors > 0 {
-		_, _ = fmt.Fprintf(r.out, ", Errors: %d", result.Errors)
+		_, _ = fmt.Fprintf(out, ", Errors: %d", result.Errors)
 	}
-	_, _ = fmt.Fprintln(r.out)
-	_, _ = fmt.Fprintf(r.out, "  Output: %s (%s)\n", output, formatBytes(result.BytesWritten))
+	_, _ = fmt.Fprintln(out)
+	_, _ = fmt.Fprintf(out, "  Output: %s (%s)\n", output, formatBytes(result.BytesWritten))
 }
 
 func resolveRestoreFormat(explicitFormat, output string) (string, error) {

--- a/cmd/cloudstic/cmd_restore_test.go
+++ b/cmd/cloudstic/cmd_restore_test.go
@@ -11,7 +11,7 @@ func TestPrintRestoreSummary_Normal(t *testing.T) {
 	var out strings.Builder
 	r := &runner{out: &out, errOut: &strings.Builder{}}
 
-	r.printRestoreSummary(&cloudstic.RestoreResult{
+	printRestoreSummary(r.out, &cloudstic.RestoreResult{
 		SnapshotRef:  "abc123",
 		FilesWritten: 42,
 		DirsWritten:  7,
@@ -32,7 +32,7 @@ func TestPrintRestoreSummary_WithErrors(t *testing.T) {
 	var out strings.Builder
 	r := &runner{out: &out, errOut: &strings.Builder{}}
 
-	r.printRestoreSummary(&cloudstic.RestoreResult{
+	printRestoreSummary(r.out, &cloudstic.RestoreResult{
 		SnapshotRef:  "xyz",
 		FilesWritten: 10,
 		DirsWritten:  2,
@@ -50,7 +50,7 @@ func TestPrintRestoreSummary_WithWarnings(t *testing.T) {
 	var out strings.Builder
 	r := &runner{out: &out, errOut: &strings.Builder{}}
 
-	r.printRestoreSummary(&cloudstic.RestoreResult{
+	printRestoreSummary(r.out, &cloudstic.RestoreResult{
 		SnapshotRef:  "warn",
 		FilesWritten: 1,
 		DirsWritten:  1,
@@ -67,7 +67,7 @@ func TestPrintRestoreSummary_DryRun(t *testing.T) {
 	var out strings.Builder
 	r := &runner{out: &out, errOut: &strings.Builder{}}
 
-	r.printRestoreSummary(&cloudstic.RestoreResult{
+	printRestoreSummary(r.out, &cloudstic.RestoreResult{
 		SnapshotRef:  "dry123",
 		FilesWritten: 5,
 		DirsWritten:  1,

--- a/cmd/cloudstic/cmd_setup.go
+++ b/cmd/cloudstic/cmd_setup.go
@@ -29,7 +29,7 @@ func defaultProfilesPathNoCreate() string {
 	return defaultProfilesFilename
 }
 
-func (r *runner) runSetup(ctx context.Context) int {
+func runSetup(r *runner, ctx context.Context) int {
 	if len(os.Args) < 3 {
 		_, _ = fmt.Fprintln(r.errOut, "Usage: cloudstic setup <subcommand> [options]")
 		_, _ = fmt.Fprintln(r.errOut, "")
@@ -39,7 +39,7 @@ func (r *runner) runSetup(ctx context.Context) int {
 
 	switch os.Args[2] {
 	case "workstation":
-		return r.runSetupWorkstation(ctx)
+		return runSetupWorkstation(r, ctx)
 	default:
 		return r.fail("Unknown setup subcommand: %s", os.Args[2])
 	}
@@ -70,7 +70,7 @@ func parseSetupWorkstationArgs() *setupWorkstationArgs {
 	return a
 }
 
-func (r *runner) runSetupWorkstation(ctx context.Context) int {
+func runSetupWorkstation(r *runner, ctx context.Context) int {
 	args := parseSetupWorkstationArgs()
 	cfg, err := loadProfilesOrInit(args.profilesFile)
 	if err != nil {
@@ -93,7 +93,7 @@ func (r *runner) runSetupWorkstation(ctx context.Context) int {
 				if !storeHasExplicitEncryption(s) {
 					r.promptEncryptionConfig(ctx, cfg, args.storeRef, args.profilesFile)
 				}
-				if err := r.checkOrInitStoreWithRecovery(ctx, cfg, args.storeRef, args.profilesFile, checkOrInitOptions{
+				if err := checkOrInitStoreWithRecovery(r, ctx, cfg, args.storeRef, args.profilesFile, checkOrInitOptions{
 					allowMissingSecrets:  true,
 					warnOnMissingSecrets: true,
 					offerInit:            true,

--- a/cmd/cloudstic/cmd_setup_test.go
+++ b/cmd/cloudstic/cmd_setup_test.go
@@ -42,7 +42,7 @@ func TestRunSetupWorkstation_DryRun(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut, client: &stubClient{}}
-	if code := r.runSetup(context.Background()); code != 0 {
+	if code := runSetup(r, context.Background()); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
 	got := out.String()
@@ -64,7 +64,7 @@ func TestRunSetupWorkstation_JSON(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut, client: &stubClient{}}
-	if code := r.runSetup(context.Background()); code != 0 {
+	if code := runSetup(r, context.Background()); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
 	if !strings.Contains(out.String(), "\"hostname\": \"testbox\"") {
@@ -96,7 +96,7 @@ func TestRunSetupWorkstation_ApplyYes(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut, client: &stubClient{}, noPrompt: true}
-	if code := r.runSetup(context.Background()); code != 0 {
+	if code := runSetup(r, context.Background()); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
 	cfg, err := cloudstic.LoadProfilesFile(profilesPath)
@@ -116,7 +116,7 @@ func TestRunSetupWorkstation_RequiresStoreResolutionWithoutPrompt(t *testing.T) 
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut, client: &stubClient{}, noPrompt: true}
-	if code := r.runSetup(context.Background()); code == 0 {
+	if code := runSetup(r, context.Background()); code == 0 {
 		t.Fatal("expected failure without store resolution")
 	}
 }

--- a/cmd/cloudstic/cmd_source.go
+++ b/cmd/cloudstic/cmd_source.go
@@ -10,7 +10,7 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 )
 
-func (r *runner) runSource(ctx context.Context) int {
+func runSource(r *runner, ctx context.Context) int {
 	if len(os.Args) < 3 {
 		_, _ = fmt.Fprintln(r.errOut, "Usage: cloudstic source <subcommand> [options]")
 		_, _ = fmt.Fprintln(r.errOut, "")
@@ -20,13 +20,13 @@ func (r *runner) runSource(ctx context.Context) int {
 
 	switch os.Args[2] {
 	case "discover":
-		return r.runSourceDiscover(ctx)
+		return runSourceDiscover(r, ctx)
 	default:
 		return r.fail("Unknown source subcommand: %s", os.Args[2])
 	}
 }
 
-func (r *runner) runSourceDiscover(ctx context.Context) int {
+func runSourceDiscover(r *runner, ctx context.Context) int {
 	fs := flag.NewFlagSet("source discover", flag.ExitOnError)
 	portableOnly := fs.Bool("portable-only", false, "Only show portable/external source candidates")
 	jsonOutput := fs.Bool("json", false, "Write discovered sources as JSON")

--- a/cmd/cloudstic/cmd_source_test.go
+++ b/cmd/cloudstic/cmd_source_test.go
@@ -24,7 +24,7 @@ func TestRunSourceDiscover(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut, client: client}
-	if code := r.runSource(context.Background()); code != 0 {
+	if code := runSource(r, context.Background()); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
 	got := out.String()
@@ -48,7 +48,7 @@ func TestRunSourceDiscover_PortableOnly(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut, client: client}
-	if code := r.runSource(context.Background()); code != 0 {
+	if code := runSource(r, context.Background()); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
 	got := out.String()
@@ -74,7 +74,7 @@ func TestRunSourceDiscover_JSON(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut, client: client}
-	if code := r.runSource(context.Background()); code != 0 {
+	if code := runSource(r, context.Background()); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
 	got := out.String()
@@ -91,7 +91,7 @@ func TestRunSourceDiscover_DefaultClient(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runSource(context.Background()); code != 0 {
+	if code := runSource(r, context.Background()); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
 }

--- a/cmd/cloudstic/cmd_store.go
+++ b/cmd/cloudstic/cmd_store.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cloudstic/cli/pkg/store"
 )
 
-func (r *runner) runStore(ctx context.Context) int {
+func runStore(r *runner, ctx context.Context) int {
 	if len(os.Args) < 3 {
 		_, _ = fmt.Fprintln(r.errOut, "Usage: cloudstic store <subcommand> [options]")
 		_, _ = fmt.Fprintln(r.errOut, "")
@@ -25,21 +25,21 @@ func (r *runner) runStore(ctx context.Context) int {
 
 	switch os.Args[2] {
 	case "list":
-		return r.runStoreList(ctx)
+		return runStoreList(r, ctx)
 	case "show":
-		return r.runStoreShow(ctx)
+		return runStoreShow(r, ctx)
 	case "new":
-		return r.runStoreNew(ctx)
+		return runStoreNew(r, ctx)
 	case "verify":
-		return r.runStoreVerify(ctx)
+		return runStoreVerify(r, ctx)
 	case "init":
-		return r.runStoreInit(ctx)
+		return runStoreInit(r, ctx)
 	default:
 		return r.fail("Unknown store subcommand: %s", os.Args[2])
 	}
 }
 
-func (r *runner) runStoreList(ctx context.Context) int {
+func runStoreList(r *runner, ctx context.Context) int {
 	fs := flag.NewFlagSet("store list", flag.ExitOnError)
 	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
 	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
@@ -52,11 +52,11 @@ func (r *runner) runStoreList(ctx context.Context) int {
 		return r.fail("Failed to load profiles: %v", err)
 	}
 
-	r.renderStoreList(cfg)
+	renderStoreList(r.out, cfg)
 	return 0
 }
 
-func (r *runner) runStoreShow(ctx context.Context) int {
+func runStoreShow(r *runner, ctx context.Context) int {
 	fs := flag.NewFlagSet("store show", flag.ExitOnError)
 	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
 	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
@@ -89,11 +89,11 @@ func (r *runner) runStoreShow(ctx context.Context) int {
 	if !ok {
 		return r.fail("Unknown store %q", name)
 	}
-	r.renderStoreShow(cfg, name, s)
+	renderStoreShow(r.out, cfg, name, s)
 	return 0
 }
 
-func (r *runner) runStoreNew(ctx context.Context) int {
+func runStoreNew(r *runner, ctx context.Context) int {
 	fs := flag.NewFlagSet("store new", flag.ExitOnError)
 	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
 	name := fs.String("name", "", "Store reference name")
@@ -222,7 +222,7 @@ func (r *runner) runStoreNew(ctx context.Context) int {
 		if forcePromptEncryption || !storeHasExplicitEncryption(s) {
 			r.promptEncryptionConfig(ctx, cfg, *name, *profilesFile)
 		}
-		if err := r.checkOrInitStoreWithRecovery(ctx, cfg, *name, *profilesFile, checkOrInitOptions{
+		if err := checkOrInitStoreWithRecovery(r, ctx, cfg, *name, *profilesFile, checkOrInitOptions{
 			allowMissingSecrets:  true,
 			warnOnMissingSecrets: !existedBefore,
 			offerInit:            true,
@@ -239,7 +239,7 @@ func (r *runner) runStoreNew(ctx context.Context) int {
 // initialize it. Encryption config should already be saved in profiles.yaml
 // before calling this. Errors are printed but never cause a non-zero exit—
 // the store config has already been saved.
-func (r *runner) runStoreVerify(ctx context.Context) int {
+func runStoreVerify(r *runner, ctx context.Context) int {
 	fs := flag.NewFlagSet("store verify", flag.ExitOnError)
 	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
 	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
@@ -275,7 +275,7 @@ func (r *runner) runStoreVerify(ctx context.Context) int {
 	if _, ok := cfg.Stores[name]; !ok {
 		return r.fail("Unknown store %q", name)
 	}
-	if err := r.checkOrInitStoreWithRecovery(ctx, cfg, name, *profilesFile, checkOrInitOptions{
+	if err := checkOrInitStoreWithRecovery(r, ctx, cfg, name, *profilesFile, checkOrInitOptions{
 		warnOnMissingSecrets: true,
 	}, false); err != nil {
 		return r.fail("%v", err)
@@ -283,7 +283,7 @@ func (r *runner) runStoreVerify(ctx context.Context) int {
 	return 0
 }
 
-func (r *runner) runStoreInit(ctx context.Context) int {
+func runStoreInit(r *runner, ctx context.Context) int {
 	fs := flag.NewFlagSet("store init", flag.ExitOnError)
 	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
 	yes := fs.Bool("yes", false, "Initialize without confirmation prompt")
@@ -320,7 +320,7 @@ func (r *runner) runStoreInit(ctx context.Context) int {
 	if _, ok := cfg.Stores[name]; !ok {
 		return r.fail("Unknown store %q", name)
 	}
-	if err := r.checkOrInitStoreWithRecovery(ctx, cfg, name, *profilesFile, checkOrInitOptions{
+	if err := checkOrInitStoreWithRecovery(r, ctx, cfg, name, *profilesFile, checkOrInitOptions{
 		warnOnMissingSecrets: true,
 		offerInit:            true,
 		assumeYes:            *yes,
@@ -337,7 +337,7 @@ type checkOrInitOptions struct {
 	assumeYes            bool
 }
 
-func (r *runner) checkOrInitStore(ctx context.Context, cfg *cloudstic.ProfilesConfig, storeName, profilesFile string, opts checkOrInitOptions) error {
+func checkOrInitStore(r *runner, ctx context.Context, cfg *cloudstic.ProfilesConfig, storeName, profilesFile string, opts checkOrInitOptions) error {
 	s := cfg.Stores[storeName]
 	g, err := globalFlagsFromProfileStore(s)
 	if err != nil {
@@ -393,7 +393,7 @@ func (r *runner) checkOrInitStore(ctx context.Context, cfg *cloudstic.ProfilesCo
 		if initErr != nil {
 			return fmt.Errorf("init failed: %w", initErr)
 		}
-		r.printInitResult(result)
+		printInitResult(r.errOut, result)
 		return nil
 	}
 
@@ -411,13 +411,13 @@ func (r *runner) checkOrInitStore(ctx context.Context, cfg *cloudstic.ProfilesCo
 	if err != nil {
 		return fmt.Errorf("init failed: %w", err)
 	}
-	r.printInitResult(result)
+	printInitResult(r.errOut, result)
 	return nil
 }
 
-func (r *runner) checkOrInitStoreWithRecovery(ctx context.Context, cfg *cloudstic.ProfilesConfig, storeName, profilesFile string, opts checkOrInitOptions, allowSkip bool) error {
+func checkOrInitStoreWithRecovery(r *runner, ctx context.Context, cfg *cloudstic.ProfilesConfig, storeName, profilesFile string, opts checkOrInitOptions, allowSkip bool) error {
 	for {
-		err := r.checkOrInitStore(ctx, cfg, storeName, profilesFile, opts)
+		err := checkOrInitStore(r, ctx, cfg, storeName, profilesFile, opts)
 		if err == nil || !r.canPrompt() {
 			return err
 		}
@@ -448,7 +448,7 @@ func (r *runner) checkOrInitStoreWithRecovery(ctx context.Context, cfg *cloudsti
 		case "Abort":
 			return err
 		case loginOption:
-			if runErr := r.runAWSSSOLogin(ctx, s); runErr != nil {
+			if runErr := runAWSSSOLogin(r, ctx, s); runErr != nil {
 				_, _ = fmt.Fprintf(r.errOut, "AWS SSO login failed: %v\n", runErr)
 			}
 		default:
@@ -693,7 +693,7 @@ func isAWSExpiredAuthError(err error) bool {
 	return false
 }
 
-func (r *runner) runAWSSSOLogin(ctx context.Context, s cloudstic.ProfileStore) error {
+func runAWSSSOLogin(r *runner, ctx context.Context, s cloudstic.ProfileStore) error {
 	args := []string{"sso", "login"}
 	if s.S3Profile != "" {
 		args = append(args, "--profile", s.S3Profile)

--- a/cmd/cloudstic/cmd_store_test.go
+++ b/cmd/cloudstic/cmd_store_test.go
@@ -55,7 +55,7 @@ func TestRunStoreNewAndListAndShow(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runStore(context.Background()); code != 0 {
+	if code := runStore(r, context.Background()); code != 0 {
 		t.Fatalf("store new failed: %s", errOut.String())
 	}
 	if !strings.Contains(out.String(), `"prod-s3" saved`) {
@@ -66,7 +66,7 @@ func TestRunStoreNewAndListAndShow(t *testing.T) {
 	os.Args = []string{"cloudstic", "store", "list", "-profiles-file", profilesPath}
 	out.Reset()
 	errOut.Reset()
-	if code := r.runStore(context.Background()); code != 0 {
+	if code := runStore(r, context.Background()); code != 0 {
 		t.Fatalf("store list failed: %s", errOut.String())
 	}
 	if !strings.Contains(out.String(), "Stores") || !strings.Contains(out.String(), "prod-s3") || !strings.Contains(out.String(), "AUTH") {
@@ -77,7 +77,7 @@ func TestRunStoreNewAndListAndShow(t *testing.T) {
 	os.Args = []string{"cloudstic", "store", "show", "-profiles-file", profilesPath, "prod-s3"}
 	out.Reset()
 	errOut.Reset()
-	if code := r.runStore(context.Background()); code != 0 {
+	if code := runStore(r, context.Background()); code != 0 {
 		t.Fatalf("store show failed: %s", errOut.String())
 	}
 	got := out.String()
@@ -104,7 +104,7 @@ func TestRunStoreNew_RequiresNameAndURI(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runStore(context.Background()); code == 0 {
+	if code := runStore(r, context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "-uri is required") {
@@ -140,7 +140,7 @@ func TestRunStoreNew_ExistingStorePrefillsUnsetValues(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runStore(context.Background()); code != 0 {
+	if code := runStore(r, context.Background()); code != 0 {
 		t.Fatalf("store new failed: %s", errOut.String())
 	}
 
@@ -198,7 +198,7 @@ func TestRunStoreShow_UnknownStore(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runStore(context.Background()); code == 0 {
+	if code := runStore(r, context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "Unknown store") {
@@ -229,7 +229,7 @@ profiles:
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runStore(context.Background()); code != 0 {
+	if code := runStore(r, context.Background()); code != 0 {
 		t.Fatalf("store show failed: %s", errOut.String())
 	}
 	got := out.String()
@@ -243,7 +243,7 @@ func TestRunStoreList_MissingFile(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runStore(context.Background()); code != 0 {
+	if code := runStore(r, context.Background()); code != 0 {
 		t.Fatalf("expected zero exit code, got err=%s", errOut.String())
 	}
 }
@@ -264,7 +264,7 @@ func TestRunStoreNew_WithEncryption(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runStore(context.Background()); code != 0 {
+	if code := runStore(r, context.Background()); code != 0 {
 		t.Fatalf("store new failed: %s", errOut.String())
 	}
 
@@ -272,7 +272,7 @@ func TestRunStoreNew_WithEncryption(t *testing.T) {
 	os.Args = []string{"cloudstic", "store", "show", "-profiles-file", profilesPath, "encrypted-s3"}
 	out.Reset()
 	errOut.Reset()
-	if code := r.runStore(context.Background()); code != 0 {
+	if code := runStore(r, context.Background()); code != 0 {
 		t.Fatalf("store show failed: %s", errOut.String())
 	}
 	got := out.String()
@@ -334,7 +334,7 @@ func TestCheckOrInitStore_AlreadyInitialized(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if err := r.checkOrInitStore(context.Background(), cfg, "test", profilesPath, checkOrInitOptions{warnOnMissingSecrets: true, offerInit: true}); err != nil {
+	if err := checkOrInitStore(r, context.Background(), cfg, "test", profilesPath, checkOrInitOptions{warnOnMissingSecrets: true, offerInit: true}); err != nil {
 		t.Fatalf("checkOrInitStore: %v", err)
 	}
 
@@ -372,7 +372,7 @@ func TestCheckOrInitStore_InitializedEncrypted_ValidCredentials(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if err := r.checkOrInitStore(context.Background(), cfg, "test", "profiles.yaml", checkOrInitOptions{warnOnMissingSecrets: true, offerInit: true}); err != nil {
+	if err := checkOrInitStore(r, context.Background(), cfg, "test", "profiles.yaml", checkOrInitOptions{warnOnMissingSecrets: true, offerInit: true}); err != nil {
 		t.Fatalf("checkOrInitStore: %v", err)
 	}
 	if !strings.Contains(out.String(), "Repository is encrypted; verifying configured credentials") {
@@ -410,7 +410,7 @@ func TestCheckOrInitStore_InitializedEncrypted_InvalidCredentials(t *testing.T) 
 	}}
 
 	r := &runner{out: &strings.Builder{}, errOut: &strings.Builder{}}
-	err = r.checkOrInitStore(context.Background(), cfg, "test", "profiles.yaml", checkOrInitOptions{warnOnMissingSecrets: true, offerInit: true})
+	err = checkOrInitStore(r, context.Background(), cfg, "test", "profiles.yaml", checkOrInitOptions{warnOnMissingSecrets: true, offerInit: true})
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -497,7 +497,7 @@ func TestRunStoreNew_InvalidURI(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runStore(context.Background()); code == 0 {
+	if code := runStore(r, context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code for invalid URI")
 	}
 	if !strings.Contains(errOut.String(), "invalid store URI") {
@@ -513,7 +513,7 @@ func TestRunStoreNew_InvalidName(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runStore(context.Background()); code == 0 {
+	if code := runStore(r, context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code for invalid name")
 	}
 	if !strings.Contains(errOut.String(), "invalid store name") {
@@ -526,7 +526,7 @@ func TestRunStore_UnknownSubcommand(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runStore(context.Background()); code == 0 {
+	if code := runStore(r, context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "Unknown store subcommand") {
@@ -556,7 +556,7 @@ stores:
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runStore(context.Background()); code != 0 {
+	if code := runStore(r, context.Background()); code != 0 {
 		t.Fatalf("store show failed: %s", errOut.String())
 	}
 	got := out.String()
@@ -598,7 +598,7 @@ stores:
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runStore(context.Background()); code != 0 {
+	if code := runStore(r, context.Background()); code != 0 {
 		t.Fatalf("store show failed: %s", errOut.String())
 	}
 	got := out.String()
@@ -633,7 +633,7 @@ stores:
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runStore(context.Background()); code != 0 {
+	if code := runStore(r, context.Background()); code != 0 {
 		t.Fatalf("store show failed: %s", errOut.String())
 	}
 	got := out.String()
@@ -666,7 +666,7 @@ func TestRunStoreNew_WithSFTPOptions(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runStore(context.Background()); code != 0 {
+	if code := runStore(r, context.Background()); code != 0 {
 		t.Fatalf("store new failed: %s", errOut.String())
 	}
 
@@ -674,7 +674,7 @@ func TestRunStoreNew_WithSFTPOptions(t *testing.T) {
 	os.Args = []string{"cloudstic", "store", "show", "-profiles-file", profilesPath, "sftp-new"}
 	out.Reset()
 	errOut.Reset()
-	if code := r.runStore(context.Background()); code != 0 {
+	if code := runStore(r, context.Background()); code != 0 {
 		t.Fatalf("store show failed: %s", errOut.String())
 	}
 	got := out.String()
@@ -708,7 +708,7 @@ func TestRunStoreNew_WithAllS3Options(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runStore(context.Background()); code != 0 {
+	if code := runStore(r, context.Background()); code != 0 {
 		t.Fatalf("store new failed: %s", errOut.String())
 	}
 
@@ -750,7 +750,7 @@ func TestRunStoreNew_WithSecretRefFlags(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runStore(context.Background()); code != 0 {
+	if code := runStore(r, context.Background()); code != 0 {
 		t.Fatalf("store new failed: %s", errOut.String())
 	}
 
@@ -995,7 +995,7 @@ func TestCheckOrInitStore_MissingSecretAllowed(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if err := r.checkOrInitStore(context.Background(), cfg, "test", "profiles.yaml", checkOrInitOptions{allowMissingSecrets: true, warnOnMissingSecrets: true, offerInit: true}); err != nil {
+	if err := checkOrInitStore(r, context.Background(), cfg, "test", "profiles.yaml", checkOrInitOptions{allowMissingSecrets: true, warnOnMissingSecrets: true, offerInit: true}); err != nil {
 		t.Fatalf("checkOrInitStore: %v", err)
 	}
 	if !strings.Contains(errOut.String(), "cloudstic store verify test") {
@@ -1014,7 +1014,7 @@ func TestCheckOrInitStore_MissingSecretAllowedSilent(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if err := r.checkOrInitStore(context.Background(), cfg, "test", "profiles.yaml", checkOrInitOptions{allowMissingSecrets: true, offerInit: true}); err != nil {
+	if err := checkOrInitStore(r, context.Background(), cfg, "test", "profiles.yaml", checkOrInitOptions{allowMissingSecrets: true, offerInit: true}); err != nil {
 		t.Fatalf("checkOrInitStore: %v", err)
 	}
 	if errOut.String() != "" {
@@ -1039,7 +1039,7 @@ func TestRunStoreVerify_MissingSecretFails(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runStore(context.Background()); code == 0 {
+	if code := runStore(r, context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "could not resolve store credentials") {
@@ -1335,7 +1335,7 @@ stores:
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runStore(context.Background()); code != 0 {
+	if code := runStore(r, context.Background()); code != 0 {
 		t.Fatalf("store list failed: %s", errOut.String())
 	}
 	got := out.String()
@@ -1362,7 +1362,7 @@ func TestRunStoreNew_LocalStore(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runStore(context.Background()); code != 0 {
+	if code := runStore(r, context.Background()); code != 0 {
 		t.Fatalf("store new failed: %s", errOut.String())
 	}
 	if !strings.Contains(out.String(), `"local-bk" saved`) {

--- a/cmd/cloudstic/cmd_tui.go
+++ b/cmd/cloudstic/cmd_tui.go
@@ -32,7 +32,7 @@ func printTUIUsage(w io.Writer) {
 	_, _ = fmt.Fprintf(w, "  -profiles-file <path>  Path to profiles YAML file (default %s)\n", defaultProfilesPathNoCreate())
 }
 
-func (r *runner) runTUI(ctx context.Context) int {
+func runTUI(r *runner, ctx context.Context) int {
 	for _, arg := range os.Args[2:] {
 		if arg == "-h" || arg == "--help" || arg == "help" {
 			printTUIUsage(r.out)

--- a/cmd/cloudstic/cmd_tui_test.go
+++ b/cmd/cloudstic/cmd_tui_test.go
@@ -343,7 +343,7 @@ func TestRunTUI_Help(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := r.runTUI(context.Background()); code != 0 {
+	if code := runTUI(r, context.Background()); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
 	if !strings.Contains(out.String(), "Usage: cloudstic tui [options]") {
@@ -375,7 +375,7 @@ func TestRunTUI_RequiresInteractiveTerminal(t *testing.T) {
 		stdin:  readEnd,
 		lineIn: bufio.NewReader(readEnd),
 	}
-	if code := r.runTUI(context.Background()); code == 0 {
+	if code := runTUI(r, context.Background()); code == 0 {
 		t.Fatalf("expected failure for non-interactive terminal")
 	}
 	if !strings.Contains(errOut.String(), "requires an interactive terminal") {
@@ -448,7 +448,7 @@ func TestRunTUI_RendersDashboardAndQuitsOnQ(t *testing.T) {
 		stdin:      readEnd,
 		lineIn:     bufio.NewReader(readEnd),
 	}
-	if code := r.runTUI(context.Background()); code != 0 {
+	if code := runTUI(r, context.Background()); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
 	got := out.String()
@@ -495,7 +495,7 @@ func TestRunTUI_ArrowNavigationChangesSelection(t *testing.T) {
 		stdin:      readEnd,
 		lineIn:     bufio.NewReader(readEnd),
 	}
-	if code := r.runTUI(context.Background()); code != 0 {
+	if code := runTUI(r, context.Background()); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
 	got := out.String()
@@ -563,7 +563,7 @@ func TestRunTUI_BackupActionRunsSelectedProfileAction(t *testing.T) {
 		stdin:      readEnd,
 		lineIn:     bufio.NewReader(readEnd),
 	}
-	if code := r.runTUI(context.Background()); code != 0 {
+	if code := runTUI(r, context.Background()); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
 	if ranProfile != "documents" {
@@ -644,7 +644,7 @@ func TestRunTUI_CheckActionRunsSelectedProfileCheck(t *testing.T) {
 		stdin:      readEnd,
 		lineIn:     bufio.NewReader(readEnd),
 	}
-	if code := r.runTUI(context.Background()); code != 0 {
+	if code := runTUI(r, context.Background()); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
 	if checkedProfile != "documents" {
@@ -702,7 +702,7 @@ func TestRunTUI_CreateActionUsesModalAndSavesProfile(t *testing.T) {
 	oldEnv := os.Getenv("CLOUDSTIC_PROFILES_FILE")
 	t.Cleanup(func() { _ = os.Setenv("CLOUDSTIC_PROFILES_FILE", oldEnv) })
 	_ = os.Setenv("CLOUDSTIC_PROFILES_FILE", profilesPath)
-	if code := r.runTUI(context.Background()); code != 0 {
+	if code := runTUI(r, context.Background()); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
 	cfg, err := cloudstic.LoadProfilesFile(profilesPath)
@@ -1392,7 +1392,7 @@ func TestTUIBuildDashboardErrorPropagates(t *testing.T) {
 
 	var errOut strings.Builder
 	r := &runner{out: io.Discard, errOut: &errOut, stdin: readEnd, stdoutFile: os.Stdout, lineIn: bufio.NewReader(readEnd)}
-	if code := r.runTUI(context.Background()); code == 0 {
+	if code := runTUI(r, context.Background()); code == 0 {
 		t.Fatalf("expected failure")
 	}
 	if !strings.Contains(errOut.String(), "Failed to build TUI dashboard") {

--- a/cmd/cloudstic/config_tables.go
+++ b/cmd/cloudstic/config_tables.go
@@ -177,14 +177,14 @@ func appendWarningRow(rows []table.Row, warnings []string) []table.Row {
 	return append(rows, table.Row{"Warnings", strings.Join(warnings, ", ")})
 }
 
-func (r *runner) renderStoreList(cfg *cloudstic.ProfilesConfig) {
+func renderStoreList(out io.Writer, cfg *cloudstic.ProfilesConfig) {
 	names := sortedKeys(cfg.Stores)
-	renderSectionHeading(r.out, "Stores", len(names))
+	renderSectionHeading(out, "Stores", len(names))
 	if len(names) == 0 {
-		renderMessageRow(r.out, "No stores configured.")
+		renderMessageRow(out, "No stores configured.")
 		return
 	}
-	t := newConfigTableWriter(r.out)
+	t := newConfigTableWriter(out)
 	t.AppendHeader(table.Row{"Name", "Type", "Target", "Auth", "Used By", "Status"})
 	for _, name := range names {
 		s := cfg.Stores[name]
@@ -201,14 +201,14 @@ func (r *runner) renderStoreList(cfg *cloudstic.ProfilesConfig) {
 	t.Render()
 }
 
-func (r *runner) renderAuthList(cfg *cloudstic.ProfilesConfig) {
+func renderAuthList(out io.Writer, cfg *cloudstic.ProfilesConfig) {
 	names := sortedKeys(cfg.Auth)
-	renderSectionHeading(r.out, "Auth", len(names))
+	renderSectionHeading(out, "Auth", len(names))
 	if len(names) == 0 {
-		renderMessageRow(r.out, "No auth entries configured.")
+		renderMessageRow(out, "No auth entries configured.")
 		return
 	}
-	t := newConfigTableWriter(r.out)
+	t := newConfigTableWriter(out)
 	t.AppendHeader(table.Row{"Name", "Provider", "Token", "Used By", "Status"})
 	for _, name := range names {
 		auth := cfg.Auth[name]
@@ -224,24 +224,24 @@ func (r *runner) renderAuthList(cfg *cloudstic.ProfilesConfig) {
 	t.Render()
 }
 
-func (r *runner) renderProfileList(cfg *cloudstic.ProfilesConfig) {
+func renderProfileList(out io.Writer, cfg *cloudstic.ProfilesConfig) {
 	names := sortedKeys(cfg.Profiles)
-	renderSectionHeading(r.out, "Profiles", len(names))
+	renderSectionHeading(out, "Profiles", len(names))
 	if len(names) == 0 {
-		renderMessageRow(r.out, "No profiles configured.")
+		renderMessageRow(out, "No profiles configured.")
 		return
 	}
-	t := newConfigTableWriter(r.out)
+	t := newConfigTableWriter(out)
 	t.AppendHeader(table.Row{"Name", "Source", "Store", "Auth", "Tags", "Status"})
 	for _, name := range names {
-		p := cfg.Profiles[name]
-		status, warnings := profileHealth(cfg, p)
+		profile := cfg.Profiles[name]
+		status, warnings := profileHealth(cfg, profile)
 		t.AppendRow(table.Row{
 			name,
-			p.Source,
-			dashIfEmpty(p.Store),
-			dashIfEmpty(p.AuthRef),
-			shortList(p.Tags, 2),
+			profile.Source,
+			dashIfEmpty(profile.Store),
+			dashIfEmpty(profile.AuthRef),
+			shortList(profile.Tags, 2),
 			statusLabel(status) + warningSuffix(warnings),
 		})
 	}
@@ -278,10 +278,10 @@ func authTokenPath(auth cloudstic.ProfileAuth) string {
 	return "-"
 }
 
-func (r *runner) renderStoreShow(cfg *cloudstic.ProfilesConfig, name string, s cloudstic.ProfileStore) {
+func renderStoreShow(out io.Writer, cfg *cloudstic.ProfilesConfig, name string, s cloudstic.ProfileStore) {
 	status, warnings := storeHealth(s)
-	renderSectionHeading(r.out, fmt.Sprintf("Store %s", name), -1)
-	renderKVTable(r.out, appendWarningRow([]table.Row{
+	renderSectionHeading(out, fmt.Sprintf("Store %s", name), -1)
+	renderKVTable(out, appendWarningRow([]table.Row{
 		{"URI", s.URI},
 		{"Type", storeScheme(s.URI)},
 		{"Auth Mode", profileStoreAuthMode(s)},
@@ -308,23 +308,23 @@ func (r *runner) renderStoreShow(cfg *cloudstic.ProfilesConfig, name string, s c
 		connection = append(connection, table.Row{"KMS Endpoint", s.KMSEndpoint})
 	}
 	if len(connection) > 0 {
-		renderSectionHeading(r.out, "Connection", -1)
-		renderKVTable(r.out, connection)
+		renderSectionHeading(out, "Connection", -1)
+		renderKVTable(out, connection)
 	}
 
 	credentials := secretDisplayRows(s)
 	if len(credentials) > 0 {
-		renderSectionHeading(r.out, "Credential References", -1)
-		renderKVTable(r.out, credentials)
+		renderSectionHeading(out, "Credential References", -1)
+		renderKVTable(out, credentials)
 	}
 
 	usedBy := profilesUsingStore(cfg, name)
-	renderSectionHeading(r.out, "Used By", len(usedBy))
+	renderSectionHeading(out, "Used By", len(usedBy))
 	if len(usedBy) == 0 {
-		renderMessageRow(r.out, "No profiles reference this store.")
+		renderMessageRow(out, "No profiles reference this store.")
 		return
 	}
-	t := newConfigTableWriter(r.out)
+	t := newConfigTableWriter(out)
 	t.AppendHeader(table.Row{"Profile"})
 	for _, ref := range usedBy {
 		t.AppendRow(table.Row{ref})
@@ -353,10 +353,10 @@ func secretDisplayRows(s cloudstic.ProfileStore) []table.Row {
 	return rows
 }
 
-func (r *runner) renderAuthShow(cfg *cloudstic.ProfilesConfig, name string, auth cloudstic.ProfileAuth) {
+func renderAuthShow(out io.Writer, cfg *cloudstic.ProfilesConfig, name string, auth cloudstic.ProfileAuth) {
 	status, warnings := authHealth(auth)
-	renderSectionHeading(r.out, fmt.Sprintf("Auth %s", name), -1)
-	renderKVTable(r.out, appendWarningRow([]table.Row{
+	renderSectionHeading(out, fmt.Sprintf("Auth %s", name), -1)
+	renderKVTable(out, appendWarningRow([]table.Row{
 		{"Provider", auth.Provider},
 		{"Token Storage", authTokenPath(auth)},
 		{"Status", statusLabel(status)},
@@ -385,17 +385,17 @@ func (r *runner) renderAuthShow(cfg *cloudstic.ProfilesConfig, name string, auth
 		providerRows = append(providerRows, table.Row{"OneDrive Token Ref", auth.OneDriveTokenRef})
 	}
 	if len(providerRows) > 0 {
-		renderSectionHeading(r.out, "Provider Details", -1)
-		renderKVTable(r.out, providerRows)
+		renderSectionHeading(out, "Provider Details", -1)
+		renderKVTable(out, providerRows)
 	}
 
 	usedBy := profilesUsingAuth(cfg, name)
-	renderSectionHeading(r.out, "Used By", len(usedBy))
+	renderSectionHeading(out, "Used By", len(usedBy))
 	if len(usedBy) == 0 {
-		renderMessageRow(r.out, "No profiles reference this auth entry.")
+		renderMessageRow(out, "No profiles reference this auth entry.")
 		return
 	}
-	t := newConfigTableWriter(r.out)
+	t := newConfigTableWriter(out)
 	t.AppendHeader(table.Row{"Profile"})
 	for _, ref := range usedBy {
 		t.AppendRow(table.Row{ref})
@@ -403,23 +403,23 @@ func (r *runner) renderAuthShow(cfg *cloudstic.ProfilesConfig, name string, auth
 	t.Render()
 }
 
-func (r *runner) renderProfileShow(cfg *cloudstic.ProfilesConfig, name string, p cloudstic.BackupProfile) {
-	status, warnings := profileHealth(cfg, p)
-	renderSectionHeading(r.out, fmt.Sprintf("Profile %s", name), -1)
-	renderKVTable(r.out, appendWarningRow([]table.Row{
-		{"Source", p.Source},
-		{"Source Type", sourceScheme(p.Source)},
-		{"Provider", dashIfEmpty(profileProviderFromSource(p.Source))},
-		{"Enabled", boolLabel(p.IsEnabled())},
+func renderProfileShow(out io.Writer, cfg *cloudstic.ProfilesConfig, name string, profile cloudstic.BackupProfile) {
+	status, warnings := profileHealth(cfg, profile)
+	renderSectionHeading(out, fmt.Sprintf("Profile %s", name), -1)
+	renderKVTable(out, appendWarningRow([]table.Row{
+		{"Source", profile.Source},
+		{"Source Type", sourceScheme(profile.Source)},
+		{"Provider", dashIfEmpty(profileProviderFromSource(profile.Source))},
+		{"Enabled", boolLabel(profile.IsEnabled())},
 		{"Status", statusLabel(status)},
 	}, warnings))
 
 	storeValue := "<missing>"
 	storeAuthMode := "-"
 	storeExtraRows := []table.Row{}
-	if p.Store == "" {
+	if profile.Store == "" {
 		storeValue = "-"
-	} else if s, ok := cfg.Stores[p.Store]; ok {
+	} else if s, ok := cfg.Stores[profile.Store]; ok {
 		storeValue = s.URI
 		storeAuthMode = profileStoreAuthMode(s)
 		if s.S3Region != "" {
@@ -434,65 +434,65 @@ func (r *runner) renderProfileShow(cfg *cloudstic.ProfilesConfig, name string, p
 	}
 	authProvider := "-"
 	authToken := "-"
-	if p.AuthRef != "" {
-		if auth, ok := cfg.Auth[p.AuthRef]; ok {
+	if profile.AuthRef != "" {
+		if auth, ok := cfg.Auth[profile.AuthRef]; ok {
 			authProvider = auth.Provider
 			authToken = authTokenPath(auth)
 		} else {
 			authProvider = "<missing>"
 		}
 	}
-	renderSectionHeading(r.out, "Resolved References", -1)
+	renderSectionHeading(out, "Resolved References", -1)
 	resolvedRows := []table.Row{
-		{"Store Ref", dashIfEmpty(p.Store)},
+		{"Store Ref", dashIfEmpty(profile.Store)},
 		{"Store URI", storeValue},
 		{"Store Auth Mode", storeAuthMode},
-		{"Auth Ref", dashIfEmpty(p.AuthRef)},
+		{"Auth Ref", dashIfEmpty(profile.AuthRef)},
 		{"Auth Provider", authProvider},
 		{"Auth Token", authToken},
 	}
 	resolvedRows = append(resolvedRows, storeExtraRows...)
-	renderKVTable(r.out, resolvedRows)
+	renderKVTable(out, resolvedRows)
 
 	optionRows := []table.Row{
-		{"Tags", joinOrDash(p.Tags)},
-		{"Excludes", fmt.Sprintf("%d pattern(s)", len(p.Excludes))},
-		{"Exclude File", dashIfEmpty(p.ExcludeFile)},
-		{"Ignore Empty Snapshot", boolLabel(p.IgnoreEmpty)},
-		{"Skip Native Files", boolLabel(p.SkipNativeFiles)},
+		{"Tags", joinOrDash(profile.Tags)},
+		{"Excludes", fmt.Sprintf("%d pattern(s)", len(profile.Excludes))},
+		{"Exclude File", dashIfEmpty(profile.ExcludeFile)},
+		{"Ignore Empty Snapshot", boolLabel(profile.IgnoreEmpty)},
+		{"Skip Native Files", boolLabel(profile.SkipNativeFiles)},
 	}
-	if p.VolumeUUID != "" {
-		optionRows = append(optionRows, table.Row{"Volume UUID", p.VolumeUUID})
+	if profile.VolumeUUID != "" {
+		optionRows = append(optionRows, table.Row{"Volume UUID", profile.VolumeUUID})
 	}
-	if p.GoogleCreds != "" {
-		optionRows = append(optionRows, table.Row{"Google Credentials File", p.GoogleCreds})
+	if profile.GoogleCreds != "" {
+		optionRows = append(optionRows, table.Row{"Google Credentials File", profile.GoogleCreds})
 	}
-	if p.GoogleCredsRef != "" {
-		optionRows = append(optionRows, table.Row{"Google Credentials Ref", p.GoogleCredsRef})
+	if profile.GoogleCredsRef != "" {
+		optionRows = append(optionRows, table.Row{"Google Credentials Ref", profile.GoogleCredsRef})
 	}
-	if p.GoogleTokenFile != "" {
-		optionRows = append(optionRows, table.Row{"Google Token File", p.GoogleTokenFile})
+	if profile.GoogleTokenFile != "" {
+		optionRows = append(optionRows, table.Row{"Google Token File", profile.GoogleTokenFile})
 	}
-	if p.GoogleTokenRef != "" {
-		optionRows = append(optionRows, table.Row{"Google Token Ref", p.GoogleTokenRef})
+	if profile.GoogleTokenRef != "" {
+		optionRows = append(optionRows, table.Row{"Google Token Ref", profile.GoogleTokenRef})
 	}
-	if p.OneDriveClientID != "" {
-		optionRows = append(optionRows, table.Row{"OneDrive Client ID", p.OneDriveClientID})
+	if profile.OneDriveClientID != "" {
+		optionRows = append(optionRows, table.Row{"OneDrive Client ID", profile.OneDriveClientID})
 	}
-	if p.OneDriveTokenFile != "" {
-		optionRows = append(optionRows, table.Row{"OneDrive Token File", p.OneDriveTokenFile})
+	if profile.OneDriveTokenFile != "" {
+		optionRows = append(optionRows, table.Row{"OneDrive Token File", profile.OneDriveTokenFile})
 	}
-	if p.OneDriveTokenRef != "" {
-		optionRows = append(optionRows, table.Row{"OneDrive Token Ref", p.OneDriveTokenRef})
+	if profile.OneDriveTokenRef != "" {
+		optionRows = append(optionRows, table.Row{"OneDrive Token Ref", profile.OneDriveTokenRef})
 	}
-	renderSectionHeading(r.out, "Options", -1)
-	renderKVTable(r.out, optionRows)
+	renderSectionHeading(out, "Options", -1)
+	renderKVTable(out, optionRows)
 
-	if len(p.Excludes) > 0 {
-		renderSectionHeading(r.out, "Exclude Patterns", len(p.Excludes))
-		t := newConfigTableWriter(r.out)
+	if len(profile.Excludes) > 0 {
+		renderSectionHeading(out, "Exclude Patterns", len(profile.Excludes))
+		t := newConfigTableWriter(out)
 		t.AppendHeader(table.Row{"Pattern"})
-		for _, pattern := range p.Excludes {
+		for _, pattern := range profile.Excludes {
 			t.AppendRow(table.Row{pattern})
 		}
 		t.Render()

--- a/cmd/cloudstic/format.go
+++ b/cmd/cloudstic/format.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/cloudstic/cli/internal/core"
@@ -33,9 +34,9 @@ func formatBytes(b int64) string {
 
 // renderSnapshotTable prints a table of snapshot entries to w. If reasons
 // is non-nil, a "Reasons" column is appended with the value for each ref.
-func (r *runner) renderSnapshotTable(entries []engine.SnapshotEntry, reasons map[string]string) {
+func renderSnapshotTable(out io.Writer, entries []engine.SnapshotEntry, reasons map[string]string) {
 	t := table.NewWriter()
-	t.SetOutputMirror(r.out)
+	t.SetOutputMirror(out)
 
 	header := table.Row{"Seq", "Created", "Snapshot Hash", "Source", "Account", "Path", "Tags"}
 	if reasons != nil {
@@ -107,7 +108,7 @@ func sourceGroupLabel(s *core.SourceInfo) string {
 }
 
 // renderGroupedSnapshotTables prints one table per source group.
-func (r *runner) renderGroupedSnapshotTables(entries []engine.SnapshotEntry) {
+func renderGroupedSnapshotTables(out io.Writer, entries []engine.SnapshotEntry) {
 	// Collect groups preserving first-seen order.
 	type group struct {
 		key     string
@@ -133,9 +134,9 @@ func (r *runner) renderGroupedSnapshotTables(entries []engine.SnapshotEntry) {
 
 	for i, g := range groups {
 		if i > 0 {
-			_, _ = fmt.Fprintln(r.out)
+			_, _ = fmt.Fprintln(out)
 		}
-		_, _ = fmt.Fprintf(r.out, "── %s (%d snapshots)\n", g.label, len(g.entries))
-		r.renderSnapshotTable(g.entries, nil)
+		_, _ = fmt.Fprintf(out, "── %s (%d snapshots)\n", g.label, len(g.entries))
+		renderSnapshotTable(out, g.entries, nil)
 	}
 }

--- a/cmd/cloudstic/format_test.go
+++ b/cmd/cloudstic/format_test.go
@@ -33,7 +33,7 @@ func TestFormatBytes(t *testing.T) {
 func TestRenderSnapshotTable_Empty(t *testing.T) {
 	r := &runner{out: &strings.Builder{}, errOut: &strings.Builder{}}
 	// Should not panic with empty entries.
-	r.renderSnapshotTable(nil, nil)
+	renderSnapshotTable(r.out, nil, nil)
 }
 
 func TestRenderSnapshotTable_WithEntries(t *testing.T) {
@@ -55,7 +55,7 @@ func TestRenderSnapshotTable_WithEntries(t *testing.T) {
 			},
 		},
 	}
-	r.renderSnapshotTable(entries, nil)
+	renderSnapshotTable(r.out, entries, nil)
 
 	got := out.String()
 	if !strings.Contains(got, "abc123") {
@@ -75,7 +75,7 @@ func TestRenderSnapshotTable_WithReasons(t *testing.T) {
 		{Ref: ref, Snap: core.Snapshot{Seq: 1, Created: time.Now().Format(time.RFC3339)}},
 	}
 	reasons := map[string]string{ref: "keep-last"}
-	r.renderSnapshotTable(entries, reasons)
+	renderSnapshotTable(r.out, entries, reasons)
 
 	got := out.String()
 	if !strings.Contains(got, "keep-last") {
@@ -105,7 +105,7 @@ func TestRenderSnapshotTable_DriveName(t *testing.T) {
 			},
 		},
 	}
-	r.renderSnapshotTable(entries, nil)
+	renderSnapshotTable(r.out, entries, nil)
 
 	got := out.String()
 	if !strings.Contains(got, "gdrive (My Drive)") {
@@ -205,7 +205,7 @@ func TestRenderGroupedSnapshotTables(t *testing.T) {
 		},
 	}
 
-	r.renderGroupedSnapshotTables(entries)
+	renderGroupedSnapshotTables(r.out, entries)
 
 	got := out.String()
 	// Should have two group headers.

--- a/cmd/cloudstic/main.go
+++ b/cmd/cloudstic/main.go
@@ -49,41 +49,41 @@ func runCmd(ctx context.Context, cmd string) int {
 		fmt.Printf("cloudstic %s (commit %s, built %s)\n", version, commit, date)
 		return 0
 	case "init":
-		return r.runInit(ctx)
+		return runInit(r, ctx)
 	case "backup":
-		return r.runBackup(ctx)
+		return runBackup(r, ctx)
 	case "restore":
-		return r.runRestore(ctx)
+		return runRestore(r, ctx)
 	case "list":
-		return r.runList(ctx)
+		return runList(r, ctx)
 	case "ls":
-		return r.runLsSnapshot(ctx)
+		return runLsSnapshot(r, ctx)
 	case "prune":
-		return r.runPrune(ctx)
+		return runPrune(r, ctx)
 	case "forget":
-		return r.runForget(ctx)
+		return runForget(r, ctx)
 	case "diff":
-		return r.runDiff(ctx)
+		return runDiff(r, ctx)
 	case "break-lock":
-		return r.runBreakLock(ctx)
+		return runBreakLock(r, ctx)
 	case "key":
-		return r.runKey(ctx)
+		return runKey(r, ctx)
 	case "check":
-		return r.runCheck(ctx)
+		return runCheck(r, ctx)
 	case "cat":
-		return r.runCat(ctx)
+		return runCat(r, ctx)
 	case "profile":
-		return r.runProfile(ctx)
+		return runProfile(r, ctx)
 	case "auth":
-		return r.runAuth(ctx)
+		return runAuth(r, ctx)
 	case "store":
-		return r.runStore(ctx)
+		return runStore(r, ctx)
 	case "source":
-		return r.runSource(ctx)
+		return runSource(r, ctx)
 	case "setup":
-		return r.runSetup(ctx)
+		return runSetup(r, ctx)
 	case "tui":
-		return r.runTUI(ctx)
+		return runTUI(r, ctx)
 	case "completion":
 		runCompletion()
 		return 0

--- a/cmd/cloudstic/tui_runtime.go
+++ b/cmd/cloudstic/tui_runtime.go
@@ -50,7 +50,7 @@ func (b tuiCLIBackend) InitProfile(ctx context.Context, profilesFile, profileNam
 	}
 	g := tuiStoreFlags(profilesFile, storeCfg)
 	*g.quiet = false
-	if code := b.r.runInitWithArgs(ctx, &initArgs{g: g}); code != 0 {
+	if code := runInitWithArgs(b.r, ctx, &initArgs{g: g}); code != 0 {
 		return fmt.Errorf("init failed")
 	}
 	return nil
@@ -74,7 +74,7 @@ func (b tuiCLIBackend) BackupProfile(ctx context.Context, profilesFile, profileN
 	}
 	b.r.client = client
 	defer func() { b.r.client = nil }()
-	if code := b.r.runSingleBackup(ctx, effective); code != 0 {
+	if code := runSingleBackup(b.r, ctx, effective); code != 0 {
 		return fmt.Errorf("backup failed")
 	}
 	return nil
@@ -94,7 +94,7 @@ func (b tuiCLIBackend) CheckProfile(ctx context.Context, profilesFile, profileNa
 	if err != nil {
 		return fmt.Errorf("check failed: %w", err)
 	}
-	if b.r.printCheckResult(result) {
+	if printCheckResult(b.r.errOut, result) {
 		return fmt.Errorf("repository check reported errors")
 	}
 	return nil


### PR DESCRIPTION
## Summary

- Converted all `print*`/`render*` helpers to free functions taking the writer(s) they need first, e.g. `printBackupSummary(out io.Writer, res *engine.RunResult)`.
- Converted all `run*`/`exec*` command functions to free functions taking `*runner` and `context.Context` as leading parameters, e.g. `runBackup(r *runner, ctx context.Context) int`, dispatched from `runCmd()` in `main.go`.
- `runner` now holds only I/O primitives as methods: `fail`, `writeJSON`, `failJSONFlagConflict`, `openClient`, `lineReader`, `canPrompt`, `prompt*`.
- Updated `AGENTS.md`'s package-layout and CLI-integration guidance to describe the free-function convention for new commands.

An initial pass wrapped the two output writers in a `printer{}` type with an `r.p()` accessor on `runner`, but that accessor was itself judged convoluted — a factory minting a throwaway struct on every call just to hang stateless methods off it. Since every presentation helper is a pure function of `(writer, data) -> text`, and the same "why is this a method on a God struct" question applies equally to command orchestration, both became plain functions instead. No `printer` type exists in the final diff.

This is a larger diff than #251 originally scoped (which proposed a `printer` type) — the design changed after discussion, and #251 has been updated to match what's actually here.

Closes #251

## Verification

- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./cmd/cloudstic` passes
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./cmd/cloudstic/...` → 0 issues
- `gofmt -l` clean
- Manual: init → backup → list → check → restore dry-run against a real repository — output byte-identical to pre-refactor behavior