### PR TITLE
fix(cli): preserve cleanup and report build metadata

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,9 +11,6 @@ builds:
       - CGO_ENABLED=0
     ldflags:
       - -s -w
-      - -X main.version={{.Version}}
-      - -X main.commit={{.ShortCommit}}
-      - -X main.date={{.Date}}
       - -X github.com/cloudstic/cli/pkg/source.defaultGoogleClientID={{ .Env.GOOGLE_CLIENT_ID }}
       - -X github.com/cloudstic/cli/pkg/source.defaultGoogleClientSecret={{ .Env.GOOGLE_CLIENT_SECRET }}
       - -X github.com/cloudstic/cli/pkg/source.defaultOneDriveClientID={{ .Env.ONEDRIVE_CLIENT_ID }}

--- a/cmd/cloudstic/cmd_backup_test.go
+++ b/cmd/cloudstic/cmd_backup_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"io"
 	"strings"
 	"testing"
 
@@ -106,7 +107,7 @@ func TestParseXattrNamespacePrefixes(t *testing.T) {
 
 func TestPrintUsage_Smoke(t *testing.T) {
 	// Verify printUsage doesn't panic.
-	printUsage()
+	printUsage(io.Discard)
 }
 
 func TestBuildBackupOpts_IgnoreEmptySnapshot(t *testing.T) {

--- a/cmd/cloudstic/main.go
+++ b/cmd/cloudstic/main.go
@@ -5,21 +5,20 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"runtime/debug"
 	"syscall"
 )
 
-var (
-	version = "dev"
-	commit  = "none"
-	date    = "unknown"
-)
-
 func main() {
+	os.Exit(run())
+}
+
+func run() int {
 	cpuprofile, memprofile := parseProfileFlags()
 
 	if len(os.Args) < 2 {
-		printUsage()
-		os.Exit(1)
+		printUsage(os.Stdout)
+		return 1
 	}
 
 	if cpuprofile != "" {
@@ -33,20 +32,20 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	exitCode := runCmd(ctx, os.Args[1], os.Args[2:])
+	exitCode := runCmd(newRunner(os.Args[2:]), ctx, os.Args[1])
 
 	if memprofile != "" {
 		writeMemProfile(memprofile)
 	}
 
-	os.Exit(exitCode)
+	return exitCode
 }
 
-func runCmd(ctx context.Context, cmd string, args []string) int {
-	r := newRunner(args)
+func runCmd(r *runner, ctx context.Context, cmd string) int {
 	switch cmd {
 	case "version", "--version", "-v":
-		fmt.Printf("cloudstic %s (commit %s, built %s)\n", version, commit, date)
+		buildVersion, buildCommit, buildDate := buildMetadata()
+		_, _ = fmt.Fprintf(r.out, "cloudstic %s (commit %s, built %s)\n", buildVersion, buildCommit, buildDate)
 		return 0
 	case "init":
 		return runInit(r, ctx)
@@ -89,11 +88,38 @@ func runCmd(ctx context.Context, cmd string, args []string) int {
 	case "__complete":
 		return runCompletionQuery(r, ctx)
 	case "help", "--help", "-h":
-		printUsage()
+		printUsage(r.out)
 		return 0
 	default:
-		fmt.Printf("Unknown command: %s\n", cmd)
-		printUsage()
+		_, _ = fmt.Fprintf(r.errOut, "Unknown command: %s\n", cmd)
+		printUsage(r.errOut)
 		return 1
 	}
+}
+
+func buildMetadata() (string, string, string) {
+	info, _ := debug.ReadBuildInfo()
+	return resolveBuildMetadata(info)
+}
+
+func resolveBuildMetadata(info *debug.BuildInfo) (string, string, string) {
+	buildVersion, buildCommit, buildDate := "dev", "none", "unknown"
+	if info != nil {
+		if info.Main.Version != "" && info.Main.Version != "(devel)" {
+			buildVersion = info.Main.Version
+		}
+		for _, setting := range info.Settings {
+			switch setting.Key {
+			case "vcs.revision":
+				if setting.Value != "" {
+					buildCommit = setting.Value
+				}
+			case "vcs.time":
+				if setting.Value != "" {
+					buildDate = setting.Value
+				}
+			}
+		}
+	}
+	return buildVersion, buildCommit, buildDate
 }

--- a/cmd/cloudstic/main_test.go
+++ b/cmd/cloudstic/main_test.go
@@ -1,7 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime/debug"
+	"strings"
 	"testing"
 )
 
@@ -36,9 +42,98 @@ func TestRunCmd_ParsingErrorsReturnExitCode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if code := runCmd(context.Background(), tt.cmd, tt.args); code != 1 {
+			r := newRunner(tt.args)
+			if code := runCmd(r, context.Background(), tt.cmd); code != 1 {
 				t.Fatalf("runCmd() exit code = %d, want 1", code)
 			}
 		})
+	}
+}
+
+func TestRunCmdVersionWritesToRunner(t *testing.T) {
+	var out, errOut bytes.Buffer
+	r := newRunner(nil)
+	r.out, r.errOut = &out, &errOut
+
+	if code := runCmd(r, context.Background(), "version"); code != 0 {
+		t.Fatalf("runCmd() exit code = %d, want 0", code)
+	}
+	if got := out.String(); !strings.HasPrefix(got, "cloudstic ") {
+		t.Fatalf("stdout = %q, want version output", got)
+	}
+	if errOut.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", errOut.String())
+	}
+}
+
+func TestRunCmdUnknownWritesToStderr(t *testing.T) {
+	var out, errOut bytes.Buffer
+	r := newRunner(nil)
+	r.out, r.errOut = &out, &errOut
+
+	if code := runCmd(r, context.Background(), "wat"); code != 1 {
+		t.Fatalf("runCmd() exit code = %d, want 1", code)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", out.String())
+	}
+	if got := errOut.String(); !strings.HasPrefix(got, "Unknown command: wat\n") {
+		t.Fatalf("stderr = %q, want unknown-command message", got)
+	}
+}
+
+func TestResolveBuildMetadataUsesBuildInfo(t *testing.T) {
+	info := &debug.BuildInfo{
+		Main: debug.Module{Version: "v1.2.3"},
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "abc123"},
+			{Key: "vcs.time", Value: "2026-07-19T16:27:05Z"},
+		},
+	}
+
+	gotVersion, gotCommit, gotDate := resolveBuildMetadata(info)
+	if gotVersion != "v1.2.3" {
+		t.Fatalf("version = %q, want v1.2.3", gotVersion)
+	}
+	if gotCommit != "abc123" {
+		t.Fatalf("commit = %q, want abc123", gotCommit)
+	}
+	if gotDate != "2026-07-19T16:27:05Z" {
+		t.Fatalf("date = %q, want build-info time", gotDate)
+	}
+}
+
+func TestResolveBuildMetadataDefaultsWithoutBuildInfo(t *testing.T) {
+	gotVersion, gotCommit, gotDate := resolveBuildMetadata(nil)
+	if gotVersion != "dev" || gotCommit != "none" || gotDate != "unknown" {
+		t.Fatalf("metadata = (%q, %q, %q), want development defaults", gotVersion, gotCommit, gotDate)
+	}
+}
+
+func TestRunFlushesCPUProfileBeforeExit(t *testing.T) {
+	if profilePath := os.Getenv("CLOUDSTIC_TEST_CPU_PROFILE_PATH"); profilePath != "" {
+		os.Args = []string{"cloudstic", "-cpuprofile", profilePath, "version"}
+		os.Exit(run())
+	}
+
+	profilePath := filepath.Join(t.TempDir(), "cpu.pprof")
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRunFlushesCPUProfileBeforeExit$")
+	cmd.Env = append(os.Environ(), "CLOUDSTIC_TEST_CPU_PROFILE_PATH="+profilePath)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("profile subprocess failed: %v\n%s", err, output)
+	}
+
+	info, err := os.Stat(profilePath)
+	if err != nil {
+		t.Fatalf("stat CPU profile: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Fatal("CPU profile is empty")
+	}
+
+	pprof := exec.Command("go", "tool", "pprof", "-top", os.Args[0], profilePath)
+	pprof.Env = append(os.Environ(), "GOCACHE="+t.TempDir())
+	if output, err := pprof.CombinedOutput(); err != nil {
+		t.Fatalf("parse CPU profile: %v\n%s", err, output)
 	}
 }

--- a/cmd/cloudstic/usage.go
+++ b/cmd/cloudstic/usage.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"fmt"
-	"os"
+	"io"
 
 	"github.com/cloudstic/cli/internal/ui"
 )
 
-func printUsage() {
-	t := ui.NewTermWriter(os.Stdout)
+func printUsage(out io.Writer) {
+	t := ui.NewTermWriter(out)
 
 	_, _ = fmt.Fprintf(t.W, "%sCloudstic%s — Content-Addressable Backup System\n", ui.Bold, ui.Reset)
 


### PR DESCRIPTION
## Summary
- return the process exit code through a cleanup-aware `run()` boundary
- use Go build information as the sole source for module version, VCS revision, and commit time
- remove redundant GoReleaser metadata injections while retaining unrelated linker settings
- route version, help, and unknown-command output through runner writers
- verify deferred CPU-profile flushing in a subprocess and parse the result with `go tool pprof`

Fixes #262

## Verification
- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./cmd/cloudstic`
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./cmd/cloudstic/...`
- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./cmd/cloudstic -run TestRunFlushesCPUProfileBeforeExit -v`
- build from an isolated local clone tagged `v1.99.99-test`, then confirm both `cloudstic version` and `go version -m` report the tag and revision without metadata ldflags