### PR TITLE
feat(cli): add structured error reporting

### DIFF
--- a/cmd/cloudstic/cmd_auth.go
+++ b/cmd/cloudstic/cmd_auth.go
@@ -39,7 +39,7 @@ func runAuthList(r *runner, ctx context.Context) int {
 	fs := flag.NewFlagSet("auth list", flag.ContinueOnError)
 	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
 	if err := parseFlags(fs, r.args); err != nil {
-		return parseErrorExitCode(err)
+		return r.parseError(err)
 	}
 
 	cfg, err := cloudstic.LoadProfilesFile(*profilesFile)
@@ -58,7 +58,7 @@ func runAuthShow(r *runner, ctx context.Context) int {
 	fs := flag.NewFlagSet("auth show", flag.ContinueOnError)
 	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
 	if err := parseFlags(fs, r.args); err != nil {
-		return parseErrorExitCode(err)
+		return r.parseError(err)
 	}
 	if fs.NArg() > 1 {
 		return r.fail("usage: cloudstic auth show [-profiles-file <path>] <name>")
@@ -105,7 +105,7 @@ func runAuthNew(r *runner, ctx context.Context) int {
 	onedriveTokenFile := fs.String("onedrive-token-file", "", "Path to OneDrive OAuth token file")
 	onedriveTokenRef := fs.String("onedrive-token-ref", "", "Secret reference to OneDrive OAuth token")
 	if err := parseFlags(fs, r.args); err != nil {
-		return parseErrorExitCode(err)
+		return r.parseError(err)
 	}
 
 	if *name == "" {
@@ -207,7 +207,7 @@ func runAuthLogin(r *runner, ctx context.Context) int {
 	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
 	name := fs.String("name", "", "Auth reference name")
 	if err := parseFlags(fs, r.args); err != nil {
-		return parseErrorExitCode(err)
+		return r.parseError(err)
 	}
 
 	cfg, err := cloudstic.LoadProfilesFile(*profilesFile)

--- a/cmd/cloudstic/cmd_backup.go
+++ b/cmd/cloudstic/cmd_backup.go
@@ -110,7 +110,7 @@ func parseBackupArgs(args []string) (*backupArgs, error) {
 func runBackup(r *runner, ctx context.Context) int {
 	a, err := parseBackupArgs(r.args)
 	if err != nil {
-		return parseErrorExitCode(err)
+		return r.parseError(err)
 	}
 
 	if a.profile != "" && a.allProfiles {

--- a/cmd/cloudstic/cmd_breaklock.go
+++ b/cmd/cloudstic/cmd_breaklock.go
@@ -25,7 +25,7 @@ func parseBreakLockArgs(args []string) (*breakLockArgs, error) {
 func runBreakLock(r *runner, ctx context.Context) int {
 	a, err := parseBreakLockArgs(r.args)
 	if err != nil {
-		return parseErrorExitCode(err)
+		return r.parseError(err)
 	}
 	if err := r.openClient(ctx, a.g); err != nil {
 		return r.fail("Failed to init store: %v", err)

--- a/cmd/cloudstic/cmd_cat.go
+++ b/cmd/cloudstic/cmd_cat.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -36,11 +37,13 @@ func parseCatArgs(args []string) (*catArgs, error) {
 func runCat(r *runner, ctx context.Context) int {
 	a, err := parseCatArgs(r.args)
 	if err != nil {
-		if parseErrorExitCode(err) == 0 {
+		if errors.Is(err, flag.ErrHelp) {
 			return 0
 		}
-		printCatUsage(r.errOut)
-		return r.fail("Error: %v", err)
+		if !r.jsonEnabled() {
+			printCatUsage(r.errOut)
+		}
+		return r.parseError(err)
 	}
 	if err := r.openClient(ctx, a.g); err != nil {
 		return r.fail("Failed to init store: %v", err)

--- a/cmd/cloudstic/cmd_check.go
+++ b/cmd/cloudstic/cmd_check.go
@@ -34,7 +34,7 @@ func parseCheckArgs(args []string) (*checkArgs, error) {
 func runCheck(r *runner, ctx context.Context) int {
 	a, err := parseCheckArgs(r.args)
 	if err != nil {
-		return parseErrorExitCode(err)
+		return r.parseError(err)
 	}
 	if err := r.openClient(ctx, a.g); err != nil {
 		return r.fail("Failed to init store: %v", err)

--- a/cmd/cloudstic/cmd_diff.go
+++ b/cmd/cloudstic/cmd_diff.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -33,12 +34,14 @@ func parseDiffArgs(args []string) (*diffArgs, error) {
 func runDiff(r *runner, ctx context.Context) int {
 	a, err := parseDiffArgs(r.args)
 	if err != nil {
-		if parseErrorExitCode(err) == 0 {
+		if errors.Is(err, flag.ErrHelp) {
 			return 0
 		}
-		_, _ = fmt.Fprintln(r.errOut, "Usage: cloudstic diff [options] <snapshot_id1> <snapshot_id2>")
-		_, _ = fmt.Fprintln(r.errOut, "       cloudstic diff [options] <snapshot_id1> latest")
-		return r.fail("Error: %v", err)
+		if !r.jsonEnabled() {
+			_, _ = fmt.Fprintln(r.errOut, "Usage: cloudstic diff [options] <snapshot_id1> <snapshot_id2>")
+			_, _ = fmt.Fprintln(r.errOut, "       cloudstic diff [options] <snapshot_id1> latest")
+		}
+		return r.parseError(err)
 	}
 	if err := r.openClient(ctx, a.g); err != nil {
 		return r.fail("Failed to init store: %v", err)

--- a/cmd/cloudstic/cmd_forget.go
+++ b/cmd/cloudstic/cmd_forget.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -155,11 +156,13 @@ func validateForgetArgs(a *forgetArgs) error {
 func runForget(r *runner, ctx context.Context) int {
 	a, err := parseForgetArgs(r.args)
 	if err != nil {
-		if parseErrorExitCode(err) == 0 {
+		if errors.Is(err, flag.ErrHelp) {
 			return 0
 		}
-		printForgetUsage(r.errOut)
-		return r.fail("\nError: %v", err)
+		if !r.jsonEnabled() {
+			printForgetUsage(r.errOut)
+		}
+		return r.parseError(err)
 	}
 	if err := r.openClient(ctx, a.g); err != nil {
 		return r.fail("Failed to init store: %v", err)

--- a/cmd/cloudstic/cmd_init.go
+++ b/cmd/cloudstic/cmd_init.go
@@ -39,7 +39,7 @@ func parseInitArgs(args []string) (*initArgs, error) {
 func runInit(r *runner, ctx context.Context) int {
 	a, err := parseInitArgs(r.args)
 	if err != nil {
-		return parseErrorExitCode(err)
+		return r.parseError(err)
 	}
 	return runInitWithArgs(r, ctx, a)
 }
@@ -65,10 +65,7 @@ func runInitWithArgs(r *runner, ctx context.Context, a *initArgs) int {
 			a.g.password = pw
 			kc, _ = a.g.buildKeychain(ctx)
 		} else {
-			_, _ = fmt.Fprintln(r.errOut, "Error: encryption is required by default.")
-			_, _ = fmt.Fprintln(r.errOut, "Provide --password or --encryption-key to encrypt your repository.")
-			_, _ = fmt.Fprintln(r.errOut, "To create an unencrypted repository, pass --no-encryption (not recommended).")
-			return 1
+			return r.fail("Error: encryption is required by default.\nProvide --password or --encryption-key to encrypt your repository.\nTo create an unencrypted repository, pass --no-encryption (not recommended).")
 		}
 	}
 

--- a/cmd/cloudstic/cmd_key.go
+++ b/cmd/cloudstic/cmd_key.go
@@ -56,7 +56,7 @@ func parseKeyListArgs(args []string) (*keyListArgs, error) {
 func runKeyList(r *runner, ctx context.Context) int {
 	a, err := parseKeyListArgs(r.args)
 	if err != nil {
-		return parseErrorExitCode(err)
+		return r.parseError(err)
 	}
 
 	raw, err := a.g.openStore(ctx)
@@ -115,7 +115,7 @@ func parseKeyPasswdArgs(args []string) (*keyPasswdArgs, error) {
 func runKeyPasswd(r *runner, ctx context.Context) int {
 	a, err := parseKeyPasswdArgs(r.args)
 	if err != nil {
-		return parseErrorExitCode(err)
+		return r.parseError(err)
 	}
 
 	raw, err := a.g.openStore(ctx)
@@ -170,7 +170,7 @@ func parseAddRecoveryKeyArgs(args []string) (*addRecoveryKeyArgs, error) {
 func runAddRecoveryKey(r *runner, ctx context.Context) int {
 	a, err := parseAddRecoveryKeyArgs(r.args)
 	if err != nil {
-		return parseErrorExitCode(err)
+		return r.parseError(err)
 	}
 
 	raw, err := a.g.openStore(ctx)

--- a/cmd/cloudstic/cmd_list.go
+++ b/cmd/cloudstic/cmd_list.go
@@ -29,7 +29,7 @@ func parseListArgs(args []string) (*listArgs, error) {
 func runList(r *runner, ctx context.Context) int {
 	a, err := parseListArgs(r.args)
 	if err != nil {
-		return parseErrorExitCode(err)
+		return r.parseError(err)
 	}
 	if err := r.openClient(ctx, a.g); err != nil {
 		return r.fail("Failed to init store: %v", err)

--- a/cmd/cloudstic/cmd_ls.go
+++ b/cmd/cloudstic/cmd_ls.go
@@ -36,7 +36,7 @@ func parseLsArgs(args []string) (*lsArgs, error) {
 func runLsSnapshot(r *runner, ctx context.Context) int {
 	a, err := parseLsArgs(r.args)
 	if err != nil {
-		return parseErrorExitCode(err)
+		return r.parseError(err)
 	}
 	if err := r.openClient(ctx, a.g); err != nil {
 		return r.fail("Failed to init store: %v", err)

--- a/cmd/cloudstic/cmd_profile.go
+++ b/cmd/cloudstic/cmd_profile.go
@@ -75,10 +75,7 @@ func parseProfileShowArgs(args []string) (*profileShowArgs, error) {
 func runProfileShow(r *runner, ctx context.Context) int {
 	a, err := parseProfileShowArgs(r.args)
 	if err != nil {
-		if parseErrorExitCode(err) == 0 {
-			return 0
-		}
-		return r.fail("%v", err)
+		return r.parseError(err)
 	}
 	cfg, err := cloudstic.LoadProfilesFile(a.profilesFile)
 	if err != nil {
@@ -138,7 +135,7 @@ func parseProfileListArgs(args []string) (*profileListArgs, error) {
 func runProfileList(r *runner, ctx context.Context) int {
 	a, err := parseProfileListArgs(r.args)
 	if err != nil {
-		return parseErrorExitCode(err)
+		return r.parseError(err)
 	}
 	cfg, err := cloudstic.LoadProfilesFile(a.profilesFile)
 	if err != nil {
@@ -240,7 +237,7 @@ func parseProfileNewArgs(args []string) (*profileNewArgs, error) {
 func runProfileNew(r *runner, ctx context.Context) int {
 	a, err := parseProfileNewArgs(r.args)
 	if err != nil {
-		return parseErrorExitCode(err)
+		return r.parseError(err)
 	}
 	if a.name == "" {
 		if r.canPrompt() {

--- a/cmd/cloudstic/cmd_prune.go
+++ b/cmd/cloudstic/cmd_prune.go
@@ -30,7 +30,7 @@ func parsePruneArgs(args []string) (*pruneArgs, error) {
 func runPrune(r *runner, ctx context.Context) int {
 	a, err := parsePruneArgs(r.args)
 	if err != nil {
-		return parseErrorExitCode(err)
+		return r.parseError(err)
 	}
 	if err := r.openClient(ctx, a.g); err != nil {
 		return r.fail("Failed to init store: %v", err)

--- a/cmd/cloudstic/cmd_restore.go
+++ b/cmd/cloudstic/cmd_restore.go
@@ -46,7 +46,7 @@ func parseRestoreArgs(args []string) (*restoreArgs, error) {
 func runRestore(r *runner, ctx context.Context) int {
 	a, err := parseRestoreArgs(r.args)
 	if err != nil {
-		return parseErrorExitCode(err)
+		return r.parseError(err)
 	}
 	format, err := resolveRestoreFormat(a.format, a.output)
 	if err != nil {

--- a/cmd/cloudstic/cmd_setup.go
+++ b/cmd/cloudstic/cmd_setup.go
@@ -77,7 +77,7 @@ func parseSetupWorkstationArgs(args []string) (*setupWorkstationArgs, error) {
 func runSetupWorkstation(r *runner, ctx context.Context) int {
 	args, err := parseSetupWorkstationArgs(r.args)
 	if err != nil {
-		return parseErrorExitCode(err)
+		return r.parseError(err)
 	}
 	cfg, err := loadProfilesOrInit(args.profilesFile)
 	if err != nil {

--- a/cmd/cloudstic/cmd_source.go
+++ b/cmd/cloudstic/cmd_source.go
@@ -32,7 +32,7 @@ func runSourceDiscover(r *runner, ctx context.Context) int {
 	portableOnly := fs.Bool("portable-only", false, "Only show portable/external source candidates")
 	jsonOutput := fs.Bool("json", false, "Write discovered sources as JSON")
 	if err := parseFlags(fs, r.args); err != nil {
-		return parseErrorExitCode(err)
+		return r.parseError(err)
 	}
 
 	if r.client == nil {

--- a/cmd/cloudstic/cmd_store.go
+++ b/cmd/cloudstic/cmd_store.go
@@ -45,7 +45,7 @@ func runStoreList(r *runner, ctx context.Context) int {
 	fs := flag.NewFlagSet("store list", flag.ContinueOnError)
 	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
 	if err := parseFlags(fs, r.args); err != nil {
-		return parseErrorExitCode(err)
+		return r.parseError(err)
 	}
 
 	cfg, err := cloudstic.LoadProfilesFile(*profilesFile)
@@ -64,7 +64,7 @@ func runStoreShow(r *runner, ctx context.Context) int {
 	fs := flag.NewFlagSet("store show", flag.ContinueOnError)
 	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
 	if err := parseFlags(fs, r.args); err != nil {
-		return parseErrorExitCode(err)
+		return r.parseError(err)
 	}
 	if fs.NArg() > 1 {
 		return r.fail("usage: cloudstic store show [-profiles-file <path>] <name>")
@@ -122,7 +122,7 @@ func runStoreNew(r *runner, ctx context.Context) int {
 	kmsRegion := fs.String("kms-region", "", "AWS KMS region")
 	kmsEndpoint := fs.String("kms-endpoint", "", "Custom AWS KMS endpoint URL")
 	if err := parseFlags(fs, r.args); err != nil {
-		return parseErrorExitCode(err)
+		return r.parseError(err)
 	}
 
 	flagsSet := map[string]bool{}
@@ -251,7 +251,7 @@ func runStoreVerify(r *runner, ctx context.Context) int {
 	fs := flag.NewFlagSet("store verify", flag.ContinueOnError)
 	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
 	if err := parseFlags(fs, r.args); err != nil {
-		return parseErrorExitCode(err)
+		return r.parseError(err)
 	}
 	if fs.NArg() > 1 {
 		return r.fail("usage: cloudstic store verify [-profiles-file <path>] <name>")
@@ -298,7 +298,7 @@ func runStoreInit(r *runner, ctx context.Context) int {
 	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
 	yes := fs.Bool("yes", false, "Initialize without confirmation prompt")
 	if err := parseFlags(fs, r.args); err != nil {
-		return parseErrorExitCode(err)
+		return r.parseError(err)
 	}
 	if fs.NArg() > 1 {
 		return r.fail("usage: cloudstic store init [-profiles-file <path>] [-yes] <name>")

--- a/cmd/cloudstic/cmd_tui.go
+++ b/cmd/cloudstic/cmd_tui.go
@@ -42,7 +42,7 @@ func runTUI(r *runner, ctx context.Context) int {
 
 	args, err := parseTUIArgs(r.args)
 	if err != nil {
-		return parseErrorExitCode(err)
+		return r.parseError(err)
 	}
 	if !r.canPrompt() {
 		return r.fail("cloudstic tui requires an interactive terminal")

--- a/cmd/cloudstic/completion.go
+++ b/cmd/cloudstic/completion.go
@@ -27,8 +27,7 @@ func runCompletion(r *runner) int {
 	case "fish":
 		completionFish(r.out)
 	default:
-		_, _ = fmt.Fprintf(r.errOut, "Unsupported shell: %s\nAvailable shells: bash, zsh, fish\n", shell)
-		return 1
+		return r.fail("Unsupported shell: %s\nAvailable shells: bash, zsh, fish", shell)
 	}
 	return 0
 }

--- a/cmd/cloudstic/flags.go
+++ b/cmd/cloudstic/flags.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -106,14 +107,17 @@ func parseFlags(fs *flag.FlagSet, args []string) error {
 	if fs.Lookup("no-prompt") == nil {
 		fs.Bool("no-prompt", false, "Disable interactive prompts (for scripts and CI)")
 	}
+	if hasGlobalFlag(args, "json") && !hasGlobalFlag(args, "h") {
+		fs.SetOutput(io.Discard)
+	}
 	return fs.Parse(reorderArgs(fs, args))
 }
 
-func parseErrorExitCode(err error) int {
+func (r *runner) parseError(err error) int {
 	if errors.Is(err, flag.ErrHelp) {
 		return 0
 	}
-	return 1
+	return r.fail("Error: %v", err)
 }
 
 // reorderArgs moves flag arguments before positional arguments so that Go's

--- a/cmd/cloudstic/flags_test.go
+++ b/cmd/cloudstic/flags_test.go
@@ -67,8 +67,9 @@ func TestParseFlags_AcceptsNoPromptForNestedCommands(t *testing.T) {
 }
 
 func TestParseErrorExitCode_HelpSucceeds(t *testing.T) {
-	if code := parseErrorExitCode(flag.ErrHelp); code != 0 {
-		t.Fatalf("parseErrorExitCode(flag.ErrHelp) = %d, want 0", code)
+	r := newRunner(nil)
+	if code := r.parseError(flag.ErrHelp); code != 0 {
+		t.Fatalf("parseError(flag.ErrHelp) = %d, want 0", code)
 	}
 }
 

--- a/cmd/cloudstic/main.go
+++ b/cmd/cloudstic/main.go
@@ -91,9 +91,11 @@ func runCmd(r *runner, ctx context.Context, cmd string) int {
 		printUsage(r.out)
 		return 0
 	default:
-		_, _ = fmt.Fprintf(r.errOut, "Unknown command: %s\n", cmd)
-		printUsage(r.errOut)
-		return 1
+		exitCode := r.fail("Unknown command: %s", cmd)
+		if !r.jsonEnabled() {
+			printUsage(r.errOut)
+		}
+		return exitCode
 	}
 }
 

--- a/cmd/cloudstic/main_test.go
+++ b/cmd/cloudstic/main_test.go
@@ -82,6 +82,20 @@ func TestRunCmdUnknownWritesToStderr(t *testing.T) {
 	}
 }
 
+func TestRunCmdUnknownWritesJSONErrorWithoutUsage(t *testing.T) {
+	var out, errOut bytes.Buffer
+	r := newRunner([]string{"--json"})
+	r.out, r.errOut = &out, &errOut
+
+	if code := runCmd(r, context.Background(), "wat"); code != exitFailure {
+		t.Fatalf("runCmd() exit code = %d, want %d", code, exitFailure)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", out.String())
+	}
+	assertJSONError(t, errOut.Bytes(), "Unknown command: wat")
+}
+
 func TestResolveBuildMetadataUsesBuildInfo(t *testing.T) {
 	info := &debug.BuildInfo{
 		Main: debug.Module{Version: "v1.2.3"},

--- a/cmd/cloudstic/runner.go
+++ b/cmd/cloudstic/runner.go
@@ -3,11 +3,22 @@ package main
 import (
 	"bufio"
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 )
+
+const (
+	exitFailure     = 1
+	exitInterrupted = 130
+)
+
+type errorOutput struct {
+	Error string `json:"error"`
+}
 
 type runner struct {
 	args              []string
@@ -67,10 +78,26 @@ func hasGlobalFlag(args []string, name string) bool {
 	return false
 }
 
-// fail writes a formatted error to r.errOut and returns exit code 1.
+func (r *runner) jsonEnabled() bool {
+	return hasGlobalFlag(r.args, "json")
+}
+
+// fail reports an error using the command's selected output format.
 func (r *runner) fail(format string, args ...any) int {
-	_, _ = fmt.Fprintf(r.errOut, format+"\n", args...)
-	return 1
+	message, exitCode := fmt.Sprintf(format, args...), exitFailure
+	for _, arg := range args {
+		err, ok := arg.(error)
+		if ok && errors.Is(err, context.Canceled) {
+			message, exitCode = "Interrupted.", exitInterrupted
+			break
+		}
+	}
+	if r.jsonEnabled() {
+		_ = json.NewEncoder(r.errOut).Encode(&errorOutput{Error: message})
+	} else {
+		_, _ = fmt.Fprintln(r.errOut, message)
+	}
+	return exitCode
 }
 
 // openClient opens the cloudstic client from the given global flags.

--- a/cmd/cloudstic/runner_test.go
+++ b/cmd/cloudstic/runner_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestRunnerFailInterrupted(t *testing.T) {
+	var errOut bytes.Buffer
+	r := newRunner(nil)
+	r.errOut = &errOut
+
+	err := fmt.Errorf("chunking file: %w", context.Canceled)
+	if code := r.fail("Backup failed: %v", err); code != exitInterrupted {
+		t.Fatalf("fail() exit code = %d, want %d", code, exitInterrupted)
+	}
+	if got, want := errOut.String(), "Interrupted.\n"; got != want {
+		t.Fatalf("stderr = %q, want %q", got, want)
+	}
+}
+
+func TestRunnerFailJSON(t *testing.T) {
+	var errOut bytes.Buffer
+	r := newRunner([]string{"--json"})
+	r.errOut = &errOut
+
+	if code := r.fail("Backup failed: %s", "store unavailable"); code != exitFailure {
+		t.Fatalf("fail() exit code = %d, want %d", code, exitFailure)
+	}
+	assertJSONError(t, errOut.Bytes(), "Backup failed: store unavailable")
+}
+
+func TestRunBackupInterruptedJSON(t *testing.T) {
+	var out, errOut bytes.Buffer
+	sourcePath := t.TempDir()
+	r := newRunner([]string{"-source", "local:" + sourcePath, "-json"})
+	r.out, r.errOut = &out, &errOut
+	r.client = &stubClient{backupErr: fmt.Errorf("chunking file: %w", context.Canceled)}
+
+	if code := runBackup(r, context.Background()); code != exitInterrupted {
+		t.Fatalf("runBackup() exit code = %d, want %d", code, exitInterrupted)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", out.String())
+	}
+	assertJSONError(t, errOut.Bytes(), "Interrupted.")
+}
+
+func TestRunBackupParseErrorJSON(t *testing.T) {
+	var out, errOut bytes.Buffer
+	r := newRunner([]string{"-json", "-unknown"})
+	r.out, r.errOut = &out, &errOut
+
+	if code := runBackup(r, context.Background()); code != exitFailure {
+		t.Fatalf("runBackup() exit code = %d, want %d", code, exitFailure)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", out.String())
+	}
+	var got errorOutput
+	if err := json.Unmarshal(errOut.Bytes(), &got); err != nil {
+		t.Fatalf("stderr is not valid JSON: %v\n%s", err, errOut.Bytes())
+	}
+	if !strings.Contains(got.Error, "flag provided but not defined: -unknown") {
+		t.Fatalf("JSON error = %q, want unknown-flag message", got.Error)
+	}
+}
+
+func TestJSONFlagAfterPositionalEnablesStructuredErrors(t *testing.T) {
+	var errOut bytes.Buffer
+	r := newRunner([]string{"snapshot", "--json"})
+	r.errOut = &errOut
+
+	r.fail("failed")
+	assertJSONError(t, errOut.Bytes(), "failed")
+}
+
+func assertJSONError(t *testing.T, data []byte, want string) {
+	t.Helper()
+	var got errorOutput
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("invalid JSON error: %v\n%s", err, data)
+	}
+	if got.Error != want {
+		t.Fatalf("JSON error = %q, want %q", got.Error, want)
+	}
+}

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -232,6 +232,11 @@ These flags apply to all commands:
 
 `-json` is available on the operational commands that return structured results, including `init`, `backup`, `restore`, `list`, `ls`, `diff`, `forget`, `prune`, `break-lock`, `check`, `key list`, `key add-recovery`, `key passwd`, and `cat`. When `-json` is set, Cloudstic suppresses progress output and writes a single JSON document to stdout instead of the usual human-readable summary.
 
+Failures in JSON mode are written to stderr as a single JSON object with an
+`error` field, for example `{"error":"store unavailable"}`. An operation
+interrupted by SIGINT or SIGTERM reports `Interrupted.` and exits with status
+130; other failures exit with status 1.
+
 ### init
 
 Initialize a new repository. Encryption is **required by default**.


### PR DESCRIPTION
## Summary
- centralize failure formatting and exit-code selection in the runner
- return exit code 130 with `Interrupted.` for wrapped context cancellation
- emit a single `{"error":"..."}` document to stderr when JSON mode is enabled
- route flag parsing and top-level dispatch failures through the shared contract
- document and test plain, JSON, parsing, and interrupted failure paths

Closes #261

## Verification
- `env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./cmd/cloudstic`
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./cmd/cloudstic/...`
- `env GOCACHE=/tmp/cloudstic-gocache go build -o /tmp/cloudstic-issue-261 ./cmd/cloudstic`
- `/tmp/cloudstic-issue-261 backup -json -unknown`