### PR TITLE
refactor(cli): convert globalFlags to value fields

### DIFF
--- a/cmd/cloudstic/cmd_backup.go
+++ b/cmd/cloudstic/cmd_backup.go
@@ -77,10 +77,10 @@ func parseBackupArgs() *backupArgs {
 	fs.Var(&a.excludes, "exclude", "Exclude pattern (gitignore syntax, repeatable)")
 	mustParse(fs)
 	a.sourceURI = *sourceURI
-	a.profile = *a.g.profile
+	a.profile = a.g.profile
 	a.allProfiles = *allProfiles
 	a.authRef = *authRef
-	a.profilesFile = *a.g.profilesFile
+	a.profilesFile = a.g.profilesFile
 	a.dryRun = *dryRun
 	a.ignoreEmpty = *ignoreEmpty
 	a.skipNativeFiles = *skipNativeFiles
@@ -469,134 +469,88 @@ func applyProfileAuthToBackupArgs(a *backupArgs, auth cloudstic.ProfileAuth) err
 	return nil
 }
 
+// cloneGlobalFlags returns an independent copy of src: globalFlags holds only
+// value fields (plus the shared *ui.SafeLogWriter debug log), so a shallow
+// struct copy is a complete, correct clone.
 func cloneGlobalFlags(src *globalFlags) *globalFlags {
 	clone := *src
-
-	store := *src.store
-	profile := *src.profile
-	profilesFile := *src.profilesFile
-	s3Endpoint := *src.s3Endpoint
-	s3Region := *src.s3Region
-	s3Profile := *src.s3Profile
-	s3AccessKey := *src.s3AccessKey
-	s3SecretKey := *src.s3SecretKey
-	sourceSFTPPassword := *src.sourceSFTPPassword
-	sourceSFTPKey := *src.sourceSFTPKey
-	storeSFTPPassword := *src.storeSFTPPassword
-	storeSFTPKey := *src.storeSFTPKey
-	encryptionKey := *src.encryptionKey
-	password := *src.password
-	recoveryKey := *src.recoveryKey
-	kmsKeyARN := *src.kmsKeyARN
-	kmsRegion := *src.kmsRegion
-	kmsEndpoint := *src.kmsEndpoint
-	disablePackfile := *src.disablePackfile
-	prompt := *src.prompt
-	verbose := *src.verbose
-	quiet := *src.quiet
-	debug := *src.debug
-
-	clone.store = &store
-	clone.profile = &profile
-	clone.profilesFile = &profilesFile
-	clone.s3Endpoint = &s3Endpoint
-	clone.s3Region = &s3Region
-	clone.s3Profile = &s3Profile
-	clone.s3AccessKey = &s3AccessKey
-	clone.s3SecretKey = &s3SecretKey
-	clone.sourceSFTPPassword = &sourceSFTPPassword
-	clone.sourceSFTPKey = &sourceSFTPKey
-	clone.storeSFTPPassword = &storeSFTPPassword
-	clone.storeSFTPKey = &storeSFTPKey
-	clone.encryptionKey = &encryptionKey
-	clone.password = &password
-	clone.recoveryKey = &recoveryKey
-	clone.kmsKeyARN = &kmsKeyARN
-	clone.kmsRegion = &kmsRegion
-	clone.kmsEndpoint = &kmsEndpoint
-	clone.disablePackfile = &disablePackfile
-	clone.prompt = &prompt
-	clone.verbose = &verbose
-	clone.quiet = &quiet
-	clone.debug = &debug
-
 	return &clone
 }
 
 func applyProfileStoreToGlobalFlags(g *globalFlags, s cloudstic.ProfileStore, flagsSet map[string]bool) error {
 	if !flagsSet["store"] && s.URI != "" {
-		*g.store = s.URI
+		g.store = s.URI
 	}
 	if !flagsSet["s3-endpoint"] && s.S3Endpoint != "" {
-		*g.s3Endpoint = s.S3Endpoint
+		g.s3Endpoint = s.S3Endpoint
 	}
 	if !flagsSet["s3-region"] && s.S3Region != "" {
-		*g.s3Region = s.S3Region
+		g.s3Region = s.S3Region
 	}
 	if !flagsSet["s3-profile"] {
 		v, err := resolveProfileStoreValue("s3_profile", s.S3Profile, "")
 		if err != nil {
 			return err
 		}
-		*g.s3Profile = v
+		g.s3Profile = v
 	}
 	if !flagsSet["s3-access-key"] {
 		v, err := resolveProfileStoreValue("s3_access_key", s.S3AccessKey, s.S3AccessKeySecret)
 		if err != nil {
 			return err
 		}
-		*g.s3AccessKey = v
+		g.s3AccessKey = v
 	}
 	if !flagsSet["s3-secret-key"] {
 		v, err := resolveProfileStoreValue("s3_secret_key", s.S3SecretKey, s.S3SecretKeySecret)
 		if err != nil {
 			return err
 		}
-		*g.s3SecretKey = v
+		g.s3SecretKey = v
 	}
 	if !flagsSet["store-sftp-password"] {
 		v, err := resolveProfileStoreValue("store_sftp_password", s.StoreSFTPPassword, s.StoreSFTPPasswordSecret)
 		if err != nil {
 			return err
 		}
-		*g.storeSFTPPassword = v
+		g.storeSFTPPassword = v
 	}
 	if !flagsSet["store-sftp-key"] {
 		v, err := resolveProfileStoreValue("store_sftp_key", s.StoreSFTPKey, s.StoreSFTPKeySecret)
 		if err != nil {
 			return err
 		}
-		*g.storeSFTPKey = v
+		g.storeSFTPKey = v
 	}
 	if !flagsSet["password"] {
 		v, err := resolveProfileStoreValue("password", "", s.PasswordSecret)
 		if err != nil {
 			return err
 		}
-		*g.password = v
+		g.password = v
 	}
 	if !flagsSet["encryption-key"] {
 		v, err := resolveProfileStoreValue("encryption_key", "", s.EncryptionKeySecret)
 		if err != nil {
 			return err
 		}
-		*g.encryptionKey = v
+		g.encryptionKey = v
 	}
 	if !flagsSet["recovery-key"] {
 		v, err := resolveProfileStoreValue("recovery_key", "", s.RecoveryKeySecret)
 		if err != nil {
 			return err
 		}
-		*g.recoveryKey = v
+		g.recoveryKey = v
 	}
 	if !flagsSet["kms-key-arn"] && s.KMSKeyARN != "" {
-		*g.kmsKeyARN = s.KMSKeyARN
+		g.kmsKeyARN = s.KMSKeyARN
 	}
 	if !flagsSet["kms-region"] && s.KMSRegion != "" {
-		*g.kmsRegion = s.KMSRegion
+		g.kmsRegion = s.KMSRegion
 	}
 	if !flagsSet["kms-endpoint"] && s.KMSEndpoint != "" {
-		*g.kmsEndpoint = s.KMSEndpoint
+		g.kmsEndpoint = s.KMSEndpoint
 	}
 	return nil
 }
