### PR TITLE
refactor: make command flag parsing testable

### DIFF
--- a/cmd/cloudstic/cmd_auth.go
+++ b/cmd/cloudstic/cmd_auth.go
@@ -12,31 +12,35 @@ import (
 )
 
 func runAuth(r *runner, ctx context.Context) int {
-	if len(os.Args) < 3 {
+	if len(r.args) < 1 {
 		_, _ = fmt.Fprintln(r.errOut, "Usage: cloudstic auth <subcommand> [options]")
 		_, _ = fmt.Fprintln(r.errOut, "")
 		_, _ = fmt.Fprintln(r.errOut, "Available subcommands: list, show, new, login")
 		return 1
 	}
 
-	switch os.Args[2] {
+	subcommand := r.args[0]
+	subRunner := r.withArgs(r.args[1:])
+	switch subcommand {
 	case "list":
-		return runAuthList(r, ctx)
+		return runAuthList(subRunner, ctx)
 	case "show":
-		return runAuthShow(r, ctx)
+		return runAuthShow(subRunner, ctx)
 	case "new":
-		return runAuthNew(r, ctx)
+		return runAuthNew(subRunner, ctx)
 	case "login":
-		return runAuthLogin(r, ctx)
+		return runAuthLogin(subRunner, ctx)
 	default:
-		return r.fail("Unknown auth subcommand: %s", os.Args[2])
+		return r.fail("Unknown auth subcommand: %s", subcommand)
 	}
 }
 
 func runAuthList(r *runner, ctx context.Context) int {
-	fs := flag.NewFlagSet("auth list", flag.ExitOnError)
+	fs := flag.NewFlagSet("auth list", flag.ContinueOnError)
 	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
-	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
+	if err := parseFlags(fs, r.args); err != nil {
+		return parseErrorExitCode(err)
+	}
 
 	cfg, err := cloudstic.LoadProfilesFile(*profilesFile)
 	if err != nil {
@@ -51,9 +55,11 @@ func runAuthList(r *runner, ctx context.Context) int {
 }
 
 func runAuthShow(r *runner, ctx context.Context) int {
-	fs := flag.NewFlagSet("auth show", flag.ExitOnError)
+	fs := flag.NewFlagSet("auth show", flag.ContinueOnError)
 	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
-	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
+	if err := parseFlags(fs, r.args); err != nil {
+		return parseErrorExitCode(err)
+	}
 	if fs.NArg() > 1 {
 		return r.fail("usage: cloudstic auth show [-profiles-file <path>] <name>")
 	}
@@ -87,7 +93,7 @@ func runAuthShow(r *runner, ctx context.Context) int {
 }
 
 func runAuthNew(r *runner, ctx context.Context) int {
-	fs := flag.NewFlagSet("auth new", flag.ExitOnError)
+	fs := flag.NewFlagSet("auth new", flag.ContinueOnError)
 	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
 	name := fs.String("name", "", "Auth reference name")
 	provider := fs.String("provider", "", "Auth provider: google|onedrive")
@@ -98,7 +104,9 @@ func runAuthNew(r *runner, ctx context.Context) int {
 	onedriveClientID := fs.String("onedrive-client-id", "", "OneDrive OAuth client ID")
 	onedriveTokenFile := fs.String("onedrive-token-file", "", "Path to OneDrive OAuth token file")
 	onedriveTokenRef := fs.String("onedrive-token-ref", "", "Secret reference to OneDrive OAuth token")
-	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
+	if err := parseFlags(fs, r.args); err != nil {
+		return parseErrorExitCode(err)
+	}
 
 	if *name == "" {
 		if r.canPrompt() {
@@ -195,10 +203,12 @@ func runAuthNew(r *runner, ctx context.Context) int {
 }
 
 func runAuthLogin(r *runner, ctx context.Context) int {
-	fs := flag.NewFlagSet("auth login", flag.ExitOnError)
+	fs := flag.NewFlagSet("auth login", flag.ContinueOnError)
 	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
 	name := fs.String("name", "", "Auth reference name")
-	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
+	if err := parseFlags(fs, r.args); err != nil {
+		return parseErrorExitCode(err)
+	}
 
 	cfg, err := cloudstic.LoadProfilesFile(*profilesFile)
 	if err != nil {

--- a/cmd/cloudstic/cmd_auth_test.go
+++ b/cmd/cloudstic/cmd_auth_test.go
@@ -15,8 +15,7 @@ func TestRunAuthNewAndListAndShow(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
 
-	os.Args = []string{
-		"cloudstic", "auth", "new",
+	args := []string{"new",
 		"-profiles-file", profilesPath,
 		"-name", "google-work",
 		"-provider", "google",
@@ -25,24 +24,24 @@ func TestRunAuthNewAndListAndShow(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runAuth(r, context.Background()); code != 0 {
+	if code := runAuth(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("auth new failed: %s", errOut.String())
 	}
 
-	os.Args = []string{"cloudstic", "auth", "list", "-profiles-file", profilesPath}
+	args = []string{"list", "-profiles-file", profilesPath}
 	out.Reset()
 	errOut.Reset()
-	if code := runAuth(r, context.Background()); code != 0 {
+	if code := runAuth(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("auth list failed: %s", errOut.String())
 	}
 	if !strings.Contains(out.String(), "Auth") || !strings.Contains(out.String(), "google-work") || !strings.Contains(out.String(), "PROVIDER") {
 		t.Fatalf("unexpected auth list output:\n%s", out.String())
 	}
 
-	os.Args = []string{"cloudstic", "auth", "show", "-profiles-file", profilesPath, "google-work"}
+	args = []string{"show", "-profiles-file", profilesPath, "google-work"}
 	out.Reset()
 	errOut.Reset()
-	if code := runAuth(r, context.Background()); code != 0 {
+	if code := runAuth(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("auth show failed: %s", errOut.String())
 	}
 	if !strings.Contains(out.String(), "Auth google-work") || !strings.Contains(out.String(), "Provider Details") || !strings.Contains(out.String(), "/tmp/google-work.json") {
@@ -51,11 +50,11 @@ func TestRunAuthNewAndListAndShow(t *testing.T) {
 }
 
 func TestRunAuth_NoSubcommand(t *testing.T) {
-	os.Args = []string{"cloudstic", "auth"}
+	args := []string{}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runAuth(r, context.Background()); code != 1 {
+	if code := runAuth(r.withArgs(args), context.Background()); code != 1 {
 		t.Fatalf("expected exit code 1, got %d", code)
 	}
 	if !strings.Contains(errOut.String(), "Available subcommands") {
@@ -64,11 +63,11 @@ func TestRunAuth_NoSubcommand(t *testing.T) {
 }
 
 func TestRunAuth_UnknownSubcommand(t *testing.T) {
-	os.Args = []string{"cloudstic", "auth", "unknown"}
+	args := []string{"unknown"}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runAuth(r, context.Background()); code != 1 {
+	if code := runAuth(r.withArgs(args), context.Background()); code != 1 {
 		t.Fatalf("expected exit code 1, got %d", code)
 	}
 	if !strings.Contains(errOut.String(), "Unknown auth subcommand") {
@@ -80,8 +79,7 @@ func TestRunAuthNew_OneDriveProvider(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
 
-	os.Args = []string{
-		"cloudstic", "auth", "new",
+	args := []string{"new",
 		"-profiles-file", profilesPath,
 		"-name", "od-personal",
 		"-provider", "onedrive",
@@ -91,15 +89,15 @@ func TestRunAuthNew_OneDriveProvider(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runAuth(r, context.Background()); code != 0 {
+	if code := runAuth(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("auth new failed: %s", errOut.String())
 	}
 
 	// Verify via show
-	os.Args = []string{"cloudstic", "auth", "show", "-profiles-file", profilesPath, "od-personal"}
+	args = []string{"show", "-profiles-file", profilesPath, "od-personal"}
 	out.Reset()
 	errOut.Reset()
-	if code := runAuth(r, context.Background()); code != 0 {
+	if code := runAuth(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("auth show failed: %s", errOut.String())
 	}
 	got := out.String()
@@ -114,11 +112,11 @@ func TestRunAuthNew_RequiresName(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
 
-	os.Args = []string{"cloudstic", "auth", "new", "-profiles-file", profilesPath, "-provider", "google"}
+	args := []string{"new", "-profiles-file", profilesPath, "-provider", "google"}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut, noPrompt: true}
-	if code := runAuth(r, context.Background()); code != 1 {
+	if code := runAuth(r.withArgs(args), context.Background()); code != 1 {
 		t.Fatalf("expected exit code 1, got %d", code)
 	}
 	if !strings.Contains(errOut.String(), "-name is required") {
@@ -130,11 +128,11 @@ func TestRunAuthNew_RequiresProvider(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
 
-	os.Args = []string{"cloudstic", "auth", "new", "-profiles-file", profilesPath, "-name", "foo"}
+	args := []string{"new", "-profiles-file", profilesPath, "-name", "foo"}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut, noPrompt: true}
-	if code := runAuth(r, context.Background()); code != 1 {
+	if code := runAuth(r.withArgs(args), context.Background()); code != 1 {
 		t.Fatalf("expected exit code 1, got %d", code)
 	}
 	if !strings.Contains(errOut.String(), "-provider must be") {
@@ -146,11 +144,11 @@ func TestRunAuthNew_InvalidName(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
 
-	os.Args = []string{"cloudstic", "auth", "new", "-profiles-file", profilesPath, "-name", "bad name!", "-provider", "google"}
+	args := []string{"new", "-profiles-file", profilesPath, "-name", "bad name!", "-provider", "google"}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runAuth(r, context.Background()); code != 1 {
+	if code := runAuth(r.withArgs(args), context.Background()); code != 1 {
 		t.Fatalf("expected exit code 1, got %d", code)
 	}
 	if !strings.Contains(errOut.String(), "invalid auth name") {
@@ -163,8 +161,7 @@ func TestRunAuthShow_UnknownAuth(t *testing.T) {
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
 
 	// Create a profiles file with one auth entry so the file exists
-	os.Args = []string{
-		"cloudstic", "auth", "new",
+	args := []string{"new",
 		"-profiles-file", profilesPath,
 		"-name", "existing",
 		"-provider", "google",
@@ -173,15 +170,15 @@ func TestRunAuthShow_UnknownAuth(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runAuth(r, context.Background()); code != 0 {
+	if code := runAuth(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("setup auth new failed: %s", errOut.String())
 	}
 
 	// Try to show a non-existent auth entry
-	os.Args = []string{"cloudstic", "auth", "show", "-profiles-file", profilesPath, "missing"}
+	args = []string{"show", "-profiles-file", profilesPath, "missing"}
 	out.Reset()
 	errOut.Reset()
-	if code := runAuth(r, context.Background()); code != 1 {
+	if code := runAuth(r.withArgs(args), context.Background()); code != 1 {
 		t.Fatalf("expected exit code 1, got %d", code)
 	}
 	if !strings.Contains(errOut.String(), "Unknown auth") {
@@ -193,11 +190,11 @@ func TestRunAuthList_MissingFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "nonexistent.yaml")
 
-	os.Args = []string{"cloudstic", "auth", "list", "-profiles-file", profilesPath}
+	args := []string{"list", "-profiles-file", profilesPath}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runAuth(r, context.Background()); code != 0 {
+	if code := runAuth(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("expected exit code 0, got %d; errOut: %s", code, errOut.String())
 	}
 }
@@ -215,8 +212,7 @@ func TestRunAuthNew_OneDriveDerivesTokenRef(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
 
-	os.Args = []string{
-		"cloudstic", "auth", "new",
+	args := []string{"new",
 		"-profiles-file", profilesPath,
 		"-name", "od-work",
 		"-provider", "onedrive",
@@ -224,7 +220,7 @@ func TestRunAuthNew_OneDriveDerivesTokenRef(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut, noPrompt: true}
-	if code := runAuth(r, context.Background()); code != 0 {
+	if code := runAuth(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("auth new failed: %s", errOut.String())
 	}
 
@@ -241,11 +237,11 @@ func TestRunAuthNew_DerivesDefaultTokenRef(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
 
-	os.Args = []string{"cloudstic", "auth", "new", "-profiles-file", profilesPath, "-name", "g", "-provider", "google"}
+	args := []string{"new", "-profiles-file", profilesPath, "-name", "g", "-provider", "google"}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut, noPrompt: true}
-	if code := runAuth(r, context.Background()); code != 0 {
+	if code := runAuth(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("auth new failed: %s", errOut.String())
 	}
 	raw, err := os.ReadFile(profilesPath)

--- a/cmd/cloudstic/cmd_backup.go
+++ b/cmd/cloudstic/cmd_backup.go
@@ -49,8 +49,8 @@ type backupArgs struct {
 	flagsSet          map[string]bool
 }
 
-func parseBackupArgs() *backupArgs {
-	fs := flag.NewFlagSet("backup", flag.ExitOnError)
+func parseBackupArgs(args []string) (*backupArgs, error) {
+	fs := flag.NewFlagSet("backup", flag.ContinueOnError)
 	a := &backupArgs{}
 	a.g = addGlobalFlags(fs)
 	sourceURI := fs.String("source", envDefault("CLOUDSTIC_SOURCE", "gdrive"), "Source URI: local:<path>, sftp://[user@]host[:port]/<path>, gdrive[://<Drive Name>][/<path>], gdrive-changes[://<Drive Name>][/<path>], onedrive[://<Drive Name>][/<path>], onedrive-changes[://<Drive Name>][/<path>]")
@@ -75,7 +75,9 @@ func parseBackupArgs() *backupArgs {
 	xattrNamespaces := fs.String("xattr-namespaces", "", "Restrict xattr collection to these prefixes (comma-separated, e.g. \"user.,com.apple.\")")
 	fs.Var(&a.tags, "tag", "Tag to apply to the snapshot (can be specified multiple times)")
 	fs.Var(&a.excludes, "exclude", "Exclude pattern (gitignore syntax, repeatable)")
-	mustParse(fs)
+	if err := parseFlags(fs, args); err != nil {
+		return nil, err
+	}
 	a.sourceURI = *sourceURI
 	a.profile = a.g.profile
 	a.allProfiles = *allProfiles
@@ -102,11 +104,14 @@ func parseBackupArgs() *backupArgs {
 	fs.Visit(func(f *flag.Flag) {
 		a.flagsSet[f.Name] = true
 	})
-	return a
+	return a, nil
 }
 
 func runBackup(r *runner, ctx context.Context) int {
-	a := parseBackupArgs()
+	a, err := parseBackupArgs(r.args)
+	if err != nil {
+		return parseErrorExitCode(err)
+	}
 
 	if a.profile != "" && a.allProfiles {
 		return r.fail("-profile and -all-profiles are mutually exclusive")

--- a/cmd/cloudstic/cmd_backup_profile_test.go
+++ b/cmd/cloudstic/cmd_backup_profile_test.go
@@ -170,9 +170,11 @@ func TestMergeProfileBackupArgs_CLIAuthRefOverridesProfile(t *testing.T) {
 	}
 }
 
-func newTestGlobalFlags() *globalFlags {
+func newTestGlobalFlags(args ...string) *globalFlags {
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
-	return addGlobalFlags(fs)
+	g := addGlobalFlags(fs)
+	_ = parseFlags(fs, args)
+	return g
 }
 
 func TestEnsureDefaultAuthRefForCloudBackup_CreatesDefaultEntry(t *testing.T) {

--- a/cmd/cloudstic/cmd_breaklock.go
+++ b/cmd/cloudstic/cmd_breaklock.go
@@ -13,15 +13,20 @@ type breakLockArgs struct {
 	g *globalFlags
 }
 
-func parseBreakLockArgs() *breakLockArgs {
-	fs := flag.NewFlagSet("break-lock", flag.ExitOnError)
+func parseBreakLockArgs(args []string) (*breakLockArgs, error) {
+	fs := flag.NewFlagSet("break-lock", flag.ContinueOnError)
 	a := &breakLockArgs{g: addGlobalFlags(fs)}
-	mustParse(fs)
-	return a
+	if err := parseFlags(fs, args); err != nil {
+		return nil, err
+	}
+	return a, nil
 }
 
 func runBreakLock(r *runner, ctx context.Context) int {
-	a := parseBreakLockArgs()
+	a, err := parseBreakLockArgs(r.args)
+	if err != nil {
+		return parseErrorExitCode(err)
+	}
 	if err := r.openClient(ctx, a.g); err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}

--- a/cmd/cloudstic/cmd_breaklock_test.go
+++ b/cmd/cloudstic/cmd_breaklock_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"os"
 	"strings"
 	"testing"
 
@@ -11,11 +10,11 @@ import (
 )
 
 func TestRunBreakLock_NoLock(t *testing.T) {
-	os.Args = []string{"cloudstic", "break-lock"}
+	args := []string{}
 	var errOut strings.Builder
 	r := &runner{out: &strings.Builder{}, errOut: &errOut, client: &stubClient{breakLockResult: nil}}
 
-	runBreakLock(r, context.Background())
+	runBreakLock(r.withArgs(args), context.Background())
 
 	if !strings.Contains(errOut.String(), "not locked") {
 		t.Errorf("expected 'not locked' message, got:\n%s", errOut.String())
@@ -23,7 +22,7 @@ func TestRunBreakLock_NoLock(t *testing.T) {
 }
 
 func TestRunBreakLock_JSON(t *testing.T) {
-	os.Args = []string{"cloudstic", "break-lock", "-json"}
+	args := []string{"-json"}
 	var out strings.Builder
 	r := &runner{out: &out, errOut: &strings.Builder{}, client: &stubClient{
 		breakLockResult: []*cloudstic.RepoLock{
@@ -31,7 +30,7 @@ func TestRunBreakLock_JSON(t *testing.T) {
 		},
 	}}
 
-	if exit := runBreakLock(r, context.Background()); exit != 0 {
+	if exit := runBreakLock(r.withArgs(args), context.Background()); exit != 0 {
 		t.Fatalf("runBreakLock() exit = %d, want 0", exit)
 	}
 
@@ -45,7 +44,7 @@ func TestRunBreakLock_JSON(t *testing.T) {
 }
 
 func TestRunBreakLock_LocksRemoved(t *testing.T) {
-	os.Args = []string{"cloudstic", "break-lock"}
+	args := []string{}
 	var errOut strings.Builder
 	r := &runner{out: &strings.Builder{}, errOut: &errOut, client: &stubClient{
 		breakLockResult: []*cloudstic.RepoLock{
@@ -59,7 +58,7 @@ func TestRunBreakLock_LocksRemoved(t *testing.T) {
 		},
 	}}
 
-	runBreakLock(r, context.Background())
+	runBreakLock(r.withArgs(args), context.Background())
 
 	got := errOut.String()
 	if !strings.Contains(got, "Locks removed") {

--- a/cmd/cloudstic/cmd_cat.go
+++ b/cmd/cloudstic/cmd_cat.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"os"
 
 	cloudstic "github.com/cloudstic/cli"
 )
@@ -18,30 +17,31 @@ type catArgs struct {
 	raw  bool
 }
 
-func parseCatArgs() *catArgs {
-	fs := flag.NewFlagSet("cat", flag.ExitOnError)
+func parseCatArgs(args []string) (*catArgs, error) {
+	fs := flag.NewFlagSet("cat", flag.ContinueOnError)
 	a := &catArgs{}
 	a.g = addGlobalFlags(fs)
 	rawFlag := fs.Bool("raw", false, "Output raw, unformatted data (useful for hashing)")
-	mustParse(fs)
+	if err := parseFlags(fs, args); err != nil {
+		return nil, err
+	}
 	if fs.NArg() < 1 {
-		fmt.Fprintln(os.Stderr, "Usage: cloudstic cat [options] <object_key> [object_key...]")
-		fmt.Fprintln(os.Stderr, "")
-		fmt.Fprintln(os.Stderr, "Examples:")
-		fmt.Fprintln(os.Stderr, "  cloudstic cat config")
-		fmt.Fprintln(os.Stderr, "  cloudstic cat index/latest")
-		fmt.Fprintln(os.Stderr, "  cloudstic cat snapshot/abc123...")
-		fmt.Fprintln(os.Stderr, "  cloudstic cat filemeta/def456... node/789abc...")
-		fmt.Fprintln(os.Stderr, "  cloudstic cat -raw filemeta/def456... | sha256sum")
-		os.Exit(1)
+		return nil, fmt.Errorf("at least one object key is required")
 	}
 	a.raw = *rawFlag
 	a.keys = fs.Args()
-	return a
+	return a, nil
 }
 
 func runCat(r *runner, ctx context.Context) int {
-	a := parseCatArgs()
+	a, err := parseCatArgs(r.args)
+	if err != nil {
+		if parseErrorExitCode(err) == 0 {
+			return 0
+		}
+		printCatUsage(r.errOut)
+		return r.fail("Error: %v", err)
+	}
 	if err := r.openClient(ctx, a.g); err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
@@ -62,6 +62,17 @@ func runCat(r *runner, ctx context.Context) int {
 	}
 	printCatResult(r.out, r.errOut, results, quiet, a.raw)
 	return 0
+}
+
+func printCatUsage(w io.Writer) {
+	_, _ = fmt.Fprintln(w, "Usage: cloudstic cat [options] <object_key> [object_key...]")
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, "Examples:")
+	_, _ = fmt.Fprintln(w, "  cloudstic cat config")
+	_, _ = fmt.Fprintln(w, "  cloudstic cat index/latest")
+	_, _ = fmt.Fprintln(w, "  cloudstic cat snapshot/abc123...")
+	_, _ = fmt.Fprintln(w, "  cloudstic cat filemeta/def456... node/789abc...")
+	_, _ = fmt.Fprintln(w, "  cloudstic cat -raw filemeta/def456... | sha256sum")
 }
 
 func printCatResult(out io.Writer, errOut io.Writer, results []*cloudstic.CatResult, quiet, raw bool) {

--- a/cmd/cloudstic/cmd_cat_test.go
+++ b/cmd/cloudstic/cmd_cat_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"os"
 	"strings"
 	"testing"
 
@@ -11,7 +10,7 @@ import (
 )
 
 func TestRunCat_SingleKey_JSON(t *testing.T) {
-	os.Args = []string{"cloudstic", "cat", "config"}
+	args := []string{"config"}
 	var out strings.Builder
 	r := &runner{out: &out, errOut: &strings.Builder{}, client: &stubClient{
 		catResults: []*cloudstic.CatResult{
@@ -19,7 +18,7 @@ func TestRunCat_SingleKey_JSON(t *testing.T) {
 		},
 	}}
 
-	runCat(r, context.Background())
+	runCat(r.withArgs(args), context.Background())
 
 	got := out.String()
 	if !strings.Contains(got, `"version"`) {
@@ -28,7 +27,7 @@ func TestRunCat_SingleKey_JSON(t *testing.T) {
 }
 
 func TestRunCat_MultipleKeys_HeadersShown(t *testing.T) {
-	os.Args = []string{"cloudstic", "cat", "config", "index/latest"}
+	args := []string{"config", "index/latest"}
 	var errOut strings.Builder
 	r := &runner{out: &strings.Builder{}, errOut: &errOut, client: &stubClient{
 		catResults: []*cloudstic.CatResult{
@@ -37,7 +36,7 @@ func TestRunCat_MultipleKeys_HeadersShown(t *testing.T) {
 		},
 	}}
 
-	runCat(r, context.Background())
+	runCat(r.withArgs(args), context.Background())
 
 	got := errOut.String()
 	if !strings.Contains(got, "==> config <==") {
@@ -49,7 +48,7 @@ func TestRunCat_MultipleKeys_HeadersShown(t *testing.T) {
 }
 
 func TestRunCat_JSON_NoHeadersAndStructuredOutput(t *testing.T) {
-	os.Args = []string{"cloudstic", "cat", "--json", "config", "index/latest"}
+	args := []string{"--json", "config", "index/latest"}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut, client: &stubClient{
@@ -59,7 +58,7 @@ func TestRunCat_JSON_NoHeadersAndStructuredOutput(t *testing.T) {
 		},
 	}}
 
-	if exit := runCat(r, context.Background()); exit != 0 {
+	if exit := runCat(r.withArgs(args), context.Background()); exit != 0 {
 		t.Fatalf("runCat() exit = %d, want 0", exit)
 	}
 
@@ -80,14 +79,14 @@ func TestRunCat_JSON_NoHeadersAndStructuredOutput(t *testing.T) {
 }
 
 func TestRunCat_RawMode(t *testing.T) {
-	os.Args = []string{"cloudstic", "cat", "-raw", "config"}
+	args := []string{"-raw", "config"}
 	var out strings.Builder
 	rawData := []byte("raw bytes here")
 	r := &runner{out: &out, errOut: &strings.Builder{}, client: &stubClient{
 		catResults: []*cloudstic.CatResult{{Key: "config", Data: rawData}},
 	}}
 
-	runCat(r, context.Background())
+	runCat(r.withArgs(args), context.Background())
 
 	if out.String() != string(rawData) {
 		t.Errorf("raw mode: expected %q, got %q", rawData, out.String())
@@ -95,13 +94,13 @@ func TestRunCat_RawMode(t *testing.T) {
 }
 
 func TestRunCat_InvalidJSON_PrintsRaw(t *testing.T) {
-	os.Args = []string{"cloudstic", "cat", "config"}
+	args := []string{"config"}
 	var out strings.Builder
 	r := &runner{out: &out, errOut: &strings.Builder{}, client: &stubClient{
 		catResults: []*cloudstic.CatResult{{Key: "config", Data: []byte("not-json")}},
 	}}
 
-	runCat(r, context.Background())
+	runCat(r.withArgs(args), context.Background())
 
 	if !strings.Contains(out.String(), "not-json") {
 		t.Errorf("expected raw fallback output, got:\n%s", out.String())
@@ -109,11 +108,11 @@ func TestRunCat_InvalidJSON_PrintsRaw(t *testing.T) {
 }
 
 func TestRunCat_JSONAndRawConflict(t *testing.T) {
-	os.Args = []string{"cloudstic", "cat", "-json", "-raw", "config"}
+	args := []string{"-json", "-raw", "config"}
 	var errOut strings.Builder
 	r := &runner{out: &strings.Builder{}, errOut: &errOut, client: &stubClient{}}
 
-	if exit := runCat(r, context.Background()); exit != 1 {
+	if exit := runCat(r.withArgs(args), context.Background()); exit != 1 {
 		t.Fatalf("runCat() exit = %d, want 1", exit)
 	}
 	if !strings.Contains(errOut.String(), "-json cannot be combined with -raw") {

--- a/cmd/cloudstic/cmd_check.go
+++ b/cmd/cloudstic/cmd_check.go
@@ -15,22 +15,27 @@ type checkArgs struct {
 	snapshotRef string
 }
 
-func parseCheckArgs() *checkArgs {
-	fs := flag.NewFlagSet("check", flag.ExitOnError)
+func parseCheckArgs(args []string) (*checkArgs, error) {
+	fs := flag.NewFlagSet("check", flag.ContinueOnError)
 	a := &checkArgs{}
 	a.g = addGlobalFlags(fs)
 	readData := fs.Bool("read-data", false, "Re-hash all chunk data for full byte-level verification")
-	mustParse(fs)
+	if err := parseFlags(fs, args); err != nil {
+		return nil, err
+	}
 	a.readData = *readData
 	a.snapshotRef = fs.Arg(0)
 	if a.snapshotRef == "" {
 		a.snapshotRef = "latest"
 	}
-	return a
+	return a, nil
 }
 
 func runCheck(r *runner, ctx context.Context) int {
-	a := parseCheckArgs()
+	a, err := parseCheckArgs(r.args)
+	if err != nil {
+		return parseErrorExitCode(err)
+	}
 	if err := r.openClient(ctx, a.g); err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}

--- a/cmd/cloudstic/cmd_check_test.go
+++ b/cmd/cloudstic/cmd_check_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"os"
 	"strings"
 	"testing"
 
@@ -12,7 +11,7 @@ import (
 )
 
 func TestRunCheck_Healthy(t *testing.T) {
-	os.Args = []string{"cloudstic", "check"}
+	args := []string{}
 	var errOut strings.Builder
 	r := &runner{out: &strings.Builder{}, errOut: &errOut, client: &stubClient{
 		checkResult: &cloudstic.CheckResult{
@@ -22,7 +21,7 @@ func TestRunCheck_Healthy(t *testing.T) {
 		},
 	}}
 
-	runCheck(r, context.Background())
+	runCheck(r.withArgs(args), context.Background())
 
 	got := errOut.String()
 	if !strings.Contains(got, "No errors found") {
@@ -34,7 +33,7 @@ func TestRunCheck_Healthy(t *testing.T) {
 }
 
 func TestRunCheck_JSONWithErrorsReturnsExitOne(t *testing.T) {
-	os.Args = []string{"cloudstic", "check", "-json"}
+	args := []string{"-json"}
 	var out strings.Builder
 	r := &runner{out: &out, errOut: &strings.Builder{}, client: &stubClient{
 		checkResult: &cloudstic.CheckResult{
@@ -46,7 +45,7 @@ func TestRunCheck_JSONWithErrorsReturnsExitOne(t *testing.T) {
 		},
 	}}
 
-	if exit := runCheck(r, context.Background()); exit != 1 {
+	if exit := runCheck(r.withArgs(args), context.Background()); exit != 1 {
 		t.Fatalf("runCheck() exit = %d, want 1", exit)
 	}
 

--- a/cmd/cloudstic/cmd_diff.go
+++ b/cmd/cloudstic/cmd_diff.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"os"
 
 	cloudstic "github.com/cloudstic/cli"
 )
@@ -16,23 +15,31 @@ type diffArgs struct {
 	snap2 string
 }
 
-func parseDiffArgs() *diffArgs {
-	fs := flag.NewFlagSet("diff", flag.ExitOnError)
+func parseDiffArgs(args []string) (*diffArgs, error) {
+	fs := flag.NewFlagSet("diff", flag.ContinueOnError)
 	a := &diffArgs{}
 	a.g = addGlobalFlags(fs)
-	mustParse(fs)
+	if err := parseFlags(fs, args); err != nil {
+		return nil, err
+	}
 	if fs.NArg() < 2 {
-		fmt.Fprintln(os.Stderr, "Usage: cloudstic diff [options] <snapshot_id1> <snapshot_id2>")
-		fmt.Fprintln(os.Stderr, "       cloudstic diff [options] <snapshot_id1> latest")
-		os.Exit(1)
+		return nil, fmt.Errorf("two snapshot IDs are required")
 	}
 	a.snap1 = fs.Arg(0)
 	a.snap2 = fs.Arg(1)
-	return a
+	return a, nil
 }
 
 func runDiff(r *runner, ctx context.Context) int {
-	a := parseDiffArgs()
+	a, err := parseDiffArgs(r.args)
+	if err != nil {
+		if parseErrorExitCode(err) == 0 {
+			return 0
+		}
+		_, _ = fmt.Fprintln(r.errOut, "Usage: cloudstic diff [options] <snapshot_id1> <snapshot_id2>")
+		_, _ = fmt.Fprintln(r.errOut, "       cloudstic diff [options] <snapshot_id1> latest")
+		return r.fail("Error: %v", err)
+	}
 	if err := r.openClient(ctx, a.g); err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}

--- a/cmd/cloudstic/cmd_diff_test.go
+++ b/cmd/cloudstic/cmd_diff_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"os"
 	"strings"
 	"testing"
 
@@ -12,7 +11,7 @@ import (
 )
 
 func TestRunDiff_Success(t *testing.T) {
-	os.Args = []string{"cloudstic", "diff", "aaa", "bbb"}
+	args := []string{"aaa", "bbb"}
 	var out strings.Builder
 	r := &runner{out: &out, errOut: &strings.Builder{}, client: &stubClient{
 		diffResult: &cloudstic.DiffResult{
@@ -26,7 +25,7 @@ func TestRunDiff_Success(t *testing.T) {
 		},
 	}}
 
-	runDiff(r, context.Background())
+	runDiff(r.withArgs(args), context.Background())
 
 	got := out.String()
 	if !strings.Contains(got, "snapshot/aaa") {
@@ -44,7 +43,7 @@ func TestRunDiff_Success(t *testing.T) {
 }
 
 func TestRunDiff_JSON(t *testing.T) {
-	os.Args = []string{"cloudstic", "diff", "-json", "aaa", "bbb"}
+	args := []string{"-json", "aaa", "bbb"}
 	var out strings.Builder
 	r := &runner{out: &out, errOut: &strings.Builder{}, client: &stubClient{
 		diffResult: &cloudstic.DiffResult{
@@ -56,7 +55,7 @@ func TestRunDiff_JSON(t *testing.T) {
 		},
 	}}
 
-	if exit := runDiff(r, context.Background()); exit != 0 {
+	if exit := runDiff(r.withArgs(args), context.Background()); exit != 0 {
 		t.Fatalf("runDiff() exit = %d, want 0", exit)
 	}
 
@@ -70,7 +69,7 @@ func TestRunDiff_JSON(t *testing.T) {
 }
 
 func TestRunDiff_NoChanges(t *testing.T) {
-	os.Args = []string{"cloudstic", "diff", "aaa", "bbb"}
+	args := []string{"aaa", "bbb"}
 	var out strings.Builder
 	r := &runner{out: &out, errOut: &strings.Builder{}, client: &stubClient{
 		diffResult: &cloudstic.DiffResult{
@@ -80,7 +79,7 @@ func TestRunDiff_NoChanges(t *testing.T) {
 		},
 	}}
 
-	runDiff(r, context.Background())
+	runDiff(r.withArgs(args), context.Background())
 
 	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
 	if len(lines) != 1 {

--- a/cmd/cloudstic/cmd_forget.go
+++ b/cmd/cloudstic/cmd_forget.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	cloudstic "github.com/cloudstic/cli"
@@ -33,8 +32,8 @@ type forgetArgs struct {
 	hasPolicy     bool
 }
 
-func parseForgetArgs() *forgetArgs {
-	fs := flag.NewFlagSet("forget", flag.ExitOnError)
+func parseForgetArgs(args []string) (*forgetArgs, error) {
+	fs := flag.NewFlagSet("forget", flag.ContinueOnError)
 	a := &forgetArgs{}
 	a.g = addGlobalFlags(fs)
 	prune := fs.Bool("prune", false, "Run prune after forgetting")
@@ -49,7 +48,9 @@ func parseForgetArgs() *forgetArgs {
 	filterSource := fs.String("source", "", "Filter by source URI (e.g. local:./docs, gdrive)")
 	filterAccount := fs.String("account", "", "Filter by account")
 	groupBy := fs.String("group-by", "source,account,path", "Group snapshots by fields (comma-separated)")
-	mustParse(fs)
+	if err := parseFlags(fs, args); err != nil {
+		return nil, err
+	}
 	fs.Visit(func(f *flag.Flag) {
 		if f.Name == "group-by" {
 			a.groupBySet = true
@@ -73,8 +74,7 @@ func parseForgetArgs() *forgetArgs {
 		default:
 			parts, err := parseSourceURI(*filterSource)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Invalid -source filter: %v\n", err)
-				os.Exit(1)
+				return nil, fmt.Errorf("invalid -source filter: %w", err)
 			}
 			a.filterSource = parts.scheme
 			a.filterPath = parts.path
@@ -86,12 +86,10 @@ func parseForgetArgs() *forgetArgs {
 	a.snapshotID = fs.Arg(0)
 
 	if err := validateForgetArgs(a); err != nil {
-		printForgetUsage(os.Stderr)
-		fmt.Fprintf(os.Stderr, "\nError: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return a
+	return a, nil
 }
 
 func printForgetUsage(w io.Writer) {
@@ -155,7 +153,14 @@ func validateForgetArgs(a *forgetArgs) error {
 }
 
 func runForget(r *runner, ctx context.Context) int {
-	a := parseForgetArgs()
+	a, err := parseForgetArgs(r.args)
+	if err != nil {
+		if parseErrorExitCode(err) == 0 {
+			return 0
+		}
+		printForgetUsage(r.errOut)
+		return r.fail("\nError: %v", err)
+	}
 	if err := r.openClient(ctx, a.g); err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}

--- a/cmd/cloudstic/cmd_forget_test.go
+++ b/cmd/cloudstic/cmd_forget_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"os"
 	"strings"
 	"testing"
 
@@ -12,13 +11,13 @@ import (
 )
 
 func TestRunForget_SingleSnapshot(t *testing.T) {
-	os.Args = []string{"cloudstic", "forget", "abc123"}
+	args := []string{"abc123"}
 	var out strings.Builder
 	r := &runner{out: &out, errOut: &strings.Builder{}, client: &stubClient{
 		forgetResult: &cloudstic.ForgetResult{Prune: nil},
 	}}
 
-	runForget(r, context.Background())
+	runForget(r.withArgs(args), context.Background())
 
 	if !strings.Contains(out.String(), "Snapshot removed.") {
 		t.Errorf("expected 'Snapshot removed.', got:\n%s", out.String())
@@ -26,7 +25,7 @@ func TestRunForget_SingleSnapshot(t *testing.T) {
 }
 
 func TestRunForget_SingleSnapshot_WithPruneResult(t *testing.T) {
-	os.Args = []string{"cloudstic", "forget", "--prune", "abc123"}
+	args := []string{"--prune", "abc123"}
 	var out strings.Builder
 	r := &runner{out: &out, errOut: &strings.Builder{}, client: &stubClient{
 		forgetResult: &cloudstic.ForgetResult{
@@ -38,7 +37,7 @@ func TestRunForget_SingleSnapshot_WithPruneResult(t *testing.T) {
 		},
 	}}
 
-	runForget(r, context.Background())
+	runForget(r.withArgs(args), context.Background())
 
 	got := out.String()
 	if !strings.Contains(got, "Snapshot removed.") {
@@ -50,7 +49,7 @@ func TestRunForget_SingleSnapshot_WithPruneResult(t *testing.T) {
 }
 
 func TestRunForget_Policy_NoRemove(t *testing.T) {
-	os.Args = []string{"cloudstic", "forget", "--keep-last", "1"}
+	args := []string{"--keep-last", "1"}
 	var out strings.Builder
 	r := &runner{out: &out, errOut: &strings.Builder{}, client: &stubClient{
 		policyResult: &cloudstic.PolicyResult{
@@ -64,7 +63,7 @@ func TestRunForget_Policy_NoRemove(t *testing.T) {
 		},
 	}}
 
-	runForget(r, context.Background())
+	runForget(r.withArgs(args), context.Background())
 
 	got := out.String()
 	if !strings.Contains(got, "No snapshots to remove") {
@@ -73,7 +72,7 @@ func TestRunForget_Policy_NoRemove(t *testing.T) {
 }
 
 func TestRunForget_Policy_WithRemoval(t *testing.T) {
-	os.Args = []string{"cloudstic", "forget", "--keep-last", "1"}
+	args := []string{"--keep-last", "1"}
 	var out strings.Builder
 	r := &runner{out: &out, errOut: &strings.Builder{}, client: &stubClient{
 		policyResult: &cloudstic.PolicyResult{
@@ -87,7 +86,7 @@ func TestRunForget_Policy_WithRemoval(t *testing.T) {
 		},
 	}}
 
-	runForget(r, context.Background())
+	runForget(r.withArgs(args), context.Background())
 
 	got := out.String()
 	if !strings.Contains(got, "1 snapshots have been removed") {
@@ -96,7 +95,7 @@ func TestRunForget_Policy_WithRemoval(t *testing.T) {
 }
 
 func TestRunForget_Policy_DryRun(t *testing.T) {
-	os.Args = []string{"cloudstic", "forget", "--keep-last", "1", "--dry-run"}
+	args := []string{"--keep-last", "1", "--dry-run"}
 	var out strings.Builder
 	r := &runner{out: &out, errOut: &strings.Builder{}, client: &stubClient{
 		policyResult: &cloudstic.PolicyResult{
@@ -109,7 +108,7 @@ func TestRunForget_Policy_DryRun(t *testing.T) {
 		},
 	}}
 
-	runForget(r, context.Background())
+	runForget(r.withArgs(args), context.Background())
 
 	got := out.String()
 	if !strings.Contains(got, "would remove") {
@@ -201,57 +200,57 @@ func TestValidateForgetArgs_RejectsSnapshotIDWithAllFilterKinds(t *testing.T) {
 }
 
 func TestParseForgetArgs_FilterOnlySourceSetsPolicyAndGrouping(t *testing.T) {
-	origArgs := os.Args
-	defer func() { os.Args = origArgs }()
 
-	os.Args = []string{
-		"cloudstic", "forget",
-		"--source", "local:/docs",
+	args := []string{"--source", "local:/docs",
 		"--account", "workstation",
 		"--group-by", "source,path",
 	}
 
-	args := parseForgetArgs()
+	parsed, err := parseForgetArgs(args)
+	if err != nil {
+		t.Fatalf("parseForgetArgs() error = %v", err)
+	}
 
-	if !args.hasFilters {
+	if !parsed.hasFilters {
 		t.Fatal("expected parseForgetArgs to detect filters")
 	}
-	if !args.hasPolicy {
+	if !parsed.hasPolicy {
 		t.Fatal("expected filter-only parse to enable policy mode")
 	}
-	if !args.groupBySet {
+	if !parsed.groupBySet {
 		t.Fatal("expected explicit group-by to be recorded")
 	}
-	if args.filterSource != "local" {
-		t.Fatalf("filterSource = %q, want %q", args.filterSource, "local")
+	if parsed.filterSource != "local" {
+		t.Fatalf("filterSource = %q, want %q", parsed.filterSource, "local")
 	}
-	if args.filterPath != "/docs" {
-		t.Fatalf("filterPath = %q, want %q", args.filterPath, "/docs")
+	if parsed.filterPath != "/docs" {
+		t.Fatalf("filterPath = %q, want %q", parsed.filterPath, "/docs")
 	}
-	if args.filterAccount != "workstation" {
-		t.Fatalf("filterAccount = %q, want %q", args.filterAccount, "workstation")
+	if parsed.filterAccount != "workstation" {
+		t.Fatalf("filterAccount = %q, want %q", parsed.filterAccount, "workstation")
 	}
-	if args.groupBy != "source,path" {
-		t.Fatalf("groupBy = %q, want %q", args.groupBy, "source,path")
+	if parsed.groupBy != "source,path" {
+		t.Fatalf("groupBy = %q, want %q", parsed.groupBy, "source,path")
 	}
 }
 
 func TestParseForgetArgs_BareSourceKeywordDoesNotSetFilterPath(t *testing.T) {
-	origArgs := os.Args
-	defer func() { os.Args = origArgs }()
 
-	os.Args = []string{"cloudstic", "forget", "--source", "local"}
+	args := []string{"--source", "local"}
 
-	args := parseForgetArgs()
-
-	if args.filterSource != "local" {
-		t.Fatalf("filterSource = %q, want %q", args.filterSource, "local")
+	parsed, err := parseForgetArgs(args)
+	if err != nil {
+		t.Fatalf("parseForgetArgs() error = %v", err)
 	}
-	if args.filterPath != "" {
-		t.Fatalf("filterPath = %q, want empty", args.filterPath)
+
+	if parsed.filterSource != "local" {
+		t.Fatalf("filterSource = %q, want %q", parsed.filterSource, "local")
 	}
-	if !args.hasFilters || !args.hasPolicy {
-		t.Fatalf("expected bare source filter to enable filter-only policy mode: %+v", args)
+	if parsed.filterPath != "" {
+		t.Fatalf("filterPath = %q, want empty", parsed.filterPath)
+	}
+	if !parsed.hasFilters || !parsed.hasPolicy {
+		t.Fatalf("expected bare source filter to enable filter-only policy mode: %+v", parsed)
 	}
 }
 

--- a/cmd/cloudstic/cmd_init.go
+++ b/cmd/cloudstic/cmd_init.go
@@ -20,22 +20,27 @@ type initArgs struct {
 	adoptSlots   bool
 }
 
-func parseInitArgs() *initArgs {
-	fs := flag.NewFlagSet("init", flag.ExitOnError)
+func parseInitArgs(args []string) (*initArgs, error) {
+	fs := flag.NewFlagSet("init", flag.ContinueOnError)
 	a := &initArgs{}
 	a.g = addGlobalFlags(fs)
 	recovery := fs.Bool("add-recovery-key", false, "Generate a recovery key (24-word seed phrase) during init")
 	noEncryption := fs.Bool("no-encryption", false, "Create an unencrypted repository (NOT recommended)")
 	adoptSlots := fs.Bool("adopt-slots", false, "Initialize by adopting existing key slots if found (prevents error if already has slots)")
-	mustParse(fs)
+	if err := parseFlags(fs, args); err != nil {
+		return nil, err
+	}
 	a.recovery = *recovery
 	a.noEncryption = *noEncryption
 	a.adoptSlots = *adoptSlots
-	return a
+	return a, nil
 }
 
 func runInit(r *runner, ctx context.Context) int {
-	a := parseInitArgs()
+	a, err := parseInitArgs(r.args)
+	if err != nil {
+		return parseErrorExitCode(err)
+	}
 	return runInitWithArgs(r, ctx, a)
 }
 

--- a/cmd/cloudstic/cmd_key.go
+++ b/cmd/cloudstic/cmd_key.go
@@ -15,7 +15,7 @@ import (
 )
 
 func runKey(r *runner, ctx context.Context) int {
-	if len(os.Args) < 3 {
+	if len(r.args) < 1 {
 		_, _ = fmt.Fprintln(r.errOut, "Usage: cloudstic key <subcommand>")
 		_, _ = fmt.Fprintln(r.errOut)
 		_, _ = fmt.Fprintln(r.errOut, "Subcommands:")
@@ -25,16 +25,16 @@ func runKey(r *runner, ctx context.Context) int {
 		return 1
 	}
 
-	sub := os.Args[2]
-	os.Args = append(os.Args[:2], os.Args[3:]...)
+	sub := r.args[0]
+	subRunner := r.withArgs(r.args[1:])
 
 	switch sub {
 	case "list":
-		return runKeyList(r, ctx)
+		return runKeyList(subRunner, ctx)
 	case "add-recovery":
-		return runAddRecoveryKey(r, ctx)
+		return runAddRecoveryKey(subRunner, ctx)
 	case "passwd":
-		return runKeyPasswd(r, ctx)
+		return runKeyPasswd(subRunner, ctx)
 	default:
 		return r.fail("Unknown key subcommand: %s", sub)
 	}
@@ -44,15 +44,20 @@ type keyListArgs struct {
 	g *globalFlags
 }
 
-func parseKeyListArgs() *keyListArgs {
-	fs := flag.NewFlagSet("key list", flag.ExitOnError)
+func parseKeyListArgs(args []string) (*keyListArgs, error) {
+	fs := flag.NewFlagSet("key list", flag.ContinueOnError)
 	a := &keyListArgs{g: addGlobalFlags(fs)}
-	mustParse(fs)
-	return a
+	if err := parseFlags(fs, args); err != nil {
+		return nil, err
+	}
+	return a, nil
 }
 
 func runKeyList(r *runner, ctx context.Context) int {
-	a := parseKeyListArgs()
+	a, err := parseKeyListArgs(r.args)
+	if err != nil {
+		return parseErrorExitCode(err)
+	}
 
 	raw, err := a.g.openStore(ctx)
 	if err != nil {
@@ -95,18 +100,23 @@ type keyPasswdArgs struct {
 	newPassword string
 }
 
-func parseKeyPasswdArgs() *keyPasswdArgs {
-	fs := flag.NewFlagSet("key passwd", flag.ExitOnError)
+func parseKeyPasswdArgs(args []string) (*keyPasswdArgs, error) {
+	fs := flag.NewFlagSet("key passwd", flag.ContinueOnError)
 	a := &keyPasswdArgs{}
 	a.g = addGlobalFlags(fs)
 	newPassword := fs.String("new-password", "", "New repository password (prompted interactively if not set)")
-	mustParse(fs)
+	if err := parseFlags(fs, args); err != nil {
+		return nil, err
+	}
 	a.newPassword = *newPassword
-	return a
+	return a, nil
 }
 
 func runKeyPasswd(r *runner, ctx context.Context) int {
-	a := parseKeyPasswdArgs()
+	a, err := parseKeyPasswdArgs(r.args)
+	if err != nil {
+		return parseErrorExitCode(err)
+	}
 
 	raw, err := a.g.openStore(ctx)
 	if err != nil {
@@ -148,15 +158,20 @@ type addRecoveryKeyArgs struct {
 	g *globalFlags
 }
 
-func parseAddRecoveryKeyArgs() *addRecoveryKeyArgs {
-	fs := flag.NewFlagSet("add-recovery-key", flag.ExitOnError)
+func parseAddRecoveryKeyArgs(args []string) (*addRecoveryKeyArgs, error) {
+	fs := flag.NewFlagSet("add-recovery-key", flag.ContinueOnError)
 	a := &addRecoveryKeyArgs{g: addGlobalFlags(fs)}
-	mustParse(fs)
-	return a
+	if err := parseFlags(fs, args); err != nil {
+		return nil, err
+	}
+	return a, nil
 }
 
 func runAddRecoveryKey(r *runner, ctx context.Context) int {
-	a := parseAddRecoveryKeyArgs()
+	a, err := parseAddRecoveryKeyArgs(r.args)
+	if err != nil {
+		return parseErrorExitCode(err)
+	}
 
 	raw, err := a.g.openStore(ctx)
 	if err != nil {

--- a/cmd/cloudstic/cmd_list.go
+++ b/cmd/cloudstic/cmd_list.go
@@ -14,18 +14,23 @@ type listArgs struct {
 	group *bool
 }
 
-func parseListArgs() *listArgs {
-	fs := flag.NewFlagSet("list", flag.ExitOnError)
+func parseListArgs(args []string) (*listArgs, error) {
+	fs := flag.NewFlagSet("list", flag.ContinueOnError)
 	a := &listArgs{
 		g:     addGlobalFlags(fs),
 		group: fs.Bool("group", false, "Group snapshots by source identity"),
 	}
-	mustParse(fs)
-	return a
+	if err := parseFlags(fs, args); err != nil {
+		return nil, err
+	}
+	return a, nil
 }
 
 func runList(r *runner, ctx context.Context) int {
-	a := parseListArgs()
+	a, err := parseListArgs(r.args)
+	if err != nil {
+		return parseErrorExitCode(err)
+	}
 	if err := r.openClient(ctx, a.g); err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}

--- a/cmd/cloudstic/cmd_list_test.go
+++ b/cmd/cloudstic/cmd_list_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"os"
 	"strings"
 	"testing"
 
@@ -13,7 +12,7 @@ import (
 )
 
 func TestRunList_Success(t *testing.T) {
-	os.Args = []string{"cloudstic", "list"}
+	args := []string{}
 	var out strings.Builder
 	r := &runner{out: &out, errOut: &strings.Builder{}, client: &stubClient{
 		listResult: &cloudstic.ListResult{
@@ -24,7 +23,7 @@ func TestRunList_Success(t *testing.T) {
 		},
 	}}
 
-	runList(r, context.Background())
+	runList(r.withArgs(args), context.Background())
 
 	got := out.String()
 	if !strings.Contains(got, "2 snapshots") {
@@ -33,7 +32,7 @@ func TestRunList_Success(t *testing.T) {
 }
 
 func TestRunList_JSON(t *testing.T) {
-	os.Args = []string{"cloudstic", "list", "-json"}
+	args := []string{"-json"}
 	var out strings.Builder
 	r := &runner{out: &out, errOut: &strings.Builder{}, client: &stubClient{
 		listResult: &cloudstic.ListResult{
@@ -43,7 +42,7 @@ func TestRunList_JSON(t *testing.T) {
 		},
 	}}
 
-	if exit := runList(r, context.Background()); exit != 0 {
+	if exit := runList(r.withArgs(args), context.Background()); exit != 0 {
 		t.Fatalf("runList() exit = %d, want 0", exit)
 	}
 
@@ -57,13 +56,13 @@ func TestRunList_JSON(t *testing.T) {
 }
 
 func TestRunList_Empty(t *testing.T) {
-	os.Args = []string{"cloudstic", "list"}
+	args := []string{}
 	var out strings.Builder
 	r := &runner{out: &out, errOut: &strings.Builder{}, client: &stubClient{
 		listResult: &cloudstic.ListResult{Snapshots: nil},
 	}}
 
-	runList(r, context.Background())
+	runList(r.withArgs(args), context.Background())
 
 	if !strings.Contains(out.String(), "0 snapshots") {
 		t.Errorf("expected '0 snapshots', got: %s", out.String())
@@ -71,7 +70,7 @@ func TestRunList_Empty(t *testing.T) {
 }
 
 func TestRunList_Group(t *testing.T) {
-	os.Args = []string{"cloudstic", "list", "-group"}
+	args := []string{"-group"}
 	var out strings.Builder
 	r := &runner{out: &out, errOut: &strings.Builder{}, client: &stubClient{
 		listResult: &cloudstic.ListResult{
@@ -94,7 +93,7 @@ func TestRunList_Group(t *testing.T) {
 		},
 	}}
 
-	runList(r, context.Background())
+	runList(r.withArgs(args), context.Background())
 
 	got := out.String()
 	if !strings.Contains(got, "2 snapshots") {

--- a/cmd/cloudstic/cmd_ls.go
+++ b/cmd/cloudstic/cmd_ls.go
@@ -19,20 +19,25 @@ type lsArgs struct {
 	snapshotID string
 }
 
-func parseLsArgs() *lsArgs {
-	fs := flag.NewFlagSet("ls", flag.ExitOnError)
+func parseLsArgs(args []string) (*lsArgs, error) {
+	fs := flag.NewFlagSet("ls", flag.ContinueOnError)
 	a := &lsArgs{}
 	a.g = addGlobalFlags(fs)
-	mustParse(fs)
+	if err := parseFlags(fs, args); err != nil {
+		return nil, err
+	}
 	a.snapshotID = "latest"
 	if fs.NArg() > 0 {
 		a.snapshotID = fs.Arg(0)
 	}
-	return a
+	return a, nil
 }
 
 func runLsSnapshot(r *runner, ctx context.Context) int {
-	a := parseLsArgs()
+	a, err := parseLsArgs(r.args)
+	if err != nil {
+		return parseErrorExitCode(err)
+	}
 	if err := r.openClient(ctx, a.g); err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}

--- a/cmd/cloudstic/cmd_profile.go
+++ b/cmd/cloudstic/cmd_profile.go
@@ -25,22 +25,24 @@ func defaultProfilesPath() (string, error) {
 }
 
 func runProfile(r *runner, ctx context.Context) int {
-	if len(os.Args) < 3 {
+	if len(r.args) < 1 {
 		_, _ = fmt.Fprintln(r.errOut, "Usage: cloudstic profile <subcommand> [options]")
 		_, _ = fmt.Fprintln(r.errOut, "")
 		_, _ = fmt.Fprintln(r.errOut, "Available subcommands: list, show, new")
 		return 1
 	}
 
-	switch os.Args[2] {
+	subcommand := r.args[0]
+	subRunner := r.withArgs(r.args[1:])
+	switch subcommand {
 	case "list":
-		return runProfileList(r, ctx)
+		return runProfileList(subRunner, ctx)
 	case "show":
-		return runProfileShow(r, ctx)
+		return runProfileShow(subRunner, ctx)
 	case "new":
-		return runProfileNew(r, ctx)
+		return runProfileNew(subRunner, ctx)
 	default:
-		return r.fail("Unknown profile subcommand: %s", os.Args[2])
+		return r.fail("Unknown profile subcommand: %s", subcommand)
 	}
 }
 
@@ -49,15 +51,17 @@ type profileShowArgs struct {
 	name         string
 }
 
-func parseProfileShowArgs() (*profileShowArgs, error) {
-	fs := flag.NewFlagSet("profile show", flag.ExitOnError)
+func parseProfileShowArgs(args []string) (*profileShowArgs, error) {
+	fs := flag.NewFlagSet("profile show", flag.ContinueOnError)
 	a := &profileShowArgs{}
 	defaultPath, err := defaultProfilesPath()
 	if err != nil {
 		defaultPath = defaultProfilesFilename
 	}
 	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultPath), "Path to profiles YAML file")
-	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
+	if err := parseFlags(fs, args); err != nil {
+		return nil, err
+	}
 	a.profilesFile = *profilesFile
 	if fs.NArg() > 1 {
 		return nil, fmt.Errorf("usage: cloudstic profile show [-profiles-file <path>] <name>")
@@ -69,8 +73,11 @@ func parseProfileShowArgs() (*profileShowArgs, error) {
 }
 
 func runProfileShow(r *runner, ctx context.Context) int {
-	a, err := parseProfileShowArgs()
+	a, err := parseProfileShowArgs(r.args)
 	if err != nil {
+		if parseErrorExitCode(err) == 0 {
+			return 0
+		}
 		return r.fail("%v", err)
 	}
 	cfg, err := cloudstic.LoadProfilesFile(a.profilesFile)
@@ -113,21 +120,26 @@ type profileListArgs struct {
 	profilesFile string
 }
 
-func parseProfileListArgs() *profileListArgs {
-	fs := flag.NewFlagSet("profile list", flag.ExitOnError)
+func parseProfileListArgs(args []string) (*profileListArgs, error) {
+	fs := flag.NewFlagSet("profile list", flag.ContinueOnError)
 	a := &profileListArgs{}
 	defaultPath, err := defaultProfilesPath()
 	if err != nil {
 		defaultPath = defaultProfilesFilename
 	}
 	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultPath), "Path to profiles YAML file")
-	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
+	if err := parseFlags(fs, args); err != nil {
+		return nil, err
+	}
 	a.profilesFile = *profilesFile
-	return a
+	return a, nil
 }
 
 func runProfileList(r *runner, ctx context.Context) int {
-	a := parseProfileListArgs()
+	a, err := parseProfileListArgs(r.args)
+	if err != nil {
+		return parseErrorExitCode(err)
+	}
 	cfg, err := cloudstic.LoadProfilesFile(a.profilesFile)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -169,8 +181,8 @@ type profileNewArgs struct {
 	flagsSet          map[string]bool
 }
 
-func parseProfileNewArgs() *profileNewArgs {
-	fs := flag.NewFlagSet("profile new", flag.ExitOnError)
+func parseProfileNewArgs(args []string) (*profileNewArgs, error) {
+	fs := flag.NewFlagSet("profile new", flag.ContinueOnError)
 	a := &profileNewArgs{}
 	defaultPath, err := defaultProfilesPath()
 	if err != nil {
@@ -196,7 +208,9 @@ func parseProfileNewArgs() *profileNewArgs {
 	onedriveTokenRef := fs.String("onedrive-token-ref", "", "Secret reference to OneDrive OAuth token")
 	fs.Var(&a.tags, "tag", "Tag to apply to snapshots (repeatable)")
 	fs.Var(&a.excludes, "exclude", "Exclude pattern (repeatable)")
-	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
+	if err := parseFlags(fs, args); err != nil {
+		return nil, err
+	}
 
 	a.flagsSet = map[string]bool{}
 	fs.Visit(func(f *flag.Flag) { a.flagsSet[f.Name] = true })
@@ -220,11 +234,14 @@ func parseProfileNewArgs() *profileNewArgs {
 	a.onedriveTokenFile = *onedriveTokenFile
 	a.onedriveTokenRef = *onedriveTokenRef
 
-	return a
+	return a, nil
 }
 
 func runProfileNew(r *runner, ctx context.Context) int {
-	a := parseProfileNewArgs()
+	a, err := parseProfileNewArgs(r.args)
+	if err != nil {
+		return parseErrorExitCode(err)
+	}
 	if a.name == "" {
 		if r.canPrompt() {
 			v, err := r.promptValidatedLine(ctx, "Profile name", "", func(v string) error {

--- a/cmd/cloudstic/cmd_profile_test.go
+++ b/cmd/cloudstic/cmd_profile_test.go
@@ -36,12 +36,12 @@ profiles:
 		t.Fatalf("write profiles file: %v", err)
 	}
 
-	os.Args = []string{"cloudstic", "profile", "list", "-profiles-file", profilesPath}
+	args := []string{"list", "-profiles-file", profilesPath}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := runProfile(r, context.Background()); code != 0 {
+	if code := runProfile(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("runProfile() code=%d err=%s", code, errOut.String())
 	}
 
@@ -76,12 +76,12 @@ profiles:
 		t.Fatalf("write profiles file: %v", err)
 	}
 
-	os.Args = []string{"cloudstic", "profile", "show", "-profiles-file", profilesPath, "work-drive"}
+	args := []string{"show", "-profiles-file", profilesPath, "work-drive"}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := runProfile(r, context.Background()); code != 0 {
+	if code := runProfile(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("runProfile() code=%d err=%s", code, errOut.String())
 	}
 	got := out.String()
@@ -100,12 +100,12 @@ func TestRunProfileShow_UnknownProfile(t *testing.T) {
 		t.Fatalf("write profiles file: %v", err)
 	}
 
-	os.Args = []string{"cloudstic", "profile", "show", "-profiles-file", profilesPath, "missing"}
+	args := []string{"show", "-profiles-file", profilesPath, "missing"}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := runProfile(r, context.Background()); code == 0 {
+	if code := runProfile(r.withArgs(args), context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "Unknown profile") {
@@ -114,12 +114,12 @@ func TestRunProfileShow_UnknownProfile(t *testing.T) {
 }
 
 func TestRunProfileList_MissingFile(t *testing.T) {
-	os.Args = []string{"cloudstic", "profile", "list", "-profiles-file", filepath.Join(t.TempDir(), "missing.yaml")}
+	args := []string{"list", "-profiles-file", filepath.Join(t.TempDir(), "missing.yaml")}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := runProfile(r, context.Background()); code != 0 {
+	if code := runProfile(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("expected zero exit code, got=%d err=%s", code, errOut.String())
 	}
 	if out.String() != "" {
@@ -131,12 +131,12 @@ func TestRunProfileList_MissingFile(t *testing.T) {
 }
 
 func TestRunProfile_UnknownSubcommand(t *testing.T) {
-	os.Args = []string{"cloudstic", "profile", "unknown"}
+	args := []string{"unknown"}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := runProfile(r, context.Background()); code == 0 {
+	if code := runProfile(r.withArgs(args), context.Background()); code == 0 {
 		t.Fatalf("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "Unknown profile subcommand") {
@@ -147,8 +147,7 @@ func TestRunProfile_UnknownSubcommand(t *testing.T) {
 func TestRunProfileNew_CreatesFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
-	os.Args = []string{
-		"cloudstic", "profile", "new",
+	args := []string{"new",
 		"-profiles-file", profilesPath,
 		"-name", "photos",
 		"-source", "local:/Volumes/Photos",
@@ -160,7 +159,7 @@ func TestRunProfileNew_CreatesFile(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := runProfile(r, context.Background()); code != 0 {
+	if code := runProfile(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("runProfile() code=%d err=%s", code, errOut.String())
 	}
 
@@ -182,8 +181,7 @@ func TestRunProfileNew_PrefillsExistingProfile(t *testing.T) {
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
 
 	// Create initial profile.
-	os.Args = []string{
-		"cloudstic", "profile", "new",
+	args := []string{"new",
 		"-profiles-file", profilesPath,
 		"-name", "photos",
 		"-source", "local:/Volumes/Photos",
@@ -194,20 +192,19 @@ func TestRunProfileNew_PrefillsExistingProfile(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runProfile(r, context.Background()); code != 0 {
+	if code := runProfile(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("initial create: code=%d err=%s", code, errOut.String())
 	}
 
 	// Re-run with same name, only override source.
-	os.Args = []string{
-		"cloudstic", "profile", "new",
+	args = []string{"new",
 		"-profiles-file", profilesPath,
 		"-name", "photos",
 		"-source", "local:/Volumes/NewPhotos",
 	}
 	out.Reset()
 	errOut.Reset()
-	if code := runProfile(r, context.Background()); code != 0 {
+	if code := runProfile(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("update: code=%d err=%s", code, errOut.String())
 	}
 
@@ -238,12 +235,12 @@ func TestRunProfileNew_PrefillsExistingProfile(t *testing.T) {
 func TestRunProfileNew_RequiresNameAndSource(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
-	os.Args = []string{"cloudstic", "profile", "new", "-profiles-file", profilesPath, "-name", "x"}
+	args := []string{"new", "-profiles-file", profilesPath, "-name", "x"}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := runProfile(r, context.Background()); code == 0 {
+	if code := runProfile(r.withArgs(args), context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "-source is required") {
@@ -254,8 +251,7 @@ func TestRunProfileNew_RequiresNameAndSource(t *testing.T) {
 func TestRunProfileNew_RequiresStore(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
-	os.Args = []string{
-		"cloudstic", "profile", "new",
+	args := []string{"new",
 		"-profiles-file", profilesPath,
 		"-name", "photos",
 		"-source", "local:/Volumes/Photos",
@@ -264,7 +260,7 @@ func TestRunProfileNew_RequiresStore(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := runProfile(r, context.Background()); code == 0 {
+	if code := runProfile(r.withArgs(args), context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "-store-ref is required") {
@@ -275,8 +271,7 @@ func TestRunProfileNew_RequiresStore(t *testing.T) {
 func TestRunProfileNew_RejectsUnknownStoreRef(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
-	os.Args = []string{
-		"cloudstic", "profile", "new",
+	args := []string{"new",
 		"-profiles-file", profilesPath,
 		"-name", "google-drive",
 		"-source", "gdrive-changes:/Test Folder 2",
@@ -286,7 +281,7 @@ func TestRunProfileNew_RejectsUnknownStoreRef(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := runProfile(r, context.Background()); code == 0 {
+	if code := runProfile(r.withArgs(args), context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "Unknown store reference") {
@@ -297,8 +292,7 @@ func TestRunProfileNew_RejectsUnknownStoreRef(t *testing.T) {
 func TestRunProfileNew_CloudSourceRequiresAuthRef(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
-	os.Args = []string{
-		"cloudstic", "profile", "new",
+	args := []string{"new",
 		"-profiles-file", profilesPath,
 		"-name", "drive-backup",
 		"-source", "gdrive:/",
@@ -308,7 +302,7 @@ func TestRunProfileNew_CloudSourceRequiresAuthRef(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := runProfile(r, context.Background()); code == 0 {
+	if code := runProfile(r.withArgs(args), context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "-auth-ref is required for cloud sources") {
@@ -319,8 +313,7 @@ func TestRunProfileNew_CloudSourceRequiresAuthRef(t *testing.T) {
 func TestRunProfileNew_RejectsUnknownAuthRef(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
-	os.Args = []string{
-		"cloudstic", "profile", "new",
+	args := []string{"new",
 		"-profiles-file", profilesPath,
 		"-name", "work-drive",
 		"-source", "gdrive-changes:/Team",
@@ -331,7 +324,7 @@ func TestRunProfileNew_RejectsUnknownAuthRef(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := runProfile(r, context.Background()); code == 0 {
+	if code := runProfile(r.withArgs(args), context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "Unknown auth reference") {
@@ -342,8 +335,7 @@ func TestRunProfileNew_RejectsUnknownAuthRef(t *testing.T) {
 func TestRunProfileNew_AuthRefRequiresCloudSource(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
-	os.Args = []string{
-		"cloudstic", "profile", "new",
+	args := []string{"new",
 		"-profiles-file", profilesPath,
 		"-name", "docs",
 		"-source", "local:/Users/me/Documents",
@@ -354,7 +346,7 @@ func TestRunProfileNew_AuthRefRequiresCloudSource(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := runProfile(r, context.Background()); code == 0 {
+	if code := runProfile(r.withArgs(args), context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "-auth-ref requires a cloud source") {
@@ -427,12 +419,12 @@ profiles:
 		t.Fatalf("write profiles file: %v", err)
 	}
 
-	os.Args = []string{"cloudstic", "profile", "show", "-profiles-file", profilesPath, "my-onedrive"}
+	args := []string{"show", "-profiles-file", profilesPath, "my-onedrive"}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := runProfile(r, context.Background()); code != 0 {
+	if code := runProfile(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("runProfile() code=%d err=%s", code, errOut.String())
 	}
 	got := out.String()
@@ -458,12 +450,12 @@ profiles:
 		t.Fatalf("write profiles file: %v", err)
 	}
 
-	os.Args = []string{"cloudstic", "profile", "show", "-profiles-file", profilesPath, "broken"}
+	args := []string{"show", "-profiles-file", profilesPath, "broken"}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := runProfile(r, context.Background()); code != 0 {
+	if code := runProfile(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("runProfile() code=%d err=%s", code, errOut.String())
 	}
 	got := out.String()
@@ -490,12 +482,12 @@ profiles:
 		t.Fatalf("write profiles file: %v", err)
 	}
 
-	os.Args = []string{"cloudstic", "profile", "show", "-profiles-file", profilesPath, "broken"}
+	args := []string{"show", "-profiles-file", profilesPath, "broken"}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := runProfile(r, context.Background()); code != 0 {
+	if code := runProfile(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("runProfile() code=%d err=%s", code, errOut.String())
 	}
 	got := out.String()
@@ -507,8 +499,7 @@ profiles:
 func TestRunProfileNew_WithExcludesAndTags(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
-	os.Args = []string{
-		"cloudstic", "profile", "new",
+	args := []string{"new",
 		"-profiles-file", profilesPath,
 		"-name", "multi",
 		"-source", "local:/data",
@@ -523,7 +514,7 @@ func TestRunProfileNew_WithExcludesAndTags(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := runProfile(r, context.Background()); code != 0 {
+	if code := runProfile(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("runProfile() code=%d err=%s", code, errOut.String())
 	}
 
@@ -542,8 +533,7 @@ func TestRunProfileNew_WithExcludesAndTags(t *testing.T) {
 func TestRunProfileNew_InvalidName(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
-	os.Args = []string{
-		"cloudstic", "profile", "new",
+	args := []string{"new",
 		"-profiles-file", profilesPath,
 		"-name", "bad name!",
 		"-source", "local:/data",
@@ -553,7 +543,7 @@ func TestRunProfileNew_InvalidName(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := runProfile(r, context.Background()); code == 0 {
+	if code := runProfile(r.withArgs(args), context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "invalid profile name") {
@@ -564,8 +554,7 @@ func TestRunProfileNew_InvalidName(t *testing.T) {
 func TestRunProfileNew_InvalidSource(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
-	os.Args = []string{
-		"cloudstic", "profile", "new",
+	args := []string{"new",
 		"-profiles-file", profilesPath,
 		"-name", "bad-source",
 		"-source", "garbage-no-scheme",
@@ -575,7 +564,7 @@ func TestRunProfileNew_InvalidSource(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := runProfile(r, context.Background()); code == 0 {
+	if code := runProfile(r.withArgs(args), context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "Invalid source") {
@@ -586,8 +575,7 @@ func TestRunProfileNew_InvalidSource(t *testing.T) {
 func TestRunProfileNew_InvalidStoreURI(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
-	os.Args = []string{
-		"cloudstic", "profile", "new",
+	args := []string{"new",
 		"-profiles-file", profilesPath,
 		"-name", "bad-store",
 		"-source", "local:/data",
@@ -597,7 +585,7 @@ func TestRunProfileNew_InvalidStoreURI(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := runProfile(r, context.Background()); code == 0 {
+	if code := runProfile(r.withArgs(args), context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "Invalid store URI") {
@@ -626,12 +614,12 @@ profiles:
 		t.Fatalf("write profiles file: %v", err)
 	}
 
-	os.Args = []string{"cloudstic", "profile", "list", "-profiles-file", profilesPath}
+	args := []string{"list", "-profiles-file", profilesPath}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := runProfile(r, context.Background()); code != 0 {
+	if code := runProfile(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("runProfile() code=%d err=%s", code, errOut.String())
 	}
 	got := out.String()
@@ -668,12 +656,12 @@ profiles:
 		t.Fatalf("write profiles file: %v", err)
 	}
 
-	os.Args = []string{"cloudstic", "profile", "show", "-profiles-file", profilesPath, "full"}
+	args := []string{"show", "-profiles-file", profilesPath, "full"}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	if code := runProfile(r, context.Background()); code != 0 {
+	if code := runProfile(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("runProfile() code=%d err=%s", code, errOut.String())
 	}
 	got := out.String()

--- a/cmd/cloudstic/cmd_prune.go
+++ b/cmd/cloudstic/cmd_prune.go
@@ -15,18 +15,23 @@ type pruneArgs struct {
 	dryRun bool
 }
 
-func parsePruneArgs() *pruneArgs {
-	fs := flag.NewFlagSet("prune", flag.ExitOnError)
+func parsePruneArgs(args []string) (*pruneArgs, error) {
+	fs := flag.NewFlagSet("prune", flag.ContinueOnError)
 	a := &pruneArgs{}
 	a.g = addGlobalFlags(fs)
 	dryRun := fs.Bool("dry-run", false, "Show what would be deleted without deleting")
-	mustParse(fs)
+	if err := parseFlags(fs, args); err != nil {
+		return nil, err
+	}
 	a.dryRun = *dryRun
-	return a
+	return a, nil
 }
 
 func runPrune(r *runner, ctx context.Context) int {
-	a := parsePruneArgs()
+	a, err := parsePruneArgs(r.args)
+	if err != nil {
+		return parseErrorExitCode(err)
+	}
 	if err := r.openClient(ctx, a.g); err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}

--- a/cmd/cloudstic/cmd_prune_test.go
+++ b/cmd/cloudstic/cmd_prune_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"os"
 	"strings"
 	"testing"
 
@@ -10,7 +9,7 @@ import (
 )
 
 func TestRunPrune_Normal(t *testing.T) {
-	os.Args = []string{"cloudstic", "prune"}
+	args := []string{}
 	var out strings.Builder
 	r := &runner{out: &out, errOut: &strings.Builder{}, client: &stubClient{
 		pruneResult: &cloudstic.PruneResult{
@@ -21,7 +20,7 @@ func TestRunPrune_Normal(t *testing.T) {
 		},
 	}}
 
-	runPrune(r, context.Background())
+	runPrune(r.withArgs(args), context.Background())
 
 	got := out.String()
 	if !strings.Contains(got, "Prune complete.") {
@@ -39,7 +38,7 @@ func TestRunPrune_Normal(t *testing.T) {
 }
 
 func TestRunPrune_DryRun(t *testing.T) {
-	os.Args = []string{"cloudstic", "prune", "--dry-run"}
+	args := []string{"--dry-run"}
 	var out strings.Builder
 	r := &runner{out: &out, errOut: &strings.Builder{}, client: &stubClient{
 		pruneResult: &cloudstic.PruneResult{
@@ -49,7 +48,7 @@ func TestRunPrune_DryRun(t *testing.T) {
 		},
 	}}
 
-	runPrune(r, context.Background())
+	runPrune(r.withArgs(args), context.Background())
 
 	got := out.String()
 	if !strings.Contains(got, "Prune dry run complete.") {

--- a/cmd/cloudstic/cmd_restore.go
+++ b/cmd/cloudstic/cmd_restore.go
@@ -21,15 +21,17 @@ type restoreArgs struct {
 	snapshotRef string
 }
 
-func parseRestoreArgs() *restoreArgs {
-	fs := flag.NewFlagSet("restore", flag.ExitOnError)
+func parseRestoreArgs(args []string) (*restoreArgs, error) {
+	fs := flag.NewFlagSet("restore", flag.ContinueOnError)
 	a := &restoreArgs{}
 	a.g = addGlobalFlags(fs)
 	output := fs.String("output", "./restore.zip", "Output path (ZIP file for -format zip, directory for -format dir)")
 	format := fs.String("format", "", "Restore format: zip or dir (default: auto from -output)")
 	dryRun := fs.Bool("dry-run", false, "Show what would be restored without writing output")
 	pathFilter := fs.String("path", "", "Restore only the given file or subtree (e.g. Documents/report.pdf or Documents/)")
-	mustParse(fs)
+	if err := parseFlags(fs, args); err != nil {
+		return nil, err
+	}
 	a.output = *output
 	a.format = strings.TrimSpace(strings.ToLower(*format))
 	a.dryRun = *dryRun
@@ -38,11 +40,14 @@ func parseRestoreArgs() *restoreArgs {
 	if fs.NArg() > 0 {
 		a.snapshotRef = fs.Arg(0)
 	}
-	return a
+	return a, nil
 }
 
 func runRestore(r *runner, ctx context.Context) int {
-	a := parseRestoreArgs()
+	a, err := parseRestoreArgs(r.args)
+	if err != nil {
+		return parseErrorExitCode(err)
+	}
 	format, err := resolveRestoreFormat(a.format, a.output)
 	if err != nil {
 		return r.fail("%v", err)

--- a/cmd/cloudstic/cmd_setup.go
+++ b/cmd/cloudstic/cmd_setup.go
@@ -30,18 +30,20 @@ func defaultProfilesPathNoCreate() string {
 }
 
 func runSetup(r *runner, ctx context.Context) int {
-	if len(os.Args) < 3 {
+	if len(r.args) < 1 {
 		_, _ = fmt.Fprintln(r.errOut, "Usage: cloudstic setup <subcommand> [options]")
 		_, _ = fmt.Fprintln(r.errOut, "")
 		_, _ = fmt.Fprintln(r.errOut, "Available subcommands: workstation")
 		return 1
 	}
 
-	switch os.Args[2] {
+	subcommand := r.args[0]
+	subRunner := r.withArgs(r.args[1:])
+	switch subcommand {
 	case "workstation":
-		return runSetupWorkstation(r, ctx)
+		return runSetupWorkstation(subRunner, ctx)
 	default:
-		return r.fail("Unknown setup subcommand: %s", os.Args[2])
+		return r.fail("Unknown setup subcommand: %s", subcommand)
 	}
 }
 
@@ -53,25 +55,30 @@ type setupWorkstationArgs struct {
 	storeRef     string
 }
 
-func parseSetupWorkstationArgs() *setupWorkstationArgs {
-	fs := flag.NewFlagSet("setup workstation", flag.ExitOnError)
+func parseSetupWorkstationArgs(args []string) (*setupWorkstationArgs, error) {
+	fs := flag.NewFlagSet("setup workstation", flag.ContinueOnError)
 	a := &setupWorkstationArgs{}
 	dryRun := fs.Bool("dry-run", false, "Preview generated profiles without writing configuration")
 	yes := fs.Bool("yes", false, "Accept default selections without prompting")
 	jsonOutput := fs.Bool("json", false, "Write onboarding plan as JSON")
 	profilesFile := fs.String("profiles-file", defaultProfilesPathNoCreate(), "Path to profiles YAML file")
 	storeRef := fs.String("store-ref", "", "Existing store reference to attach to generated profiles")
-	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
+	if err := parseFlags(fs, args); err != nil {
+		return nil, err
+	}
 	a.dryRun = *dryRun
 	a.yes = *yes
 	a.jsonOutput = *jsonOutput
 	a.profilesFile = *profilesFile
 	a.storeRef = strings.TrimSpace(*storeRef)
-	return a
+	return a, nil
 }
 
 func runSetupWorkstation(r *runner, ctx context.Context) int {
-	args := parseSetupWorkstationArgs()
+	args, err := parseSetupWorkstationArgs(r.args)
+	if err != nil {
+		return parseErrorExitCode(err)
+	}
 	cfg, err := loadProfilesOrInit(args.profilesFile)
 	if err != nil {
 		return r.fail("Failed to load profiles: %v", err)

--- a/cmd/cloudstic/cmd_setup_test.go
+++ b/cmd/cloudstic/cmd_setup_test.go
@@ -34,15 +34,12 @@ func TestRunSetupWorkstation_DryRun(t *testing.T) {
 			SkippedIntentionally: []string{"Downloads (/Users/test/Downloads)"},
 		},
 	}, nil)
-
-	osArgs := os.Args
-	t.Cleanup(func() { os.Args = osArgs })
-	os.Args = []string{"cloudstic", "setup", "workstation", "-dry-run"}
+	args := []string{"workstation", "-dry-run"}
 
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut, client: &stubClient{}}
-	if code := runSetup(r, context.Background()); code != 0 {
+	if code := runSetup(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
 	got := out.String()
@@ -56,15 +53,12 @@ func TestRunSetupWorkstation_JSON(t *testing.T) {
 	stubSetupWorkstationPlan(t, &cloudstic.WorkstationSetupPlan{
 		Hostname: "testbox",
 	}, nil)
-
-	osArgs := os.Args
-	t.Cleanup(func() { os.Args = osArgs })
-	os.Args = []string{"cloudstic", "setup", "workstation", "-dry-run", "-json"}
+	args := []string{"workstation", "-dry-run", "-json"}
 
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut, client: &stubClient{}}
-	if code := runSetup(r, context.Background()); code != 0 {
+	if code := runSetup(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
 	if !strings.Contains(out.String(), "\"hostname\": \"testbox\"") {
@@ -88,15 +82,12 @@ func TestRunSetupWorkstation_ApplyYes(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("SaveProfilesFile: %v", err)
 	}
-
-	osArgs := os.Args
-	t.Cleanup(func() { os.Args = osArgs })
-	os.Args = []string{"cloudstic", "setup", "workstation", "-yes", "-profiles-file", profilesPath}
+	args := []string{"workstation", "-yes", "-profiles-file", profilesPath}
 
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut, client: &stubClient{}, noPrompt: true}
-	if code := runSetup(r, context.Background()); code != 0 {
+	if code := runSetup(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
 	cfg, err := cloudstic.LoadProfilesFile(profilesPath)
@@ -109,14 +100,12 @@ func TestRunSetupWorkstation_ApplyYes(t *testing.T) {
 }
 
 func TestRunSetupWorkstation_RequiresStoreResolutionWithoutPrompt(t *testing.T) {
-	osArgs := os.Args
-	t.Cleanup(func() { os.Args = osArgs })
-	os.Args = []string{"cloudstic", "setup", "workstation", "-yes"}
+	args := []string{"workstation", "-yes"}
 
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut, client: &stubClient{}, noPrompt: true}
-	if code := runSetup(r, context.Background()); code == 0 {
+	if code := runSetup(r.withArgs(args), context.Background()); code == 0 {
 		t.Fatal("expected failure without store resolution")
 	}
 }

--- a/cmd/cloudstic/cmd_source.go
+++ b/cmd/cloudstic/cmd_source.go
@@ -4,33 +4,36 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"os"
 
 	cloudstic "github.com/cloudstic/cli"
 	"github.com/jedib0t/go-pretty/v6/table"
 )
 
 func runSource(r *runner, ctx context.Context) int {
-	if len(os.Args) < 3 {
+	if len(r.args) < 1 {
 		_, _ = fmt.Fprintln(r.errOut, "Usage: cloudstic source <subcommand> [options]")
 		_, _ = fmt.Fprintln(r.errOut, "")
 		_, _ = fmt.Fprintln(r.errOut, "Available subcommands: discover")
 		return 1
 	}
 
-	switch os.Args[2] {
+	subcommand := r.args[0]
+	subRunner := r.withArgs(r.args[1:])
+	switch subcommand {
 	case "discover":
-		return runSourceDiscover(r, ctx)
+		return runSourceDiscover(subRunner, ctx)
 	default:
-		return r.fail("Unknown source subcommand: %s", os.Args[2])
+		return r.fail("Unknown source subcommand: %s", subcommand)
 	}
 }
 
 func runSourceDiscover(r *runner, ctx context.Context) int {
-	fs := flag.NewFlagSet("source discover", flag.ExitOnError)
+	fs := flag.NewFlagSet("source discover", flag.ContinueOnError)
 	portableOnly := fs.Bool("portable-only", false, "Only show portable/external source candidates")
 	jsonOutput := fs.Bool("json", false, "Write discovered sources as JSON")
-	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
+	if err := parseFlags(fs, r.args); err != nil {
+		return parseErrorExitCode(err)
+	}
 
 	if r.client == nil {
 		r.client = &cloudstic.Client{}

--- a/cmd/cloudstic/cmd_source_test.go
+++ b/cmd/cloudstic/cmd_source_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"os"
 	"strings"
 	"testing"
 
@@ -16,15 +15,12 @@ func TestRunSourceDiscover(t *testing.T) {
 			{DisplayName: "Photos", SourceURI: "local:/Volumes/Photos", MountPoint: "/Volumes/Photos", Identity: "UUID-1", FsType: "exfat", Portable: true},
 		},
 	}
-
-	osArgs := os.Args
-	t.Cleanup(func() { os.Args = osArgs })
-	os.Args = []string{"cloudstic", "source", "discover"}
+	args := []string{"discover"}
 
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut, client: client}
-	if code := runSource(r, context.Background()); code != 0 {
+	if code := runSource(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
 	got := out.String()
@@ -40,15 +36,12 @@ func TestRunSourceDiscover_PortableOnly(t *testing.T) {
 			{DisplayName: "Photos", SourceURI: "local:/Volumes/Photos", MountPoint: "/Volumes/Photos", Portable: true},
 		},
 	}
-
-	osArgs := os.Args
-	t.Cleanup(func() { os.Args = osArgs })
-	os.Args = []string{"cloudstic", "source", "discover", "-portable-only"}
+	args := []string{"discover", "-portable-only"}
 
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut, client: client}
-	if code := runSource(r, context.Background()); code != 0 {
+	if code := runSource(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
 	got := out.String()
@@ -66,15 +59,12 @@ func TestRunSourceDiscover_JSON(t *testing.T) {
 			{DisplayName: "Photos", SourceURI: "local:/Volumes/Photos", MountPoint: "/Volumes/Photos", Portable: true},
 		},
 	}
-
-	osArgs := os.Args
-	t.Cleanup(func() { os.Args = osArgs })
-	os.Args = []string{"cloudstic", "source", "discover", "-json"}
+	args := []string{"discover", "-json"}
 
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut, client: client}
-	if code := runSource(r, context.Background()); code != 0 {
+	if code := runSource(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
 	got := out.String()
@@ -84,14 +74,12 @@ func TestRunSourceDiscover_JSON(t *testing.T) {
 }
 
 func TestRunSourceDiscover_DefaultClient(t *testing.T) {
-	osArgs := os.Args
-	t.Cleanup(func() { os.Args = osArgs })
-	os.Args = []string{"cloudstic", "source", "discover", "-json"}
+	args := []string{"discover", "-json"}
 
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runSource(r, context.Background()); code != 0 {
+	if code := runSource(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
 }

--- a/cmd/cloudstic/cmd_store.go
+++ b/cmd/cloudstic/cmd_store.go
@@ -16,33 +16,37 @@ import (
 )
 
 func runStore(r *runner, ctx context.Context) int {
-	if len(os.Args) < 3 {
+	if len(r.args) < 1 {
 		_, _ = fmt.Fprintln(r.errOut, "Usage: cloudstic store <subcommand> [options]")
 		_, _ = fmt.Fprintln(r.errOut, "")
 		_, _ = fmt.Fprintln(r.errOut, "Available subcommands: list, show, new, verify, init")
 		return 1
 	}
 
-	switch os.Args[2] {
+	subcommand := r.args[0]
+	subRunner := r.withArgs(r.args[1:])
+	switch subcommand {
 	case "list":
-		return runStoreList(r, ctx)
+		return runStoreList(subRunner, ctx)
 	case "show":
-		return runStoreShow(r, ctx)
+		return runStoreShow(subRunner, ctx)
 	case "new":
-		return runStoreNew(r, ctx)
+		return runStoreNew(subRunner, ctx)
 	case "verify":
-		return runStoreVerify(r, ctx)
+		return runStoreVerify(subRunner, ctx)
 	case "init":
-		return runStoreInit(r, ctx)
+		return runStoreInit(subRunner, ctx)
 	default:
-		return r.fail("Unknown store subcommand: %s", os.Args[2])
+		return r.fail("Unknown store subcommand: %s", subcommand)
 	}
 }
 
 func runStoreList(r *runner, ctx context.Context) int {
-	fs := flag.NewFlagSet("store list", flag.ExitOnError)
+	fs := flag.NewFlagSet("store list", flag.ContinueOnError)
 	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
-	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
+	if err := parseFlags(fs, r.args); err != nil {
+		return parseErrorExitCode(err)
+	}
 
 	cfg, err := cloudstic.LoadProfilesFile(*profilesFile)
 	if err != nil {
@@ -57,9 +61,11 @@ func runStoreList(r *runner, ctx context.Context) int {
 }
 
 func runStoreShow(r *runner, ctx context.Context) int {
-	fs := flag.NewFlagSet("store show", flag.ExitOnError)
+	fs := flag.NewFlagSet("store show", flag.ContinueOnError)
 	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
-	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
+	if err := parseFlags(fs, r.args); err != nil {
+		return parseErrorExitCode(err)
+	}
 	if fs.NArg() > 1 {
 		return r.fail("usage: cloudstic store show [-profiles-file <path>] <name>")
 	}
@@ -94,7 +100,7 @@ func runStoreShow(r *runner, ctx context.Context) int {
 }
 
 func runStoreNew(r *runner, ctx context.Context) int {
-	fs := flag.NewFlagSet("store new", flag.ExitOnError)
+	fs := flag.NewFlagSet("store new", flag.ContinueOnError)
 	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
 	name := fs.String("name", "", "Store reference name")
 	uri := fs.String("uri", "", "Store URI (e.g. s3:bucket/path, local:/path, sftp://host/path)")
@@ -115,7 +121,9 @@ func runStoreNew(r *runner, ctx context.Context) int {
 	kmsKeyARN := fs.String("kms-key-arn", "", "AWS KMS key ARN")
 	kmsRegion := fs.String("kms-region", "", "AWS KMS region")
 	kmsEndpoint := fs.String("kms-endpoint", "", "Custom AWS KMS endpoint URL")
-	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
+	if err := parseFlags(fs, r.args); err != nil {
+		return parseErrorExitCode(err)
+	}
 
 	flagsSet := map[string]bool{}
 	fs.Visit(func(f *flag.Flag) { flagsSet[f.Name] = true })
@@ -240,9 +248,11 @@ func runStoreNew(r *runner, ctx context.Context) int {
 // before calling this. Errors are printed but never cause a non-zero exit—
 // the store config has already been saved.
 func runStoreVerify(r *runner, ctx context.Context) int {
-	fs := flag.NewFlagSet("store verify", flag.ExitOnError)
+	fs := flag.NewFlagSet("store verify", flag.ContinueOnError)
 	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
-	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
+	if err := parseFlags(fs, r.args); err != nil {
+		return parseErrorExitCode(err)
+	}
 	if fs.NArg() > 1 {
 		return r.fail("usage: cloudstic store verify [-profiles-file <path>] <name>")
 	}
@@ -284,10 +294,12 @@ func runStoreVerify(r *runner, ctx context.Context) int {
 }
 
 func runStoreInit(r *runner, ctx context.Context) int {
-	fs := flag.NewFlagSet("store init", flag.ExitOnError)
+	fs := flag.NewFlagSet("store init", flag.ContinueOnError)
 	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
 	yes := fs.Bool("yes", false, "Initialize without confirmation prompt")
-	_ = fs.Parse(reorderArgs(fs, os.Args[3:]))
+	if err := parseFlags(fs, r.args); err != nil {
+		return parseErrorExitCode(err)
+	}
 	if fs.NArg() > 1 {
 		return r.fail("usage: cloudstic store init [-profiles-file <path>] [-yes] <name>")
 	}
@@ -350,6 +362,7 @@ func checkOrInitStore(r *runner, ctx context.Context, cfg *cloudstic.ProfilesCon
 		}
 		return fmt.Errorf("could not resolve store credentials: %w", err)
 	}
+	g.noPrompt = r.noPrompt
 	raw, err := g.initObjectStore(ctx)
 	if err != nil {
 		return fmt.Errorf("could not connect to store: %w", err)

--- a/cmd/cloudstic/cmd_store_test.go
+++ b/cmd/cloudstic/cmd_store_test.go
@@ -44,8 +44,7 @@ func TestRunStoreNewAndListAndShow(t *testing.T) {
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
 
 	// Create a store.
-	os.Args = []string{
-		"cloudstic", "store", "new",
+	args := []string{"new",
 		"-profiles-file", profilesPath,
 		"-name", "prod-s3",
 		"-uri", "s3:my-bucket/backups",
@@ -55,7 +54,7 @@ func TestRunStoreNewAndListAndShow(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runStore(r, context.Background()); code != 0 {
+	if code := runStore(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("store new failed: %s", errOut.String())
 	}
 	if !strings.Contains(out.String(), `"prod-s3" saved`) {
@@ -63,10 +62,10 @@ func TestRunStoreNewAndListAndShow(t *testing.T) {
 	}
 
 	// List stores.
-	os.Args = []string{"cloudstic", "store", "list", "-profiles-file", profilesPath}
+	args = []string{"list", "-profiles-file", profilesPath}
 	out.Reset()
 	errOut.Reset()
-	if code := runStore(r, context.Background()); code != 0 {
+	if code := runStore(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("store list failed: %s", errOut.String())
 	}
 	if !strings.Contains(out.String(), "Stores") || !strings.Contains(out.String(), "prod-s3") || !strings.Contains(out.String(), "AUTH") {
@@ -74,10 +73,10 @@ func TestRunStoreNewAndListAndShow(t *testing.T) {
 	}
 
 	// Show store.
-	os.Args = []string{"cloudstic", "store", "show", "-profiles-file", profilesPath, "prod-s3"}
+	args = []string{"show", "-profiles-file", profilesPath, "prod-s3"}
 	out.Reset()
 	errOut.Reset()
-	if code := runStore(r, context.Background()); code != 0 {
+	if code := runStore(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("store show failed: %s", errOut.String())
 	}
 	got := out.String()
@@ -100,11 +99,11 @@ func TestRunStoreNew_RequiresNameAndURI(t *testing.T) {
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
 
 	// Missing URI.
-	os.Args = []string{"cloudstic", "store", "new", "-profiles-file", profilesPath, "-name", "x"}
+	args := []string{"new", "-profiles-file", profilesPath, "-name", "x"}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runStore(r, context.Background()); code == 0 {
+	if code := runStore(r.withArgs(args), context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "-uri is required") {
@@ -131,8 +130,7 @@ func TestRunStoreNew_ExistingStorePrefillsUnsetValues(t *testing.T) {
 		t.Fatalf("SaveProfilesFile: %v", err)
 	}
 
-	os.Args = []string{
-		"cloudstic", "store", "new",
+	args := []string{"new",
 		"-profiles-file", profilesPath,
 		"-name", "prod",
 		"-s3-profile", "new-profile",
@@ -140,7 +138,7 @@ func TestRunStoreNew_ExistingStorePrefillsUnsetValues(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runStore(r, context.Background()); code != 0 {
+	if code := runStore(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("store new failed: %s", errOut.String())
 	}
 
@@ -173,16 +171,14 @@ func TestNoPromptDisablesInteractivity(t *testing.T) {
 }
 
 func TestHasGlobalFlag(t *testing.T) {
-	orig := os.Args
-	defer func() { os.Args = orig }()
 
-	os.Args = []string{"cloudstic", "store", "new", "--no-prompt", "-name", "x"}
-	if !hasGlobalFlag("no-prompt") {
+	args := []string{"new", "--no-prompt", "-name", "x"}
+	if !hasGlobalFlag(args, "no-prompt") {
 		t.Fatal("expected hasGlobalFlag to find --no-prompt")
 	}
 
-	os.Args = []string{"cloudstic", "store", "new", "-name", "x"}
-	if hasGlobalFlag("no-prompt") {
+	args = []string{"new", "-name", "x"}
+	if hasGlobalFlag(args, "no-prompt") {
 		t.Fatal("expected hasGlobalFlag to not find --no-prompt")
 	}
 }
@@ -194,11 +190,11 @@ func TestRunStoreShow_UnknownStore(t *testing.T) {
 		t.Fatalf("write profiles: %v", err)
 	}
 
-	os.Args = []string{"cloudstic", "store", "show", "-profiles-file", profilesPath, "missing"}
+	args := []string{"show", "-profiles-file", profilesPath, "missing"}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runStore(r, context.Background()); code == 0 {
+	if code := runStore(r.withArgs(args), context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "Unknown store") {
@@ -225,11 +221,11 @@ profiles:
 		t.Fatalf("write profiles: %v", err)
 	}
 
-	os.Args = []string{"cloudstic", "store", "show", "-profiles-file", profilesPath, "main"}
+	args := []string{"show", "-profiles-file", profilesPath, "main"}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runStore(r, context.Background()); code != 0 {
+	if code := runStore(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("store show failed: %s", errOut.String())
 	}
 	got := out.String()
@@ -239,11 +235,11 @@ profiles:
 }
 
 func TestRunStoreList_MissingFile(t *testing.T) {
-	os.Args = []string{"cloudstic", "store", "list", "-profiles-file", filepath.Join(t.TempDir(), "missing.yaml")}
+	args := []string{"list", "-profiles-file", filepath.Join(t.TempDir(), "missing.yaml")}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runStore(r, context.Background()); code != 0 {
+	if code := runStore(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("expected zero exit code, got err=%s", errOut.String())
 	}
 }
@@ -252,8 +248,7 @@ func TestRunStoreNew_WithEncryption(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
 
-	os.Args = []string{
-		"cloudstic", "store", "new",
+	args := []string{"new",
 		"-profiles-file", profilesPath,
 		"-name", "encrypted-s3",
 		"-uri", "s3:secure-bucket/backups",
@@ -264,15 +259,15 @@ func TestRunStoreNew_WithEncryption(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runStore(r, context.Background()); code != 0 {
+	if code := runStore(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("store new failed: %s", errOut.String())
 	}
 
 	// Verify show displays encryption fields.
-	os.Args = []string{"cloudstic", "store", "show", "-profiles-file", profilesPath, "encrypted-s3"}
+	args = []string{"show", "-profiles-file", profilesPath, "encrypted-s3"}
 	out.Reset()
 	errOut.Reset()
-	if code := runStore(r, context.Background()); code != 0 {
+	if code := runStore(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("store show failed: %s", errOut.String())
 	}
 	got := out.String()
@@ -493,11 +488,11 @@ func TestRunStoreNew_InvalidURI(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
 
-	os.Args = []string{"cloudstic", "store", "new", "-profiles-file", profilesPath, "-name", "bad", "-uri", "garbage-no-scheme"}
+	args := []string{"new", "-profiles-file", profilesPath, "-name", "bad", "-uri", "garbage-no-scheme"}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runStore(r, context.Background()); code == 0 {
+	if code := runStore(r.withArgs(args), context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code for invalid URI")
 	}
 	if !strings.Contains(errOut.String(), "invalid store URI") {
@@ -509,11 +504,11 @@ func TestRunStoreNew_InvalidName(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
 
-	os.Args = []string{"cloudstic", "store", "new", "-profiles-file", profilesPath, "-name", "bad name!", "-uri", "local:/tmp/store"}
+	args := []string{"new", "-profiles-file", profilesPath, "-name", "bad name!", "-uri", "local:/tmp/store"}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runStore(r, context.Background()); code == 0 {
+	if code := runStore(r.withArgs(args), context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code for invalid name")
 	}
 	if !strings.Contains(errOut.String(), "invalid store name") {
@@ -522,11 +517,11 @@ func TestRunStoreNew_InvalidName(t *testing.T) {
 }
 
 func TestRunStore_UnknownSubcommand(t *testing.T) {
-	os.Args = []string{"cloudstic", "store", "unknown"}
+	args := []string{"unknown"}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runStore(r, context.Background()); code == 0 {
+	if code := runStore(r.withArgs(args), context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "Unknown store subcommand") {
@@ -552,11 +547,11 @@ stores:
 		t.Fatalf("write profiles: %v", err)
 	}
 
-	os.Args = []string{"cloudstic", "store", "show", "-profiles-file", profilesPath, "enc-store"}
+	args := []string{"show", "-profiles-file", profilesPath, "enc-store"}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runStore(r, context.Background()); code != 0 {
+	if code := runStore(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("store show failed: %s", errOut.String())
 	}
 	got := out.String()
@@ -594,11 +589,11 @@ stores:
 		t.Fatalf("write profiles: %v", err)
 	}
 
-	os.Args = []string{"cloudstic", "store", "show", "-profiles-file", profilesPath, "sftp-store"}
+	args := []string{"show", "-profiles-file", profilesPath, "sftp-store"}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runStore(r, context.Background()); code != 0 {
+	if code := runStore(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("store show failed: %s", errOut.String())
 	}
 	got := out.String()
@@ -629,11 +624,11 @@ stores:
 		t.Fatalf("write profiles: %v", err)
 	}
 
-	os.Args = []string{"cloudstic", "store", "show", "-profiles-file", profilesPath, "s3env-store"}
+	args := []string{"show", "-profiles-file", profilesPath, "s3env-store"}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runStore(r, context.Background()); code != 0 {
+	if code := runStore(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("store show failed: %s", errOut.String())
 	}
 	got := out.String()
@@ -655,8 +650,7 @@ func TestRunStoreNew_WithSFTPOptions(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
 
-	os.Args = []string{
-		"cloudstic", "store", "new",
+	args := []string{"new",
 		"-profiles-file", profilesPath,
 		"-name", "sftp-new",
 		"-uri", "sftp://user@host/path",
@@ -666,15 +660,15 @@ func TestRunStoreNew_WithSFTPOptions(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runStore(r, context.Background()); code != 0 {
+	if code := runStore(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("store new failed: %s", errOut.String())
 	}
 
 	// Verify via show.
-	os.Args = []string{"cloudstic", "store", "show", "-profiles-file", profilesPath, "sftp-new"}
+	args = []string{"show", "-profiles-file", profilesPath, "sftp-new"}
 	out.Reset()
 	errOut.Reset()
-	if code := runStore(r, context.Background()); code != 0 {
+	if code := runStore(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("store show failed: %s", errOut.String())
 	}
 	got := out.String()
@@ -694,8 +688,7 @@ func TestRunStoreNew_WithAllS3Options(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
 
-	os.Args = []string{
-		"cloudstic", "store", "new",
+	args := []string{"new",
 		"-profiles-file", profilesPath,
 		"-name", "full-s3",
 		"-uri", "s3:bucket",
@@ -708,7 +701,7 @@ func TestRunStoreNew_WithAllS3Options(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runStore(r, context.Background()); code != 0 {
+	if code := runStore(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("store new failed: %s", errOut.String())
 	}
 
@@ -734,8 +727,7 @@ func TestRunStoreNew_WithSecretRefFlags(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
 
-	os.Args = []string{
-		"cloudstic", "store", "new",
+	args := []string{"new",
 		"-profiles-file", profilesPath,
 		"-name", "secrets-store",
 		"-uri", "s3:bucket",
@@ -750,7 +742,7 @@ func TestRunStoreNew_WithSecretRefFlags(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runStore(r, context.Background()); code != 0 {
+	if code := runStore(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("store new failed: %s", errOut.String())
 	}
 
@@ -1035,11 +1027,11 @@ func TestRunStoreVerify_MissingSecretFails(t *testing.T) {
 		t.Fatalf("SaveProfilesFile: %v", err)
 	}
 
-	os.Args = []string{"cloudstic", "store", "verify", "-profiles-file", profilesPath, "test"}
+	args := []string{"verify", "-profiles-file", profilesPath, "test"}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runStore(r, context.Background()); code == 0 {
+	if code := runStore(r.withArgs(args), context.Background()); code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
 	if !strings.Contains(errOut.String(), "could not resolve store credentials") {
@@ -1331,11 +1323,11 @@ stores:
 		t.Fatalf("write profiles: %v", err)
 	}
 
-	os.Args = []string{"cloudstic", "store", "list", "-profiles-file", profilesPath}
+	args := []string{"list", "-profiles-file", profilesPath}
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runStore(r, context.Background()); code != 0 {
+	if code := runStore(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("store list failed: %s", errOut.String())
 	}
 	got := out.String()
@@ -1353,8 +1345,7 @@ func TestRunStoreNew_LocalStore(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
 
-	os.Args = []string{
-		"cloudstic", "store", "new",
+	args := []string{"new",
 		"-profiles-file", profilesPath,
 		"-name", "local-bk",
 		"-uri", "local:/tmp/backup",
@@ -1362,7 +1353,7 @@ func TestRunStoreNew_LocalStore(t *testing.T) {
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runStore(r, context.Background()); code != 0 {
+	if code := runStore(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("store new failed: %s", errOut.String())
 	}
 	if !strings.Contains(out.String(), `"local-bk" saved`) {

--- a/cmd/cloudstic/cmd_tui.go
+++ b/cmd/cloudstic/cmd_tui.go
@@ -12,12 +12,12 @@ type tuiArgs struct {
 	profilesFile string
 }
 
-func parseTUIArgs() (*tuiArgs, error) {
+func parseTUIArgs(args []string) (*tuiArgs, error) {
 	fs := flag.NewFlagSet("tui", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	a := &tuiArgs{}
 	fs.StringVar(&a.profilesFile, "profiles-file", defaultProfilesPathNoCreate(), "Path to profiles YAML file")
-	if err := fs.Parse(reorderArgs(fs, os.Args[2:])); err != nil {
+	if err := parseFlags(fs, args); err != nil {
 		return nil, err
 	}
 	return a, nil
@@ -33,16 +33,16 @@ func printTUIUsage(w io.Writer) {
 }
 
 func runTUI(r *runner, ctx context.Context) int {
-	for _, arg := range os.Args[2:] {
+	for _, arg := range r.args {
 		if arg == "-h" || arg == "--help" || arg == "help" {
 			printTUIUsage(r.out)
 			return 0
 		}
 	}
 
-	args, err := parseTUIArgs()
+	args, err := parseTUIArgs(r.args)
 	if err != nil {
-		return 1
+		return parseErrorExitCode(err)
 	}
 	if !r.canPrompt() {
 		return r.fail("cloudstic tui requires an interactive terminal")

--- a/cmd/cloudstic/cmd_tui_test.go
+++ b/cmd/cloudstic/cmd_tui_test.go
@@ -336,14 +336,12 @@ func stubTUITestHooks(t *testing.T) {
 }
 
 func TestRunTUI_Help(t *testing.T) {
-	oldArgs := os.Args
-	t.Cleanup(func() { os.Args = oldArgs })
-	os.Args = []string{"cloudstic", "tui", "--help"}
+	args := []string{"--help"}
 
 	var out strings.Builder
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
-	if code := runTUI(r, context.Background()); code != 0 {
+	if code := runTUI(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
 	if !strings.Contains(out.String(), "Usage: cloudstic tui [options]") {
@@ -355,10 +353,7 @@ func TestRunTUI_RequiresInteractiveTerminal(t *testing.T) {
 	oldIsTerminal := isTerminalFunc
 	t.Cleanup(func() { isTerminalFunc = oldIsTerminal })
 	isTerminalFunc = func(uintptr) bool { return false }
-
-	oldArgs := os.Args
-	t.Cleanup(func() { os.Args = oldArgs })
-	os.Args = []string{"cloudstic", "tui"}
+	args := []string{}
 
 	readEnd, writeEnd, err := os.Pipe()
 	if err != nil {
@@ -375,7 +370,7 @@ func TestRunTUI_RequiresInteractiveTerminal(t *testing.T) {
 		stdin:  readEnd,
 		lineIn: bufio.NewReader(readEnd),
 	}
-	if code := runTUI(r, context.Background()); code == 0 {
+	if code := runTUI(r.withArgs(args), context.Background()); code == 0 {
 		t.Fatalf("expected failure for non-interactive terminal")
 	}
 	if !strings.Contains(errOut.String(), "requires an interactive terminal") {
@@ -399,15 +394,12 @@ func TestRunTUI_RendersDashboardAndQuitsOnQ(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("SaveProfilesFile: %v", err)
 	}
-
-	oldArgs := os.Args
 	oldNoPrompt := os.Getenv("CLOUDSTIC_PROFILES_FILE")
 	t.Cleanup(func() {
-		os.Args = oldArgs
 		_ = os.Setenv("CLOUDSTIC_PROFILES_FILE", oldNoPrompt)
 	})
 	_ = os.Setenv("CLOUDSTIC_PROFILES_FILE", profilesPath)
-	os.Args = []string{"cloudstic", "tui", "-profiles-file", profilesPath}
+	args := []string{"-profiles-file", profilesPath}
 
 	readEnd, writeEnd, err := os.Pipe()
 	if err != nil {
@@ -448,7 +440,7 @@ func TestRunTUI_RendersDashboardAndQuitsOnQ(t *testing.T) {
 		stdin:      readEnd,
 		lineIn:     bufio.NewReader(readEnd),
 	}
-	if code := runTUI(r, context.Background()); code != 0 {
+	if code := runTUI(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
 	got := out.String()
@@ -459,10 +451,7 @@ func TestRunTUI_RendersDashboardAndQuitsOnQ(t *testing.T) {
 
 func TestRunTUI_ArrowNavigationChangesSelection(t *testing.T) {
 	stubTUITestHooks(t)
-
-	oldArgs := os.Args
-	t.Cleanup(func() { os.Args = oldArgs })
-	os.Args = []string{"cloudstic", "tui"}
+	args := []string{}
 
 	readEnd, writeEnd, err := os.Pipe()
 	if err != nil {
@@ -495,7 +484,7 @@ func TestRunTUI_ArrowNavigationChangesSelection(t *testing.T) {
 		stdin:      readEnd,
 		lineIn:     bufio.NewReader(readEnd),
 	}
-	if code := runTUI(r, context.Background()); code != 0 {
+	if code := runTUI(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
 	got := out.String()
@@ -506,10 +495,7 @@ func TestRunTUI_ArrowNavigationChangesSelection(t *testing.T) {
 
 func TestRunTUI_BackupActionRunsSelectedProfileAction(t *testing.T) {
 	stubTUITestHooks(t)
-
-	oldArgs := os.Args
-	t.Cleanup(func() { os.Args = oldArgs })
-	os.Args = []string{"cloudstic", "tui"}
+	args := []string{}
 
 	readEnd, writeEnd, err := os.Pipe()
 	if err != nil {
@@ -563,7 +549,7 @@ func TestRunTUI_BackupActionRunsSelectedProfileAction(t *testing.T) {
 		stdin:      readEnd,
 		lineIn:     bufio.NewReader(readEnd),
 	}
-	if code := runTUI(r, context.Background()); code != 0 {
+	if code := runTUI(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
 	if ranProfile != "documents" {
@@ -582,10 +568,7 @@ func TestRunTUI_BackupActionRunsSelectedProfileAction(t *testing.T) {
 
 func TestRunTUI_CheckActionRunsSelectedProfileCheck(t *testing.T) {
 	stubTUITestHooks(t)
-
-	oldArgs := os.Args
-	t.Cleanup(func() { os.Args = oldArgs })
-	os.Args = []string{"cloudstic", "tui"}
+	args := []string{}
 
 	readEnd, writeEnd, err := os.Pipe()
 	if err != nil {
@@ -644,7 +627,7 @@ func TestRunTUI_CheckActionRunsSelectedProfileCheck(t *testing.T) {
 		stdin:      readEnd,
 		lineIn:     bufio.NewReader(readEnd),
 	}
-	if code := runTUI(r, context.Background()); code != 0 {
+	if code := runTUI(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
 	if checkedProfile != "documents" {
@@ -660,10 +643,7 @@ func TestRunTUI_CheckActionRunsSelectedProfileCheck(t *testing.T) {
 
 func TestRunTUI_CreateActionUsesModalAndSavesProfile(t *testing.T) {
 	stubTUITestHooks(t)
-
-	oldArgs := os.Args
-	t.Cleanup(func() { os.Args = oldArgs })
-	os.Args = []string{"cloudstic", "tui"}
+	args := []string{}
 
 	dir := t.TempDir()
 	profilesPath := dir + "/profiles.yaml"
@@ -702,7 +682,7 @@ func TestRunTUI_CreateActionUsesModalAndSavesProfile(t *testing.T) {
 	oldEnv := os.Getenv("CLOUDSTIC_PROFILES_FILE")
 	t.Cleanup(func() { _ = os.Setenv("CLOUDSTIC_PROFILES_FILE", oldEnv) })
 	_ = os.Setenv("CLOUDSTIC_PROFILES_FILE", profilesPath)
-	if code := runTUI(r, context.Background()); code != 0 {
+	if code := runTUI(r.withArgs(args), context.Background()); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
 	cfg, err := cloudstic.LoadProfilesFile(profilesPath)
@@ -1373,14 +1353,11 @@ func TestTUIBuildDashboardErrorPropagates(t *testing.T) {
 	tuiBuildDashboard = func(context.Context, string) (tui.Dashboard, error) {
 		return tui.Dashboard{}, errors.New("boom")
 	}
-
-	oldArgs := os.Args
 	oldIsTerminal := isTerminalFunc
 	t.Cleanup(func() {
-		os.Args = oldArgs
 		isTerminalFunc = oldIsTerminal
 	})
-	os.Args = []string{"cloudstic", "tui"}
+	args := []string{}
 	isTerminalFunc = func(uintptr) bool { return true }
 
 	readEnd, writeEnd, err := os.Pipe()
@@ -1392,7 +1369,7 @@ func TestTUIBuildDashboardErrorPropagates(t *testing.T) {
 
 	var errOut strings.Builder
 	r := &runner{out: io.Discard, errOut: &errOut, stdin: readEnd, stdoutFile: os.Stdout, lineIn: bufio.NewReader(readEnd)}
-	if code := runTUI(r, context.Background()); code == 0 {
+	if code := runTUI(r.withArgs(args), context.Background()); code == 0 {
 		t.Fatalf("expected failure")
 	}
 	if !strings.Contains(errOut.String(), "Failed to build TUI dashboard") {

--- a/cmd/cloudstic/completion.go
+++ b/cmd/cloudstic/completion.go
@@ -3,34 +3,34 @@ package main
 import (
 	"fmt"
 	"io"
-	"os"
 )
 
-func runCompletion() {
-	if len(os.Args) < 3 {
-		fmt.Fprintln(os.Stderr, "Usage: cloudstic completion <shell>")
-		fmt.Fprintln(os.Stderr, "")
-		fmt.Fprintln(os.Stderr, "Available shells: bash, zsh, fish")
-		fmt.Fprintln(os.Stderr, "")
-		fmt.Fprintln(os.Stderr, "Setup:")
-		fmt.Fprintln(os.Stderr, "  bash:  source <(cloudstic completion bash)")
-		fmt.Fprintln(os.Stderr, "  zsh:   source <(cloudstic completion zsh)")
-		fmt.Fprintln(os.Stderr, "  fish:  cloudstic completion fish | source")
-		os.Exit(1)
+func runCompletion(r *runner) int {
+	if len(r.args) < 1 {
+		_, _ = fmt.Fprintln(r.errOut, "Usage: cloudstic completion <shell>")
+		_, _ = fmt.Fprintln(r.errOut)
+		_, _ = fmt.Fprintln(r.errOut, "Available shells: bash, zsh, fish")
+		_, _ = fmt.Fprintln(r.errOut)
+		_, _ = fmt.Fprintln(r.errOut, "Setup:")
+		_, _ = fmt.Fprintln(r.errOut, "  bash:  source <(cloudstic completion bash)")
+		_, _ = fmt.Fprintln(r.errOut, "  zsh:   source <(cloudstic completion zsh)")
+		_, _ = fmt.Fprintln(r.errOut, "  fish:  cloudstic completion fish | source")
+		return 1
 	}
 
-	shell := os.Args[2]
+	shell := r.args[0]
 	switch shell {
 	case "bash":
-		completionBash(os.Stdout)
+		completionBash(r.out)
 	case "zsh":
-		completionZsh(os.Stdout)
+		completionZsh(r.out)
 	case "fish":
-		completionFish(os.Stdout)
+		completionFish(r.out)
 	default:
-		fmt.Fprintf(os.Stderr, "Unsupported shell: %s\nAvailable shells: bash, zsh, fish\n", shell)
-		os.Exit(1)
+		_, _ = fmt.Fprintf(r.errOut, "Unsupported shell: %s\nAvailable shells: bash, zsh, fish\n", shell)
+		return 1
 	}
+	return 0
 }
 
 // completionBash writes a bash completion script to w.

--- a/cmd/cloudstic/completion_dynamic.go
+++ b/cmd/cloudstic/completion_dynamic.go
@@ -13,21 +13,25 @@ import (
 
 var completionLoadProfilesFile = cloudstic.LoadProfilesFile
 
-func runCompletionQuery(ctx context.Context) int {
-	if len(os.Args) < 3 {
+func runCompletionQuery(r *runner, ctx context.Context) int {
+	if len(r.args) < 1 {
 		return 0
 	}
-	kind := os.Args[2]
+	kind := r.args[0]
 	current := ""
-	if len(os.Args) > 3 {
-		current = os.Args[3]
+	if len(r.args) > 1 {
+		current = r.args[1]
 	}
-	candidates, err := completionCandidates(ctx, kind, current, os.Args[4:])
+	var commandArgs []string
+	if len(r.args) > 2 {
+		commandArgs = r.args[2:]
+	}
+	candidates, err := completionCandidates(ctx, kind, current, commandArgs)
 	if err != nil {
 		return 0
 	}
 	for _, candidate := range candidates {
-		_, _ = fmt.Fprintln(os.Stdout, candidate)
+		_, _ = fmt.Fprintln(r.out, candidate)
 	}
 	return 0
 }

--- a/cmd/cloudstic/completion_dynamic_test.go
+++ b/cmd/cloudstic/completion_dynamic_test.go
@@ -67,10 +67,6 @@ func TestRunCompletionQuery_WritesCandidates(t *testing.T) {
 	}
 	t.Cleanup(func() { completionLoadProfilesFile = oldLoad })
 
-	oldArgs := os.Args
-	t.Cleanup(func() { os.Args = oldArgs })
-	os.Args = []string{"cloudstic", "__complete", "profile-names", "", "backup"}
-
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("os.Pipe: %v", err)
@@ -78,11 +74,8 @@ func TestRunCompletionQuery_WritesCandidates(t *testing.T) {
 	defer func() { _ = r.Close() }()
 	defer func() { _ = w.Close() }()
 
-	oldStdout := os.Stdout
-	t.Cleanup(func() { os.Stdout = oldStdout })
-	os.Stdout = w
-
-	if code := runCompletionQuery(context.Background()); code != 0 {
+	queryRunner := &runner{args: []string{"profile-names", "", "backup"}, out: w}
+	if code := runCompletionQuery(queryRunner, context.Background()); code != 0 {
 		t.Fatalf("runCompletionQuery code = %d, want 0", code)
 	}
 	_ = w.Close()

--- a/cmd/cloudstic/completion_test.go
+++ b/cmd/cloudstic/completion_test.go
@@ -2,9 +2,29 @@ package main
 
 import (
 	"bytes"
+	"io"
 	"strings"
 	"testing"
 )
+
+func TestRunCompletion(t *testing.T) {
+	for _, shell := range []string{"bash", "zsh", "fish"} {
+		t.Run(shell, func(t *testing.T) {
+			r := &runner{args: []string{shell}, out: io.Discard, errOut: io.Discard}
+			if code := runCompletion(r); code != 0 {
+				t.Fatalf("runCompletion() exit code = %d, want 0", code)
+			}
+		})
+	}
+
+	var errOut bytes.Buffer
+	if code := runCompletion(&runner{out: io.Discard, errOut: &errOut}); code != 1 {
+		t.Fatalf("runCompletion() without a shell exit code = %d, want 1", code)
+	}
+	if !strings.Contains(errOut.String(), "Usage: cloudstic completion <shell>") {
+		t.Fatalf("unexpected usage output: %q", errOut.String())
+	}
+}
 
 func TestCompletionBash(t *testing.T) {
 	var buf bytes.Buffer

--- a/cmd/cloudstic/flags.go
+++ b/cmd/cloudstic/flags.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -37,13 +38,15 @@ type globalFlags struct {
 	recoveryKey                       string
 	kmsKeyARN, kmsRegion, kmsEndpoint string
 	disablePackfile                   bool
-	prompt, verbose, quiet, debug     bool
+	prompt, noPrompt                  bool
+	verbose, quiet, debug             bool
 	json                              bool
 	debugLog                          *ui.SafeLogWriter
+	flagSet                           *flag.FlagSet
 }
 
 func addGlobalFlags(fs *flag.FlagSet) *globalFlags {
-	g := &globalFlags{}
+	g := &globalFlags{flagSet: fs}
 	fs.StringVar(&g.store, "store", envDefault("CLOUDSTIC_STORE", "local:./backup_store"), "Storage backend URI: local:<path>, s3:<bucket>[/<prefix>], b2:<bucket>[/<prefix>], sftp://[user@]host[:port]/<path>")
 	defaultProfilesPath, err := defaultProfilesPath()
 	if err != nil {
@@ -75,6 +78,7 @@ func addGlobalFlags(fs *flag.FlagSet) *globalFlags {
 	fs.StringVar(&g.kmsEndpoint, "kms-endpoint", envDefault("CLOUDSTIC_KMS_ENDPOINT", ""), "Custom AWS KMS endpoint URL")
 	fs.BoolVar(&g.disablePackfile, "disable-packfile", envBool("CLOUDSTIC_DISABLE_PACKFILE"), "Disable bundling small objects into 8MB packs")
 	fs.BoolVar(&g.prompt, "prompt", false, "Prompt for password interactively (use alongside --encryption-key or --kms-key-arn to add a password layer)")
+	fs.BoolVar(&g.noPrompt, "no-prompt", false, "Disable interactive prompts (for scripts and CI)")
 	fs.BoolVar(&g.verbose, "verbose", false, "Log detailed file-level operations")
 	fs.BoolVar(&g.quiet, "quiet", false, "Suppress progress bars (keeps final summary)")
 	fs.BoolVar(&g.json, "json", false, "Write command result as JSON to stdout")
@@ -86,24 +90,30 @@ func (g *globalFlags) jsonEnabled() bool {
 	return g != nil && g.json
 }
 
-func cliFlagProvided(name string) bool {
-	for _, arg := range os.Args[1:] {
-		if arg == "-"+name || arg == "--"+name {
-			return true
-		}
-		if strings.HasPrefix(arg, "-"+name+"=") || strings.HasPrefix(arg, "--"+name+"=") {
-			return true
-		}
-	}
-	return false
+func (g *globalFlags) flagProvided(name string) bool {
+	provided := false
+	g.flagSet.Visit(func(f *flag.Flag) {
+		provided = provided || f.Name == name
+	})
+	return provided
 }
 
-// mustParse parses os.Args[2:] into fs, reordering positional arguments after
+// parseFlags parses args into fs, reordering positional arguments after
 // flags so that flags can appear anywhere on the command line (e.g.
 // "cloudstic restore abc123 -output ./out.zip" works as well as the reverse).
 // Using this consistently means every command supports flexible argument ordering.
-func mustParse(fs *flag.FlagSet) {
-	_ = fs.Parse(reorderArgs(fs, os.Args[2:]))
+func parseFlags(fs *flag.FlagSet, args []string) error {
+	if fs.Lookup("no-prompt") == nil {
+		fs.Bool("no-prompt", false, "Disable interactive prompts (for scripts and CI)")
+	}
+	return fs.Parse(reorderArgs(fs, args))
+}
+
+func parseErrorExitCode(err error) int {
+	if errors.Is(err, flag.ErrHelp) {
+		return 0
+	}
+	return 1
 }
 
 // reorderArgs moves flag arguments before positional arguments so that Go's
@@ -111,8 +121,14 @@ func mustParse(fs *flag.FlagSet) {
 // of where they appear on the command line.
 func reorderArgs(fs *flag.FlagSet, args []string) []string {
 	var flags, positional []string
+	terminated := false
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
+		if arg == "--" {
+			terminated = true
+			positional = append(positional, args[i+1:]...)
+			break
+		}
 		if !strings.HasPrefix(arg, "-") {
 			positional = append(positional, arg)
 			continue
@@ -133,6 +149,9 @@ func reorderArgs(fs *flag.FlagSet, args []string) []string {
 			i++
 			flags = append(flags, args[i])
 		}
+	}
+	if terminated {
+		flags = append(flags, "--")
 	}
 	return append(flags, positional...)
 }

--- a/cmd/cloudstic/flags_test.go
+++ b/cmd/cloudstic/flags_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"flag"
+	"reflect"
+	"testing"
+)
+
+func TestReorderArgs_PreservesTerminator(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	jsonOutput := fs.Bool("json", false, "")
+
+	if err := parseFlags(fs, []string{"object", "-json", "--", "-no-prompt"}); err != nil {
+		t.Fatalf("parseFlags() error = %v", err)
+	}
+	if !*jsonOutput {
+		t.Fatal("expected -json to be parsed before the positional argument")
+	}
+	if got, want := fs.Args(), []string{"object", "-no-prompt"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Args() = %q, want %q", got, want)
+	}
+}
+
+func TestParseCatArgs_TerminatedFlagShapedKey(t *testing.T) {
+	args, err := parseCatArgs([]string{"--", "-weirdly-named-file"})
+	if err != nil {
+		t.Fatalf("parseCatArgs() error = %v", err)
+	}
+	if got, want := args.keys, []string{"-weirdly-named-file"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("keys = %q, want %q", got, want)
+	}
+}
+
+func TestParseHelpers_ReturnErrors(t *testing.T) {
+	if _, err := parseCatArgs([]string{"-unknown"}); err == nil {
+		t.Fatal("parseCatArgs() expected an unknown-flag error")
+	}
+	if _, err := parseDiffArgs([]string{"only-one-snapshot"}); err == nil {
+		t.Fatal("parseDiffArgs() expected a validation error")
+	}
+	if _, err := parseForgetArgs(nil); err == nil {
+		t.Fatal("parseForgetArgs() expected a validation error")
+	}
+}
+
+func TestGlobalFlagScans_StopAtTerminator(t *testing.T) {
+	args := []string{"--", "-no-prompt"}
+	if hasGlobalFlag(args, "no-prompt") {
+		t.Fatal("hasGlobalFlag() treated a positional argument as a flag")
+	}
+
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	g := addGlobalFlags(fs)
+	if err := parseFlags(fs, []string{"--", "-store"}); err != nil {
+		t.Fatalf("parseFlags() error = %v", err)
+	}
+	if g.flagProvided("store") {
+		t.Fatal("globalFlags.flagProvided() treated a positional argument as a flag")
+	}
+}
+
+func TestParseFlags_AcceptsNoPromptForNestedCommands(t *testing.T) {
+	fs := flag.NewFlagSet("nested", flag.ContinueOnError)
+	if err := parseFlags(fs, []string{"-no-prompt"}); err != nil {
+		t.Fatalf("parseFlags() error = %v", err)
+	}
+}
+
+func TestParseErrorExitCode_HelpSucceeds(t *testing.T) {
+	if code := parseErrorExitCode(flag.ErrHelp); code != 0 {
+		t.Fatalf("parseErrorExitCode(flag.ErrHelp) = %d, want 0", code)
+	}
+}
+
+func TestRunnerWithArgs_DoesNotMutateParent(t *testing.T) {
+	parent := newRunner([]string{"store", "list"})
+	child := parent.withArgs([]string{"list", "-no-prompt"})
+
+	if got, want := parent.args, []string{"store", "list"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("parent args = %q, want %q", got, want)
+	}
+	if got, want := child.args, []string{"list", "-no-prompt"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("child args = %q, want %q", got, want)
+	}
+	if !child.noPrompt {
+		t.Fatal("child runner did not inherit prompt control from its arguments")
+	}
+}

--- a/cmd/cloudstic/main.go
+++ b/cmd/cloudstic/main.go
@@ -33,7 +33,7 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	exitCode := runCmd(ctx, os.Args[1])
+	exitCode := runCmd(ctx, os.Args[1], os.Args[2:])
 
 	if memprofile != "" {
 		writeMemProfile(memprofile)
@@ -42,8 +42,8 @@ func main() {
 	os.Exit(exitCode)
 }
 
-func runCmd(ctx context.Context, cmd string) int {
-	r := newRunner()
+func runCmd(ctx context.Context, cmd string, args []string) int {
+	r := newRunner(args)
 	switch cmd {
 	case "version", "--version", "-v":
 		fmt.Printf("cloudstic %s (commit %s, built %s)\n", version, commit, date)
@@ -85,10 +85,9 @@ func runCmd(ctx context.Context, cmd string) int {
 	case "tui":
 		return runTUI(r, ctx)
 	case "completion":
-		runCompletion()
-		return 0
+		return runCompletion(r)
 	case "__complete":
-		return runCompletionQuery(ctx)
+		return runCompletionQuery(r, ctx)
 	case "help", "--help", "-h":
 		printUsage()
 		return 0

--- a/cmd/cloudstic/main_test.go
+++ b/cmd/cloudstic/main_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+func TestRunCmd_ParsingErrorsReturnExitCode(t *testing.T) {
+	t.Setenv("CLOUDSTIC_CONFIG_DIR", t.TempDir())
+
+	tests := []struct {
+		name string
+		cmd  string
+		args []string
+	}{
+		{name: "init", cmd: "init", args: []string{"-unknown"}},
+		{name: "backup", cmd: "backup", args: []string{"-unknown"}},
+		{name: "restore", cmd: "restore", args: []string{"-unknown"}},
+		{name: "list", cmd: "list", args: []string{"-unknown"}},
+		{name: "ls", cmd: "ls", args: []string{"-unknown"}},
+		{name: "prune", cmd: "prune", args: []string{"-unknown"}},
+		{name: "forget", cmd: "forget", args: []string{"-unknown"}},
+		{name: "diff", cmd: "diff", args: []string{"-unknown"}},
+		{name: "break lock", cmd: "break-lock", args: []string{"-unknown"}},
+		{name: "key", cmd: "key", args: []string{"list", "-unknown"}},
+		{name: "check", cmd: "check", args: []string{"-unknown"}},
+		{name: "cat", cmd: "cat", args: []string{"-unknown"}},
+		{name: "profile", cmd: "profile", args: []string{"list", "-unknown"}},
+		{name: "auth", cmd: "auth", args: []string{"list", "-unknown"}},
+		{name: "store", cmd: "store", args: []string{"list", "-unknown"}},
+		{name: "source", cmd: "source", args: []string{"discover", "-unknown"}},
+		{name: "setup", cmd: "setup", args: []string{"workstation", "-unknown"}},
+		{name: "tui", cmd: "tui", args: []string{"-unknown"}},
+		{name: "completion", cmd: "completion", args: []string{"unknown"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if code := runCmd(context.Background(), tt.cmd, tt.args); code != 1 {
+				t.Fatalf("runCmd() exit code = %d, want 1", code)
+			}
+		})
+	}
+}

--- a/cmd/cloudstic/runner.go
+++ b/cmd/cloudstic/runner.go
@@ -10,6 +10,7 @@ import (
 )
 
 type runner struct {
+	args              []string
 	out               io.Writer
 	errOut            io.Writer
 	stdoutFile        *os.File
@@ -20,15 +21,25 @@ type runner struct {
 	runInteractiveCmd func(context.Context, *os.File, io.Writer, io.Writer, string, ...string) error
 }
 
-func newRunner() *runner {
+func newRunner(args []string) *runner {
 	return &runner{
+		args:              args,
 		out:               os.Stdout,
 		errOut:            os.Stderr,
 		stdoutFile:        os.Stdout,
-		noPrompt:          hasGlobalFlag("no-prompt"),
+		noPrompt:          hasGlobalFlag(args, "no-prompt"),
 		stdin:             os.Stdin,
 		runInteractiveCmd: defaultRunInteractiveCmd,
 	}
+}
+
+// withArgs returns a shallow runner copy for nested command dispatch. The
+// parent runner and its argument slice are never mutated.
+func (r *runner) withArgs(args []string) *runner {
+	child := *r
+	child.args = args
+	child.noPrompt = r.noPrompt || hasGlobalFlag(args, "no-prompt")
+	return &child
 }
 
 func (r *runner) lineReader() *bufio.Reader {
@@ -41,10 +52,13 @@ func (r *runner) lineReader() *bufio.Reader {
 	return r.lineIn
 }
 
-// hasGlobalFlag checks whether a boolean flag appears anywhere in os.Args.
+// hasGlobalFlag checks whether a boolean flag appears before the -- terminator.
 // This is used for flags that must be parsed before subcommand flag sets.
-func hasGlobalFlag(name string) bool {
-	for _, arg := range os.Args[1:] {
+func hasGlobalFlag(args []string, name string) bool {
+	for _, arg := range args {
+		if arg == "--" {
+			break
+		}
 		if arg == "-"+name || arg == "--"+name ||
 			arg == "-"+name+"=true" || arg == "--"+name+"=true" {
 			return true

--- a/cmd/cloudstic/store.go
+++ b/cmd/cloudstic/store.go
@@ -115,7 +115,7 @@ func (g *globalFlags) applyProfileStoreOverrides() error {
 		"store-sftp-password", "store-sftp-key",
 		"password", "encryption-key", "recovery-key", "kms-key-arn", "kms-region", "kms-endpoint",
 	} {
-		flagsSet[name] = cliFlagProvided(name)
+		flagsSet[name] = g.flagProvided(name)
 	}
 	if err := applyProfileStoreToGlobalFlags(g, s, flagsSet); err != nil {
 		return fmt.Errorf("profile %q store %q: %w", g.profile, p.Store, err)
@@ -170,7 +170,7 @@ func (g *globalFlags) buildKeychain(ctx context.Context) (keychain.Chain, error)
 		chain = append(chain, keychain.WithRecoveryKey(g.recoveryKey))
 	}
 	promptRequested := g.prompt
-	if (len(chain) == 0 || promptRequested) && !hasGlobalFlag("no-prompt") && term.IsTerminal(os.Stdin.Fd()) {
+	if (len(chain) == 0 || promptRequested) && !g.noPrompt && term.IsTerminal(os.Stdin.Fd()) {
 		chain = append(chain, keychain.WithPrompt(
 			func() (string, error) { return ui.PromptPassword("Repository password") },
 			func() (string, error) { return ui.PromptPasswordConfirm("Enter new repository password") },

--- a/cmd/cloudstic/store_profile_test.go
+++ b/cmd/cloudstic/store_profile_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -24,7 +23,6 @@ func TestApplyProfileStoreOverrides_AppliesProfileStore(t *testing.T) {
 		t.Fatalf("SaveProfilesFile: %v", err)
 	}
 
-	os.Args = []string{"cloudstic", "list", "-profile", "p", "-profiles-file", profilesPath}
 	g := newTestGlobalFlags()
 	g.profile = "p"
 	g.profilesFile = profilesPath
@@ -72,7 +70,6 @@ func TestApplyProfileStoreOverrides_EncryptionFields(t *testing.T) {
 		t.Fatalf("SaveProfilesFile: %v", err)
 	}
 
-	os.Args = []string{"cloudstic", "list", "-profile", "p", "-profiles-file", profilesPath}
 	g := newTestGlobalFlags()
 	g.profile = "p"
 	g.profilesFile = profilesPath
@@ -116,8 +113,7 @@ func TestApplyProfileStoreOverrides_DoesNotOverrideExplicitStoreFlag(t *testing.
 		t.Fatalf("SaveProfilesFile: %v", err)
 	}
 
-	os.Args = []string{"cloudstic", "list", "-profile", "p", "-profiles-file", profilesPath, "-store", "local:/explicit"}
-	g := newTestGlobalFlags()
+	g := newTestGlobalFlags("-store", "local:/explicit")
 	g.profile = "p"
 	g.profilesFile = profilesPath
 	g.store = "local:/explicit"


### PR DESCRIPTION
## Summary
- inject command arguments through the runner while keeping parser helpers pure and independently testable
- return flag and validation errors through command exit codes instead of terminating inside parsers
- honor the `--` terminator, track explicitly parsed global flags, and avoid treating flag-shaped positionals as options
- remove command-test `os.Args` mutation and cover parsing errors, nested dispatch, and terminated positionals

Closes #253

## Verification
- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./...`
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./cmd/cloudstic/...`