@@ -615,7 +569,7 @@ func parseExcludePatterns(a *backupArgs) ([]string, error) {
 
 func buildBackupOpts(a *backupArgs, excludePatterns []string) []cloudstic.BackupOption {
 	var opts []cloudstic.BackupOption
-	if *a.g.verbose {
+	if a.g.verbose {
 		opts = append(opts, cloudstic.WithVerbose())
 	}
 	if a.dryRun {

--- a/cmd/cloudstic/cmd_backup_profile_test.go
+++ b/cmd/cloudstic/cmd_backup_profile_test.go
@@ -41,11 +41,11 @@ func TestMergeProfileBackupArgs_AppliesProfileAndStore(t *testing.T) {
 	if eff.sourceURI != "local:/data" {
 		t.Fatalf("sourceURI=%q want local:/data", eff.sourceURI)
 	}
-	if *eff.g.store != "s3:bucket/prefix" {
-		t.Fatalf("store=%q want s3:bucket/prefix", *eff.g.store)
+	if eff.g.store != "s3:bucket/prefix" {
+		t.Fatalf("store=%q want s3:bucket/prefix", eff.g.store)
 	}
-	if *eff.g.s3Region != "eu-west-1" {
-		t.Fatalf("s3Region=%q want eu-west-1", *eff.g.s3Region)
+	if eff.g.s3Region != "eu-west-1" {
+		t.Fatalf("s3Region=%q want eu-west-1", eff.g.s3Region)
 	}
 	if len(eff.tags) != 1 || eff.tags[0] != "daily" {
 		t.Fatalf("tags=%v want [daily]", eff.tags)
@@ -64,7 +64,7 @@ func TestMergeProfileBackupArgs_CLIFlagsWin(t *testing.T) {
 		g:         newTestGlobalFlags(),
 		flagsSet:  map[string]bool{"source": true, "store": true},
 	}
-	*base.g.store = "local:/cli-store"
+	base.g.store = "local:/cli-store"
 
 	cfg := &cloudstic.ProfilesConfig{
 		Stores: map[string]cloudstic.ProfileStore{"s": {URI: "s3:bucket"}},
@@ -78,8 +78,8 @@ func TestMergeProfileBackupArgs_CLIFlagsWin(t *testing.T) {
 	if eff.sourceURI != "local:/cli" {
 		t.Fatalf("sourceURI=%q want local:/cli", eff.sourceURI)
 	}
-	if *eff.g.store != "local:/cli-store" {
-		t.Fatalf("store=%q want local:/cli-store", *eff.g.store)
+	if eff.g.store != "local:/cli-store" {
+		t.Fatalf("store=%q want local:/cli-store", eff.g.store)
 	}
 }
 
@@ -274,31 +274,31 @@ func TestApplyProfileAuthToBackupArgs_CLIFlagsPreserved(t *testing.T) {
 
 func TestCloneGlobalFlags_Independence(t *testing.T) {
 	orig := newTestGlobalFlags()
-	*orig.store = "original-store"
-	*orig.profile = "orig-profile"
-	*orig.profilesFile = "/tmp/orig-profiles.yaml"
-	*orig.s3Profile = "orig-s3-profile"
+	orig.store = "original-store"
+	orig.profile = "orig-profile"
+	orig.profilesFile = "/tmp/orig-profiles.yaml"
+	orig.s3Profile = "orig-s3-profile"
 
 	clone := cloneGlobalFlags(orig)
-	*clone.store = "modified-store"
-	*clone.profile = "clone-profile"
-	*clone.profilesFile = "/tmp/clone-profiles.yaml"
-	*clone.s3Profile = "clone-s3-profile"
+	clone.store = "modified-store"
+	clone.profile = "clone-profile"
+	clone.profilesFile = "/tmp/clone-profiles.yaml"
+	clone.s3Profile = "clone-s3-profile"
 
-	if *orig.store != "original-store" {
-		t.Fatalf("original store=%q want original-store", *orig.store)
+	if orig.store != "original-store" {
+		t.Fatalf("original store=%q want original-store", orig.store)
 	}
-	if *clone.store != "modified-store" {
-		t.Fatalf("clone store=%q want modified-store", *clone.store)
+	if clone.store != "modified-store" {
+		t.Fatalf("clone store=%q want modified-store", clone.store)
 	}
-	if *orig.profile != "orig-profile" {
-		t.Fatalf("original profile=%q want orig-profile", *orig.profile)
+	if orig.profile != "orig-profile" {
+		t.Fatalf("original profile=%q want orig-profile", orig.profile)
 	}
-	if *orig.profilesFile != "/tmp/orig-profiles.yaml" {
-		t.Fatalf("original profilesFile=%q want /tmp/orig-profiles.yaml", *orig.profilesFile)
+	if orig.profilesFile != "/tmp/orig-profiles.yaml" {
+		t.Fatalf("original profilesFile=%q want /tmp/orig-profiles.yaml", orig.profilesFile)
 	}
-	if *orig.s3Profile != "orig-s3-profile" {
-		t.Fatalf("original s3Profile=%q want orig-s3-profile", *orig.s3Profile)
+	if orig.s3Profile != "orig-s3-profile" {
+		t.Fatalf("original s3Profile=%q want orig-s3-profile", orig.s3Profile)
 	}
 }
 
@@ -330,53 +330,53 @@ func TestApplyProfileStoreToGlobalFlags_AllFields(t *testing.T) {
 		t.Fatalf("applyProfileStoreToGlobalFlags: %v", err)
 	}
 
-	if *g.store != "s3:my-bucket/prefix" {
-		t.Fatalf("store=%q want s3:my-bucket/prefix", *g.store)
+	if g.store != "s3:my-bucket/prefix" {
+		t.Fatalf("store=%q want s3:my-bucket/prefix", g.store)
 	}
-	if *g.s3Region != "us-east-1" {
-		t.Fatalf("s3Region=%q want us-east-1", *g.s3Region)
+	if g.s3Region != "us-east-1" {
+		t.Fatalf("s3Region=%q want us-east-1", g.s3Region)
 	}
-	if *g.s3Endpoint != "https://s3.example.com" {
-		t.Fatalf("s3Endpoint=%q want https://s3.example.com", *g.s3Endpoint)
+	if g.s3Endpoint != "https://s3.example.com" {
+		t.Fatalf("s3Endpoint=%q want https://s3.example.com", g.s3Endpoint)
 	}
-	if *g.s3Profile != "prod" {
-		t.Fatalf("s3Profile=%q want prod", *g.s3Profile)
+	if g.s3Profile != "prod" {
+		t.Fatalf("s3Profile=%q want prod", g.s3Profile)
 	}
-	if *g.s3AccessKey != "AKIATEST" {
-		t.Fatalf("s3AccessKey=%q want AKIATEST", *g.s3AccessKey)
+	if g.s3AccessKey != "AKIATEST" {
+		t.Fatalf("s3AccessKey=%q want AKIATEST", g.s3AccessKey)
 	}
-	if *g.s3SecretKey != "SECRETTEST" {
-		t.Fatalf("s3SecretKey=%q want SECRETTEST", *g.s3SecretKey)
+	if g.s3SecretKey != "SECRETTEST" {
+		t.Fatalf("s3SecretKey=%q want SECRETTEST", g.s3SecretKey)
 	}
-	if *g.storeSFTPPassword != "sftp-pw" {
-		t.Fatalf("storeSFTPPassword=%q want sftp-pw", *g.storeSFTPPassword)
+	if g.storeSFTPPassword != "sftp-pw" {
+		t.Fatalf("storeSFTPPassword=%q want sftp-pw", g.storeSFTPPassword)
 	}
-	if *g.storeSFTPKey != "/tmp/sftp.key" {
-		t.Fatalf("storeSFTPKey=%q want /tmp/sftp.key", *g.storeSFTPKey)
+	if g.storeSFTPKey != "/tmp/sftp.key" {
+		t.Fatalf("storeSFTPKey=%q want /tmp/sftp.key", g.storeSFTPKey)
 	}
-	if *g.password != "secret-pw" {
-		t.Fatalf("password=%q want secret-pw", *g.password)
+	if g.password != "secret-pw" {
+		t.Fatalf("password=%q want secret-pw", g.password)
 	}
-	if *g.encryptionKey != "enc-key-val" {
-		t.Fatalf("encryptionKey=%q want enc-key-val", *g.encryptionKey)
+	if g.encryptionKey != "enc-key-val" {
+		t.Fatalf("encryptionKey=%q want enc-key-val", g.encryptionKey)
 	}
-	if *g.recoveryKey != "rec-key-val" {
-		t.Fatalf("recoveryKey=%q want rec-key-val", *g.recoveryKey)
+	if g.recoveryKey != "rec-key-val" {
+		t.Fatalf("recoveryKey=%q want rec-key-val", g.recoveryKey)
 	}
-	if *g.kmsKeyARN != "arn:aws:kms:us-east-1:123:key/abc" {
-		t.Fatalf("kmsKeyARN=%q want arn:aws:kms:us-east-1:123:key/abc", *g.kmsKeyARN)
+	if g.kmsKeyARN != "arn:aws:kms:us-east-1:123:key/abc" {
+		t.Fatalf("kmsKeyARN=%q want arn:aws:kms:us-east-1:123:key/abc", g.kmsKeyARN)
 	}
-	if *g.kmsRegion != "us-east-1" {
-		t.Fatalf("kmsRegion=%q want us-east-1", *g.kmsRegion)
+	if g.kmsRegion != "us-east-1" {
+		t.Fatalf("kmsRegion=%q want us-east-1", g.kmsRegion)
 	}
-	if *g.kmsEndpoint != "https://kms.example.com" {
-		t.Fatalf("kmsEndpoint=%q want https://kms.example.com", *g.kmsEndpoint)
+	if g.kmsEndpoint != "https://kms.example.com" {
+		t.Fatalf("kmsEndpoint=%q want https://kms.example.com", g.kmsEndpoint)
 	}
 }
 
 func TestApplyProfileStoreToGlobalFlags_CLIFlagOverrides(t *testing.T) {
 	g := newTestGlobalFlags()
-	*g.store = "local:/cli-store"
+	g.store = "local:/cli-store"
 	flagsSet := map[string]bool{"store": true}
 	s := cloudstic.ProfileStore{URI: "s3:profile-bucket"}
 
@@ -384,8 +384,8 @@ func TestApplyProfileStoreToGlobalFlags_CLIFlagOverrides(t *testing.T) {
 		t.Fatalf("applyProfileStoreToGlobalFlags: %v", err)
 	}
 
-	if *g.store != "local:/cli-store" {
-		t.Fatalf("store=%q want local:/cli-store", *g.store)
+	if g.store != "local:/cli-store" {
+		t.Fatalf("store=%q want local:/cli-store", g.store)
 	}
 }
 
@@ -401,8 +401,8 @@ func TestApplyProfileStoreToGlobalFlags_SecretRef(t *testing.T) {
 	if err := applyProfileStoreToGlobalFlags(g, s, flagsSet); err != nil {
 		t.Fatalf("applyProfileStoreToGlobalFlags: %v", err)
 	}
-	if *g.password != "from-secret-ref" {
-		t.Fatalf("password=%q want from-secret-ref", *g.password)
+	if g.password != "from-secret-ref" {
+		t.Fatalf("password=%q want from-secret-ref", g.password)
 	}
 }
 

--- a/cmd/cloudstic/cmd_cat.go
+++ b/cmd/cloudstic/cmd_cat.go
@@ -50,7 +50,7 @@ func runCat(r *runner, ctx context.Context) int {
 		return r.failJSONFlagConflict("-json", "-raw")
 	}
 
-	quiet := *a.g.quiet || a.g.jsonEnabled()
+	quiet := a.g.quiet || a.g.jsonEnabled()
 
 	results, err := r.client.Cat(ctx, a.keys...)
 	if err != nil {

--- a/cmd/cloudstic/cmd_check.go
+++ b/cmd/cloudstic/cmd_check.go
@@ -61,7 +61,7 @@ func buildCheckOpts(a *checkArgs) []cloudstic.CheckOption {
 	if a.readData {
 		checkOpts = append(checkOpts, cloudstic.WithReadData())
 	}
-	if *a.g.verbose {
+	if a.g.verbose {
 		checkOpts = append(checkOpts, cloudstic.WithCheckVerbose())
 	}
 	if a.snapshotRef != "" {

--- a/cmd/cloudstic/cmd_diff.go
+++ b/cmd/cloudstic/cmd_diff.go
@@ -52,7 +52,7 @@ func runDiff(r *runner, ctx context.Context) int {
 
 func buildDiffOpts(a *diffArgs) []cloudstic.DiffOption {
 	var diffOpts []cloudstic.DiffOption
-	if *a.g.verbose {
+	if a.g.verbose {
 		diffOpts = append(diffOpts, cloudstic.WithDiffVerbose())
 	}
 	return diffOpts

--- a/cmd/cloudstic/cmd_forget.go
+++ b/cmd/cloudstic/cmd_forget.go
@@ -171,7 +171,7 @@ func execForgetSingle(r *runner, ctx context.Context, a *forgetArgs) int {
 	if a.prune {
 		forgetOpts = append(forgetOpts, cloudstic.WithPrune())
 	}
-	if *a.g.verbose {
+	if a.g.verbose {
 		forgetOpts = append(forgetOpts, cloudstic.WithForgetVerbose())
 	}
 	result, err := r.client.Forget(ctx, a.snapshotID, forgetOpts...)
@@ -213,7 +213,7 @@ func buildForgetPolicyOpts(a *forgetArgs) []cloudstic.ForgetOption {
 	if a.dryRun {
 		opts = append(opts, cloudstic.WithDryRun())
 	}
-	if *a.g.verbose {
+	if a.g.verbose {
 		opts = append(opts, cloudstic.WithForgetVerbose())
 	}
 	if a.keepLast > 0 {

--- a/cmd/cloudstic/cmd_init.go
+++ b/cmd/cloudstic/cmd_init.go
@@ -57,7 +57,7 @@ func runInitWithArgs(r *runner, ctx context.Context, a *initArgs) int {
 			if err != nil {
 				return r.fail("Error: %v", err)
 			}
-			*a.g.password = pw
+			a.g.password = pw
 			kc, _ = a.g.buildKeychain(ctx)
 		} else {
 			_, _ = fmt.Fprintln(r.errOut, "Error: encryption is required by default.")

--- a/cmd/cloudstic/cmd_list.go
+++ b/cmd/cloudstic/cmd_list.go
@@ -45,7 +45,7 @@ func runList(r *runner, ctx context.Context) int {
 
 func buildListOpts(a *listArgs) []cloudstic.ListOption {
 	var listOpts []cloudstic.ListOption
-	if *a.g.verbose {
+	if a.g.verbose {
 		listOpts = append(listOpts, cloudstic.WithListVerbose())
 	}
 	return listOpts

--- a/cmd/cloudstic/cmd_ls.go
+++ b/cmd/cloudstic/cmd_ls.go
@@ -53,7 +53,7 @@ func runLsSnapshot(r *runner, ctx context.Context) int {
 
 func buildLsOpts(a *lsArgs) []cloudstic.LsSnapshotOption {
 	var lsOpts []cloudstic.LsSnapshotOption
-	if *a.g.verbose {
+	if a.g.verbose {
 		lsOpts = append(lsOpts, cloudstic.WithLsVerbose())
 	}
 	return lsOpts

--- a/cmd/cloudstic/cmd_prune.go
+++ b/cmd/cloudstic/cmd_prune.go
@@ -50,7 +50,7 @@ func buildPruneOpts(a *pruneArgs) []cloudstic.PruneOption {
 	if a.dryRun {
 		pruneOpts = append(pruneOpts, engine.WithPruneDryRun())
 	}
-	if *a.g.verbose {
+	if a.g.verbose {
 		pruneOpts = append(pruneOpts, engine.WithPruneVerbose())
 	}
 	return pruneOpts

--- a/cmd/cloudstic/cmd_restore.go
+++ b/cmd/cloudstic/cmd_restore.go
@@ -106,7 +106,7 @@ func buildRestoreOpts(a *restoreArgs) []cloudstic.RestoreOption {
 	if a.dryRun {
 		restoreOpts = append(restoreOpts, engine.WithRestoreDryRun())
 	}
-	if *a.g.verbose {
+	if a.g.verbose {
 		restoreOpts = append(restoreOpts, engine.WithRestoreVerbose())
 	}
 	if a.pathFilter != "" {

--- a/cmd/cloudstic/cmd_store.go
+++ b/cmd/cloudstic/cmd_store.go
@@ -728,76 +728,59 @@ func existingStoreInteractivePlan(canPrompt, hasOverrides, hasEncryption bool) (
 // globalFlagsFromProfileStore builds a globalFlags populated from a ProfileStore,
 // resolving env var indirections for secrets.
 func globalFlagsFromProfileStore(s cloudstic.ProfileStore) (*globalFlags, error) {
-
 	g := &globalFlags{}
-	store := s.URI
-	g.store = &store
-	s3Endpoint := s.S3Endpoint
-	g.s3Endpoint = &s3Endpoint
-	s3Region := s.S3Region
-	if s3Region == "" {
-		s3Region = "us-east-1"
+	g.store = s.URI
+	g.s3Endpoint = s.S3Endpoint
+	g.s3Region = s.S3Region
+	if g.s3Region == "" {
+		g.s3Region = "us-east-1"
 	}
-	g.s3Region = &s3Region
-	s3Profile, err := resolveProfileStoreValue("s3_profile", s.S3Profile, "")
-	if err != nil {
-		return nil, err
-	}
-	g.s3Profile = &s3Profile
-	s3AccessKey, err := resolveProfileStoreValue("s3_access_key", s.S3AccessKey, s.S3AccessKeySecret)
-	if err != nil {
-		return nil, err
-	}
-	g.s3AccessKey = &s3AccessKey
-	s3SecretKey, err := resolveProfileStoreValue("s3_secret_key", s.S3SecretKey, s.S3SecretKeySecret)
-	if err != nil {
-		return nil, err
-	}
-	g.s3SecretKey = &s3SecretKey
-	storeSFTPPassword, err := resolveProfileStoreValue("store_sftp_password", s.StoreSFTPPassword, s.StoreSFTPPasswordSecret)
-	if err != nil {
-		return nil, err
-	}
-	g.storeSFTPPassword = &storeSFTPPassword
-	storeSFTPKey, err := resolveProfileStoreValue("store_sftp_key", s.StoreSFTPKey, s.StoreSFTPKeySecret)
-	if err != nil {
-		return nil, err
-	}
-	g.storeSFTPKey = &storeSFTPKey
-	password, err := resolveProfileStoreValue("password", "", s.PasswordSecret)
-	if err != nil {
-		return nil, err
-	}
-	g.password = &password
-	encryptionKey, err := resolveProfileStoreValue("encryption_key", "", s.EncryptionKeySecret)
-	if err != nil {
-		return nil, err
-	}
-	g.encryptionKey = &encryptionKey
-	recoveryKey, err := resolveProfileStoreValue("recovery_key", "", s.RecoveryKeySecret)
-	if err != nil {
-		return nil, err
-	}
-	g.recoveryKey = &recoveryKey
-	kmsKeyARN := s.KMSKeyARN
-	g.kmsKeyARN = &kmsKeyARN
-	kmsRegion := s.KMSRegion
-	g.kmsRegion = &kmsRegion
-	kmsEndpoint := s.KMSEndpoint
-	g.kmsEndpoint = &kmsEndpoint
 
-	// Non-store fields with safe defaults.
-	empty := ""
-	g.sourceSFTPPassword = &empty
-	g.sourceSFTPKey = &empty
-	falseVal := false
-	g.disablePackfile = &falseVal
-	g.prompt = &falseVal
-	g.verbose = &falseVal
-	g.quiet = &falseVal
-	g.debug = &falseVal
-	g.profile = &empty
-	g.profilesFile = &empty
+	var err error
+	if g.s3Profile, err = resolveProfileStoreValue("s3_profile", s.S3Profile, ""); err != nil {
+		return nil, err
+	}
+	if g.s3AccessKey, err = resolveProfileStoreValue("s3_access_key", s.S3AccessKey, s.S3AccessKeySecret); err != nil {
+		return nil, err
+	}
+	if g.s3SecretKey, err = resolveProfileStoreValue("s3_secret_key", s.S3SecretKey, s.S3SecretKeySecret); err != nil {
+		return nil, err
+	}
+	if g.storeSFTPPassword, err = resolveProfileStoreValue("store_sftp_password", s.StoreSFTPPassword, s.StoreSFTPPasswordSecret); err != nil {
+		return nil, err
+	}
+	if g.storeSFTPKey, err = resolveProfileStoreValue("store_sftp_key", s.StoreSFTPKey, s.StoreSFTPKeySecret); err != nil {
+		return nil, err
+	}
+	if g.password, err = resolveProfileStoreValue("password", "", s.PasswordSecret); err != nil {
+		return nil, err
+	}
+	if g.encryptionKey, err = resolveProfileStoreValue("encryption_key", "", s.EncryptionKeySecret); err != nil {
+		return nil, err
+	}
+	if g.recoveryKey, err = resolveProfileStoreValue("recovery_key", "", s.RecoveryKeySecret); err != nil {
+		return nil, err
+	}
+	g.kmsKeyARN = s.KMSKeyARN
+	g.kmsRegion = s.KMSRegion
+	g.kmsEndpoint = s.KMSEndpoint
+
+	// Non-store fields with safe defaults: ProfileStore carries no source-side
+	// SFTP credentials or SFTP host-key-verification overrides, so those stay
+	// at their zero value (disabled/empty) rather than left unset.
+	g.sourceSFTPPassword = ""
+	g.sourceSFTPKey = ""
+	g.sourceSFTPInsecure = false
+	g.sourceSFTPKnownHosts = ""
+	g.storeSFTPInsecure = false
+	g.storeSFTPKnownHosts = ""
+	g.disablePackfile = false
+	g.prompt = false
+	g.verbose = false
+	g.quiet = false
+	g.debug = false
+	g.profile = ""
+	g.profilesFile = ""
 
 	return g, nil
 }

--- a/cmd/cloudstic/cmd_store_test.go
+++ b/cmd/cloudstic/cmd_store_test.go
@@ -437,23 +437,23 @@ func TestGlobalFlagsFromProfileStore_ResolvesEnvVars(t *testing.T) {
 	if err != nil {
 		t.Fatalf("globalFlagsFromProfileStore: %v", err)
 	}
-	if *g.store != "s3:bucket/prefix" {
-		t.Fatalf("store=%q", *g.store)
+	if g.store != "s3:bucket/prefix" {
+		t.Fatalf("store=%q", g.store)
 	}
-	if *g.s3Region != "eu-west-1" {
-		t.Fatalf("s3Region=%q", *g.s3Region)
+	if g.s3Region != "eu-west-1" {
+		t.Fatalf("s3Region=%q", g.s3Region)
 	}
-	if *g.s3AccessKey != "my-access-key" {
-		t.Fatalf("s3AccessKey=%q", *g.s3AccessKey)
+	if g.s3AccessKey != "my-access-key" {
+		t.Fatalf("s3AccessKey=%q", g.s3AccessKey)
 	}
-	if *g.s3SecretKey != "my-secret-key" {
-		t.Fatalf("s3SecretKey=%q", *g.s3SecretKey)
+	if g.s3SecretKey != "my-secret-key" {
+		t.Fatalf("s3SecretKey=%q", g.s3SecretKey)
 	}
-	if *g.password != "s3cret" {
-		t.Fatalf("password=%q", *g.password)
+	if g.password != "s3cret" {
+		t.Fatalf("password=%q", g.password)
 	}
-	if *g.kmsKeyARN != "arn:aws:kms:us-east-1:123:key/abc" {
-		t.Fatalf("kmsKeyARN=%q", *g.kmsKeyARN)
+	if g.kmsKeyARN != "arn:aws:kms:us-east-1:123:key/abc" {
+		t.Fatalf("kmsKeyARN=%q", g.kmsKeyARN)
 	}
 }
 
@@ -469,8 +469,8 @@ func TestGlobalFlagsFromProfileStore_ResolvesSecretRef(t *testing.T) {
 	if err != nil {
 		t.Fatalf("globalFlagsFromProfileStore: %v", err)
 	}
-	if *g.s3AccessKey != "secret-ak" {
-		t.Fatalf("s3AccessKey=%q want secret-ak", *g.s3AccessKey)
+	if g.s3AccessKey != "secret-ak" {
+		t.Fatalf("s3AccessKey=%q want secret-ak", g.s3AccessKey)
 	}
 }
 
@@ -1387,8 +1387,8 @@ func TestGlobalFlagsFromProfileStore_DefaultRegion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("globalFlagsFromProfileStore: %v", err)
 	}
-	if *g.s3Region != "us-east-1" {
-		t.Fatalf("expected default region us-east-1, got %q", *g.s3Region)
+	if g.s3Region != "us-east-1" {
+		t.Fatalf("expected default region us-east-1, got %q", g.s3Region)
 	}
 }
 
@@ -1402,10 +1402,10 @@ func TestGlobalFlagsFromProfileStore_SFTPFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("globalFlagsFromProfileStore: %v", err)
 	}
-	if *g.storeSFTPPassword != "direct-pw" {
-		t.Fatalf("expected storeSFTPPassword=direct-pw, got %q", *g.storeSFTPPassword)
+	if g.storeSFTPPassword != "direct-pw" {
+		t.Fatalf("expected storeSFTPPassword=direct-pw, got %q", g.storeSFTPPassword)
 	}
-	if *g.storeSFTPKey != "/path/to/key" {
-		t.Fatalf("expected storeSFTPKey=/path/to/key, got %q", *g.storeSFTPKey)
+	if g.storeSFTPKey != "/path/to/key" {
+		t.Fatalf("expected storeSFTPKey=/path/to/key, got %q", g.storeSFTPKey)
 	}
 }

--- a/cmd/cloudstic/cmd_tui_activity.go
+++ b/cmd/cloudstic/cmd_tui_activity.go
@@ -312,15 +312,12 @@ func (p tuiReporterPhase) Error() {
 func tuiStoreFlags(profilesFile string, storeCfg cloudstic.ProfileStore) *globalFlags {
 	fs := flag.NewFlagSet("tui-store", flag.ContinueOnError)
 	g := addGlobalFlags(fs)
-	*g.profilesFile = profilesFile
+	g.profilesFile = profilesFile
 	flagsSet := map[string]bool{}
 	_ = applyProfileStoreToGlobalFlags(g, storeCfg, flagsSet)
-	quiet := true
-	debug := false
-	verbose := false
-	g.quiet = &quiet
-	g.debug = &debug
-	g.verbose = &verbose
+	g.quiet = true
+	g.debug = false
+	g.verbose = false
 	return g
 }
 

--- a/cmd/cloudstic/flags.go
+++ b/cmd/cloudstic/flags.go
@@ -22,68 +22,68 @@ func envBool(key string) bool {
 }
 
 type globalFlags struct {
-	store                             *string
-	profile, profilesFile             *string
-	s3Endpoint, s3Region, s3Profile   *string
-	s3AccessKey, s3SecretKey          *string
-	sourceSFTPPassword, sourceSFTPKey *string
-	sourceSFTPInsecure                *bool
-	sourceSFTPKnownHosts              *string
-	storeSFTPPassword, storeSFTPKey   *string
-	storeSFTPInsecure                 *bool
-	storeSFTPKnownHosts               *string
-	encryptionKey                     *string
-	password                          *string
-	recoveryKey                       *string
-	kmsKeyARN, kmsRegion, kmsEndpoint *string
-	disablePackfile                   *bool
-	prompt, verbose, quiet, debug     *bool
-	json                              *bool
+	store                             string
+	profile, profilesFile             string
+	s3Endpoint, s3Region, s3Profile   string
+	s3AccessKey, s3SecretKey          string
+	sourceSFTPPassword, sourceSFTPKey string
+	sourceSFTPInsecure                bool
+	sourceSFTPKnownHosts              string
+	storeSFTPPassword, storeSFTPKey   string
+	storeSFTPInsecure                 bool
+	storeSFTPKnownHosts               string
+	encryptionKey                     string
+	password                          string
+	recoveryKey                       string
+	kmsKeyARN, kmsRegion, kmsEndpoint string
+	disablePackfile                   bool
+	prompt, verbose, quiet, debug     bool
+	json                              bool
 	debugLog                          *ui.SafeLogWriter
 }
 
 func addGlobalFlags(fs *flag.FlagSet) *globalFlags {
 	g := &globalFlags{}
-	g.store = fs.String("store", envDefault("CLOUDSTIC_STORE", "local:./backup_store"), "Storage backend URI: local:<path>, s3:<bucket>[/<prefix>], b2:<bucket>[/<prefix>], sftp://[user@]host[:port]/<path>")
+	fs.StringVar(&g.store, "store", envDefault("CLOUDSTIC_STORE", "local:./backup_store"), "Storage backend URI: local:<path>, s3:<bucket>[/<prefix>], b2:<bucket>[/<prefix>], sftp://[user@]host[:port]/<path>")
 	defaultProfilesPath, err := defaultProfilesPath()
 	if err != nil {
 		defaultProfilesPath = defaultProfilesFilename
 	}
-	g.profile = fs.String("profile", envDefault("CLOUDSTIC_PROFILE", ""), "Profile name from profiles.yaml")
-	g.profilesFile = fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPath), "Path to profiles YAML file")
-	g.s3Endpoint = fs.String("s3-endpoint", envDefault("CLOUDSTIC_S3_ENDPOINT", ""), "S3 compatible endpoint URL (for MinIO, R2, etc.)")
-	g.s3Region = fs.String("s3-region", envDefault("CLOUDSTIC_S3_REGION", "us-east-1"), "S3 region")
-	g.s3Profile = fs.String("s3-profile", envDefault("CLOUDSTIC_S3_PROFILE", envDefault("AWS_PROFILE", "")), "AWS shared config profile for S3 credentials")
-	g.s3AccessKey = fs.String("s3-access-key", envDefault("AWS_ACCESS_KEY_ID", ""), "S3 access key ID")
-	g.s3SecretKey = fs.String("s3-secret-key", envDefault("AWS_SECRET_ACCESS_KEY", ""), "S3 secret access key")
+	fs.StringVar(&g.profile, "profile", envDefault("CLOUDSTIC_PROFILE", ""), "Profile name from profiles.yaml")
+	fs.StringVar(&g.profilesFile, "profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPath), "Path to profiles YAML file")
+	fs.StringVar(&g.s3Endpoint, "s3-endpoint", envDefault("CLOUDSTIC_S3_ENDPOINT", ""), "S3 compatible endpoint URL (for MinIO, R2, etc.)")
+	fs.StringVar(&g.s3Region, "s3-region", envDefault("CLOUDSTIC_S3_REGION", "us-east-1"), "S3 region")
+	fs.StringVar(&g.s3Profile, "s3-profile", envDefault("CLOUDSTIC_S3_PROFILE", envDefault("AWS_PROFILE", "")), "AWS shared config profile for S3 credentials")
+	fs.StringVar(&g.s3AccessKey, "s3-access-key", envDefault("AWS_ACCESS_KEY_ID", ""), "S3 access key ID")
+	fs.StringVar(&g.s3SecretKey, "s3-secret-key", envDefault("AWS_SECRET_ACCESS_KEY", ""), "S3 secret access key")
 
-	g.sourceSFTPPassword = fs.String("source-sftp-password", envDefault("CLOUDSTIC_SOURCE_SFTP_PASSWORD", ""), "SFTP source password")
-	g.sourceSFTPKey = fs.String("source-sftp-key", envDefault("CLOUDSTIC_SOURCE_SFTP_KEY", ""), "Path to SSH private key for SFTP source")
-	g.sourceSFTPInsecure = fs.Bool("source-sftp-insecure", envBool("CLOUDSTIC_SOURCE_SFTP_INSECURE"), "Skip host key validation for SFTP source (INSECURE)")
-	g.sourceSFTPKnownHosts = fs.String("source-sftp-known-hosts", envDefault("CLOUDSTIC_SOURCE_SFTP_KNOWN_HOSTS", ""), "Path to known_hosts file for SFTP source")
+	fs.StringVar(&g.sourceSFTPPassword, "source-sftp-password", envDefault("CLOUDSTIC_SOURCE_SFTP_PASSWORD", ""), "SFTP source password")
+	fs.StringVar(&g.sourceSFTPKey, "source-sftp-key", envDefault("CLOUDSTIC_SOURCE_SFTP_KEY", ""), "Path to SSH private key for SFTP source")
+	fs.BoolVar(&g.sourceSFTPInsecure, "source-sftp-insecure", envBool("CLOUDSTIC_SOURCE_SFTP_INSECURE"), "Skip host key validation for SFTP source (INSECURE)")
+	fs.StringVar(&g.sourceSFTPKnownHosts, "source-sftp-known-hosts", envDefault("CLOUDSTIC_SOURCE_SFTP_KNOWN_HOSTS", ""), "Path to known_hosts file for SFTP source")
 
-	g.storeSFTPPassword = fs.String("store-sftp-password", envDefault("CLOUDSTIC_STORE_SFTP_PASSWORD", ""), "SFTP store password")
-	g.storeSFTPKey = fs.String("store-sftp-key", envDefault("CLOUDSTIC_STORE_SFTP_KEY", ""), "Path to SSH private key for SFTP store")
-	g.storeSFTPInsecure = fs.Bool("store-sftp-insecure", envBool("CLOUDSTIC_STORE_SFTP_INSECURE"), "Skip host key validation for SFTP store (INSECURE)")
-	g.storeSFTPKnownHosts = fs.String("store-sftp-known-hosts", envDefault("CLOUDSTIC_STORE_SFTP_KNOWN_HOSTS", ""), "Path to known_hosts file for SFTP store")
+	fs.StringVar(&g.storeSFTPPassword, "store-sftp-password", envDefault("CLOUDSTIC_STORE_SFTP_PASSWORD", ""), "SFTP store password")
+	fs.StringVar(&g.storeSFTPKey, "store-sftp-key", envDefault("CLOUDSTIC_STORE_SFTP_KEY", ""), "Path to SSH private key for SFTP store")
+	fs.BoolVar(&g.storeSFTPInsecure, "store-sftp-insecure", envBool("CLOUDSTIC_STORE_SFTP_INSECURE"), "Skip host key validation for SFTP store (INSECURE)")
+	fs.StringVar(&g.storeSFTPKnownHosts, "store-sftp-known-hosts", envDefault("CLOUDSTIC_STORE_SFTP_KNOWN_HOSTS", ""), "Path to known_hosts file for SFTP store")
 
-	g.encryptionKey = fs.String("encryption-key", envDefault("CLOUDSTIC_ENCRYPTION_KEY", ""), "Platform key (hex-encoded, 32 bytes)")
-	g.password = fs.String("password", envDefault("CLOUDSTIC_PASSWORD", ""), "Repository password")
-	g.recoveryKey = fs.String("recovery-key", envDefault("CLOUDSTIC_RECOVERY_KEY", ""), "Recovery key (BIP39 24-word mnemonic)")
-	g.kmsKeyARN = fs.String("kms-key-arn", envDefault("CLOUDSTIC_KMS_KEY_ARN", ""), "AWS KMS key ARN for kms-platform slots")
-	g.kmsRegion = fs.String("kms-region", envDefault("CLOUDSTIC_KMS_REGION", ""), "AWS KMS region (defaults to us-east-1)")
-	g.kmsEndpoint = fs.String("kms-endpoint", envDefault("CLOUDSTIC_KMS_ENDPOINT", ""), "Custom AWS KMS endpoint URL")
-	g.disablePackfile = fs.Bool("disable-packfile", envBool("CLOUDSTIC_DISABLE_PACKFILE"), "Disable bundling small objects into 8MB packs")
-	g.prompt = fs.Bool("prompt", false, "Prompt for password interactively (use alongside --encryption-key or --kms-key-arn to add a password layer)")
-	g.verbose = fs.Bool("verbose", false, "Log detailed file-level operations")
-	g.quiet = fs.Bool("quiet", false, "Suppress progress bars (keeps final summary)")
-	g.json = fs.Bool("json", false, "Write command result as JSON to stdout")
-	g.debug = fs.Bool("debug", false, "Log every store request (network calls, timing, sizes)")
+	fs.StringVar(&g.encryptionKey, "encryption-key", envDefault("CLOUDSTIC_ENCRYPTION_KEY", ""), "Platform key (hex-encoded, 32 bytes)")
+	fs.StringVar(&g.password, "password", envDefault("CLOUDSTIC_PASSWORD", ""), "Repository password")
+	fs.StringVar(&g.recoveryKey, "recovery-key", envDefault("CLOUDSTIC_RECOVERY_KEY", ""), "Recovery key (BIP39 24-word mnemonic)")
+	fs.StringVar(&g.kmsKeyARN, "kms-key-arn", envDefault("CLOUDSTIC_KMS_KEY_ARN", ""), "AWS KMS key ARN for kms-platform slots")
+	fs.StringVar(&g.kmsRegion, "kms-region", envDefault("CLOUDSTIC_KMS_REGION", ""), "AWS KMS region (defaults to us-east-1)")
+	fs.StringVar(&g.kmsEndpoint, "kms-endpoint", envDefault("CLOUDSTIC_KMS_ENDPOINT", ""), "Custom AWS KMS endpoint URL")
+	fs.BoolVar(&g.disablePackfile, "disable-packfile", envBool("CLOUDSTIC_DISABLE_PACKFILE"), "Disable bundling small objects into 8MB packs")
+	fs.BoolVar(&g.prompt, "prompt", false, "Prompt for password interactively (use alongside --encryption-key or --kms-key-arn to add a password layer)")
+	fs.BoolVar(&g.verbose, "verbose", false, "Log detailed file-level operations")
+	fs.BoolVar(&g.quiet, "quiet", false, "Suppress progress bars (keeps final summary)")
+	fs.BoolVar(&g.json, "json", false, "Write command result as JSON to stdout")
+	fs.BoolVar(&g.debug, "debug", false, "Log every store request (network calls, timing, sizes)")
 	return g
 }
 
 func (g *globalFlags) jsonEnabled() bool {
-	return g != nil && g.json != nil && *g.json
+	return g != nil && g.json
 }
 
 func cliFlagProvided(name string) bool {

--- a/cmd/cloudstic/store.go
+++ b/cmd/cloudstic/store.go
@@ -35,7 +35,7 @@ func (g *globalFlags) openStore(ctx context.Context) (store.ObjectStore, error) 
 // applyDebug wraps a store with a DebugStore and enables the global debug
 // logger when --debug is set. It returns the (possibly wrapped) store.
 func (g *globalFlags) applyDebug(s store.ObjectStore) store.ObjectStore {
-	if g.debug == nil || !*g.debug {
+	if !g.debug {
 		return s
 	}
 	if g.debugLog == nil {
@@ -59,11 +59,11 @@ func (g *globalFlags) openClientWithReporter(ctx context.Context, reporterOverri
 	}
 	raw = g.applyDebug(raw)
 
-	packfileEnabled := g.disablePackfile == nil || !*g.disablePackfile
+	packfileEnabled := !g.disablePackfile
 
 	reporter := reporterOverride
 	if reporter == nil {
-		if *g.quiet || g.jsonEnabled() {
+		if g.quiet || g.jsonEnabled() {
 			reporter = ui.NewNoOpReporter()
 		} else {
 			cr := ui.NewConsoleReporter()
@@ -87,27 +87,27 @@ func (g *globalFlags) openClientWithReporter(ctx context.Context, reporterOverri
 }
 
 func (g *globalFlags) applyProfileStoreOverrides() error {
-	if g.profile == nil || *g.profile == "" {
+	if g.profile == "" {
 		return nil
 	}
 	profilesFile := defaultProfilesFilename
-	if g.profilesFile != nil && *g.profilesFile != "" {
-		profilesFile = *g.profilesFile
+	if g.profilesFile != "" {
+		profilesFile = g.profilesFile
 	}
 	cfg, err := cloudstic.LoadProfilesFile(profilesFile)
 	if err != nil {
 		return fmt.Errorf("load profiles file %q: %w", profilesFile, err)
 	}
-	p, ok := cfg.Profiles[*g.profile]
+	p, ok := cfg.Profiles[g.profile]
 	if !ok {
-		return fmt.Errorf("unknown profile %q", *g.profile)
+		return fmt.Errorf("unknown profile %q", g.profile)
 	}
 	if p.Store == "" {
 		return nil
 	}
 	s, ok := cfg.Stores[p.Store]
 	if !ok {
-		return fmt.Errorf("profile %q references unknown store %q", *g.profile, p.Store)
+		return fmt.Errorf("profile %q references unknown store %q", g.profile, p.Store)
 	}
 	flagsSet := map[string]bool{}
 	for _, name := range []string{
@@ -118,7 +118,7 @@ func (g *globalFlags) applyProfileStoreOverrides() error {
 		flagsSet[name] = cliFlagProvided(name)
 	}
 	if err := applyProfileStoreToGlobalFlags(g, s, flagsSet); err != nil {
-		return fmt.Errorf("profile %q store %q: %w", *g.profile, p.Store, err)
+		return fmt.Errorf("profile %q store %q: %w", g.profile, p.Store, err)
 	}
 	return nil
 }
@@ -126,17 +126,17 @@ func (g *globalFlags) applyProfileStoreOverrides() error {
 // buildKMSClient creates an AWS KMS client if -kms-key-arn is set, otherwise
 // returns nil. The returned client implements both KMSEncrypter and KMSDecrypter.
 func (g *globalFlags) buildKMSClient(ctx context.Context) (crypto.KMSClient, error) {
-	if g.kmsKeyARN == nil || *g.kmsKeyARN == "" {
+	if g.kmsKeyARN == "" {
 		return nil, nil
 	}
 	var opts []crypto.KMSClientOption
-	if g.kmsRegion != nil && *g.kmsRegion != "" {
-		opts = append(opts, crypto.WithKMSRegion(*g.kmsRegion))
+	if g.kmsRegion != "" {
+		opts = append(opts, crypto.WithKMSRegion(g.kmsRegion))
 	}
-	if g.kmsEndpoint != nil && *g.kmsEndpoint != "" {
-		opts = append(opts, crypto.WithKMSEndpoint(*g.kmsEndpoint))
+	if g.kmsEndpoint != "" {
+		opts = append(opts, crypto.WithKMSEndpoint(g.kmsEndpoint))
 	}
-	client, err := crypto.NewAWSKMSClient(ctx, *g.kmsKeyARN, opts...)
+	client, err := crypto.NewAWSKMSClient(ctx, g.kmsKeyARN, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("init KMS client: %w", err)
 	}
@@ -163,13 +163,13 @@ func (g *globalFlags) buildKeychain(ctx context.Context) (keychain.Chain, error)
 	if len(platformKey) > 0 {
 		chain = append(chain, keychain.WithPlatformKey(platformKey))
 	}
-	if *g.password != "" {
-		chain = append(chain, keychain.WithPassword(*g.password))
+	if g.password != "" {
+		chain = append(chain, keychain.WithPassword(g.password))
 	}
-	if *g.recoveryKey != "" {
-		chain = append(chain, keychain.WithRecoveryKey(*g.recoveryKey))
+	if g.recoveryKey != "" {
+		chain = append(chain, keychain.WithRecoveryKey(g.recoveryKey))
 	}
-	promptRequested := g.prompt != nil && *g.prompt
+	promptRequested := g.prompt
 	if (len(chain) == 0 || promptRequested) && !hasGlobalFlag("no-prompt") && term.IsTerminal(os.Stdin.Fd()) {
 		chain = append(chain, keychain.WithPrompt(
 			func() (string, error) { return ui.PromptPassword("Repository password") },
@@ -181,7 +181,7 @@ func (g *globalFlags) buildKeychain(ctx context.Context) (keychain.Chain, error)
 }
 
 func (g *globalFlags) parsePlatformKey() ([]byte, error) {
-	encKeyHex := *g.encryptionKey
+	encKeyHex := g.encryptionKey
 	if encKeyHex == "" {
 		return nil, nil
 	}
@@ -267,7 +267,7 @@ func parseStoreURI(raw string) (*storeURIParts, error) {
 }
 
 func (g *globalFlags) initObjectStore(ctx context.Context) (store.ObjectStore, error) {
-	uri, err := parseStoreURI(*g.store)
+	uri, err := parseStoreURI(g.store)
 	if err != nil {
 		return nil, err
 	}
@@ -287,10 +287,10 @@ func (g *globalFlags) initObjectStore(ctx context.Context) (store.ObjectStore, e
 		inner, err = store.NewS3Store(
 			ctx,
 			uri.bucket,
-			store.WithS3Endpoint(*g.s3Endpoint),
-			store.WithS3Region(*g.s3Region),
-			store.WithS3Profile(*g.s3Profile),
-			store.WithS3Credentials(*g.s3AccessKey, *g.s3SecretKey),
+			store.WithS3Endpoint(g.s3Endpoint),
+			store.WithS3Region(g.s3Region),
+			store.WithS3Profile(g.s3Profile),
+			store.WithS3Credentials(g.s3AccessKey, g.s3SecretKey),
 			store.WithS3Prefix(uri.prefix),
 		)
 	case "sftp":
@@ -316,17 +316,17 @@ func (g *globalFlags) buildSFTPStoreOpts(uri *storeURIParts) []store.SFTPStoreOp
 	if uri.user != "" {
 		opts = append(opts, store.WithSFTPUser(uri.user))
 	}
-	if pw := *g.storeSFTPPassword; pw != "" {
+	if pw := g.storeSFTPPassword; pw != "" {
 		opts = append(opts, store.WithSFTPPassword(pw))
 	}
-	if k := *g.storeSFTPKey; k != "" {
+	if k := g.storeSFTPKey; k != "" {
 		opts = append(opts, store.WithSFTPKey(k))
 	}
-	if *g.storeSFTPInsecure {
+	if g.storeSFTPInsecure {
 		opts = append(opts, store.WithSFTPHostKeyCallback(ssh.InsecureIgnoreHostKey())) //nolint:gosec // explicitly requested by user
 	}
-	if *g.storeSFTPKnownHosts != "" {
-		opts = append(opts, store.WithSFTPKnownHosts(*g.storeSFTPKnownHosts))
+	if g.storeSFTPKnownHosts != "" {
+		opts = append(opts, store.WithSFTPKnownHosts(g.storeSFTPKnownHosts))
 	}
 	return opts
 }
@@ -431,17 +431,17 @@ func (g *globalFlags) buildSFTPSourceOpts(uri *sourceURIParts) []source.SFTPOpti
 	if uri.user != "" {
 		opts = append(opts, source.WithSFTPSourceUser(uri.user))
 	}
-	if pw := *g.sourceSFTPPassword; pw != "" {
+	if pw := g.sourceSFTPPassword; pw != "" {
 		opts = append(opts, source.WithSFTPSourcePassword(pw))
 	}
-	if k := *g.sourceSFTPKey; k != "" {
+	if k := g.sourceSFTPKey; k != "" {
 		opts = append(opts, source.WithSFTPSourceKey(k))
 	}
-	if *g.sourceSFTPInsecure {
+	if g.sourceSFTPInsecure {
 		opts = append(opts, source.WithSFTPSourceHostKeyCallback(ssh.InsecureIgnoreHostKey())) //nolint:gosec // explicitly requested by user
 	}
-	if *g.sourceSFTPKnownHosts != "" {
-		opts = append(opts, source.WithSFTPSourceKnownHosts(*g.sourceSFTPKnownHosts))
+	if g.sourceSFTPKnownHosts != "" {
+		opts = append(opts, source.WithSFTPSourceKnownHosts(g.sourceSFTPKnownHosts))
 	}
 	return opts
 }

--- a/cmd/cloudstic/store_profile_test.go
+++ b/cmd/cloudstic/store_profile_test.go
@@ -26,20 +26,20 @@ func TestApplyProfileStoreOverrides_AppliesProfileStore(t *testing.T) {
 
 	os.Args = []string{"cloudstic", "list", "-profile", "p", "-profiles-file", profilesPath}
 	g := newTestGlobalFlags()
-	*g.profile = "p"
-	*g.profilesFile = profilesPath
+	g.profile = "p"
+	g.profilesFile = profilesPath
 
 	if err := g.applyProfileStoreOverrides(); err != nil {
 		t.Fatalf("applyProfileStoreOverrides: %v", err)
 	}
-	if *g.store != "s3:bucket/prefix" {
-		t.Fatalf("store=%q want s3:bucket/prefix", *g.store)
+	if g.store != "s3:bucket/prefix" {
+		t.Fatalf("store=%q want s3:bucket/prefix", g.store)
 	}
-	if *g.s3Region != "eu-west-1" {
-		t.Fatalf("s3Region=%q want eu-west-1", *g.s3Region)
+	if g.s3Region != "eu-west-1" {
+		t.Fatalf("s3Region=%q want eu-west-1", g.s3Region)
 	}
-	if *g.s3Profile != "prod" {
-		t.Fatalf("s3Profile=%q want prod", *g.s3Profile)
+	if g.s3Profile != "prod" {
+		t.Fatalf("s3Profile=%q want prod", g.s3Profile)
 	}
 }
 
@@ -74,29 +74,29 @@ func TestApplyProfileStoreOverrides_EncryptionFields(t *testing.T) {
 
 	os.Args = []string{"cloudstic", "list", "-profile", "p", "-profiles-file", profilesPath}
 	g := newTestGlobalFlags()
-	*g.profile = "p"
-	*g.profilesFile = profilesPath
+	g.profile = "p"
+	g.profilesFile = profilesPath
 
 	if err := g.applyProfileStoreOverrides(); err != nil {
 		t.Fatalf("applyProfileStoreOverrides: %v", err)
 	}
-	if *g.password != "s3cret" {
-		t.Fatalf("password=%q want s3cret", *g.password)
+	if g.password != "s3cret" {
+		t.Fatalf("password=%q want s3cret", g.password)
 	}
-	if *g.encryptionKey != "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
-		t.Fatalf("encryptionKey=%q want aaa...", *g.encryptionKey)
+	if g.encryptionKey != "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
+		t.Fatalf("encryptionKey=%q want aaa...", g.encryptionKey)
 	}
-	if *g.recoveryKey == "" {
+	if g.recoveryKey == "" {
 		t.Fatal("expected recoveryKey to be set from env")
 	}
-	if *g.kmsKeyARN != "arn:aws:kms:us-east-1:123456:key/abcd" {
-		t.Fatalf("kmsKeyARN=%q want arn:...", *g.kmsKeyARN)
+	if g.kmsKeyARN != "arn:aws:kms:us-east-1:123456:key/abcd" {
+		t.Fatalf("kmsKeyARN=%q want arn:...", g.kmsKeyARN)
 	}
-	if *g.kmsRegion != "us-east-1" {
-		t.Fatalf("kmsRegion=%q want us-east-1", *g.kmsRegion)
+	if g.kmsRegion != "us-east-1" {
+		t.Fatalf("kmsRegion=%q want us-east-1", g.kmsRegion)
 	}
-	if *g.kmsEndpoint != "https://kms.example.com" {
-		t.Fatalf("kmsEndpoint=%q want https://kms.example.com", *g.kmsEndpoint)
+	if g.kmsEndpoint != "https://kms.example.com" {
+		t.Fatalf("kmsEndpoint=%q want https://kms.example.com", g.kmsEndpoint)
 	}
 }
 
@@ -118,14 +118,14 @@ func TestApplyProfileStoreOverrides_DoesNotOverrideExplicitStoreFlag(t *testing.
 
 	os.Args = []string{"cloudstic", "list", "-profile", "p", "-profiles-file", profilesPath, "-store", "local:/explicit"}
 	g := newTestGlobalFlags()
-	*g.profile = "p"
-	*g.profilesFile = profilesPath
-	*g.store = "local:/explicit"
+	g.profile = "p"
+	g.profilesFile = profilesPath
+	g.store = "local:/explicit"
 
 	if err := g.applyProfileStoreOverrides(); err != nil {
 		t.Fatalf("applyProfileStoreOverrides: %v", err)
 	}
-	if *g.store != "local:/explicit" {
-		t.Fatalf("store=%q want local:/explicit", *g.store)
+	if g.store != "local:/explicit" {
+		t.Fatalf("store=%q want local:/explicit", g.store)
 	}
 }

--- a/cmd/cloudstic/store_test.go
+++ b/cmd/cloudstic/store_test.go
@@ -171,15 +171,15 @@ func TestApplyDebug_Enabled(t *testing.T) {
 	}
 }
 
-func TestApplyDebug_NilDebugField(t *testing.T) {
+func TestApplyDebug_DebugFieldFalse(t *testing.T) {
 	logger.Writer = nil
 
-	g := &globalFlags{} // debug field is nil
+	g := &globalFlags{} // debug field defaults to false
 	inner := newTestLocalStore(t)
 	result := g.applyDebug(inner)
 
-	// With nil debug pointer, the store should be returned as-is.
+	// With debug disabled, the store should be returned as-is.
 	if result != inner {
-		t.Error("Expected applyDebug to return the original store when debug is nil")
+		t.Error("Expected applyDebug to return the original store when debug is false")
 	}
 }

--- a/cmd/cloudstic/tui_runtime.go
+++ b/cmd/cloudstic/tui_runtime.go
@@ -49,7 +49,7 @@ func (b tuiCLIBackend) InitProfile(ctx context.Context, profilesFile, profileNam
 		return fmt.Errorf("profile %q references unknown store %q", profileName, profileCfg.Store)
 	}
 	g := tuiStoreFlags(profilesFile, storeCfg)
-	*g.quiet = false
+	g.quiet = false
 	if code := runInitWithArgs(b.r, ctx, &initArgs{g: g}); code != 0 {
 		return fmt.Errorf("init failed")
 	}
@@ -63,7 +63,7 @@ func (b tuiCLIBackend) BackupProfile(ctx context.Context, profilesFile, profileN
 		profilesFile: profilesFile,
 		flagsSet:     map[string]bool{},
 	}
-	*base.g.profilesFile = profilesFile
+	base.g.profilesFile = profilesFile
 	effective, err := mergeProfileBackupArgs(base, profileName, profileCfg, cfg)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

- Bound flags with `fs.StringVar`/`fs.BoolVar` directly into value fields on `globalFlags`, instead of pointer fields assigned from `fs.String()`/`fs.Bool()`'s return values.
- `cloneGlobalFlags` collapses to a single shallow struct copy (`c := *src; return &c`), down from ~50 lines of manual pointer-to-local-to-pointer copying.
- `globalFlagsFromProfileStore` now assigns fields directly instead of taking the address of throwaway local variables just to satisfy pointer fields.
- Updated every `*g.field`/`*a.g.field` access site across the package accordingly.

This also fixes a latent nil-pointer panic: `cloneGlobalFlags` never copied `sourceSFTPInsecure`, `sourceSFTPKnownHosts`, `storeSFTPInsecure`, or `storeSFTPKnownHosts` (clones silently aliased the original's pointers), and `globalFlagsFromProfileStore` never set the store-side SFTP insecure/known-hosts fields at all. A profile store configured with an `sftp://` URI would have dereferenced a nil `*bool` in `buildSFTPStoreOpts` the first time `cloudstic store verify`/`store init` ran against it — confirmed by tracing the call path (`checkOrInitStore` → `globalFlagsFromProfileStore` → `initObjectStore` → `buildSFTPStoreOpts` → `*g.storeSFTPInsecure`). Value fields make this class of bug impossible: the zero value is always a safe, well-typed default (`false`/`""`), not a nil pointer.

Closes #252

## Verification

- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./cmd/cloudstic` passes
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./cmd/cloudstic/...` → 0 issues
- `gofmt -l` clean
- Manual: init → backup → list → check with plain flags; a separate profile-based backup exercising `cloneGlobalFlags`/`applyProfileStoreOverrides`/`globalFlagsFromProfileStore` end-to-end (store + password resolved via `password_secret: env://...`); `-json` and `-disable-packfile` bool-flag paths — all behave identically to pre-refactor