### PR TITLE
refactor(cli): drive commands from declarative specs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,7 @@ Backends expose `Load`/`Save`/`Delete`; unsupported operations return a typed `s
 | `CLOUDSTIC_RECOVERY_KEY` | BIP39 recovery mnemonic for unlock/recovery. |
 | `CLOUDSTIC_KMS_KEY_ARN` / `CLOUDSTIC_KMS_REGION` / `CLOUDSTIC_KMS_ENDPOINT` | AWS KMS envelope-encryption config for `kms-platform` slots. |
 | `CLOUDSTIC_STORE` / `CLOUDSTIC_SOURCE` | Default store / source URI when no flag is given. |
+| `B2_KEY_ID` / `B2_APP_KEY` | Backblaze B2 credentials (`-b2-key-id` / `-b2-app-key`). |
 | `CLOUDSTIC_PROFILE` / `CLOUDSTIC_PROFILES_FILE` | Active backup profile and override for the profiles file path. |
 | `CLOUDSTIC_CONFIG_DIR` | Override the config/state directory (default `~/.config/cloudstic`). |
 | `CLOUDSTIC_{STORE,SOURCE}_SFTP_{PASSWORD,KEY,KNOWN_HOSTS,INSECURE}` | SFTP auth/host-key config for the store and source backends. |

--- a/cmd/cloudstic/cmd_auth.go
+++ b/cmd/cloudstic/cmd_auth.go
@@ -11,34 +11,37 @@ import (
 	cloudstic "github.com/cloudstic/cli"
 )
 
-func runAuth(r *runner, ctx context.Context) int {
-	if len(r.args) < 1 {
-		_, _ = fmt.Fprintln(r.errOut, "Usage: cloudstic auth <subcommand> [options]")
-		_, _ = fmt.Fprintln(r.errOut, "")
-		_, _ = fmt.Fprintln(r.errOut, "Available subcommands: list, show, new, login")
-		return 1
-	}
+func authCommandSpec() *commandSpec {
+	return group("auth", "Manage reusable cloud auth entries",
+		authNewCommandSpec(), authListCommandSpec(), authShowCommandSpec(), authLoginCommandSpec())
+}
 
-	subcommand := r.args[0]
-	subRunner := r.withArgs(r.args[1:])
-	switch subcommand {
-	case "list":
-		return runAuthList(subRunner, ctx)
-	case "show":
-		return runAuthShow(subRunner, ctx)
-	case "new":
-		return runAuthNew(subRunner, ctx)
-	case "login":
-		return runAuthLogin(subRunner, ctx)
-	default:
-		return r.fail("Unknown auth subcommand: %s", subcommand)
-	}
+func authNewCommandSpec() *commandSpec {
+	return leaf("new", "Create or update a reusable cloud auth entry", "", runAuthNew,
+		profilesFileFlag(), valueFlag("name", "name", "Auth reference name", completionNone),
+		valueFlag("provider", "provider", "Auth provider", completionNone), googleCredentialsFlag(),
+		valueFlag("google-credentials-ref", "ref", "Google credentials reference", completionNone), googleTokenFileFlag(),
+		valueFlag("google-token-ref", "ref", "Google token reference", completionNone), onedriveClientIDFlag(), onedriveTokenFileFlag(),
+		valueFlag("onedrive-token-ref", "ref", "OneDrive token reference", completionNone))
+}
+
+func authListCommandSpec() *commandSpec {
+	return leaf("list", "List configured auth entries", "", runAuthList, profilesFileFlag())
+}
+
+func authShowCommandSpec() *commandSpec {
+	return leaf("show", "Show one auth entry", "<name>", runAuthShow, profilesFileFlag())
+}
+
+func authLoginCommandSpec() *commandSpec {
+	return leaf("login", "Run OAuth login for one auth entry", "", runAuthLogin,
+		profilesFileFlag(), valueFlag("name", "name", "Auth reference name", completionAuth))
 }
 
 func runAuthList(r *runner, ctx context.Context) int {
 	fs := flag.NewFlagSet("auth list", flag.ContinueOnError)
-	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
-	if err := parseFlags(fs, r.args); err != nil {
+	profilesFile := fs.String("profiles-file", defaultProfilesPathFallback(), "Path to profiles YAML file")
+	if err := parseFlags(fs, r.args, authListCommandSpec()); err != nil {
 		return r.parseError(err)
 	}
 
@@ -56,8 +59,8 @@ func runAuthList(r *runner, ctx context.Context) int {
 
 func runAuthShow(r *runner, ctx context.Context) int {
 	fs := flag.NewFlagSet("auth show", flag.ContinueOnError)
-	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
-	if err := parseFlags(fs, r.args); err != nil {
+	profilesFile := fs.String("profiles-file", defaultProfilesPathFallback(), "Path to profiles YAML file")
+	if err := parseFlags(fs, r.args, authShowCommandSpec()); err != nil {
 		return r.parseError(err)
 	}
 	if fs.NArg() > 1 {
@@ -94,7 +97,7 @@ func runAuthShow(r *runner, ctx context.Context) int {
 
 func runAuthNew(r *runner, ctx context.Context) int {
 	fs := flag.NewFlagSet("auth new", flag.ContinueOnError)
-	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
+	profilesFile := fs.String("profiles-file", defaultProfilesPathFallback(), "Path to profiles YAML file")
 	name := fs.String("name", "", "Auth reference name")
 	provider := fs.String("provider", "", "Auth provider: google|onedrive")
 	googleCreds := fs.String("google-credentials", "", "Path to Google service account credentials JSON file")
@@ -104,7 +107,7 @@ func runAuthNew(r *runner, ctx context.Context) int {
 	onedriveClientID := fs.String("onedrive-client-id", "", "OneDrive OAuth client ID")
 	onedriveTokenFile := fs.String("onedrive-token-file", "", "Path to OneDrive OAuth token file")
 	onedriveTokenRef := fs.String("onedrive-token-ref", "", "Secret reference to OneDrive OAuth token")
-	if err := parseFlags(fs, r.args); err != nil {
+	if err := parseFlags(fs, r.args, authNewCommandSpec()); err != nil {
 		return r.parseError(err)
 	}
 
@@ -204,9 +207,9 @@ func runAuthNew(r *runner, ctx context.Context) int {
 
 func runAuthLogin(r *runner, ctx context.Context) int {
 	fs := flag.NewFlagSet("auth login", flag.ContinueOnError)
-	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
+	profilesFile := fs.String("profiles-file", defaultProfilesPathFallback(), "Path to profiles YAML file")
 	name := fs.String("name", "", "Auth reference name")
-	if err := parseFlags(fs, r.args); err != nil {
+	if err := parseFlags(fs, r.args, authLoginCommandSpec()); err != nil {
 		return r.parseError(err)
 	}
 

--- a/cmd/cloudstic/cmd_backup.go
+++ b/cmd/cloudstic/cmd_backup.go
@@ -47,27 +47,53 @@ type backupArgs struct {
 	tags              stringArrayFlags
 	excludes          stringArrayFlags
 	flagsSet          map[string]bool
+	sources           map[string]valueSource
+}
+
+func backupCommandSpec() *commandSpec {
+	return leaf("backup", "Create a new backup snapshot from a source", "", runBackup,
+		sourceFlag(), boolFlag("all-profiles", "Run all enabled profiles"),
+		valueFlag("auth-ref", "name", "Named cloud auth entry", completionAuth), boolFlag("dry-run", "Scan without writing"),
+		boolFlag("ignore-empty-snapshot", "Skip an unchanged snapshot"), boolFlag("skip-native-files", "Exclude cloud-native files"),
+		valueFlag("exclude-file", "path", "Exclude-pattern file", completionFile), volumeUUIDFlag(),
+		googleCredentialsFlag(), valueFlag("google-credentials-ref", "ref", "Google credentials secret reference", completionNone),
+		googleCredentialsJSONFlag(), googleTokenFileFlag(),
+		valueFlag("google-token-ref", "ref", "Google OAuth token reference", completionNone), onedriveClientIDFlag(),
+		onedriveTokenFileFlag(), valueFlag("onedrive-token-ref", "ref", "OneDrive token reference", completionNone),
+		boolFlag("skip-mode", "Skip POSIX metadata"), boolFlag("skip-flags", "Skip file flags"), boolFlag("skip-xattrs", "Skip extended attributes"),
+		valueFlag("xattr-namespaces", "prefixes", "Extended-attribute namespaces", completionNone), valueFlag("tag", "tag", "Snapshot tag", completionNone),
+		valueFlag("exclude", "pattern", "Exclude pattern", completionNone)).withGlobalFlags().withNotes(
+		"Source URIs: local:<path>, sftp://host/path, gdrive, gdrive-changes, onedrive, or onedrive-changes.",
+		"Repeat -tag and -exclude to provide multiple values.")
+}
+
+func (a *backupArgs) valueSource(name string) valueSource {
+	if source, ok := a.sources[name]; ok {
+		return source
+	}
+	return valueSourceDefault
 }
 
 func parseBackupArgs(args []string) (*backupArgs, error) {
+	command := backupCommandSpec()
 	fs := flag.NewFlagSet("backup", flag.ContinueOnError)
 	a := &backupArgs{}
 	a.g = addGlobalFlags(fs)
-	sourceURI := fs.String("source", envDefault("CLOUDSTIC_SOURCE", "gdrive"), "Source URI: local:<path>, sftp://[user@]host[:port]/<path>, gdrive[://<Drive Name>][/<path>], gdrive-changes[://<Drive Name>][/<path>], onedrive[://<Drive Name>][/<path>], onedrive-changes[://<Drive Name>][/<path>]")
+	sourceURI := fs.String("source", "gdrive", "Source URI: local:<path>, sftp://[user@]host[:port]/<path>, gdrive[://<Drive Name>][/<path>], gdrive-changes[://<Drive Name>][/<path>], onedrive[://<Drive Name>][/<path>], onedrive-changes[://<Drive Name>][/<path>]")
 	allProfiles := fs.Bool("all-profiles", false, "Run backup for all enabled profiles from profiles.yaml")
 	authRef := fs.String("auth-ref", "", "Use named auth entry from profiles.yaml for cloud source credentials")
 	dryRun := fs.Bool("dry-run", false, "Scan source and report changes without writing to the store")
 	ignoreEmpty := fs.Bool("ignore-empty-snapshot", false, "Skip creating a new snapshot when nothing changed")
 	skipNativeFiles := fs.Bool("skip-native-files", false, "Exclude Google-native files (Docs, Sheets, Slides, etc.) from the backup")
 	excludeFile := fs.String("exclude-file", "", "Path to file with exclude patterns (one per line, gitignore syntax)")
-	volumeUUID := fs.String("volume-uuid", envDefault("CLOUDSTIC_VOLUME_UUID", ""), "Override volume UUID for local source (enables cross-machine incremental backup)")
-	googleCreds := fs.String("google-credentials", envDefault("GOOGLE_APPLICATION_CREDENTIALS", ""), "Path to Google service account credentials JSON file")
+	volumeUUID := fs.String("volume-uuid", "", "Override volume UUID for local source (enables cross-machine incremental backup)")
+	googleCreds := fs.String("google-credentials", "", "Path to Google service account credentials JSON file")
 	googleCredsRef := fs.String("google-credentials-ref", "", "Secret reference to Google service account credentials JSON")
-	googleCredsJSON := fs.String("google-credentials-json", envDefault("GOOGLE_CREDENTIALS_JSON", ""), "Inline Google credentials JSON (OAuth client or service account)")
-	googleTokenFile := fs.String("google-token-file", envDefault("GOOGLE_TOKEN_FILE", ""), "Path to Google OAuth token file")
+	googleCredsJSON := fs.String("google-credentials-json", "", "Inline Google credentials JSON (OAuth client or service account)")
+	googleTokenFile := fs.String("google-token-file", "", "Path to Google OAuth token file")
 	googleTokenRef := fs.String("google-token-ref", "", "Secret reference to Google OAuth token")
-	onedriveClientID := fs.String("onedrive-client-id", envDefault("ONEDRIVE_CLIENT_ID", ""), "OneDrive OAuth client ID")
-	onedriveTokenFile := fs.String("onedrive-token-file", envDefault("ONEDRIVE_TOKEN_FILE", ""), "Path to OneDrive OAuth token file")
+	onedriveClientID := fs.String("onedrive-client-id", "", "OneDrive OAuth client ID")
+	onedriveTokenFile := fs.String("onedrive-token-file", "", "Path to OneDrive OAuth token file")
 	onedriveTokenRef := fs.String("onedrive-token-ref", "", "Secret reference to OneDrive OAuth token")
 	skipMode := fs.Bool("skip-mode", false, "Skip POSIX mode, uid, gid, btime, and flags collection")
 	skipFlags := fs.Bool("skip-flags", false, "Skip file flags collection")
@@ -75,7 +101,7 @@ func parseBackupArgs(args []string) (*backupArgs, error) {
 	xattrNamespaces := fs.String("xattr-namespaces", "", "Restrict xattr collection to these prefixes (comma-separated, e.g. \"user.,com.apple.\")")
 	fs.Var(&a.tags, "tag", "Tag to apply to the snapshot (can be specified multiple times)")
 	fs.Var(&a.excludes, "exclude", "Exclude pattern (gitignore syntax, repeatable)")
-	if err := parseFlags(fs, args); err != nil {
+	if err := parseFlags(fs, args, command); err != nil {
 		return nil, err
 	}
 	a.sourceURI = *sourceURI
@@ -100,10 +126,8 @@ func parseBackupArgs(args []string) (*backupArgs, error) {
 	a.skipFlags = *skipFlags
 	a.skipXattrs = *skipXattrs
 	a.xattrNamespaces = *xattrNamespaces
-	a.flagsSet = map[string]bool{}
-	fs.Visit(func(f *flag.Flag) {
-		a.flagsSet[f.Name] = true
-	})
+	a.sources = commandValueSources(fs, command)
+	a.flagsSet = suppliedFlags(a.sources)
 	return a, nil
 }
 
@@ -334,9 +358,14 @@ func mergeProfileBackupArgs(base *backupArgs, profileName string, p cloudstic.Ba
 	g := cloneGlobalFlags(base.g)
 	a := *base
 	a.g = g
+	a.sources = make(map[string]valueSource, len(base.sources))
+	for name, source := range base.sources {
+		a.sources[name] = source
+	}
 
 	if !a.flagsSet["source"] {
 		a.sourceURI = p.Source
+		a.sources["source"] = valueSourceProfile
 	}
 	if a.sourceURI == "" {
 		return nil, fmt.Errorf("profile %q has empty source", profileName)
@@ -344,46 +373,60 @@ func mergeProfileBackupArgs(base *backupArgs, profileName string, p cloudstic.Ba
 
 	if !a.flagsSet["skip-native-files"] {
 		a.skipNativeFiles = p.SkipNativeFiles
+		a.sources["skip-native-files"] = valueSourceProfile
 	}
 	if !a.flagsSet["volume-uuid"] && p.VolumeUUID != "" {
 		a.volumeUUID = p.VolumeUUID
+		a.sources["volume-uuid"] = valueSourceProfile
 	}
 	if !a.flagsSet["google-credentials"] && p.GoogleCreds != "" {
 		a.googleCreds = p.GoogleCreds
+		a.sources["google-credentials"] = valueSourceProfile
 	}
 	if !a.flagsSet["google-credentials-ref"] && p.GoogleCredsRef != "" {
 		a.googleCredsRef = p.GoogleCredsRef
+		a.sources["google-credentials-ref"] = valueSourceProfile
 	}
 	if !a.flagsSet["google-credentials-json"] && p.GoogleCredsJSON != "" {
 		a.googleCredsJSON = p.GoogleCredsJSON
+		a.sources["google-credentials-json"] = valueSourceProfile
 	}
 	if !a.flagsSet["google-token-file"] && p.GoogleTokenFile != "" {
 		a.googleTokenFile = p.GoogleTokenFile
+		a.sources["google-token-file"] = valueSourceProfile
 	}
 	if !a.flagsSet["google-token-ref"] && p.GoogleTokenRef != "" {
 		a.googleTokenRef = p.GoogleTokenRef
+		a.sources["google-token-ref"] = valueSourceProfile
 	}
 	if !a.flagsSet["onedrive-client-id"] && p.OneDriveClientID != "" {
 		a.onedriveClientID = p.OneDriveClientID
+		a.sources["onedrive-client-id"] = valueSourceProfile
 	}
 	if !a.flagsSet["onedrive-token-file"] && p.OneDriveTokenFile != "" {
 		a.onedriveTokenFile = p.OneDriveTokenFile
+		a.sources["onedrive-token-file"] = valueSourceProfile
 	}
 	if !a.flagsSet["onedrive-token-ref"] && p.OneDriveTokenRef != "" {
 		a.onedriveTokenRef = p.OneDriveTokenRef
+		a.sources["onedrive-token-ref"] = valueSourceProfile
 	}
 
 	if len(a.tags) == 0 && len(p.Tags) > 0 {
 		a.tags = append(stringArrayFlags{}, p.Tags...)
+		a.sources["tag"] = valueSourceProfile
 	}
 	if len(a.excludes) == 0 && len(p.Excludes) > 0 {
 		a.excludes = append(stringArrayFlags{}, p.Excludes...)
+		a.sources["exclude"] = valueSourceProfile
 	}
 	if !a.flagsSet["exclude-file"] && p.ExcludeFile != "" {
 		a.excludeFile = p.ExcludeFile
+		a.sources["exclude-file"] = valueSourceProfile
 	}
 	if !a.flagsSet["ignore-empty-snapshot"] {
 		a.ignoreEmpty = p.IgnoreEmpty
+		a.sources["ignore-empty-snapshot"] = valueSourceProfile
 	}
 
 	if p.Store != "" {
@@ -422,6 +465,9 @@ func mergeProfileBackupArgs(base *backupArgs, profileName string, p cloudstic.Ba
 }
 
 func applyProfileAuthToBackupArgs(a *backupArgs, auth cloudstic.ProfileAuth) error {
+	if a.sources == nil {
+		a.sources = map[string]valueSource{}
+	}
 	uri, err := parseSourceURI(a.sourceURI)
 	if err != nil {
 		return fmt.Errorf("parse source URI: %w", err)
@@ -444,53 +490,69 @@ func applyProfileAuthToBackupArgs(a *backupArgs, auth cloudstic.ProfileAuth) err
 	if requiredProvider == "google" {
 		if !a.flagsSet["google-credentials"] && auth.GoogleCreds != "" {
 			a.googleCreds = auth.GoogleCreds
+			a.sources["google-credentials"] = valueSourceProfile
 		}
 		if !a.flagsSet["google-credentials-ref"] && auth.GoogleCredsRef != "" {
 			a.googleCredsRef = auth.GoogleCredsRef
+			a.sources["google-credentials-ref"] = valueSourceProfile
 		}
 		if !a.flagsSet["google-credentials-json"] && auth.GoogleCredsJSON != "" {
 			a.googleCredsJSON = auth.GoogleCredsJSON
+			a.sources["google-credentials-json"] = valueSourceProfile
 		}
 		if !a.flagsSet["google-token-file"] && auth.GoogleTokenFile != "" {
 			a.googleTokenFile = auth.GoogleTokenFile
+			a.sources["google-token-file"] = valueSourceProfile
 		}
 		if !a.flagsSet["google-token-ref"] && auth.GoogleTokenRef != "" {
 			a.googleTokenRef = auth.GoogleTokenRef
+			a.sources["google-token-ref"] = valueSourceProfile
 		}
 	}
 
 	if requiredProvider == "onedrive" {
 		if !a.flagsSet["onedrive-client-id"] && auth.OneDriveClientID != "" {
 			a.onedriveClientID = auth.OneDriveClientID
+			a.sources["onedrive-client-id"] = valueSourceProfile
 		}
 		if !a.flagsSet["onedrive-token-file"] && auth.OneDriveTokenFile != "" {
 			a.onedriveTokenFile = auth.OneDriveTokenFile
+			a.sources["onedrive-token-file"] = valueSourceProfile
 		}
 		if !a.flagsSet["onedrive-token-ref"] && auth.OneDriveTokenRef != "" {
 			a.onedriveTokenRef = auth.OneDriveTokenRef
+			a.sources["onedrive-token-ref"] = valueSourceProfile
 		}
 	}
 
 	return nil
 }
 
-// cloneGlobalFlags returns an independent copy of src: globalFlags holds only
-// value fields (plus the shared *ui.SafeLogWriter debug log), so a shallow
-// struct copy is a complete, correct clone.
+// cloneGlobalFlags returns an independent value/provenance copy of src. The
+// immutable FlagSet and debug writer remain shared across per-profile runs.
 func cloneGlobalFlags(src *globalFlags) *globalFlags {
 	clone := *src
+	if src.sources != nil {
+		clone.sources = make(map[string]valueSource, len(src.sources))
+		for name, source := range src.sources {
+			clone.sources[name] = source
+		}
+	}
 	return &clone
 }
 
 func applyProfileStoreToGlobalFlags(g *globalFlags, s cloudstic.ProfileStore, flagsSet map[string]bool) error {
 	if !flagsSet["store"] && s.URI != "" {
 		g.store = s.URI
+		g.setValueSource("store", valueSourceProfile)
 	}
 	if !flagsSet["s3-endpoint"] && s.S3Endpoint != "" {
 		g.s3Endpoint = s.S3Endpoint
+		g.setValueSource("s3-endpoint", valueSourceProfile)
 	}
 	if !flagsSet["s3-region"] && s.S3Region != "" {
 		g.s3Region = s.S3Region
+		g.setValueSource("s3-region", valueSourceProfile)
 	}
 	if !flagsSet["s3-profile"] {
 		v, err := resolveProfileStoreValue("s3_profile", s.S3Profile, "")
@@ -498,6 +560,9 @@ func applyProfileStoreToGlobalFlags(g *globalFlags, s cloudstic.ProfileStore, fl
 			return err
 		}
 		g.s3Profile = v
+		if v != "" {
+			g.setValueSource("s3-profile", valueSourceProfile)
+		}
 	}
 	if !flagsSet["s3-access-key"] {
 		v, err := resolveProfileStoreValue("s3_access_key", s.S3AccessKey, s.S3AccessKeySecret)
@@ -505,6 +570,9 @@ func applyProfileStoreToGlobalFlags(g *globalFlags, s cloudstic.ProfileStore, fl
 			return err
 		}
 		g.s3AccessKey = v
+		if v != "" {
+			g.setValueSource("s3-access-key", valueSourceProfile)
+		}
 	}
 	if !flagsSet["s3-secret-key"] {
 		v, err := resolveProfileStoreValue("s3_secret_key", s.S3SecretKey, s.S3SecretKeySecret)
@@ -512,6 +580,29 @@ func applyProfileStoreToGlobalFlags(g *globalFlags, s cloudstic.ProfileStore, fl
 			return err
 		}
 		g.s3SecretKey = v
+		if v != "" {
+			g.setValueSource("s3-secret-key", valueSourceProfile)
+		}
+	}
+	if !flagsSet["b2-key-id"] {
+		v, err := resolveProfileStoreValue("b2_key_id", s.B2KeyID, s.B2KeyIDSecret)
+		if err != nil {
+			return err
+		}
+		g.b2KeyID = v
+		if v != "" {
+			g.setValueSource("b2-key-id", valueSourceProfile)
+		}
+	}
+	if !flagsSet["b2-app-key"] {
+		v, err := resolveProfileStoreValue("b2_app_key", s.B2AppKey, s.B2AppKeySecret)
+		if err != nil {
+			return err
+		}
+		g.b2AppKey = v
+		if v != "" {
+			g.setValueSource("b2-app-key", valueSourceProfile)
+		}
 	}
 	if !flagsSet["store-sftp-password"] {
 		v, err := resolveProfileStoreValue("store_sftp_password", s.StoreSFTPPassword, s.StoreSFTPPasswordSecret)
@@ -519,6 +610,9 @@ func applyProfileStoreToGlobalFlags(g *globalFlags, s cloudstic.ProfileStore, fl
 			return err
 		}
 		g.storeSFTPPassword = v
+		if v != "" {
+			g.setValueSource("store-sftp-password", valueSourceProfile)
+		}
 	}
 	if !flagsSet["store-sftp-key"] {
 		v, err := resolveProfileStoreValue("store_sftp_key", s.StoreSFTPKey, s.StoreSFTPKeySecret)
@@ -526,6 +620,9 @@ func applyProfileStoreToGlobalFlags(g *globalFlags, s cloudstic.ProfileStore, fl
 			return err
 		}
 		g.storeSFTPKey = v
+		if v != "" {
+			g.setValueSource("store-sftp-key", valueSourceProfile)
+		}
 	}
 	if !flagsSet["password"] {
 		v, err := resolveProfileStoreValue("password", "", s.PasswordSecret)
@@ -533,6 +630,9 @@ func applyProfileStoreToGlobalFlags(g *globalFlags, s cloudstic.ProfileStore, fl
 			return err
 		}
 		g.password = v
+		if v != "" {
+			g.setValueSource("password", valueSourceProfile)
+		}
 	}
 	if !flagsSet["encryption-key"] {
 		v, err := resolveProfileStoreValue("encryption_key", "", s.EncryptionKeySecret)
@@ -540,6 +640,9 @@ func applyProfileStoreToGlobalFlags(g *globalFlags, s cloudstic.ProfileStore, fl
 			return err
 		}
 		g.encryptionKey = v
+		if v != "" {
+			g.setValueSource("encryption-key", valueSourceProfile)
+		}
 	}
 	if !flagsSet["recovery-key"] {
 		v, err := resolveProfileStoreValue("recovery_key", "", s.RecoveryKeySecret)
@@ -547,15 +650,21 @@ func applyProfileStoreToGlobalFlags(g *globalFlags, s cloudstic.ProfileStore, fl
 			return err
 		}
 		g.recoveryKey = v
+		if v != "" {
+			g.setValueSource("recovery-key", valueSourceProfile)
+		}
 	}
 	if !flagsSet["kms-key-arn"] && s.KMSKeyARN != "" {
 		g.kmsKeyARN = s.KMSKeyARN
+		g.setValueSource("kms-key-arn", valueSourceProfile)
 	}
 	if !flagsSet["kms-region"] && s.KMSRegion != "" {
 		g.kmsRegion = s.KMSRegion
+		g.setValueSource("kms-region", valueSourceProfile)
 	}
 	if !flagsSet["kms-endpoint"] && s.KMSEndpoint != "" {
 		g.kmsEndpoint = s.KMSEndpoint
+		g.setValueSource("kms-endpoint", valueSourceProfile)
 	}
 	return nil
 }

--- a/cmd/cloudstic/cmd_backup_profile_test.go
+++ b/cmd/cloudstic/cmd_backup_profile_test.go
@@ -173,7 +173,7 @@ func TestMergeProfileBackupArgs_CLIAuthRefOverridesProfile(t *testing.T) {
 func newTestGlobalFlags(args ...string) *globalFlags {
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	g := addGlobalFlags(fs)
-	_ = parseFlags(fs, args)
+	_ = parseFlags(fs, args, nil)
 	return g
 }
 
@@ -280,12 +280,14 @@ func TestCloneGlobalFlags_Independence(t *testing.T) {
 	orig.profile = "orig-profile"
 	orig.profilesFile = "/tmp/orig-profiles.yaml"
 	orig.s3Profile = "orig-s3-profile"
+	orig.setValueSource("store", valueSourceEnvironment)
 
 	clone := cloneGlobalFlags(orig)
 	clone.store = "modified-store"
 	clone.profile = "clone-profile"
 	clone.profilesFile = "/tmp/clone-profiles.yaml"
 	clone.s3Profile = "clone-s3-profile"
+	clone.setValueSource("store", valueSourceProfile)
 
 	if orig.store != "original-store" {
 		t.Fatalf("original store=%q want original-store", orig.store)
@@ -301,6 +303,12 @@ func TestCloneGlobalFlags_Independence(t *testing.T) {
 	}
 	if orig.s3Profile != "orig-s3-profile" {
 		t.Fatalf("original s3Profile=%q want orig-s3-profile", orig.s3Profile)
+	}
+	if source := orig.valueSource("store"); source != valueSourceEnvironment {
+		t.Fatalf("original store source=%q want %q", source, valueSourceEnvironment)
+	}
+	if source := clone.valueSource("store"); source != valueSourceProfile {
+		t.Fatalf("clone store source=%q want %q", source, valueSourceProfile)
 	}
 }
 

--- a/cmd/cloudstic/cmd_breaklock.go
+++ b/cmd/cloudstic/cmd_breaklock.go
@@ -13,10 +13,15 @@ type breakLockArgs struct {
 	g *globalFlags
 }
 
+func breakLockCommandSpec() *commandSpec {
+	return leaf("break-lock", "Remove a stale repository lock", "", runBreakLock).withGlobalFlags().withNotes(
+		"Only use this when no other repository operation is running.")
+}
+
 func parseBreakLockArgs(args []string) (*breakLockArgs, error) {
 	fs := flag.NewFlagSet("break-lock", flag.ContinueOnError)
 	a := &breakLockArgs{g: addGlobalFlags(fs)}
-	if err := parseFlags(fs, args); err != nil {
+	if err := parseFlags(fs, args, breakLockCommandSpec()); err != nil {
 		return nil, err
 	}
 	return a, nil

--- a/cmd/cloudstic/cmd_cat.go
+++ b/cmd/cloudstic/cmd_cat.go
@@ -18,12 +18,18 @@ type catArgs struct {
 	raw  bool
 }
 
+func catCommandSpec() *commandSpec {
+	return leaf("cat", "Display raw repository objects", "<object_key> [object_key...]", runCat,
+		boolFlag("raw", "Output raw data")).withGlobalFlags().withNotes(
+		"Object keys include snapshot/, filemeta/, content/, node/, chunk/, config, index/latest, and keys/.")
+}
+
 func parseCatArgs(args []string) (*catArgs, error) {
 	fs := flag.NewFlagSet("cat", flag.ContinueOnError)
 	a := &catArgs{}
 	a.g = addGlobalFlags(fs)
 	rawFlag := fs.Bool("raw", false, "Output raw, unformatted data (useful for hashing)")
-	if err := parseFlags(fs, args); err != nil {
+	if err := parseFlags(fs, args, catCommandSpec()); err != nil {
 		return nil, err
 	}
 	if fs.NArg() < 1 {

--- a/cmd/cloudstic/cmd_check.go
+++ b/cmd/cloudstic/cmd_check.go
@@ -15,12 +15,18 @@ type checkArgs struct {
 	snapshotRef string
 }
 
+func checkCommandSpec() *commandSpec {
+	return leaf("check", "Verify repository integrity", "[snapshot_id]", runCheck,
+		boolFlag("read-data", "Re-hash all chunk data")).withGlobalFlags().withNotes(
+		"Walks the complete snapshot reference chain and reports missing, corrupt, or unreadable objects.")
+}
+
 func parseCheckArgs(args []string) (*checkArgs, error) {
 	fs := flag.NewFlagSet("check", flag.ContinueOnError)
 	a := &checkArgs{}
 	a.g = addGlobalFlags(fs)
 	readData := fs.Bool("read-data", false, "Re-hash all chunk data for full byte-level verification")
-	if err := parseFlags(fs, args); err != nil {
+	if err := parseFlags(fs, args, checkCommandSpec()); err != nil {
 		return nil, err
 	}
 	a.readData = *readData

--- a/cmd/cloudstic/cmd_diff.go
+++ b/cmd/cloudstic/cmd_diff.go
@@ -16,11 +16,16 @@ type diffArgs struct {
 	snap2 string
 }
 
+func diffCommandSpec() *commandSpec {
+	return leaf("diff", "Compare two snapshots", "<snapshot_1> <snapshot_2>", runDiff).withGlobalFlags().withNotes(
+		"Use 'latest' as an alias for the most recent snapshot.")
+}
+
 func parseDiffArgs(args []string) (*diffArgs, error) {
 	fs := flag.NewFlagSet("diff", flag.ContinueOnError)
 	a := &diffArgs{}
 	a.g = addGlobalFlags(fs)
-	if err := parseFlags(fs, args); err != nil {
+	if err := parseFlags(fs, args, diffCommandSpec()); err != nil {
 		return nil, err
 	}
 	if fs.NArg() < 2 {

--- a/cmd/cloudstic/cmd_forget.go
+++ b/cmd/cloudstic/cmd_forget.go
@@ -33,6 +33,16 @@ type forgetArgs struct {
 	hasPolicy     bool
 }
 
+func forgetCommandSpec() *commandSpec {
+	return leaf("forget", "Remove snapshots from history", "[snapshot_id]", runForget,
+		boolFlag("prune", "Prune after forgetting"), boolFlag("dry-run", "Preview without removing"),
+		valueFlag("keep-last", "n", "Keep recent snapshots", completionNone), valueFlag("keep-hourly", "n", "Keep hourly snapshots", completionNone),
+		valueFlag("keep-daily", "n", "Keep daily snapshots", completionNone), valueFlag("keep-weekly", "n", "Keep weekly snapshots", completionNone),
+		valueFlag("keep-monthly", "n", "Keep monthly snapshots", completionNone), valueFlag("keep-yearly", "n", "Keep yearly snapshots", completionNone),
+		valueFlag("tag", "tag", "Filter by tag", completionNone), sourceURIFlag("source", "Filter by source"),
+		valueFlag("account", "id", "Filter by account", completionNone), valueFlag("group-by", "fields", "Grouping fields", completionNone)).withGlobalFlags()
+}
+
 func parseForgetArgs(args []string) (*forgetArgs, error) {
 	fs := flag.NewFlagSet("forget", flag.ContinueOnError)
 	a := &forgetArgs{}
@@ -49,7 +59,7 @@ func parseForgetArgs(args []string) (*forgetArgs, error) {
 	filterSource := fs.String("source", "", "Filter by source URI (e.g. local:./docs, gdrive)")
 	filterAccount := fs.String("account", "", "Filter by account")
 	groupBy := fs.String("group-by", "source,account,path", "Group snapshots by fields (comma-separated)")
-	if err := parseFlags(fs, args); err != nil {
+	if err := parseFlags(fs, args, forgetCommandSpec()); err != nil {
 		return nil, err
 	}
 	fs.Visit(func(f *flag.Flag) {

--- a/cmd/cloudstic/cmd_init.go
+++ b/cmd/cloudstic/cmd_init.go
@@ -20,6 +20,13 @@ type initArgs struct {
 	adoptSlots   bool
 }
 
+func initCommandSpec() *commandSpec {
+	return leaf("init", "Initialize a new repository", "", runInit,
+		boolFlag("add-recovery-key", "Generate a 24-word recovery key"),
+		boolFlag("no-encryption", "Create an unencrypted repository"),
+		boolFlag("adopt-slots", "Adopt existing key slots")).withGlobalFlags()
+}
+
 func parseInitArgs(args []string) (*initArgs, error) {
 	fs := flag.NewFlagSet("init", flag.ContinueOnError)
 	a := &initArgs{}
@@ -27,7 +34,7 @@ func parseInitArgs(args []string) (*initArgs, error) {
 	recovery := fs.Bool("add-recovery-key", false, "Generate a recovery key (24-word seed phrase) during init")
 	noEncryption := fs.Bool("no-encryption", false, "Create an unencrypted repository (NOT recommended)")
 	adoptSlots := fs.Bool("adopt-slots", false, "Initialize by adopting existing key slots if found (prevents error if already has slots)")
-	if err := parseFlags(fs, args); err != nil {
+	if err := parseFlags(fs, args, initCommandSpec()); err != nil {
 		return nil, err
 	}
 	a.recovery = *recovery

--- a/cmd/cloudstic/cmd_key.go
+++ b/cmd/cloudstic/cmd_key.go
@@ -14,30 +14,24 @@ import (
 	"github.com/moby/term"
 )
 
-func runKey(r *runner, ctx context.Context) int {
-	if len(r.args) < 1 {
-		_, _ = fmt.Fprintln(r.errOut, "Usage: cloudstic key <subcommand>")
-		_, _ = fmt.Fprintln(r.errOut)
-		_, _ = fmt.Fprintln(r.errOut, "Subcommands:")
-		_, _ = fmt.Fprintln(r.errOut, "  list           List all encryption key slots in the repository")
-		_, _ = fmt.Fprintln(r.errOut, "  add-recovery   Generate a 24-word recovery key")
-		_, _ = fmt.Fprintln(r.errOut, "  passwd         Change the repository password")
-		return 1
-	}
+func keyCommandSpec() *commandSpec {
+	return group("key", "Manage encryption key slots",
+		keyListCommandSpec(), keyAddRecoveryCommandSpec(), keyPasswdCommandSpec())
+}
 
-	sub := r.args[0]
-	subRunner := r.withArgs(r.args[1:])
+func keyListCommandSpec() *commandSpec {
+	return leaf("list", "List encryption key slots", "", runKeyList).withGlobalFlags()
+}
 
-	switch sub {
-	case "list":
-		return runKeyList(subRunner, ctx)
-	case "add-recovery":
-		return runAddRecoveryKey(subRunner, ctx)
-	case "passwd":
-		return runKeyPasswd(subRunner, ctx)
-	default:
-		return r.fail("Unknown key subcommand: %s", sub)
-	}
+func keyAddRecoveryCommandSpec() *commandSpec {
+	return leaf("add-recovery", "Generate a 24-word recovery key", "", runAddRecoveryKey).withGlobalFlags().withNotes(
+		"Requires repository unlock credentials and prints a new 24-word recovery key.")
+}
+
+func keyPasswdCommandSpec() *commandSpec {
+	return leaf("passwd", "Change the repository password", "", runKeyPasswd,
+		valueFlag("new-password", "password", "New repository password", completionNone)).withGlobalFlags().withNotes(
+		"Current repository credentials are required to replace the password slot.")
 }
 
 type keyListArgs struct {
@@ -47,7 +41,7 @@ type keyListArgs struct {
 func parseKeyListArgs(args []string) (*keyListArgs, error) {
 	fs := flag.NewFlagSet("key list", flag.ContinueOnError)
 	a := &keyListArgs{g: addGlobalFlags(fs)}
-	if err := parseFlags(fs, args); err != nil {
+	if err := parseFlags(fs, args, keyListCommandSpec()); err != nil {
 		return nil, err
 	}
 	return a, nil
@@ -105,7 +99,7 @@ func parseKeyPasswdArgs(args []string) (*keyPasswdArgs, error) {
 	a := &keyPasswdArgs{}
 	a.g = addGlobalFlags(fs)
 	newPassword := fs.String("new-password", "", "New repository password (prompted interactively if not set)")
-	if err := parseFlags(fs, args); err != nil {
+	if err := parseFlags(fs, args, keyPasswdCommandSpec()); err != nil {
 		return nil, err
 	}
 	a.newPassword = *newPassword
@@ -161,7 +155,7 @@ type addRecoveryKeyArgs struct {
 func parseAddRecoveryKeyArgs(args []string) (*addRecoveryKeyArgs, error) {
 	fs := flag.NewFlagSet("add-recovery-key", flag.ContinueOnError)
 	a := &addRecoveryKeyArgs{g: addGlobalFlags(fs)}
-	if err := parseFlags(fs, args); err != nil {
+	if err := parseFlags(fs, args, keyAddRecoveryCommandSpec()); err != nil {
 		return nil, err
 	}
 	return a, nil

--- a/cmd/cloudstic/cmd_list.go
+++ b/cmd/cloudstic/cmd_list.go
@@ -14,13 +14,18 @@ type listArgs struct {
 	group *bool
 }
 
+func listCommandSpec() *commandSpec {
+	return leaf("list", "List all backup snapshots", "", runList,
+		boolFlag("group", "Group snapshots by source identity")).withGlobalFlags()
+}
+
 func parseListArgs(args []string) (*listArgs, error) {
 	fs := flag.NewFlagSet("list", flag.ContinueOnError)
 	a := &listArgs{
 		g:     addGlobalFlags(fs),
 		group: fs.Bool("group", false, "Group snapshots by source identity"),
 	}
-	if err := parseFlags(fs, args); err != nil {
+	if err := parseFlags(fs, args, listCommandSpec()); err != nil {
 		return nil, err
 	}
 	return a, nil

--- a/cmd/cloudstic/cmd_ls.go
+++ b/cmd/cloudstic/cmd_ls.go
@@ -19,11 +19,16 @@ type lsArgs struct {
 	snapshotID string
 }
 
+func lsCommandSpec() *commandSpec {
+	return leaf("ls", "List files within a snapshot", "[snapshot_id]", runLsSnapshot).withGlobalFlags().withNotes(
+		"Defaults to the latest snapshot.")
+}
+
 func parseLsArgs(args []string) (*lsArgs, error) {
 	fs := flag.NewFlagSet("ls", flag.ContinueOnError)
 	a := &lsArgs{}
 	a.g = addGlobalFlags(fs)
-	if err := parseFlags(fs, args); err != nil {
+	if err := parseFlags(fs, args, lsCommandSpec()); err != nil {
 		return nil, err
 	}
 	a.snapshotID = "latest"

--- a/cmd/cloudstic/cmd_profile.go
+++ b/cmd/cloudstic/cmd_profile.go
@@ -24,26 +24,31 @@ func defaultProfilesPath() (string, error) {
 	return filepath.Join(configDir, defaultProfilesFilename), nil
 }
 
-func runProfile(r *runner, ctx context.Context) int {
-	if len(r.args) < 1 {
-		_, _ = fmt.Fprintln(r.errOut, "Usage: cloudstic profile <subcommand> [options]")
-		_, _ = fmt.Fprintln(r.errOut, "")
-		_, _ = fmt.Fprintln(r.errOut, "Available subcommands: list, show, new")
-		return 1
-	}
+func profileCommandSpec() *commandSpec {
+	return group("profile", "Manage backup profiles",
+		profileNewCommandSpec(), profileListCommandSpec(), profileShowCommandSpec())
+}
 
-	subcommand := r.args[0]
-	subRunner := r.withArgs(r.args[1:])
-	switch subcommand {
-	case "list":
-		return runProfileList(subRunner, ctx)
-	case "show":
-		return runProfileShow(subRunner, ctx)
-	case "new":
-		return runProfileNew(subRunner, ctx)
-	default:
-		return r.fail("Unknown profile subcommand: %s", subcommand)
-	}
+func profileNewCommandSpec() *commandSpec {
+	return leaf("new", "Create or update a backup profile", "", runProfileNew,
+		profilesFileFlag(), valueFlag("name", "name", "Profile name", completionNone), sourceFlag(),
+		valueFlag("store-ref", "name", "Store reference", completionNone), storeFlag(),
+		valueFlag("auth-ref", "name", "Auth reference", completionAuth), valueFlag("tag", "tag", "Snapshot tag", completionNone),
+		valueFlag("exclude", "pattern", "Exclude pattern", completionNone), valueFlag("exclude-file", "path", "Exclude-pattern file", completionFile),
+		boolFlag("ignore-empty-snapshot", "Skip unchanged snapshots"), boolFlag("skip-native-files", "Exclude cloud-native files"),
+		volumeUUIDFlag(), googleCredentialsFlag(), valueFlag("google-credentials-ref", "ref", "Google credentials reference", completionNone),
+		googleCredentialsJSONFlag(), googleTokenFileFlag(), valueFlag("google-token-ref", "ref", "Google token reference", completionNone),
+		onedriveClientIDFlag(), onedriveTokenFileFlag(), valueFlag("onedrive-token-ref", "ref", "OneDrive token reference", completionNone)).withNotes(
+		"Use -store-ref to select an existing store; add -store to create or update it.",
+		"Use -auth-ref to reuse cloud OAuth settings across profiles.")
+}
+
+func profileListCommandSpec() *commandSpec {
+	return leaf("list", "List stores, auth entries, and backup profiles", "", runProfileList, profilesFileFlag())
+}
+
+func profileShowCommandSpec() *commandSpec {
+	return leaf("show", "Show one profile and resolved references", "<name>", runProfileShow, profilesFileFlag())
 }
 
 type profileShowArgs struct {
@@ -58,8 +63,8 @@ func parseProfileShowArgs(args []string) (*profileShowArgs, error) {
 	if err != nil {
 		defaultPath = defaultProfilesFilename
 	}
-	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultPath), "Path to profiles YAML file")
-	if err := parseFlags(fs, args); err != nil {
+	profilesFile := fs.String("profiles-file", defaultPath, "Path to profiles YAML file")
+	if err := parseFlags(fs, args, profileShowCommandSpec()); err != nil {
 		return nil, err
 	}
 	a.profilesFile = *profilesFile
@@ -124,8 +129,8 @@ func parseProfileListArgs(args []string) (*profileListArgs, error) {
 	if err != nil {
 		defaultPath = defaultProfilesFilename
 	}
-	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultPath), "Path to profiles YAML file")
-	if err := parseFlags(fs, args); err != nil {
+	profilesFile := fs.String("profiles-file", defaultPath, "Path to profiles YAML file")
+	if err := parseFlags(fs, args, profileListCommandSpec()); err != nil {
 		return nil, err
 	}
 	a.profilesFile = *profilesFile
@@ -179,13 +184,14 @@ type profileNewArgs struct {
 }
 
 func parseProfileNewArgs(args []string) (*profileNewArgs, error) {
+	command := profileNewCommandSpec()
 	fs := flag.NewFlagSet("profile new", flag.ContinueOnError)
 	a := &profileNewArgs{}
 	defaultPath, err := defaultProfilesPath()
 	if err != nil {
 		defaultPath = defaultProfilesFilename
 	}
-	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultPath), "Path to profiles YAML file")
+	profilesFile := fs.String("profiles-file", defaultPath, "Path to profiles YAML file")
 	name := fs.String("name", "", "Profile name")
 	source := fs.String("source", "", "Source URI")
 	storeRef := fs.String("store-ref", "", "Store reference name from top-level stores map")
@@ -205,12 +211,11 @@ func parseProfileNewArgs(args []string) (*profileNewArgs, error) {
 	onedriveTokenRef := fs.String("onedrive-token-ref", "", "Secret reference to OneDrive OAuth token")
 	fs.Var(&a.tags, "tag", "Tag to apply to snapshots (repeatable)")
 	fs.Var(&a.excludes, "exclude", "Exclude pattern (repeatable)")
-	if err := parseFlags(fs, args); err != nil {
+	if err := parseFlags(fs, args, command); err != nil {
 		return nil, err
 	}
 
-	a.flagsSet = map[string]bool{}
-	fs.Visit(func(f *flag.Flag) { a.flagsSet[f.Name] = true })
+	a.flagsSet = suppliedFlags(commandValueSources(fs, command))
 
 	a.profilesFile = *profilesFile
 	a.name = *name

--- a/cmd/cloudstic/cmd_prune.go
+++ b/cmd/cloudstic/cmd_prune.go
@@ -15,12 +15,17 @@ type pruneArgs struct {
 	dryRun bool
 }
 
+func pruneCommandSpec() *commandSpec {
+	return leaf("prune", "Remove unused data chunks", "", runPrune,
+		boolFlag("dry-run", "Preview without deleting")).withGlobalFlags()
+}
+
 func parsePruneArgs(args []string) (*pruneArgs, error) {
 	fs := flag.NewFlagSet("prune", flag.ContinueOnError)
 	a := &pruneArgs{}
 	a.g = addGlobalFlags(fs)
 	dryRun := fs.Bool("dry-run", false, "Show what would be deleted without deleting")
-	if err := parseFlags(fs, args); err != nil {
+	if err := parseFlags(fs, args, pruneCommandSpec()); err != nil {
 		return nil, err
 	}
 	a.dryRun = *dryRun

--- a/cmd/cloudstic/cmd_restore.go
+++ b/cmd/cloudstic/cmd_restore.go
@@ -21,6 +21,14 @@ type restoreArgs struct {
 	snapshotRef string
 }
 
+func restoreCommandSpec() *commandSpec {
+	return leaf("restore", "Restore files from a backup snapshot", "[snapshot_id]", runRestore,
+		valueFlag("output", "path", "Restore output path", completionFile),
+		valueFlag("format", "format", "Restore format", completionNone).withCompletionValues("zip", "dir"),
+		valueFlag("path", "path", "File or subtree to restore", completionNone),
+		boolFlag("dry-run", "Preview without writing output")).withGlobalFlags()
+}
+
 func parseRestoreArgs(args []string) (*restoreArgs, error) {
 	fs := flag.NewFlagSet("restore", flag.ContinueOnError)
 	a := &restoreArgs{}
@@ -29,7 +37,7 @@ func parseRestoreArgs(args []string) (*restoreArgs, error) {
 	format := fs.String("format", "", "Restore format: zip or dir (default: auto from -output)")
 	dryRun := fs.Bool("dry-run", false, "Show what would be restored without writing output")
 	pathFilter := fs.String("path", "", "Restore only the given file or subtree (e.g. Documents/report.pdf or Documents/)")
-	if err := parseFlags(fs, args); err != nil {
+	if err := parseFlags(fs, args, restoreCommandSpec()); err != nil {
 		return nil, err
 	}
 	a.output = *output

--- a/cmd/cloudstic/cmd_setup.go
+++ b/cmd/cloudstic/cmd_setup.go
@@ -17,10 +17,7 @@ import (
 var planWorkstationSetup = cloudstic.PlanWorkstationSetup
 
 func defaultProfilesPathNoCreate() string {
-	if path := os.Getenv("CLOUDSTIC_PROFILES_FILE"); path != "" {
-		return path
-	}
-	if dir := os.Getenv("CLOUDSTIC_CONFIG_DIR"); dir != "" {
+	if dir, ok := nonEmptyEnvironment("CLOUDSTIC_CONFIG_DIR"); ok {
 		return filepath.Join(dir, defaultProfilesFilename)
 	}
 	if dir, err := os.UserConfigDir(); err == nil {
@@ -29,22 +26,15 @@ func defaultProfilesPathNoCreate() string {
 	return defaultProfilesFilename
 }
 
-func runSetup(r *runner, ctx context.Context) int {
-	if len(r.args) < 1 {
-		_, _ = fmt.Fprintln(r.errOut, "Usage: cloudstic setup <subcommand> [options]")
-		_, _ = fmt.Fprintln(r.errOut, "")
-		_, _ = fmt.Fprintln(r.errOut, "Available subcommands: workstation")
-		return 1
-	}
+func setupCommandSpec() *commandSpec {
+	return group("setup", "Guided setup and onboarding flows", setupWorkstationCommandSpec())
+}
 
-	subcommand := r.args[0]
-	subRunner := r.withArgs(r.args[1:])
-	switch subcommand {
-	case "workstation":
-		return runSetupWorkstation(subRunner, ctx)
-	default:
-		return r.fail("Unknown setup subcommand: %s", subcommand)
-	}
+func setupWorkstationCommandSpec() *commandSpec {
+	return leaf("workstation", "Guide workstation onboarding and profile setup", "", runSetupWorkstation,
+		boolFlag("dry-run", "Preview without writing configuration"), boolFlag("yes", "Accept defaults without prompting"),
+		boolFlag("json", "Write onboarding plan as JSON"), profilesFileFlag(),
+		valueFlag("store-ref", "name", "Store reference to attach", completionNone))
 }
 
 type setupWorkstationArgs struct {
@@ -63,7 +53,7 @@ func parseSetupWorkstationArgs(args []string) (*setupWorkstationArgs, error) {
 	jsonOutput := fs.Bool("json", false, "Write onboarding plan as JSON")
 	profilesFile := fs.String("profiles-file", defaultProfilesPathNoCreate(), "Path to profiles YAML file")
 	storeRef := fs.String("store-ref", "", "Existing store reference to attach to generated profiles")
-	if err := parseFlags(fs, args); err != nil {
+	if err := parseFlags(fs, args, setupWorkstationCommandSpec()); err != nil {
 		return nil, err
 	}
 	a.dryRun = *dryRun

--- a/cmd/cloudstic/cmd_source.go
+++ b/cmd/cloudstic/cmd_source.go
@@ -9,29 +9,21 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 )
 
-func runSource(r *runner, ctx context.Context) int {
-	if len(r.args) < 1 {
-		_, _ = fmt.Fprintln(r.errOut, "Usage: cloudstic source <subcommand> [options]")
-		_, _ = fmt.Fprintln(r.errOut, "")
-		_, _ = fmt.Fprintln(r.errOut, "Available subcommands: discover")
-		return 1
-	}
+func sourceCommandSpec() *commandSpec {
+	return group("source", "Discover source candidates for onboarding", sourceDiscoverCommandSpec())
+}
 
-	subcommand := r.args[0]
-	subRunner := r.withArgs(r.args[1:])
-	switch subcommand {
-	case "discover":
-		return runSourceDiscover(subRunner, ctx)
-	default:
-		return r.fail("Unknown source subcommand: %s", subcommand)
-	}
+func sourceDiscoverCommandSpec() *commandSpec {
+	return leaf("discover", "Discover local source candidates", "", runSourceDiscover,
+		boolFlag("portable-only", "Only show portable source candidates"),
+		boolFlag("json", "Write sources as JSON"))
 }
 
 func runSourceDiscover(r *runner, ctx context.Context) int {
 	fs := flag.NewFlagSet("source discover", flag.ContinueOnError)
 	portableOnly := fs.Bool("portable-only", false, "Only show portable/external source candidates")
 	jsonOutput := fs.Bool("json", false, "Write discovered sources as JSON")
-	if err := parseFlags(fs, r.args); err != nil {
+	if err := parseFlags(fs, r.args, sourceDiscoverCommandSpec()); err != nil {
 		return r.parseError(err)
 	}
 

--- a/cmd/cloudstic/cmd_store.go
+++ b/cmd/cloudstic/cmd_store.go
@@ -15,36 +15,50 @@ import (
 	"github.com/cloudstic/cli/pkg/store"
 )
 
-func runStore(r *runner, ctx context.Context) int {
-	if len(r.args) < 1 {
-		_, _ = fmt.Fprintln(r.errOut, "Usage: cloudstic store <subcommand> [options]")
-		_, _ = fmt.Fprintln(r.errOut, "")
-		_, _ = fmt.Fprintln(r.errOut, "Available subcommands: list, show, new, verify, init")
-		return 1
-	}
+func storeCommandSpec() *commandSpec {
+	return group("store", "Manage backup stores",
+		storeNewCommandSpec(), storeListCommandSpec(), storeShowCommandSpec(), storeVerifyCommandSpec(), storeInitCommandSpec())
+}
 
-	subcommand := r.args[0]
-	subRunner := r.withArgs(r.args[1:])
-	switch subcommand {
-	case "list":
-		return runStoreList(subRunner, ctx)
-	case "show":
-		return runStoreShow(subRunner, ctx)
-	case "new":
-		return runStoreNew(subRunner, ctx)
-	case "verify":
-		return runStoreVerify(subRunner, ctx)
-	case "init":
-		return runStoreInit(subRunner, ctx)
-	default:
-		return r.fail("Unknown store subcommand: %s", subcommand)
-	}
+func storeNewCommandSpec() *commandSpec {
+	return leaf("new", "Create or update a store entry", "", runStoreNew,
+		profilesFileFlag(), valueFlag("name", "name", "Store reference name", completionNone),
+		storeURIFlag("uri", "Store URI"), valueFlag("s3-region", "region", "S3 region", completionNone),
+		valueFlag("s3-profile", "name", "AWS profile", completionNone), valueFlag("s3-endpoint", "url", "S3 endpoint", completionNone),
+		valueFlag("s3-access-key", "key", "S3 access key", completionNone), valueFlag("s3-secret-key", "secret", "S3 secret key", completionNone),
+		valueFlag("s3-access-key-secret", "ref", "S3 access-key reference", completionNone), valueFlag("s3-secret-key-secret", "ref", "S3 secret-key reference", completionNone),
+		valueFlag("b2-key-id", "key", "B2 key ID", completionNone), valueFlag("b2-app-key", "key", "B2 application key", completionNone),
+		valueFlag("b2-key-id-secret", "ref", "B2 key-ID reference", completionNone), valueFlag("b2-app-key-secret", "ref", "B2 application-key reference", completionNone),
+		valueFlag("store-sftp-password", "password", "SFTP password", completionNone), valueFlag("store-sftp-key", "path", "SFTP private key", completionFile),
+		valueFlag("store-sftp-password-secret", "ref", "SFTP password reference", completionNone), valueFlag("store-sftp-key-secret", "ref", "SFTP key reference", completionNone),
+		valueFlag("password-secret", "ref", "Repository-password reference", completionNone), valueFlag("encryption-key-secret", "ref", "Encryption-key reference", completionNone),
+		valueFlag("recovery-key-secret", "ref", "Recovery-key reference", completionNone), valueFlag("kms-key-arn", "arn", "AWS KMS key ARN", completionNone),
+		valueFlag("kms-region", "region", "AWS KMS region", completionNone), valueFlag("kms-endpoint", "url", "AWS KMS endpoint", completionNone)).withNotes(
+		"Create or update a store entry in profiles.yaml.",
+		"Prefer secret-reference flags for credentials; KMS settings are stored directly.")
+}
+
+func storeListCommandSpec() *commandSpec {
+	return leaf("list", "List configured stores", "", runStoreList, profilesFileFlag())
+}
+
+func storeShowCommandSpec() *commandSpec {
+	return leaf("show", "Show one store and its configuration", "<name>", runStoreShow, profilesFileFlag())
+}
+
+func storeVerifyCommandSpec() *commandSpec {
+	return leaf("verify", "Verify one store's credentials and connectivity", "<name>", runStoreVerify, profilesFileFlag())
+}
+
+func storeInitCommandSpec() *commandSpec {
+	return leaf("init", "Initialize a configured store", "<name>", runStoreInit,
+		profilesFileFlag(), boolFlag("yes", "Initialize without confirmation"))
 }
 
 func runStoreList(r *runner, ctx context.Context) int {
 	fs := flag.NewFlagSet("store list", flag.ContinueOnError)
-	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
-	if err := parseFlags(fs, r.args); err != nil {
+	profilesFile := fs.String("profiles-file", defaultProfilesPathFallback(), "Path to profiles YAML file")
+	if err := parseFlags(fs, r.args, storeListCommandSpec()); err != nil {
 		return r.parseError(err)
 	}
 
@@ -62,8 +76,8 @@ func runStoreList(r *runner, ctx context.Context) int {
 
 func runStoreShow(r *runner, ctx context.Context) int {
 	fs := flag.NewFlagSet("store show", flag.ContinueOnError)
-	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
-	if err := parseFlags(fs, r.args); err != nil {
+	profilesFile := fs.String("profiles-file", defaultProfilesPathFallback(), "Path to profiles YAML file")
+	if err := parseFlags(fs, r.args, storeShowCommandSpec()); err != nil {
 		return r.parseError(err)
 	}
 	if fs.NArg() > 1 {
@@ -100,8 +114,9 @@ func runStoreShow(r *runner, ctx context.Context) int {
 }
 
 func runStoreNew(r *runner, ctx context.Context) int {
+	command := storeNewCommandSpec()
 	fs := flag.NewFlagSet("store new", flag.ContinueOnError)
-	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
+	profilesFile := fs.String("profiles-file", defaultProfilesPathFallback(), "Path to profiles YAML file")
 	name := fs.String("name", "", "Store reference name")
 	uri := fs.String("uri", "", "Store URI (e.g. s3:bucket/path, local:/path, sftp://host/path)")
 	s3Region := fs.String("s3-region", "", "S3 region")
@@ -111,6 +126,10 @@ func runStoreNew(r *runner, ctx context.Context) int {
 	s3SecretKey := fs.String("s3-secret-key", "", "S3 static secret key")
 	s3AccessKeySecret := fs.String("s3-access-key-secret", "", "Secret reference for S3 access key (e.g. env://..., keychain://...)")
 	s3SecretKeySecret := fs.String("s3-secret-key-secret", "", "Secret reference for S3 secret key (e.g. env://..., keychain://...)")
+	b2KeyID := fs.String("b2-key-id", "", "Backblaze B2 application key ID")
+	b2AppKey := fs.String("b2-app-key", "", "Backblaze B2 application key")
+	b2KeyIDSecret := fs.String("b2-key-id-secret", "", "Secret reference for B2 key ID (e.g. env://..., keychain://...)")
+	b2AppKeySecret := fs.String("b2-app-key-secret", "", "Secret reference for B2 application key (e.g. env://..., keychain://...)")
 	sftpPassword := fs.String("store-sftp-password", "", "SFTP password")
 	sftpKey := fs.String("store-sftp-key", "", "Path to SFTP private key")
 	sftpPasswordSecret := fs.String("store-sftp-password-secret", "", "Secret reference for SFTP password (e.g. env://..., keychain://...)")
@@ -121,12 +140,11 @@ func runStoreNew(r *runner, ctx context.Context) int {
 	kmsKeyARN := fs.String("kms-key-arn", "", "AWS KMS key ARN")
 	kmsRegion := fs.String("kms-region", "", "AWS KMS region")
 	kmsEndpoint := fs.String("kms-endpoint", "", "Custom AWS KMS endpoint URL")
-	if err := parseFlags(fs, r.args); err != nil {
+	if err := parseFlags(fs, r.args, command); err != nil {
 		return r.parseError(err)
 	}
 
-	flagsSet := map[string]bool{}
-	fs.Visit(func(f *flag.Flag) { flagsSet[f.Name] = true })
+	flagsSet := suppliedFlags(commandValueSources(fs, command))
 	storeFlags := storeNewFlagPtrs{
 		uri:                 uri,
 		s3Region:            s3Region,
@@ -136,6 +154,10 @@ func runStoreNew(r *runner, ctx context.Context) int {
 		s3SecretKey:         s3SecretKey,
 		s3AccessKeySecret:   s3AccessKeySecret,
 		s3SecretKeySecret:   s3SecretKeySecret,
+		b2KeyID:             b2KeyID,
+		b2AppKey:            b2AppKey,
+		b2KeyIDSecret:       b2KeyIDSecret,
+		b2AppKeySecret:      b2AppKeySecret,
 		sftpPassword:        sftpPassword,
 		sftpKey:             sftpKey,
 		sftpPasswordSecret:  sftpPasswordSecret,
@@ -249,8 +271,8 @@ func runStoreNew(r *runner, ctx context.Context) int {
 // the store config has already been saved.
 func runStoreVerify(r *runner, ctx context.Context) int {
 	fs := flag.NewFlagSet("store verify", flag.ContinueOnError)
-	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
-	if err := parseFlags(fs, r.args); err != nil {
+	profilesFile := fs.String("profiles-file", defaultProfilesPathFallback(), "Path to profiles YAML file")
+	if err := parseFlags(fs, r.args, storeVerifyCommandSpec()); err != nil {
 		return r.parseError(err)
 	}
 	if fs.NArg() > 1 {
@@ -295,9 +317,9 @@ func runStoreVerify(r *runner, ctx context.Context) int {
 
 func runStoreInit(r *runner, ctx context.Context) int {
 	fs := flag.NewFlagSet("store init", flag.ContinueOnError)
-	profilesFile := fs.String("profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback()), "Path to profiles YAML file")
+	profilesFile := fs.String("profiles-file", defaultProfilesPathFallback(), "Path to profiles YAML file")
 	yes := fs.Bool("yes", false, "Initialize without confirmation prompt")
-	if err := parseFlags(fs, r.args); err != nil {
+	if err := parseFlags(fs, r.args, storeInitCommandSpec()); err != nil {
 		return r.parseError(err)
 	}
 	if fs.NArg() > 1 {
@@ -757,6 +779,12 @@ func globalFlagsFromProfileStore(s cloudstic.ProfileStore) (*globalFlags, error)
 		return nil, err
 	}
 	if g.s3SecretKey, err = resolveProfileStoreValue("s3_secret_key", s.S3SecretKey, s.S3SecretKeySecret); err != nil {
+		return nil, err
+	}
+	if g.b2KeyID, err = resolveProfileStoreValue("b2_key_id", s.B2KeyID, s.B2KeyIDSecret); err != nil {
+		return nil, err
+	}
+	if g.b2AppKey, err = resolveProfileStoreValue("b2_app_key", s.B2AppKey, s.B2AppKeySecret); err != nil {
 		return nil, err
 	}
 	if g.storeSFTPPassword, err = resolveProfileStoreValue("store_sftp_password", s.StoreSFTPPassword, s.StoreSFTPPasswordSecret); err != nil {

--- a/cmd/cloudstic/cmd_tui.go
+++ b/cmd/cloudstic/cmd_tui.go
@@ -12,12 +12,23 @@ type tuiArgs struct {
 	profilesFile string
 }
 
+func tuiCommandSpec() *commandSpec {
+	command := leaf("tui", "Launch the interactive terminal dashboard", "", runTUI, profilesFileFlag())
+	command.flagProbe = probeTUIFlags
+	return command
+}
+
+func probeTUIFlags(r *runner, _ context.Context) int {
+	_, _ = parseTUIArgs(r.args)
+	return 0
+}
+
 func parseTUIArgs(args []string) (*tuiArgs, error) {
 	fs := flag.NewFlagSet("tui", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	a := &tuiArgs{}
 	fs.StringVar(&a.profilesFile, "profiles-file", defaultProfilesPathNoCreate(), "Path to profiles YAML file")
-	if err := parseFlags(fs, args); err != nil {
+	if err := parseFlags(fs, args, tuiCommandSpec()); err != nil {
 		return nil, err
 	}
 	return a, nil

--- a/cmd/cloudstic/cmd_tui_store_form.go
+++ b/cmd/cloudstic/cmd_tui_store_form.go
@@ -196,6 +196,8 @@ func newTUIStoreModal(profilesFile, existingName string, editing bool) (*tuiStor
 				{Key: "s3_endpoint", Label: "S3 Endpoint", Kind: tui.ModalFieldText, Value: existing.S3Endpoint},
 				{Key: "s3_access_key_secret", Label: "Access Key Ref", Kind: tui.ModalFieldText, Value: existing.S3AccessKeySecret},
 				{Key: "s3_secret_key_secret", Label: "Secret Key Ref", Kind: tui.ModalFieldText, Value: existing.S3SecretKeySecret},
+				{Key: "b2_key_id_secret", Label: "B2 Key ID Ref", Kind: tui.ModalFieldText, Value: existing.B2KeyIDSecret},
+				{Key: "b2_app_key_secret", Label: "B2 App Key Ref", Kind: tui.ModalFieldText, Value: existing.B2AppKeySecret},
 				{Key: "sftp_password_secret", Label: "Password Ref", Kind: tui.ModalFieldText, Value: existing.StoreSFTPPasswordSecret},
 				{Key: "sftp_key_secret", Label: "Key Ref", Kind: tui.ModalFieldText, Value: existing.StoreSFTPKeySecret},
 				{Key: "encryption_mode", Label: "Encryption", Kind: tui.ModalFieldSelect, Value: string(encryptionMode), Options: append([]string{}, tuiStoreEncryptionOptions...), Required: true},
@@ -378,25 +380,41 @@ func (m *tuiStoreModal) submit() (string, error) {
 func (m *tuiStoreModal) applyConnectionFields(store *cloudstic.ProfileStore) {
 	storeType := m.currentStore().Type
 	switch storeType {
-	case "s3", "b2":
+	case "s3":
 		store.S3Region = m.textFieldValue("s3_region")
 		store.S3Profile = m.textFieldValue("s3_profile")
 		store.S3Endpoint = m.textFieldValue("s3_endpoint")
 		store.S3AccessKeySecret = m.textFieldValue("s3_access_key_secret")
 		store.S3SecretKeySecret = m.textFieldValue("s3_secret_key_secret")
+		store.B2KeyIDSecret = ""
+		store.B2AppKeySecret = ""
+	case "b2":
+		store.S3Region = ""
+		store.S3Profile = ""
+		store.S3Endpoint = ""
+		store.S3AccessKeySecret = ""
+		store.S3SecretKeySecret = ""
+		store.B2KeyIDSecret = m.textFieldValue("b2_key_id_secret")
+		store.B2AppKeySecret = m.textFieldValue("b2_app_key_secret")
 	case "local":
 		store.S3Region = ""
 		store.S3Profile = ""
 		store.S3Endpoint = ""
 		store.S3AccessKeySecret = ""
 		store.S3SecretKeySecret = ""
+		store.B2KeyIDSecret = ""
+		store.B2AppKeySecret = ""
 	}
-	if storeType != "s3" && storeType != "b2" {
+	if storeType != "s3" {
 		store.S3Region = ""
 		store.S3Profile = ""
 		store.S3Endpoint = ""
 		store.S3AccessKeySecret = ""
 		store.S3SecretKeySecret = ""
+	}
+	if storeType != "b2" {
+		store.B2KeyIDSecret = ""
+		store.B2AppKeySecret = ""
 	}
 	if storeType == "sftp" {
 		store.StoreSFTPPasswordSecret = m.textFieldValue("sftp_password_secret")
@@ -421,6 +439,8 @@ func (m *tuiStoreModal) applyEncryptionFields(store *cloudstic.ProfileStore) err
 	}{
 		{key: "s3_access_key_secret", value: m.textFieldValue("s3_access_key_secret")},
 		{key: "s3_secret_key_secret", value: m.textFieldValue("s3_secret_key_secret")},
+		{key: "b2_key_id_secret", value: m.textFieldValue("b2_key_id_secret")},
+		{key: "b2_app_key_secret", value: m.textFieldValue("b2_app_key_secret")},
 		{key: "sftp_password_secret", value: m.textFieldValue("sftp_password_secret")},
 		{key: "sftp_key_secret", value: m.textFieldValue("sftp_key_secret")},
 		{key: "password_secret", value: passwordRef},
@@ -501,11 +521,19 @@ func (m *tuiStoreModal) updateStoreFieldMetadata() {
 func (m *tuiStoreModal) updateConnectionFields() {
 	storeType := m.currentStore().Type
 	s3Fields := []string{"s3_region", "s3_profile", "s3_endpoint", "s3_access_key_secret", "s3_secret_key_secret"}
+	b2Fields := []string{"b2_key_id_secret", "b2_app_key_secret"}
 	sftpFields := []string{"sftp_password_secret", "sftp_key_secret"}
-	enableS3 := storeType == "s3" || storeType == "b2"
+	enableS3 := storeType == "s3"
 	for _, key := range s3Fields {
 		if field := m.fieldByKey(key); field != nil {
 			field.Disabled = !enableS3
+			field.Required = false
+		}
+	}
+	enableB2 := storeType == "b2"
+	for _, key := range b2Fields {
+		if field := m.fieldByKey(key); field != nil {
+			field.Disabled = !enableB2
 			field.Required = false
 		}
 	}
@@ -600,7 +628,7 @@ func storeFieldHelp(selectedField string, store tuiStoreConfig, mode tuiStoreEnc
 			return nil
 		}
 		return []string{fmt.Sprintf("%s%s%s", ui.Dim, example, ui.Reset)}
-	case "s3_access_key_secret", "s3_secret_key_secret", "sftp_password_secret", "sftp_key_secret", "password_secret", "encryption_key_secret":
+	case "s3_access_key_secret", "s3_secret_key_secret", "b2_key_id_secret", "b2_app_key_secret", "sftp_password_secret", "sftp_key_secret", "password_secret", "encryption_key_secret":
 		return []string{fmt.Sprintf("%sType e to configure secret storage.%s", ui.Dim, ui.Reset)}
 	case "kms_key_arn":
 		return []string{fmt.Sprintf("%sExample: arn:aws:kms:us-east-1:123456789012:key/abcd...%s", ui.Dim, ui.Reset)}
@@ -683,6 +711,18 @@ func tuiSecretFieldSpecForKey(key string) (tuiSecretFieldSpec, bool) {
 			SecretLabel:    "S3 secret key",
 			DefaultEnvName: "AWS_SECRET_ACCESS_KEY",
 			DefaultAccount: "s3-secret-key",
+		},
+		"b2_key_id_secret": {
+			FieldKey:       "b2_key_id_secret",
+			SecretLabel:    "B2 key ID",
+			DefaultEnvName: "B2_KEY_ID",
+			DefaultAccount: "b2-key-id",
+		},
+		"b2_app_key_secret": {
+			FieldKey:       "b2_app_key_secret",
+			SecretLabel:    "B2 application key",
+			DefaultEnvName: "B2_APP_KEY",
+			DefaultAccount: "b2-app-key",
 		},
 		"sftp_password_secret": {
 			FieldKey:       "sftp_password_secret",

--- a/cmd/cloudstic/command_registry.go
+++ b/cmd/cloudstic/command_registry.go
@@ -1,0 +1,315 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+type commandRun func(*runner, context.Context) int
+
+type completionKind string
+type flagSection string
+
+const (
+	completionNone        completionKind = ""
+	completionFile        completionKind = "file"
+	completionProfile     completionKind = "profile"
+	completionAuth        completionKind = "auth"
+	flagSectionEncryption flagSection    = "encryption"
+)
+
+type flagSpec struct {
+	name             string
+	description      string
+	value            string
+	completion       completionKind
+	completionValues []string
+	environment      []environmentSpec
+	section          flagSection
+}
+
+type environmentSpec struct {
+	name       string
+	sensitive  bool
+	documented bool
+}
+
+func environment(name string) environmentSpec {
+	return environmentSpec{name: name, documented: true}
+}
+
+func sensitiveEnvironment(name string) environmentSpec {
+	spec := environment(name)
+	spec.sensitive = true
+	return spec
+}
+
+func hiddenEnvironment(name string) environmentSpec {
+	return environmentSpec{name: name}
+}
+
+func boolFlag(name, description string) flagSpec {
+	return flagSpec{name: name, description: description}
+}
+
+func valueFlag(name, value, description string, completion completionKind) flagSpec {
+	return flagSpec{name: name, value: value, description: description, completion: completion}
+}
+
+func (f flagSpec) takesValue() bool { return f.value != "" }
+
+func (f flagSpec) withEnvironment(environment ...environmentSpec) flagSpec {
+	f.environment = environment
+	return f
+}
+
+func (f flagSpec) withCompletionValues(values ...string) flagSpec {
+	f.completionValues = values
+	return f
+}
+
+func (f flagSpec) inSection(section flagSection) flagSpec {
+	f.section = section
+	return f
+}
+
+type commandSpec struct {
+	name            string
+	aliases         []string
+	summary         string
+	args            string
+	hidden          bool
+	usesGlobalFlags bool
+	run             commandRun
+	flags           []flagSpec
+	notes           []string
+	argumentName    string
+	argumentValues  []string
+	children        []*commandSpec
+	flagProbe       commandRun
+	parent          *commandSpec
+}
+
+func commandRegistry() []*commandSpec {
+	return []*commandSpec{
+		initCommandSpec(),
+		backupCommandSpec(),
+		authCommandSpec(),
+		storeCommandSpec(),
+		sourceCommandSpec(),
+		setupCommandSpec(),
+		tuiCommandSpec(),
+		profileCommandSpec(),
+		restoreCommandSpec(),
+		listCommandSpec(),
+		lsCommandSpec(),
+		pruneCommandSpec(),
+		forgetCommandSpec(),
+		diffCommandSpec(),
+		breakLockCommandSpec(),
+		keyCommandSpec(),
+		checkCommandSpec(),
+		catCommandSpec(),
+		completionCommandSpec(),
+		versionCommandSpec(),
+		helpCommandSpec(),
+		completionQueryCommandSpec(),
+	}
+}
+
+func (c *commandSpec) path() string {
+	if c.parent == nil {
+		return c.name
+	}
+	return c.parent.path() + " " + c.name
+}
+
+func (c *commandSpec) effectiveFlags() []flagSpec {
+	byName := make(map[string]flagSpec)
+	if c.usesGlobalFlags {
+		for _, f := range globalFlagSpecs {
+			byName[f.name] = f
+		}
+	} else if c.flagProbe != nil {
+		// parseFlags installs -no-prompt for every real FlagSet.
+		byName["no-prompt"] = globalFlagByName("no-prompt")
+	}
+	for _, f := range c.flags {
+		byName[f.name] = f
+	}
+	result := make([]flagSpec, 0, len(byName))
+	for _, f := range byName {
+		result = append(result, f)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].name < result[j].name })
+	return result
+}
+
+func (c *commandSpec) flag(name string) (flagSpec, bool) {
+	for _, spec := range c.effectiveFlags() {
+		if spec.name == name {
+			return spec, true
+		}
+	}
+	return flagSpec{}, false
+}
+
+func globalFlagByName(name string) flagSpec {
+	for _, spec := range globalFlagSpecs {
+		if spec.name == name {
+			return spec
+		}
+	}
+	return flagSpec{name: name}
+}
+
+func leaf(name, summary, args string, run commandRun, flags ...flagSpec) *commandSpec {
+	return &commandSpec{name: name, summary: summary, args: args, run: run, flagProbe: run, flags: flags}
+}
+
+func leafAliases(name string, aliases []string, summary, args string, run commandRun, flags ...flagSpec) *commandSpec {
+	c := leaf(name, summary, args, run, flags...)
+	c.aliases = aliases
+	return c
+}
+
+func (c *commandSpec) withGlobalFlags() *commandSpec {
+	c.usesGlobalFlags = true
+	return c
+}
+
+func (c *commandSpec) withNotes(notes ...string) *commandSpec {
+	c.notes = notes
+	return c
+}
+
+func (c *commandSpec) withArgumentValues(name string, values ...string) *commandSpec {
+	c.argumentName = name
+	c.argumentValues = values
+	return c
+}
+
+func group(name, summary string, children ...*commandSpec) *commandSpec {
+	c := &commandSpec{name: name, summary: summary, children: children}
+	for _, child := range children {
+		child.parent = c
+	}
+	return c
+}
+
+func (c *commandSpec) hide() *commandSpec {
+	c.hidden = true
+	return c
+}
+
+func (c *commandSpec) withoutFlagProbe() *commandSpec {
+	c.flagProbe = nil
+	return c
+}
+
+func findCommand(commands []*commandSpec, name string) *commandSpec {
+	for _, command := range commands {
+		if command.name == name {
+			return command
+		}
+		for _, alias := range command.aliases {
+			if alias == name {
+				return command
+			}
+		}
+	}
+	return nil
+}
+
+func rootCommand(name string) *commandSpec { return findCommand(commandRegistry(), name) }
+
+func dispatchCommand(r *runner, ctx context.Context, command *commandSpec) int {
+	if len(command.children) == 0 {
+		return command.run(r, ctx)
+	}
+	if len(r.args) == 0 {
+		printGroupUsage(r.errOut, command)
+		return exitFailure
+	}
+	child := findCommand(command.children, r.args[0])
+	if child == nil {
+		return r.fail("Unknown %s subcommand: %s", command.path(), r.args[0])
+	}
+	return dispatchCommand(r.withArgs(r.args[1:]), ctx, child)
+}
+
+func printGroupUsage(out io.Writer, command *commandSpec) {
+	_, _ = fmt.Fprintf(out, "Usage: cloudstic %s <subcommand> [options]\n\n", command.path())
+	_, _ = fmt.Fprintln(out, "Available subcommands:")
+	for _, child := range command.children {
+		if !child.hidden {
+			_, _ = fmt.Fprintf(out, "  %-14s %s\n", child.name, child.summary)
+		}
+	}
+}
+
+func publicLeafCommands() []*commandSpec {
+	var result []*commandSpec
+	var walk func([]*commandSpec)
+	walk = func(commands []*commandSpec) {
+		for _, command := range commands {
+			if command.hidden {
+				continue
+			}
+			if len(command.children) != 0 {
+				walk(command.children)
+				continue
+			}
+			result = append(result, command)
+		}
+	}
+	walk(commandRegistry())
+	return result
+}
+
+func publicRootCommands() []*commandSpec {
+	commands := commandRegistry()
+	result := make([]*commandSpec, 0, len(commands))
+	for _, command := range commands {
+		if !command.hidden {
+			result = append(result, command)
+		}
+	}
+	return result
+}
+
+func commandWords(commands []*commandSpec) string {
+	names := make([]string, 0, len(commands))
+	for _, command := range commands {
+		if !command.hidden {
+			names = append(names, command.name)
+		}
+	}
+	return strings.Join(names, " ")
+}
+
+func flagWords(flags []flagSpec) string {
+	words := make([]string, 0, len(flags))
+	for _, spec := range flags {
+		words = append(words, "-"+spec.name)
+	}
+	return strings.Join(words, " ")
+}
+
+func valueFlagWords(flags []flagSpec) string {
+	words := make([]string, 0, len(flags))
+	for _, spec := range flags {
+		if spec.takesValue() {
+			words = append(words, "-"+spec.name)
+		}
+	}
+	return strings.Join(words, " ")
+}
+
+// flagSetObserver is used by registry parity tests to inspect the real FlagSet
+// immediately before parsing. Production code leaves it nil.
+var flagSetObserver func(*flag.FlagSet)

--- a/cmd/cloudstic/command_registry_test.go
+++ b/cmd/cloudstic/command_registry_test.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// These compatibility helpers keep focused command tests concise while the
+// production path uses the recursive registry dispatcher directly.
+func runAuth(r *runner, ctx context.Context) int {
+	return dispatchCommand(r, ctx, rootCommand("auth"))
+}
+
+func runStore(r *runner, ctx context.Context) int {
+	return dispatchCommand(r, ctx, rootCommand("store"))
+}
+
+func runProfile(r *runner, ctx context.Context) int {
+	return dispatchCommand(r, ctx, rootCommand("profile"))
+}
+
+func runSource(r *runner, ctx context.Context) int {
+	return dispatchCommand(r, ctx, rootCommand("source"))
+}
+
+func runSetup(r *runner, ctx context.Context) int {
+	return dispatchCommand(r, ctx, rootCommand("setup"))
+}
+
+func TestCommandRegistryIsValid(t *testing.T) {
+	seenPaths := make(map[string]bool)
+	seenRoots := make(map[string]bool)
+	for _, root := range commandRegistry() {
+		if seenRoots[root.name] {
+			t.Errorf("duplicate root command %q", root.name)
+		}
+		seenRoots[root.name] = true
+		for _, alias := range root.aliases {
+			if seenRoots[alias] {
+				t.Errorf("duplicate command name or alias %q", alias)
+			}
+			seenRoots[alias] = true
+		}
+	}
+	for _, command := range publicLeafCommands() {
+		if seenPaths[command.path()] {
+			t.Errorf("duplicate command path %q", command.path())
+		}
+		seenPaths[command.path()] = true
+		if command.summary == "" {
+			t.Errorf("public command %q has no summary", command.path())
+		}
+		if command.run == nil {
+			t.Errorf("leaf command %q has no handler", command.path())
+		}
+		if len(command.argumentValues) != 0 && command.argumentName == "" {
+			t.Errorf("command %q has positional values without an argument name", command.path())
+		}
+		seenFlags := make(map[string]bool)
+		for _, spec := range command.effectiveFlags() {
+			if seenFlags[spec.name] {
+				t.Errorf("command %q has duplicate flag %q", command.path(), spec.name)
+			}
+			seenFlags[spec.name] = true
+			if spec.description == "" {
+				t.Errorf("command %q flag %q has no description", command.path(), spec.name)
+			}
+			if spec.completion != completionNone && !spec.takesValue() {
+				t.Errorf("command %q boolean flag %q has a value completer", command.path(), spec.name)
+			}
+			if len(spec.completionValues) != 0 && !spec.takesValue() {
+				t.Errorf("command %q boolean flag %q has completion values", command.path(), spec.name)
+			}
+			if len(spec.completionValues) != 0 && spec.completion != completionNone {
+				t.Errorf("command %q flag %q mixes static and dynamic completion", command.path(), spec.name)
+			}
+		}
+	}
+}
+
+func TestCommandRegistryFlagsMatchParsers(t *testing.T) {
+	for _, command := range publicLeafCommands() {
+		if command.flagProbe == nil {
+			continue
+		}
+		t.Run(strings.ReplaceAll(command.path(), " ", "_"), func(t *testing.T) {
+			actual := probeCommandFlags(t, command)
+			want := make(map[string]bool)
+			for _, spec := range command.effectiveFlags() {
+				want[spec.name] = spec.takesValue()
+			}
+			if !reflect.DeepEqual(actual, want) {
+				t.Errorf("flag parity mismatch\nactual: %#v\nwant:   %#v", actual, want)
+			}
+		})
+	}
+}
+
+func probeCommandFlags(t *testing.T, command *commandSpec) map[string]bool {
+	t.Helper()
+	var observed *flag.FlagSet
+	previous := flagSetObserver
+	flagSetObserver = func(fs *flag.FlagSet) {
+		observed = fs
+		fs.SetOutput(io.Discard)
+	}
+	t.Cleanup(func() { flagSetObserver = previous })
+	r := &runner{args: []string{"-h"}, out: io.Discard, errOut: io.Discard, noPrompt: true}
+	command.flagProbe(r, context.Background())
+	if observed == nil {
+		t.Fatalf("command did not parse a FlagSet")
+	}
+	result := make(map[string]bool)
+	observed.VisitAll(func(f *flag.Flag) {
+		boolean := false
+		if boolValue, ok := f.Value.(interface{ IsBoolFlag() bool }); ok {
+			boolean = boolValue.IsBoolFlag()
+		}
+		result[f.Name] = !boolean
+	})
+	return result
+}
+
+func TestUsageListsPublicLeaves(t *testing.T) {
+	var out bytes.Buffer
+	printUsage(&out)
+	usage := out.String()
+	commandsSection := usage
+	if _, after, ok := strings.Cut(usage, "COMMANDS"); ok {
+		commandsSection = after
+	}
+	if before, _, ok := strings.Cut(commandsSection, "GLOBAL OPTIONS"); ok {
+		commandsSection = before
+	}
+	for _, command := range publicLeafCommands() {
+		if !strings.Contains(usage, command.path()) {
+			t.Errorf("usage missing public command %q", command.path())
+		}
+	}
+	for _, hidden := range []string{"__complete", "--version", "--help"} {
+		if strings.Contains(commandsSection, hidden) {
+			t.Errorf("usage contains hidden command or alias %q", hidden)
+		}
+	}
+	for _, required := range []string{"store init", "version"} {
+		if !strings.Contains(usage, required) {
+			t.Errorf("usage missing newly visible command %q", required)
+		}
+	}
+}
+
+func TestUsageFlagsAndEnvironmentComeFromRegistries(t *testing.T) {
+	var out bytes.Buffer
+	printUsage(&out)
+	usage := out.String()
+
+	for _, spec := range globalFlagSpecs {
+		if !strings.Contains(usage, "-"+spec.name) {
+			t.Errorf("usage missing global flag -%s", spec.name)
+		}
+	}
+	for _, command := range publicLeafCommands() {
+		for _, spec := range command.flags {
+			if !strings.Contains(usage, "-"+spec.name) {
+				t.Errorf("usage missing %q flag -%s", command.path(), spec.name)
+			}
+		}
+		for _, note := range command.notes {
+			if !strings.Contains(usage, note) {
+				t.Errorf("usage missing %q note %q", command.path(), note)
+			}
+		}
+	}
+	for _, variable := range environmentVariables() {
+		if variable.Documented && !strings.Contains(usage, variable.Name) {
+			t.Errorf("usage missing documented environment variable %s", variable.Name)
+		}
+	}
+
+	_, storeNew, ok := strings.Cut(usage, "store new")
+	if !ok {
+		t.Fatal("usage missing store new details")
+	}
+	storeNew, _, _ = strings.Cut(storeNew, "store list")
+	for _, line := range strings.Split(storeNew, "\n") {
+		if strings.Contains(line, "-s3-region") && strings.Contains(line, "CLOUDSTIC_S3_REGION") {
+			t.Error("store new incorrectly advertises an environment binding owned by the global flag spec")
+		}
+	}
+}
+
+func TestNestedRegistryDispatch(t *testing.T) {
+	var errOut bytes.Buffer
+	r := &runner{args: []string{"wat"}, out: io.Discard, errOut: &errOut}
+	if code := runCmd(r, context.Background(), "auth"); code != exitFailure {
+		t.Fatalf("exit code = %d, want %d", code, exitFailure)
+	}
+	if !strings.Contains(errOut.String(), "Unknown auth subcommand: wat") {
+		t.Fatalf("unexpected error: %q", errOut.String())
+	}
+}

--- a/cmd/cloudstic/completion.go
+++ b/cmd/cloudstic/completion.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"strings"
 )
 
 func runCompletion(r *runner) int {
@@ -18,8 +20,7 @@ func runCompletion(r *runner) int {
 		return 1
 	}
 
-	shell := r.args[0]
-	switch shell {
+	switch r.args[0] {
 	case "bash":
 		completionBash(r.out)
 	case "zsh":
@@ -27,18 +28,23 @@ func runCompletion(r *runner) int {
 	case "fish":
 		completionFish(r.out)
 	default:
-		return r.fail("Unsupported shell: %s\nAvailable shells: bash, zsh, fish", shell)
+		return r.fail("Unsupported shell: %s\nAvailable shells: bash, zsh, fish", r.args[0])
 	}
 	return 0
 }
 
-// completionBash writes a bash completion script to w.
+func completionCommandSpec() *commandSpec {
+	return leaf("completion", "Generate shell completion scripts", "<bash|zsh|fish>",
+		func(r *runner, _ context.Context) int { return runCompletion(r) }).withoutFlagProbe().withArgumentValues(
+		"shell", "bash", "zsh", "fish").withNotes(
+		"Supported shells: bash, zsh, and fish.")
+}
+
 func completionBash(w io.Writer) {
-	_, _ = fmt.Fprint(w, `# bash completion for cloudstic
+	_, _ = fmt.Fprintf(w, `# bash completion for cloudstic
 
 _cloudstic_query() {
-    local kind="$1"
-    local cur="$2"
+    local kind="$1" cur="$2"
     shift 2
     cloudstic __complete "$kind" "$cur" "$@" 2>/dev/null
 }
@@ -47,234 +53,84 @@ _cloudstic() {
     local cur prev words cword
     _init_completion || return
 
-    local commands="init backup auth profile store source setup tui restore list ls prune forget diff break-lock key cat completion version help"
+    local commands=%q
+    local global_flags=%q
+    local global_value_flags=%q
+    local root=""
+    local root_index=0
+    local sub=""
+    local path=""
+    local cmd_flags=""
+    local value_flags=""
+    local i value_flag
 
-    local global_flags="-store -profile -profiles-file -s3-endpoint -s3-region -s3-profile -s3-access-key -s3-secret-key -source-sftp-password -source-sftp-key -source-sftp-known-hosts -source-sftp-insecure -store-sftp-password -store-sftp-key -store-sftp-known-hosts -store-sftp-insecure -encryption-key -password -recovery-key -kms-key-arn -kms-region -kms-endpoint -disable-packfile -prompt -no-prompt -verbose -quiet -json -debug"
-
-    # Identify the subcommand
-    local cmd=""
-    local i
-    for ((i=1; i < cword; i++)); do
-        case "${words[i]}" in
-            -*)
-                # skip flags and their values
-                case "${words[i]}" in
-					-store|-profile|-profiles-file|-s3-endpoint|-s3-region|-s3-profile|-s3-access-key|-s3-secret-key|-source-sftp-password|-source-sftp-key|-source-sftp-known-hosts|-store|-store-sftp-password|-store-sftp-key|-store-sftp-known-hosts|-encryption-key|-password|-recovery-key|-kms-key-arn|-kms-region|-kms-endpoint|-source|-all-profiles|-auth-ref|-google-credentials|-google-credentials-ref|-google-credentials-json|-google-token-file|-google-token-ref|-onedrive-client-id|-onedrive-token-file|-onedrive-token-ref|-tag|-output|-keep-last|-keep-hourly|-keep-daily|-keep-weekly|-keep-monthly|-keep-yearly|-group-by|-account|-xattr-namespaces)
-						((i++)) ;;
-				esac
-                ;;
-            *)
-                cmd="${words[i]}"
-                break
-                ;;
-        esac
+    for ((i=1; i<cword; i++)); do
+        if [[ "${words[i]}" == -* ]]; then
+            for value_flag in $global_value_flags; do
+                if [[ "${words[i]}" == "$value_flag" ]]; then
+                    ((i++))
+                    break
+                fi
+            done
+            continue
+        fi
+        root="${words[i]}"
+        root_index=$i
+        break
     done
 
-    # Complete subcommand
-    if [[ -z "$cmd" ]]; then
-        case "$prev" in
-            -profile)
-                COMPREPLY=($(compgen -W "$(_cloudstic_query profile-names "$cur" "${words[@]:1:$((cword-1))}")" -- "$cur"))
-                return ;;
-            -store)
-                COMPREPLY=($(compgen -W "local: s3: b2: sftp://" -- "$cur"))
-                return ;;
-            -source-sftp-key|-store-sftp-key|-output|-profiles-file)
-                _filedir
-                return ;;
-        esac
-        COMPREPLY=($(compgen -W "$commands" -- "$cur"))
+    if [[ -z "$root" ]]; then
+`, commandWords(publicRootCommands()), flagWords(globalFlagSpecs), valueFlagWords(globalFlagSpecs))
+	writeBashRootCompletionCases(w)
+	_, _ = fmt.Fprint(w, `
+        if [[ "$cur" == -* ]]; then
+            COMPREPLY=($(compgen -W "$global_flags" -- "$cur"))
+        else
+            COMPREPLY=($(compgen -W "$commands" -- "$cur"))
+        fi
         return
     fi
 
-    # Complete flags per subcommand
-    local cmd_flags=""
-    case "$cmd" in
-		init)
-			cmd_flags="-add-recovery-key -no-encryption -adopt-slots" ;;
-		backup)
-			cmd_flags="-source -profile -all-profiles -auth-ref -profiles-file -skip-native-files -google-credentials -google-credentials-ref -google-credentials-json -google-token-file -google-token-ref -onedrive-client-id -onedrive-token-file -onedrive-token-ref -tag -ignore-empty-snapshot -dry-run -skip-mode -skip-flags -skip-xattrs -xattr-namespaces" ;;
-        restore)
-            cmd_flags="-output -format -path -dry-run" ;;
-        prune)
-            cmd_flags="-dry-run" ;;
-        forget)
-            cmd_flags="-prune -dry-run -keep-last -keep-hourly -keep-daily -keep-weekly -keep-monthly -keep-yearly -tag -source -account -group-by" ;;
-        cat)
-            cmd_flags="-raw" ;;
-        completion)
-            COMPREPLY=($(compgen -W "bash zsh fish" -- "$cur"))
-            return ;;
-        key)
-            # Handle key subcommands
-            local key_sub=""
-            local j
-            for ((j=i+1; j < cword; j++)); do
-                case "${words[j]}" in
-                    -*) ;;
-                    *) key_sub="${words[j]}"; break ;;
-                esac
-            done
-            if [[ -z "$key_sub" ]]; then
-                COMPREPLY=($(compgen -W "list add-recovery passwd" -- "$cur"))
-                return
-            fi
-            case "$key_sub" in
-                passwd)
-                    cmd_flags="-new-password" ;;
-                *)
-                    cmd_flags="" ;;
-            esac
-            ;;
-        list)
-            cmd_flags="-group" ;;
-        profile)
-            local profile_sub=""
-            local j
-            for ((j=i+1; j < cword; j++)); do
-                case "${words[j]}" in
-                    -*) ;;
-                    *) profile_sub="${words[j]}"; break ;;
-                esac
-            done
-            if [[ -z "$profile_sub" ]]; then
-                COMPREPLY=($(compgen -W "list show new" -- "$cur"))
-                return
-            fi
-            case "$profile_sub" in
-                list)
-                    cmd_flags="-profiles-file" ;;
-                show)
-                    cmd_flags="-profiles-file" ;;
-                new)
-                    cmd_flags="-profiles-file -name -source -store-ref -store -auth-ref -tag -exclude -exclude-file -ignore-empty-snapshot -skip-native-files -volume-uuid -google-credentials -google-credentials-ref -google-credentials-json -google-token-file -google-token-ref -onedrive-client-id -onedrive-token-file -onedrive-token-ref" ;;
-                *)
-                    cmd_flags="" ;;
-            esac
-            ;;
-        auth)
-            local auth_sub=""
-            local j
-            for ((j=i+1; j < cword; j++)); do
-                case "${words[j]}" in
-                    -*) ;;
-                    *) auth_sub="${words[j]}"; break ;;
-                esac
-            done
-            if [[ -z "$auth_sub" ]]; then
-                COMPREPLY=($(compgen -W "list show new login" -- "$cur"))
-                return
-            fi
-            case "$auth_sub" in
-                list)
-                    cmd_flags="-profiles-file" ;;
-                show)
-                    cmd_flags="-profiles-file" ;;
-                new)
-                    cmd_flags="-profiles-file -name -provider -google-credentials -google-credentials-ref -google-credentials-json -google-token-file -google-token-ref -onedrive-client-id -onedrive-token-file -onedrive-token-ref" ;;
-                login)
-                    cmd_flags="-profiles-file -name" ;;
-                *)
-                    cmd_flags="" ;;
-            esac
-            ;;
-        store)
-            local store_sub=""
-            local j
-            for ((j=i+1; j < cword; j++)); do
-                case "${words[j]}" in
-                    -*) ;;
-                    *) store_sub="${words[j]}"; break ;;
-                esac
-            done
-		if [[ -z "$store_sub" ]]; then
-			COMPREPLY=($(compgen -W "list show new verify init" -- "$cur"))
-			return
-		fi
-		case "$store_sub" in
-			list)
-				cmd_flags="-profiles-file" ;;
-			show)
-				cmd_flags="-profiles-file" ;;
-			verify)
-				cmd_flags="-profiles-file" ;;
-			init)
-				cmd_flags="-profiles-file -yes" ;;
-			new)
-				cmd_flags="-profiles-file -name -uri -s3-region -s3-profile -s3-endpoint -s3-access-key -s3-secret-key -s3-access-key-secret -s3-secret-key-secret -store-sftp-password -store-sftp-key -store-sftp-known-hosts -store-sftp-insecure -store-sftp-password-secret -store-sftp-key-secret -password-secret -encryption-key-secret -recovery-key-secret -kms-key-arn -kms-region -kms-endpoint" ;;
-                *)
-                    cmd_flags="" ;;
-            esac
-            ;;
-        source)
-            local source_sub=""
-            local j
-            for ((j=i+1; j < cword; j++)); do
-                case "${words[j]}" in
-                    -*) ;;
-                    *) source_sub="${words[j]}"; break ;;
-                esac
-            done
-            if [[ -z "$source_sub" ]]; then
-                COMPREPLY=($(compgen -W "discover" -- "$cur"))
-                return
-            fi
-            case "$source_sub" in
-                discover)
-                    cmd_flags="-portable-only -json" ;;
-                *)
-                    cmd_flags="" ;;
-            esac
-            ;;
-        setup)
-            local setup_sub=""
-            local j
-            for ((j=i+1; j < cword; j++)); do
-                case "${words[j]}" in
-                    -*) ;;
-                    *) setup_sub="${words[j]}"; break ;;
-                esac
-            done
-            if [[ -z "$setup_sub" ]]; then
-                COMPREPLY=($(compgen -W "workstation" -- "$cur"))
-                return
-            fi
-            case "$setup_sub" in
-                workstation)
-                    cmd_flags="-dry-run -yes -profiles-file -store-ref -json" ;;
-                *)
-                    cmd_flags="" ;;
-            esac
-            ;;
-        check)
-            cmd_flags="-read-data" ;;
-        ls|diff|break-lock|version|help)
-            cmd_flags="" ;;
-    esac
+    path="$root"
 
-    case "$prev" in
-        -profile)
-            COMPREPLY=($(compgen -W "$(_cloudstic_query profile-names "$cur" "${words[@]:1:$((cword-1))}")" -- "$cur"))
-            return ;;
-        -auth-ref)
-            COMPREPLY=($(compgen -W "$(_cloudstic_query auth-names "$cur" "${words[@]:1:$((cword-1))}")" -- "$cur"))
-            return ;;
-        -store)
-            # URI completion hint: show scheme prefixes
-            COMPREPLY=($(compgen -W "local: s3: b2: sftp://" -- "$cur"))
-            return ;;
-        -source)
-            # URI completion hint: show scheme prefixes and bare keywords
-            COMPREPLY=($(compgen -W "local: sftp:// gdrive gdrive-changes onedrive onedrive-changes" -- "$cur"))
-            return ;;
-        -source-sftp-key|-store-sftp-key|-output|-profiles-file)
-            _filedir
-            return ;;
-    esac
+    case "$root" in
+`)
+	for _, root := range publicRootCommands() {
+		if len(root.children) == 0 {
+			continue
+		}
+		_, _ = fmt.Fprintf(w, "        %s)\n", root.name)
+		_, _ = fmt.Fprintf(w, "            sub=\"${words[root_index+1]}\"\n")
+		_, _ = fmt.Fprintf(w, "            if [[ $cword -eq $((root_index+1)) ]]; then\n")
+		_, _ = fmt.Fprintf(w, "                COMPREPLY=($(compgen -W %q -- \"$cur\")); return\n", commandWords(root.children))
+		_, _ = fmt.Fprintf(w, "            fi\n")
+		_, _ = fmt.Fprintf(w, "            path=\"$root $sub\" ;;\n")
+	}
+	_, _ = fmt.Fprint(w, `    esac
 
+    case "$path" in
+`)
+	for _, command := range publicLeafCommands() {
+		flags := command.effectiveFlags()
+		_, _ = fmt.Fprintf(w, "        %q) cmd_flags=%q; value_flags=%q ;;\n", command.path(), flagWords(flags), valueFlagWords(flags))
+	}
+	_, _ = fmt.Fprint(w, `    esac
+
+    case "$path:$prev" in
+`)
+	writeBashCompletionCases(w)
+	_, _ = fmt.Fprint(w, "    esac\n\n")
+	writeBashArgumentCases(w)
+	_, _ = fmt.Fprint(w, `
+
+    if [[ -n "$value_flags" ]]; then
+        local value_flag
+        for value_flag in $value_flags; do
+            [[ "$prev" == "$value_flag" ]] && return
+        done
+    fi
     if [[ -z "$cur" || "$cur" == -* ]]; then
-        COMPREPLY=($(compgen -W "$cmd_flags $global_flags" -- "$cur"))
-        return
+        COMPREPLY=($(compgen -W "$cmd_flags" -- "$cur"))
     fi
 }
 
@@ -282,685 +138,239 @@ complete -F _cloudstic cloudstic
 `)
 }
 
-// completionZsh writes a zsh completion script to w.
+func writeBashArgumentCases(w io.Writer) {
+	_, _ = fmt.Fprintln(w, "    case \"$path:$((cword-root_index))\" in")
+	for _, command := range publicLeafCommands() {
+		if len(command.argumentValues) == 0 {
+			continue
+		}
+		word := 1
+		if command.parent != nil {
+			word = 2
+		}
+		_, _ = fmt.Fprintf(w, "        %q) COMPREPLY=($(compgen -W %q -- \"$cur\")); return ;;\n",
+			fmt.Sprintf("%s:%d", command.path(), word), strings.Join(command.argumentValues, " "))
+	}
+	_, _ = fmt.Fprintln(w, "    esac")
+}
+
+func writeBashRootCompletionCases(w io.Writer) {
+	_, _ = fmt.Fprintln(w, "        case \"$prev\" in")
+	for _, spec := range globalFlagSpecs {
+		writeBashCompletionCase(w, "            ", "-"+spec.name, spec)
+	}
+	_, _ = fmt.Fprintln(w, "        esac")
+}
+
+func writeBashCompletionCases(w io.Writer) {
+	for _, command := range publicLeafCommands() {
+		for _, spec := range command.effectiveFlags() {
+			writeBashCompletionCase(w, "        ", command.path()+":-"+spec.name, spec)
+		}
+	}
+}
+
+func writeBashCompletionCase(w io.Writer, indent, key string, spec flagSpec) {
+	if len(spec.completionValues) != 0 {
+		_, _ = fmt.Fprintf(w, "%s%q) COMPREPLY=($(compgen -W %q -- \"$cur\")); return ;;\n",
+			indent, key, strings.Join(spec.completionValues, " "))
+		return
+	}
+	switch spec.completion {
+	case completionProfile:
+		_, _ = fmt.Fprintf(w, "%s%q) COMPREPLY=($(compgen -W \"$(_cloudstic_query profile-names \"$cur\" \"${words[@]:1:$((cword-1))}\")\" -- \"$cur\")); return ;;\n", indent, key)
+	case completionAuth:
+		_, _ = fmt.Fprintf(w, "%s%q) COMPREPLY=($(compgen -W \"$(_cloudstic_query auth-names \"$cur\" \"${words[@]:1:$((cword-1))}\")\" -- \"$cur\")); return ;;\n", indent, key)
+	case completionFile:
+		_, _ = fmt.Fprintf(w, "%s%q) _filedir; return ;;\n", indent, key)
+	}
+}
+
 func completionZsh(w io.Writer) {
-	_, _ = fmt.Fprint(w, `#compdef cloudstic
+	_, _ = fmt.Fprintf(w, `#compdef cloudstic
 
 # zsh completion for cloudstic
-
 _cloudstic_query() {
     local kind="$1"
     shift
-    local -a prior_words
-    prior_words=("${words[@]:2:$(( CURRENT - 2 ))}")
-    cloudstic __complete "$kind" "$PREFIX" "${prior_words[@]}" 2>/dev/null
+    cloudstic __complete "$kind" "$PREFIX" "${words[@]:2:$(( CURRENT - 2 ))}" 2>/dev/null
 }
 
-_cloudstic_dynamic_values() {
-    local kind="$1"
-    local label="$2"
-    local -a values
-    values=(${(f)"$(_cloudstic_query "$kind")"})
-    _describe -t "$kind" "$label" values
-}
-
-_cloudstic_profile_names() {
-    _cloudstic_dynamic_values profile-names 'profile'
-}
-
-_cloudstic_auth_names() {
-    _cloudstic_dynamic_values auth-names 'auth entry'
-}
-
-_cloudstic_store_prefixes() {
-    local -a values
-    values=('local:' 's3:' 'b2:' 'sftp://')
-    compadd -Q -S '' -X 'store URI prefix' -- "${values[@]}"
-}
+_cloudstic_profile_names() { compadd ${(f)"$(_cloudstic_query profile-names)"}; }
+_cloudstic_auth_names() { compadd ${(f)"$(_cloudstic_query auth-names)"}; }
 
 _cloudstic() {
-    local -a commands
+	local root="" sub="" path=""
+	local -i root_index=0 i
+	local value_flag
+	local -a commands subcommands specs global_value_flags
+	global_value_flags=(%s)
+
     commands=(
-        'init:Initialize a new repository'
-        'backup:Create a new backup snapshot from a source'
-        'auth:Manage reusable cloud auth entries'
-        'profile:Manage backup profiles'
-        'source:Discover source candidates for onboarding'
-        'setup:Guided setup and onboarding flows'
-        'tui:Launch the interactive terminal dashboard'
-        'restore:Restore files from a backup snapshot'
-        'list:List all backup snapshots in the repository'
-        'ls:List files within a specific snapshot'
-        'prune:Remove unused data chunks from the repository'
-        'forget:Remove a specific snapshot from history'
-        'diff:Compare two snapshots or a snapshot against latest'
-        'break-lock:Remove a stale repository lock'
-        'key:Manage encryption key slots'
-        'cat:Display raw JSON content of repository objects'
-        'completion:Generate shell completion scripts'
-        'version:Print version information'
-        'help:Show usage information'
-    )
+`, valueFlagWords(globalFlagSpecs))
+	for _, command := range publicRootCommands() {
+		_, _ = fmt.Fprintf(w, "        %s:%s\n", zshQuote(command.name), zshQuote(command.summary))
+	}
+	_, _ = fmt.Fprint(w, `    )
 
-    local prev_word="${words[CURRENT-1]}"
+	for ((i=2; i<CURRENT; i++)); do
+		if [[ "${words[i]}" == -* ]]; then
+			for value_flag in $global_value_flags; do
+				if [[ "${words[i]}" == "$value_flag" ]]; then
+					((i++))
+					break
+				fi
+			done
+			continue
+		fi
+		root="${words[i]}"
+		root_index=$i
+		break
+	done
 
-    local -a global_flags
-    global_flags=(
-        '-store[Storage backend URI]:uri:_cloudstic_store_prefixes'
-        '-profile[Profile name from profiles.yaml]:name:_cloudstic_profile_names'
-        '-profiles-file[Path to profiles YAML file]:path:_files'
-        '-s3-endpoint[S3 compatible endpoint URL]:url:'
-        '-s3-region[S3 region]:region:'
-        '-s3-profile[AWS shared config profile for S3 auth]:name:'
-        '-s3-access-key[S3 access key ID]:key:'
-        '-s3-secret-key[S3 secret access key]:secret:'
-        '-source-sftp-password[SFTP source password]:password:'
-        '-source-sftp-key[Path to SSH private key for SFTP source]:key:_files'
-        '-source-sftp-known-hosts[Path to known_hosts file for SFTP source]:path:_files'
-        '-source-sftp-insecure[Skip host key validation for SFTP source (INSECURE)]'
-        '-store-sftp-password[SFTP store password]:password:'
-        '-store-sftp-key[Path to SSH private key for SFTP store]:key:_files'
-        '-store-sftp-known-hosts[Path to known_hosts file for SFTP store]:path:_files'
-        '-store-sftp-insecure[Skip host key validation for SFTP store (INSECURE)]'
-        '-encryption-key[Platform key (hex-encoded)]:key:'
-        '-password[Repository password]:password:'
-        '-recovery-key[Recovery key (24-word mnemonic)]:words:'
-        '-kms-key-arn[AWS KMS key ARN]:arn:'
-        '-kms-region[AWS KMS region]:region:'
-        '-kms-endpoint[Custom AWS KMS endpoint]:url:'
-        '-disable-packfile[Disable bundling small objects into packs]'
-        '-prompt[Prompt for password interactively]'
-        '-no-prompt[Disable interactive prompts (for scripts and CI)]'
-        '-verbose[Log detailed operations]'
-        '-quiet[Suppress progress bars]'
-        '-json[Write command result as JSON to stdout]'
-        '-debug[Log every store request]'
-    )
-    # Check if a subcommand has been given
-    local cmd
-    local -i i=2
-    while (( i < CURRENT )); do
-        case "${words[i]}" in
-            -*)
-                # Skip flags with values
-                case "${words[i]}" in
-					-store|-profile|-profiles-file|-s3-endpoint|-s3-region|-s3-profile|-s3-access-key|-s3-secret-key|-source-sftp-password|-source-sftp-key|-store-sftp-password|-store-sftp-key|-encryption-key|-password|-recovery-key|-kms-key-arn|-kms-region|-kms-endpoint|-source|-auth-ref|-google-credentials|-google-credentials-ref|-google-credentials-json|-google-token-file|-google-token-ref|-onedrive-client-id|-onedrive-token-file|-onedrive-token-ref|-tag|-output|-keep-last|-keep-hourly|-keep-daily|-keep-weekly|-keep-monthly|-keep-yearly|-group-by|-account)
-						(( i++ )) ;;
-				esac
-                ;;
-            *)
-                cmd="${words[i]}"
-                break
-                ;;
-        esac
-        (( i++ ))
-    done
+	if [[ -z "$root" ]]; then
+		specs=(
+`)
+	for _, spec := range globalFlagSpecs {
+		_, _ = fmt.Fprintf(w, "            %s\n", zshQuote(zshFlagSpec(spec)))
+	}
+	_, _ = fmt.Fprint(w, `        )
+		_describe -t commands 'cloudstic command' commands
+		_arguments $specs
+		return
+	fi
 
-    if [[ -z "$cmd" ]]; then
-        case "$prev_word" in
-            -store|-profile|-profiles-file|-s3-endpoint|-s3-region|-s3-profile|-s3-access-key|-s3-secret-key|-source-sftp-password|-source-sftp-key|-source-sftp-known-hosts|-store-sftp-password|-store-sftp-key|-store-sftp-known-hosts|-encryption-key|-password|-recovery-key|-kms-key-arn|-kms-region|-kms-endpoint)
-                _arguments $global_flags
-                return
-                ;;
-        esac
-        _describe -t commands 'cloudstic command' commands
-        _arguments $global_flags
-        return
-    fi
+	path="$root"
 
-    case "$cmd" in
-        init)
-            _arguments $global_flags \
-                '-add-recovery-key[Generate a 24-word recovery key]' \
-                '-no-encryption[Create an unencrypted repository]' \
-                '-adopt-slots[Adopt existing key slots]'
-            ;;
-        backup)
-            _arguments $global_flags \
-                '-source[Source URI]:uri:(local: sftp:// gdrive gdrive-changes onedrive onedrive-changes)' \
-                '-profile[Backup profile name]:name:' \
-                '-all-profiles[Run all enabled backup profiles]' \
-                '-auth-ref[Use named auth entry from profiles.yaml]:name:_cloudstic_auth_names' \
-                '-profiles-file[Path to profiles YAML file]:path:_files' \
-                '-skip-native-files[Exclude Google-native files]' \
-                '-google-credentials[Google service account credentials JSON]:path:_files' \
-                '-google-credentials-ref[Secret reference to Google credentials]:ref:' \
-                '-google-credentials-json[Inline Google credentials JSON]:json:' \
-                '-google-token-file[Google OAuth token file]:path:_files' \
-                '-google-token-ref[Secret reference to Google OAuth token]:ref:' \
-                '-onedrive-client-id[OneDrive OAuth client ID]:id:' \
-                '-onedrive-token-file[OneDrive OAuth token file]:path:_files' \
-                '-onedrive-token-ref[Secret reference to OneDrive OAuth token]:ref:' \
-                '*-tag[Tag for the snapshot]:tag:' \
-                '-ignore-empty-snapshot[Skip creating a new snapshot when nothing changed]' \
-                '-dry-run[Scan without writing]' \
-                '-skip-mode[Skip POSIX mode/uid/gid/btime/flags]' \
-                '-skip-flags[Skip file flags collection]' \
-                '-skip-xattrs[Skip extended attribute collection]' \
-                '-xattr-namespaces[Restrict xattr collection to prefixes]:prefixes:'
-            ;;
-        profile)
-            local -a profile_commands
-            profile_commands=(
-                'list:List stores, auth entries, and backup profiles'
-                'show:Show one profile and resolved store/auth references'
-                'new:Create or update a backup profile'
-            )
-            local profile_sub
-            local -i pi=$((i+1))
-            while (( pi < CURRENT )); do
-                case "${words[pi]}" in
-                    -*) ;;
-                    *) profile_sub="${words[pi]}"; break ;;
-                esac
-                (( pi++ ))
-            done
-            if [[ -z "$profile_sub" ]]; then
-                _describe -t profile-commands 'profile subcommand' profile_commands
-                return
-            fi
-            case "$profile_sub" in
-                list)
-                    _arguments '-profiles-file[Path to profiles YAML file]:path:_files'
-                    ;;
-                show)
-                    _arguments '-profiles-file[Path to profiles YAML file]:path:_files' ':profile name:'
-                    ;;
-                new)
-                    _arguments \
-                        '-profiles-file[Path to profiles YAML file]:path:_files' \
-                        '-name[Profile name]:name:' \
-                        '-source[Source URI]:uri:(local: sftp:// gdrive gdrive-changes onedrive onedrive-changes)' \
-                        '-store-ref[Store reference name]:name:' \
-                        '-store[Store URI]:uri:' \
-                        '-auth-ref[Auth reference name]:name:_cloudstic_auth_names' \
-                        '*-tag[Tag for snapshots]:tag:' \
-                        '*-exclude[Exclude pattern]:pattern:' \
-                        '-exclude-file[Path to exclude file]:path:_files' \
-                        '-ignore-empty-snapshot[Skip creating a new snapshot when nothing changed]' \
-                        '-skip-native-files[Exclude Google-native files]' \
-                        '-volume-uuid[Volume UUID override]:uuid:' \
-                        '-google-credentials[Google service account credentials JSON]:path:_files' \
-                        '-google-credentials-ref[Secret reference to Google credentials]:ref:' \
-                        '-google-credentials-json[Inline Google credentials JSON]:json:' \
-                        '-google-token-file[Google OAuth token file]:path:_files' \
-                        '-google-token-ref[Secret reference to Google OAuth token]:ref:' \
-                        '-onedrive-client-id[OneDrive OAuth client ID]:id:' \
-                        '-onedrive-token-file[OneDrive OAuth token file]:path:_files' \
-                        '-onedrive-token-ref[Secret reference to OneDrive OAuth token]:ref:'
-                    ;;
-                *)
-                    _arguments
-                    ;;
-            esac
-            ;;
-        auth)
-            local -a auth_commands
-            auth_commands=(
-                'list:List auth entries from profiles.yaml'
-                'show:Show one auth entry'
-                'new:Create or update a reusable cloud auth entry'
-                'login:Run OAuth login flow for one auth entry'
-            )
-            local auth_sub
-            local -i ai=$((i+1))
-            while (( ai < CURRENT )); do
-                case "${words[ai]}" in
-                    -*) ;;
-                    *) auth_sub="${words[ai]}"; break ;;
-                esac
-                (( ai++ ))
-            done
-            if [[ -z "$auth_sub" ]]; then
-                _describe -t auth-commands 'auth subcommand' auth_commands
-                return
-            fi
-            case "$auth_sub" in
-                list)
-                    _arguments '-profiles-file[Path to profiles YAML file]:path:_files'
-                    ;;
-                show)
-                    _arguments '-profiles-file[Path to profiles YAML file]:path:_files' ':auth name:'
-                    ;;
-                new)
-                    _arguments \
-                        '-profiles-file[Path to profiles YAML file]:path:_files' \
-                        '-name[Auth reference name]:name:' \
-                        '-provider[Auth provider]:provider:(google onedrive)' \
-                        '-google-credentials[Google service account credentials JSON]:path:_files' \
-                        '-google-credentials-json[Inline Google credentials JSON]:json:' \
-                        '-google-token-file[Google OAuth token file]:path:_files' \
-                        '-onedrive-client-id[OneDrive OAuth client ID]:id:' \
-                        '-onedrive-token-file[OneDrive OAuth token file]:path:_files'
-                    ;;
-                login)
-                    _arguments \
-                        '-profiles-file[Path to profiles YAML file]:path:_files' \
-                        '-name[Auth reference name]:name:'
-                    ;;
-                *)
-                    _arguments
-                    ;;
-            esac
-            ;;
-        store)
-            local -a store_commands
-			store_commands=(
-				'list:List configured stores'
-				'show:Show one store and its configuration'
-				'new:Create or update a store entry'
-				'verify:Verify store credentials and connectivity'
-				'init:Initialize a store by reference'
-			)
-            local store_sub
-            local -i si=$((i+1))
-            while (( si < CURRENT )); do
-                case "${words[si]}" in
-                    -*) ;;
-                    *) store_sub="${words[si]}"; break ;;
-                esac
-                (( si++ ))
-            done
-            if [[ -z "$store_sub" ]]; then
-                _describe -t store-commands 'store subcommand' store_commands
-                return
-            fi
-			case "$store_sub" in
-				list)
-					_arguments '-profiles-file[Path to profiles YAML file]:path:_files'
-					;;
-				show)
-					_arguments '-profiles-file[Path to profiles YAML file]:path:_files' ':store name:'
-					;;
-				verify)
-					_arguments '-profiles-file[Path to profiles YAML file]:path:_files' ':store name:'
-					;;
-				init)
-					_arguments '-profiles-file[Path to profiles YAML file]:path:_files' '-yes[Initialize without confirmation prompt]' ':store name:'
-					;;
-				new)
-                    _arguments \
-                        '-profiles-file[Path to profiles YAML file]:path:_files' \
-                        '-name[Store reference name]:name:' \
-                        '-uri[Store URI]:uri:' \
-                        '-s3-region[S3 region]:region:' \
-                        '-s3-profile[AWS shared config profile]:profile:' \
-                        '-s3-endpoint[S3-compatible endpoint URL]:url:' \
-                        '-s3-access-key[S3 static access key]:key:' \
-                        '-s3-secret-key[S3 static secret key]:key:' \
-                        '-s3-access-key-secret[Secret ref for S3 access key]:ref:' \
-                        '-s3-secret-key-secret[Secret ref for S3 secret key]:ref:' \
-                        '-store-sftp-password[SFTP password]:password:' \
-                        '-store-sftp-key[SFTP private key path]:path:_files' \
-                        '-store-sftp-known-hosts[SFTP known_hosts path]:path:_files' \
-                        '-store-sftp-insecure[Skip SFTP host key validation (INSECURE)]' \
-                        '-store-sftp-password-secret[Secret ref for SFTP password]:ref:' \
-                        '-store-sftp-key-secret[Secret ref for SFTP key path]:ref:' \
-                        '-password-secret[Secret ref for repository password]:ref:' \
-                        '-encryption-key-secret[Secret ref for platform key]:ref:' \
-                        '-recovery-key-secret[Secret ref for recovery key mnemonic]:ref:' \
-                        '-kms-key-arn[AWS KMS key ARN]:arn:' \
-                        '-kms-region[AWS KMS region]:region:' \
-                        '-kms-endpoint[Custom KMS endpoint URL]:url:'
-                    ;;
-                *)
-                    _arguments
-                    ;;
-            esac
-            ;;
-        source)
-            local -a source_commands
-            source_commands=(
-                'discover:Discover local source candidates'
-            )
-            local source_sub
-            local -i soi=$((i+1))
-            while (( soi < CURRENT )); do
-                case "${words[soi]}" in
-                    -*) ;;
-                    *) source_sub="${words[soi]}"; break ;;
-                esac
-                (( soi++ ))
-            done
-            if [[ -z "$source_sub" ]]; then
-                _describe -t source-commands 'source subcommand' source_commands
-                return
-            fi
-            case "$source_sub" in
-                discover)
-                    _arguments '-portable-only[Only show portable or external source candidates]' '-json[Write discovered sources as JSON]'
-                    ;;
-                *)
-                    _arguments
-                    ;;
-            esac
-            ;;
-        setup)
-            local -a setup_commands
-            setup_commands=(
-                'workstation:Preview workstation onboarding plan'
-            )
-            local setup_sub
-            local -i sui=$((i+1))
-            while (( sui < CURRENT )); do
-                case "${words[sui]}" in
-                    -*) ;;
-                    *) setup_sub="${words[sui]}"; break ;;
-                esac
-                (( sui++ ))
-            done
-            if [[ -z "$setup_sub" ]]; then
-                _describe -t setup-commands 'setup subcommand' setup_commands
-                return
-            fi
-            case "$setup_sub" in
-                workstation)
-                    _arguments \
-                        '-dry-run[Preview generated profiles without writing configuration]' \
-                        '-yes[Accept default selections without prompting]' \
-                        '-profiles-file[Path to profiles YAML file]:path:_files' \
-                        '-store-ref[Existing store reference to attach]:name:' \
-                        '-json[Write onboarding plan as JSON]'
-                    ;;
-                *)
-                    _arguments
-                    ;;
-            esac
-            ;;
-        restore)
-            _arguments $global_flags \
-                '-output[Output path for zip or dir restore]:path:_files' \
-                '-format[Restore format]:format:(zip dir)' \
-                '-path[Restore only the given file or subtree]:path:' \
-                '-dry-run[Show what would be restored without writing output]' \
-                ':snapshot ID:'
-            ;;
-        list)
-            _arguments $global_flags \
-                '-group[Group output by source identity]'
-            ;;
-        ls)
-            _arguments $global_flags \
-                ':snapshot ID:'
-            ;;
-        prune)
-            _arguments $global_flags \
-                '-dry-run[Show what would be deleted]'
-            ;;
-        forget)
-            _arguments $global_flags \
-                '-prune[Run prune after forgetting]' \
-                '-dry-run[Show what would be removed]' \
-                '-keep-last[Keep N most recent snapshots]:count:' \
-                '-keep-hourly[Keep N hourly snapshots]:count:' \
-                '-keep-daily[Keep N daily snapshots]:count:' \
-                '-keep-weekly[Keep N weekly snapshots]:count:' \
-                '-keep-monthly[Keep N monthly snapshots]:count:' \
-                '-keep-yearly[Keep N yearly snapshots]:count:' \
-                '*-tag[Filter by tag]:tag:' \
-                '-source[Filter by source URI (e.g. local:./docs, gdrive)]:uri:' \
-                '-account[Filter by account]:account:' \
-                '-group-by[Group snapshots by fields]:fields:' \
-                ':snapshot ID:'
-            ;;
-        diff)
-            _arguments $global_flags \
-                ':snapshot 1:' \
-                ':snapshot 2:'
-            ;;
-        break-lock)
-            _arguments $global_flags
-            ;;
-        key)
-            local -a key_commands
-            key_commands=(
-                'list:List all encryption key slots'
-                'add-recovery:Generate a 24-word recovery key'
-                'passwd:Change the repository password'
-            )
-            # Check if a key subcommand has been given
-            local key_sub
-            local -i ki=$((i+1))
-            while (( ki < CURRENT )); do
-                case "${words[ki]}" in
-                    -*) ;;
-                    *) key_sub="${words[ki]}"; break ;;
-                esac
-                (( ki++ ))
-            done
-            if [[ -z "$key_sub" ]]; then
-                _describe -t key-commands 'key subcommand' key_commands
-                return
-            fi
-            case "$key_sub" in
-                passwd)
-                    _arguments $global_flags \
-                        '-new-password[New repository password]:password:'
-                    ;;
-                *)
-                    _arguments $global_flags
-                    ;;
-            esac
-            ;;
-        cat)
-            _arguments $global_flags \
-                '-raw[Output raw, unformatted data]' \
-                '*:object key:'
-            ;;
-        completion)
-            _arguments ':shell:(bash zsh fish)'
-            ;;
-    esac
+    case "$root" in
+`)
+	for _, root := range publicRootCommands() {
+		if len(root.children) == 0 {
+			continue
+		}
+		_, _ = fmt.Fprintf(w, "        %s)\n", root.name)
+		_, _ = fmt.Fprint(w, "            sub=\"${words[root_index+1]}\"\n")
+		_, _ = fmt.Fprint(w, "            subcommands=(\n")
+		for _, child := range root.children {
+			if !child.hidden {
+				_, _ = fmt.Fprintf(w, "                %s:%s\n", zshQuote(child.name), zshQuote(child.summary))
+			}
+		}
+		_, _ = fmt.Fprint(w, "            )\n")
+		_, _ = fmt.Fprint(w, "            if (( CURRENT == root_index + 1 )); then _describe -t subcommands 'subcommand' subcommands; return; fi\n")
+		_, _ = fmt.Fprint(w, "            path=\"$root $sub\" ;;\n")
+	}
+	_, _ = fmt.Fprint(w, `    esac
+
+    case "$path" in
+`)
+	for _, command := range publicLeafCommands() {
+		_, _ = fmt.Fprintf(w, "        %s)\n", zshQuote(command.path()))
+		_, _ = fmt.Fprint(w, "            specs=(\n")
+		for _, spec := range command.effectiveFlags() {
+			_, _ = fmt.Fprintf(w, "                %s\n", zshQuote(zshFlagSpec(spec)))
+		}
+		if len(command.argumentValues) != 0 {
+			_, _ = fmt.Fprintf(w, "                %s\n", zshQuote("1:"+command.argumentName+":("+strings.Join(command.argumentValues, " ")+")"))
+		}
+		_, _ = fmt.Fprint(w, "            ) ;;\n")
+	}
+	_, _ = fmt.Fprint(w, `    esac
+    (( ${#specs} )) && _arguments $specs
 }
 
 compdef _cloudstic cloudstic
 `)
 }
 
-// completionFish writes a fish completion script to w.
+func zshFlagSpec(spec flagSpec) string {
+	result := "-" + spec.name + "[" + strings.ReplaceAll(spec.description, "]", "\\]") + "]"
+	if !spec.takesValue() {
+		return result
+	}
+	result += ":" + spec.value + ":"
+	if len(spec.completionValues) != 0 {
+		return result + "(" + strings.Join(spec.completionValues, " ") + ")"
+	}
+	switch spec.completion {
+	case completionFile:
+		return result + "_files"
+	case completionProfile:
+		return result + "_cloudstic_profile_names"
+	case completionAuth:
+		return result + "_cloudstic_auth_names"
+	default:
+		return result
+	}
+}
+
+func zshQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+}
+
 func completionFish(w io.Writer) {
 	_, _ = fmt.Fprint(w, `# fish completion for cloudstic
+complete -c cloudstic -f
 
 function __fish_cloudstic_query
     set -l kind $argv[1]
-    cloudstic __complete $kind (commandline -ct) (commandline -opc) 2>/dev/null
+    cloudstic __complete $kind (commandline -ct) (commandline -opc)[2..-1] 2>/dev/null
 end
 
-# Disable file completions by default
-complete -c cloudstic -f
-
-# Subcommands
-complete -c cloudstic -n __fish_use_subcommand -a init -d 'Initialize a new repository'
-complete -c cloudstic -n __fish_use_subcommand -a backup -d 'Create a new backup snapshot'
-complete -c cloudstic -n __fish_use_subcommand -a auth -d 'Manage reusable cloud auth entries'
-complete -c cloudstic -n __fish_use_subcommand -a profile -d 'Manage backup profiles'
-complete -c cloudstic -n __fish_use_subcommand -a source -d 'Discover source candidates for onboarding'
-complete -c cloudstic -n __fish_use_subcommand -a setup -d 'Guided setup and onboarding flows'
-complete -c cloudstic -n __fish_use_subcommand -a tui -d 'Launch the interactive terminal dashboard'
-complete -c cloudstic -n __fish_use_subcommand -a restore -d 'Restore files from a snapshot'
-complete -c cloudstic -n __fish_use_subcommand -a list -d 'List all backup snapshots'
-complete -c cloudstic -n __fish_use_subcommand -a ls -d 'List files within a snapshot'
-complete -c cloudstic -n __fish_use_subcommand -a prune -d 'Remove unused data chunks'
-complete -c cloudstic -n __fish_use_subcommand -a forget -d 'Remove a snapshot from history'
-complete -c cloudstic -n __fish_use_subcommand -a diff -d 'Compare two snapshots'
-complete -c cloudstic -n __fish_use_subcommand -a break-lock -d 'Remove a stale repository lock'
-complete -c cloudstic -n __fish_use_subcommand -a key -d 'Manage encryption key slots'
-complete -c cloudstic -n __fish_use_subcommand -a cat -d 'Display raw JSON of repository objects'
-complete -c cloudstic -n __fish_use_subcommand -a completion -d 'Generate shell completion scripts'
-complete -c cloudstic -n __fish_use_subcommand -a version -d 'Print version information'
-complete -c cloudstic -n __fish_use_subcommand -a help -d 'Show usage information'
-
-# Global flags (available for all subcommands)
-complete -c cloudstic -o store -l store -x -a 'local: s3: b2: sftp://' -d 'Storage backend URI (local:<path>, s3:<bucket>[/<prefix>], b2:<bucket>[/<prefix>], sftp://[user@]host[:port]/<path>)'
-complete -c cloudstic -o profile -l profile -x -a '(__fish_cloudstic_query profile-names)' -d 'Profile name from profiles.yaml'
-complete -c cloudstic -o profiles-file -l profiles-file -r -F -d 'Path to profiles YAML file'
-complete -c cloudstic -l s3-endpoint -x -d 'S3 compatible endpoint URL'
-complete -c cloudstic -l s3-region -x -d 'S3 region'
-complete -c cloudstic -l s3-profile -x -d 'AWS shared config profile for S3 auth'
-complete -c cloudstic -l s3-access-key -x -d 'S3 access key ID'
-complete -c cloudstic -l s3-secret-key -x -d 'S3 secret access key'
-complete -c cloudstic -l source-sftp-password -x -d 'SFTP source password'
-complete -c cloudstic -l source-sftp-key -r -F -d 'Path to SSH private key for SFTP source'
-complete -c cloudstic -l source-sftp-known-hosts -r -F -d 'Path to known_hosts file for SFTP source'
-complete -c cloudstic -l source-sftp-insecure -d 'Skip host key validation for SFTP source (INSECURE)'
-complete -c cloudstic -l store-sftp-password -x -d 'SFTP store password'
-complete -c cloudstic -l store-sftp-key -r -F -d 'Path to SSH private key for SFTP store'
-complete -c cloudstic -l store-sftp-known-hosts -r -F -d 'Path to known_hosts file for SFTP store'
-complete -c cloudstic -l store-sftp-insecure -d 'Skip host key validation for SFTP store (INSECURE)'
-complete -c cloudstic -l encryption-key -x -d 'Platform key (hex-encoded)'
-complete -c cloudstic -l password -x -d 'Repository password'
-complete -c cloudstic -l recovery-key -x -d 'Recovery key (24-word mnemonic)'
-complete -c cloudstic -l kms-key-arn -x -d 'AWS KMS key ARN'
-complete -c cloudstic -l kms-region -x -d 'AWS KMS region'
-complete -c cloudstic -l kms-endpoint -x -d 'Custom AWS KMS endpoint'
-complete -c cloudstic -l disable-packfile -d 'Disable bundling small objects into packs'
-complete -c cloudstic -l prompt -d 'Prompt for password interactively'
-complete -c cloudstic -l no-prompt -d 'Disable interactive prompts (for scripts and CI)'
-complete -c cloudstic -l verbose -d 'Log detailed operations'
-complete -c cloudstic -l quiet -d 'Suppress progress bars'
-complete -c cloudstic -l json -d 'Write command result as JSON to stdout'
-complete -c cloudstic -l debug -d 'Log every store request'
-
-# init
-complete -c cloudstic -n '__fish_seen_subcommand_from init' -l add-recovery-key -d 'Generate a 24-word recovery key'
-complete -c cloudstic -n '__fish_seen_subcommand_from init' -l no-encryption -d 'Create an unencrypted repository'
-complete -c cloudstic -n '__fish_seen_subcommand_from init' -l adopt-slots -d 'Adopt existing key slots'
-
-# backup
-complete -c cloudstic -n '__fish_seen_subcommand_from backup' -o source -l source -x -a 'local: sftp:// gdrive gdrive-changes onedrive onedrive-changes' -d 'Source URI'
-complete -c cloudstic -n '__fish_seen_subcommand_from backup' -o profile -l profile -x -a '(__fish_cloudstic_query profile-names)' -d 'Backup profile name'
-complete -c cloudstic -n '__fish_seen_subcommand_from backup' -o all-profiles -l all-profiles -d 'Run all enabled backup profiles'
-complete -c cloudstic -n '__fish_seen_subcommand_from backup' -o auth-ref -l auth-ref -x -a '(__fish_cloudstic_query auth-names)' -d 'Use named auth entry from profiles.yaml'
-complete -c cloudstic -n '__fish_seen_subcommand_from backup' -o profiles-file -l profiles-file -r -F -d 'Path to profiles YAML file'
-complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l skip-native-files -d 'Exclude Google-native files'
-complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l google-credentials -r -F -d 'Google service account credentials JSON'
-complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l google-credentials-ref -x -d 'Secret reference to Google credentials'
-complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l google-credentials-json -x -d 'Inline Google credentials JSON'
-complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l google-token-file -r -F -d 'Google OAuth token file'
-complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l google-token-ref -x -d 'Secret reference to Google OAuth token'
-complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l onedrive-client-id -x -d 'OneDrive OAuth client ID'
-complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l onedrive-token-file -r -F -d 'OneDrive OAuth token file'
-complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l onedrive-token-ref -x -d 'Secret reference to OneDrive OAuth token'
-complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l tag -x -d 'Tag for the snapshot'
-complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l ignore-empty-snapshot -d 'Skip creating a new snapshot when nothing changed'
-complete -c cloudstic -n '__fish_seen_subcommand_from backup' -o dry-run -l dry-run -d 'Scan without writing'
-complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l skip-mode -d 'Skip POSIX mode/uid/gid/btime/flags'
-complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l skip-flags -d 'Skip file flags collection'
-complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l skip-xattrs -d 'Skip extended attribute collection'
-complete -c cloudstic -n '__fish_seen_subcommand_from backup' -l xattr-namespaces -x -d 'Restrict xattr collection to prefixes'
-
-# profile subcommands
-complete -c cloudstic -n '__fish_seen_subcommand_from profile; and not __fish_seen_subcommand_from list show new' -a list -d 'List stores, auth entries, and backup profiles'
-complete -c cloudstic -n '__fish_seen_subcommand_from profile; and not __fish_seen_subcommand_from list show new' -a show -d 'Show one profile and resolved refs'
-complete -c cloudstic -n '__fish_seen_subcommand_from profile; and not __fish_seen_subcommand_from list show new' -a new -d 'Create or update backup profile'
-complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from list' -l profiles-file -r -F -d 'Path to profiles YAML file'
-complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from show' -l profiles-file -r -F -d 'Path to profiles YAML file'
-complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l profiles-file -r -F -d 'Path to profiles YAML file'
-complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l name -x -d 'Profile name'
-complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l source -x -a 'local: sftp:// gdrive gdrive-changes onedrive onedrive-changes' -d 'Source URI'
-complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l store-ref -x -d 'Store reference name'
-complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l store -x -d 'Store URI'
-complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l auth-ref -x -a '(__fish_cloudstic_query auth-names)' -d 'Auth reference name'
-complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l tag -x -d 'Tag for snapshots'
-complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l exclude -x -d 'Exclude pattern'
-complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l exclude-file -r -F -d 'Path to exclude file'
-complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l ignore-empty-snapshot -d 'Skip creating a new snapshot when nothing changed'
-complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l skip-native-files -d 'Exclude Google-native files'
-complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l volume-uuid -x -d 'Volume UUID override'
-complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l google-credentials -r -F -d 'Google service account credentials JSON'
-complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l google-credentials-ref -x -d 'Secret reference to Google credentials'
-complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l google-credentials-json -x -d 'Inline Google credentials JSON'
-complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l google-token-file -r -F -d 'Google OAuth token file'
-complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l google-token-ref -x -d 'Secret reference to Google OAuth token'
-complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l onedrive-client-id -x -d 'OneDrive OAuth client ID'
-complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l onedrive-token-file -r -F -d 'OneDrive OAuth token file'
-complete -c cloudstic -n '__fish_seen_subcommand_from profile; and __fish_seen_subcommand_from new' -l onedrive-token-ref -x -d 'Secret reference to OneDrive OAuth token'
-
-# store subcommands
-complete -c cloudstic -n '__fish_seen_subcommand_from store; and not __fish_seen_subcommand_from list show new verify init' -a list -d 'List configured stores'
-complete -c cloudstic -n '__fish_seen_subcommand_from store; and not __fish_seen_subcommand_from list show new verify init' -a show -d 'Show one store and its configuration'
-complete -c cloudstic -n '__fish_seen_subcommand_from store; and not __fish_seen_subcommand_from list show new verify init' -a new -d 'Create or update a store entry'
-complete -c cloudstic -n '__fish_seen_subcommand_from store; and not __fish_seen_subcommand_from list show new verify init' -a verify -d 'Verify store credentials and connectivity'
-complete -c cloudstic -n '__fish_seen_subcommand_from store; and not __fish_seen_subcommand_from list show new verify init' -a init -d 'Initialize a store by reference'
-complete -c cloudstic -n '__fish_seen_subcommand_from store; and __fish_seen_subcommand_from list' -l profiles-file -r -F -d 'Path to profiles YAML file'
-complete -c cloudstic -n '__fish_seen_subcommand_from store; and __fish_seen_subcommand_from show' -l profiles-file -r -F -d 'Path to profiles YAML file'
-complete -c cloudstic -n '__fish_seen_subcommand_from store; and __fish_seen_subcommand_from new' -l profiles-file -r -F -d 'Path to profiles YAML file'
-complete -c cloudstic -n '__fish_seen_subcommand_from store; and __fish_seen_subcommand_from new' -l store-sftp-password -x -d 'SFTP store password'
-complete -c cloudstic -n '__fish_seen_subcommand_from store; and __fish_seen_subcommand_from new' -l store-sftp-key -r -F -d 'Path to SSH private key for SFTP store'
-complete -c cloudstic -n '__fish_seen_subcommand_from store; and __fish_seen_subcommand_from new' -l store-sftp-known-hosts -r -F -d 'Path to known_hosts file for SFTP store'
-complete -c cloudstic -n '__fish_seen_subcommand_from store; and __fish_seen_subcommand_from new' -l store-sftp-insecure -d 'Skip host key validation for SFTP store (INSECURE)'
-complete -c cloudstic -n '__fish_seen_subcommand_from store; and __fish_seen_subcommand_from verify' -l profiles-file -r -F -d 'Path to profiles YAML file'
-complete -c cloudstic -n '__fish_seen_subcommand_from store; and __fish_seen_subcommand_from init' -l profiles-file -r -F -d 'Path to profiles YAML file'
-complete -c cloudstic -n '__fish_seen_subcommand_from store; and __fish_seen_subcommand_from init' -l yes -d 'Initialize without confirmation prompt'
-
-# source subcommands
-complete -c cloudstic -n '__fish_seen_subcommand_from source; and not __fish_seen_subcommand_from discover' -a discover -d 'Discover local source candidates'
-complete -c cloudstic -n '__fish_seen_subcommand_from source; and __fish_seen_subcommand_from discover' -l portable-only -d 'Only show portable or external source candidates'
-complete -c cloudstic -n '__fish_seen_subcommand_from source; and __fish_seen_subcommand_from discover' -l json -d 'Write discovered sources as JSON'
-
-# setup subcommands
-complete -c cloudstic -n '__fish_seen_subcommand_from setup; and not __fish_seen_subcommand_from workstation' -a workstation -d 'Preview workstation onboarding plan'
-complete -c cloudstic -n '__fish_seen_subcommand_from setup; and __fish_seen_subcommand_from workstation' -l dry-run -d 'Preview generated profiles without writing configuration'
-complete -c cloudstic -n '__fish_seen_subcommand_from setup; and __fish_seen_subcommand_from workstation' -l yes -d 'Accept default selections without prompting'
-complete -c cloudstic -n '__fish_seen_subcommand_from setup; and __fish_seen_subcommand_from workstation' -l profiles-file -r -F -d 'Path to profiles YAML file'
-complete -c cloudstic -n '__fish_seen_subcommand_from setup; and __fish_seen_subcommand_from workstation' -l store-ref -x -d 'Existing store reference to attach'
-complete -c cloudstic -n '__fish_seen_subcommand_from setup; and __fish_seen_subcommand_from workstation' -l json -d 'Write onboarding plan as JSON'
-
-# auth subcommands
-complete -c cloudstic -n '__fish_seen_subcommand_from auth; and not __fish_seen_subcommand_from list show new login' -a list -d 'List auth entries from profiles.yaml'
-complete -c cloudstic -n '__fish_seen_subcommand_from auth; and not __fish_seen_subcommand_from list show new login' -a show -d 'Show one auth entry'
-complete -c cloudstic -n '__fish_seen_subcommand_from auth; and not __fish_seen_subcommand_from list show new login' -a new -d 'Create or update reusable auth entry'
-complete -c cloudstic -n '__fish_seen_subcommand_from auth; and not __fish_seen_subcommand_from list show new login' -a login -d 'Run OAuth login flow for auth entry'
-complete -c cloudstic -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from list' -l profiles-file -r -F -d 'Path to profiles YAML file'
-complete -c cloudstic -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from show' -l profiles-file -r -F -d 'Path to profiles YAML file'
-complete -c cloudstic -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from new' -l profiles-file -r -F -d 'Path to profiles YAML file'
-complete -c cloudstic -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from new' -l name -x -d 'Auth reference name'
-complete -c cloudstic -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from new' -l provider -x -a 'google onedrive' -d 'Auth provider'
-complete -c cloudstic -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from new' -l google-credentials -r -F -d 'Google service account credentials JSON'
-complete -c cloudstic -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from new' -l google-credentials-ref -x -d 'Secret reference to Google credentials'
-complete -c cloudstic -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from new' -l google-credentials-json -x -d 'Inline Google credentials JSON'
-complete -c cloudstic -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from new' -l google-token-file -r -F -d 'Google OAuth token file'
-complete -c cloudstic -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from new' -l google-token-ref -x -d 'Secret reference to Google OAuth token'
-complete -c cloudstic -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from new' -l onedrive-client-id -x -d 'OneDrive OAuth client ID'
-complete -c cloudstic -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from new' -l onedrive-token-file -r -F -d 'OneDrive OAuth token file'
-complete -c cloudstic -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from new' -l onedrive-token-ref -x -d 'Secret reference to OneDrive OAuth token'
-complete -c cloudstic -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from login' -l profiles-file -r -F -d 'Path to profiles YAML file'
-complete -c cloudstic -n '__fish_seen_subcommand_from auth; and __fish_seen_subcommand_from login' -l name -x -d 'Auth reference name'
-
-# restore
-complete -c cloudstic -n '__fish_seen_subcommand_from restore' -l output -r -F -d 'Output ZIP file path'
-complete -c cloudstic -n '__fish_seen_subcommand_from restore' -l dry-run -d 'Show what would be restored'
-
-# list
-complete -c cloudstic -n '__fish_seen_subcommand_from list' -l group -d 'Group output by source identity'
-
-# prune
-complete -c cloudstic -n '__fish_seen_subcommand_from prune' -l dry-run -d 'Show what would be deleted'
-
-# forget
-complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l prune -d 'Run prune after forgetting'
-complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l dry-run -d 'Show what would be removed'
-complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l keep-last -x -d 'Keep N most recent snapshots'
-complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l keep-hourly -x -d 'Keep N hourly snapshots'
-complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l keep-daily -x -d 'Keep N daily snapshots'
-complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l keep-weekly -x -d 'Keep N weekly snapshots'
-complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l keep-monthly -x -d 'Keep N monthly snapshots'
-complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l keep-yearly -x -d 'Keep N yearly snapshots'
-complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l tag -x -d 'Filter by tag'
-complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l source -x -d 'Filter by source URI (e.g. local:./docs, gdrive)'
-complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l account -x -d 'Filter by account'
-complete -c cloudstic -n '__fish_seen_subcommand_from forget' -l group-by -x -d 'Group snapshots by fields'
-
-# key subcommands
-complete -c cloudstic -n '__fish_seen_subcommand_from key; and not __fish_seen_subcommand_from list add-recovery passwd' -a list -d 'List all encryption key slots'
-complete -c cloudstic -n '__fish_seen_subcommand_from key; and not __fish_seen_subcommand_from list add-recovery passwd' -a add-recovery -d 'Generate a 24-word recovery key'
-complete -c cloudstic -n '__fish_seen_subcommand_from key; and not __fish_seen_subcommand_from list add-recovery passwd' -a passwd -d 'Change the repository password'
-complete -c cloudstic -n '__fish_seen_subcommand_from key; and __fish_seen_subcommand_from passwd' -l new-password -x -d 'New repository password'
-
-# cat
-complete -c cloudstic -n '__fish_seen_subcommand_from cat' -l raw -d 'Output raw, unformatted data'
-
-# completion
-complete -c cloudstic -n '__fish_seen_subcommand_from completion' -a 'bash zsh fish' -d 'Shell type'
 `)
+	for _, root := range publicRootCommands() {
+		_, _ = fmt.Fprintf(w, "complete -c cloudstic -n __fish_use_subcommand -a %s -d %s\n", fishQuote(root.name), fishQuote(root.summary))
+	}
+	for _, spec := range globalFlagSpecs {
+		writeFishFlag(w, "__fish_use_subcommand", spec)
+	}
+	for _, root := range publicRootCommands() {
+		for _, child := range root.children {
+			if child.hidden {
+				continue
+			}
+			condition := fmt.Sprintf("__fish_seen_subcommand_from %s; and not __fish_seen_subcommand_from %s", root.name, commandWords(root.children))
+			_, _ = fmt.Fprintf(w, "complete -c cloudstic -n %s -a %s -d %s\n", fishQuote(condition), fishQuote(child.name), fishQuote(child.summary))
+		}
+	}
+	for _, command := range publicLeafCommands() {
+		condition := fishCommandCondition(command)
+		for _, spec := range command.effectiveFlags() {
+			writeFishFlag(w, condition, spec)
+		}
+		if len(command.argumentValues) != 0 {
+			_, _ = fmt.Fprintf(w, "complete -c cloudstic -n %s -a %s\n", fishQuote(condition), fishQuote(strings.Join(command.argumentValues, " ")))
+		}
+	}
+}
+
+func writeFishFlag(w io.Writer, condition string, spec flagSpec) {
+	_, _ = fmt.Fprintf(w, "complete -c cloudstic -n %s -l %s", fishQuote(condition), spec.name)
+	if spec.takesValue() {
+		_, _ = fmt.Fprint(w, " -r")
+	}
+	if len(spec.completionValues) != 0 {
+		_, _ = fmt.Fprintf(w, " -a %s", fishQuote(strings.Join(spec.completionValues, " ")))
+	} else {
+		switch spec.completion {
+		case completionFile:
+			_, _ = fmt.Fprint(w, " -F")
+		case completionProfile:
+			_, _ = fmt.Fprint(w, " -a '(__fish_cloudstic_query profile-names)'")
+		case completionAuth:
+			_, _ = fmt.Fprint(w, " -a '(__fish_cloudstic_query auth-names)'")
+		}
+	}
+	_, _ = fmt.Fprintf(w, " -d %s\n", fishQuote(spec.description))
+}
+
+func fishCommandCondition(command *commandSpec) string {
+	if command.parent == nil {
+		return "__fish_seen_subcommand_from " + command.name
+	}
+	return "__fish_seen_subcommand_from " + command.parent.name + "; and __fish_seen_subcommand_from " + command.name
+}
+
+func fishQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "\\'") + "'"
 }

--- a/cmd/cloudstic/completion_dynamic.go
+++ b/cmd/cloudstic/completion_dynamic.go
@@ -13,6 +13,10 @@ import (
 
 var completionLoadProfilesFile = cloudstic.LoadProfilesFile
 
+func completionQueryCommandSpec() *commandSpec {
+	return leaf("__complete", "", "", runCompletionQuery, profilesFileFlag()).hide().withoutFlagProbe()
+}
+
 func runCompletionQuery(r *runner, ctx context.Context) int {
 	if len(r.args) < 1 {
 		return 0
@@ -76,17 +80,19 @@ func completionLoadProfilesConfig(path string) (*cloudstic.ProfilesConfig, error
 }
 
 func completionProfilesPath(args []string) string {
+	command := completionQueryCommandSpec()
 	fs := flag.NewFlagSet("__complete", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	defaultPath := envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback())
-	profilesFile := fs.String("profiles-file", defaultPath, "")
-	_ = fs.Parse(filterCompletionFlags(args, map[string]bool{
-		"profiles-file": true,
-	}))
+	profilesFile := fs.String("profiles-file", defaultProfilesPathFallback(), "")
+	_ = parseFlags(fs, filterCompletionFlags(args, command.flags), command)
 	return *profilesFile
 }
 
-func filterCompletionFlags(args []string, specs map[string]bool) []string {
+func filterCompletionFlags(args []string, flagSpecs []flagSpec) []string {
+	specs := make(map[string]bool, len(flagSpecs))
+	for _, spec := range flagSpecs {
+		specs[spec.name] = spec.takesValue()
+	}
 	filtered := make([]string, 0, len(args))
 	for i := 0; i < len(args); i++ {
 		arg := args[i]

--- a/cmd/cloudstic/completion_test.go
+++ b/cmd/cloudstic/completion_test.go
@@ -3,9 +3,40 @@ package main
 import (
 	"bytes"
 	"io"
+	"slices"
 	"strings"
 	"testing"
 )
+
+func TestStaticCompletionValuesComeFromFlagSpecs(t *testing.T) {
+	tests := []struct {
+		name string
+		spec flagSpec
+		want []string
+	}{
+		{"global store", globalFlagByName("store"), []string{"local:", "s3:", "b2:", "sftp://"}},
+		{"backup source", mustCommandFlag(t, backupCommandSpec(), "source"), []string{"local:", "sftp://", "gdrive", "gdrive-changes", "onedrive", "onedrive-changes"}},
+		{"store new uri", mustCommandFlag(t, storeNewCommandSpec(), "uri"), []string{"local:", "s3:", "b2:", "sftp://"}},
+		{"forget source", mustCommandFlag(t, forgetCommandSpec(), "source"), []string{"local:", "sftp://", "gdrive", "gdrive-changes", "onedrive", "onedrive-changes"}},
+		{"restore format", mustCommandFlag(t, restoreCommandSpec(), "format"), []string{"zip", "dir"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if !slices.Equal(test.spec.completionValues, test.want) {
+				t.Fatalf("completion values = %v, want %v", test.spec.completionValues, test.want)
+			}
+		})
+	}
+}
+
+func mustCommandFlag(t *testing.T, command *commandSpec, name string) flagSpec {
+	t.Helper()
+	spec, ok := command.flag(name)
+	if !ok {
+		t.Fatalf("command %s is missing -%s", command.path(), name)
+	}
+	return spec
+}
 
 func TestRunCompletion(t *testing.T) {
 	for _, shell := range []string{"bash", "zsh", "fish"} {
@@ -19,171 +50,90 @@ func TestRunCompletion(t *testing.T) {
 
 	var errOut bytes.Buffer
 	if code := runCompletion(&runner{out: io.Discard, errOut: &errOut}); code != 1 {
-		t.Fatalf("runCompletion() without a shell exit code = %d, want 1", code)
+		t.Fatalf("runCompletion() without shell exit code = %d, want 1", code)
 	}
 	if !strings.Contains(errOut.String(), "Usage: cloudstic completion <shell>") {
 		t.Fatalf("unexpected usage output: %q", errOut.String())
 	}
 }
 
-func TestCompletionBash(t *testing.T) {
-	var buf bytes.Buffer
-	completionBash(&buf)
-	out := buf.String()
-
-	if out == "" {
-		t.Fatal("bash completion output is empty")
+func TestGeneratedCompletionsContainRegistry(t *testing.T) {
+	tests := []struct {
+		name     string
+		generate func(io.Writer)
+		markers  []string
+	}{
+		{name: "bash", generate: completionBash, markers: []string{"_cloudstic()", "complete -F _cloudstic cloudstic", "profile-names", "auth-names"}},
+		{name: "zsh", generate: completionZsh, markers: []string{"#compdef cloudstic", "_cloudstic()", "compdef _cloudstic cloudstic", "_cloudstic_profile_names", "_cloudstic_auth_names"}},
+		{name: "fish", generate: completionFish, markers: []string{"complete -c cloudstic -f", "function __fish_cloudstic_query", "profile-names", "auth-names"}},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			tt.generate(&out)
+			script := out.String()
+			for _, marker := range tt.markers {
+				if !strings.Contains(script, marker) {
+					t.Errorf("completion missing marker %q", marker)
+				}
+			}
+			for _, root := range publicRootCommands() {
+				if !strings.Contains(script, root.name) {
+					t.Errorf("completion missing root command %q", root.name)
+				}
+			}
+			for _, command := range publicLeafCommands() {
+				for _, spec := range command.effectiveFlags() {
+					if !strings.Contains(script, spec.name) {
+						t.Errorf("completion missing %q flag %q", command.path(), spec.name)
+					}
+				}
+			}
+			if strings.Contains(script, "__complete:Display") || strings.Contains(script, "--version:Display") {
+				t.Error("completion exposes a hidden command or alias")
+			}
+		})
+	}
+}
 
-	// Verify it's a valid bash completion script
-	for _, marker := range []string{
-		"_cloudstic()",
-		"_cloudstic_query()",
-		"complete -F _cloudstic cloudstic",
-		// All commands are listed
-		"init", "backup", "auth", "profile", "store", "source", "setup", "tui", "restore", "list", "ls", "prune", "forget",
-		"diff", "break-lock", "key", "cat", "completion",
-		// Key subcommands
-		"list add-recovery passwd",
-		// Global flags
-		"-store", "-password", "-verbose",
-		// Command-specific flags
-		"-dry-run", "-add-recovery-key", "-source", "-output",
-		"-profiles-file",
-		"-profile", "-all-profiles",
-		"-auth-ref",
-		"profile-names",
-		"auth-names",
-		"-ignore-empty-snapshot",
-		"workstation",
-		"-store-ref",
-		// Value completions
-		"local: s3: b2: sftp://",
-		"gdrive", "onedrive",
-	} {
-		if !strings.Contains(out, marker) {
-			t.Errorf("bash completion missing expected marker: %q", marker)
+func TestBashCompletionBooleanSFTPFlags(t *testing.T) {
+	var out bytes.Buffer
+	completionBash(&out)
+	script := out.String()
+	for _, name := range []string{"source-sftp-insecure", "store-sftp-insecure"} {
+		if !strings.Contains(script, "-"+name) {
+			t.Fatalf("bash completion missing -%s", name)
+		}
+		for _, line := range strings.Split(script, "\n") {
+			_, valueList, ok := strings.Cut(line, "value_flags=")
+			if ok && strings.Contains(valueList, "-"+name) {
+				t.Errorf("boolean flag -%s appears in value-taking list: %s", name, line)
+			}
+		}
+	}
+	if !strings.Contains(script, `if [[ -z "$root" ]]`) {
+		t.Error("bash completion does not handle partial root commands")
+	}
+	if !strings.Contains(script, "for value_flag in $value_flags") {
+		t.Error("bash completion does not skip values using the generated value flag list")
+	}
+}
+
+func TestStoreNewCompletionOmitsUnsupportedHostKeyFlags(t *testing.T) {
+	storeNew := findCommand(rootCommand("store").children, "new")
+	for _, spec := range storeNew.effectiveFlags() {
+		if spec.name == "store-sftp-known-hosts" || spec.name == "store-sftp-insecure" {
+			t.Errorf("store new still advertises unsupported flag %q", spec.name)
 		}
 	}
 }
 
-func TestCompletionZsh(t *testing.T) {
-	var buf bytes.Buffer
-	completionZsh(&buf)
-	out := buf.String()
-
-	if out == "" {
-		t.Fatal("zsh completion output is empty")
+func TestCompletionProfilesPathUsesSpecEnvironmentAndFlagPrecedence(t *testing.T) {
+	t.Setenv("CLOUDSTIC_PROFILES_FILE", "/environment/profiles.yaml")
+	if got := completionProfilesPath(nil); got != "/environment/profiles.yaml" {
+		t.Fatalf("environment profiles path = %q", got)
 	}
-
-	for _, marker := range []string{
-		"#compdef cloudstic",
-		"_cloudstic()",
-		"_cloudstic_query()",
-		"_cloudstic_profile_names",
-		"_cloudstic_auth_names",
-		"_cloudstic_store_prefixes()",
-		"compdef _cloudstic cloudstic",
-		// Commands with descriptions
-		"init:Initialize a new repository",
-		"backup:Create a new backup snapshot",
-		"auth:Manage reusable cloud auth entries",
-		"profile:Manage backup profiles",
-		"tui:Launch the interactive terminal dashboard",
-		"new:Create or update a backup profile",
-		"show:Show one profile and resolved store/auth references",
-		"new:Create or update a reusable cloud auth entry",
-		"login:Run OAuth login flow for one auth entry",
-		"key:Manage encryption key slots",
-		"completion:Generate shell completion scripts",
-		"source:Discover source candidates for onboarding",
-		"discover:Discover local source candidates",
-		"setup:Guided setup and onboarding flows",
-		"workstation:Preview workstation onboarding plan",
-		// Key subcommands
-		"list:List all encryption key slots",
-		"add-recovery:Generate a 24-word recovery key",
-		"passwd:Change the repository password",
-		"-new-password[New repository password]",
-		// Global flags with descriptions
-		"-store[Storage backend URI]:uri:_cloudstic_store_prefixes",
-		"-verbose[Log detailed operations]",
-		// Subcommand-specific flags
-		"-add-recovery-key[Generate a 24-word recovery key]",
-		"-dry-run[Scan without writing]",
-		"-keep-last[Keep N most recent snapshots]",
-		"list:List stores, auth entries, and backup profiles",
-		"-profile[Backup profile name]",
-		"-all-profiles[Run all enabled backup profiles]",
-		"-auth-ref[Use named auth entry from profiles.yaml]",
-		"-ignore-empty-snapshot[Skip creating a new snapshot when nothing changed]",
-		"-store-ref[Existing store reference to attach]",
-		// Value completions (source type list still present)
-		"(local: sftp:// gdrive gdrive-changes onedrive onedrive-changes)",
-		"(bash zsh fish)",
-	} {
-		if !strings.Contains(out, marker) {
-			t.Errorf("zsh completion missing expected marker: %q", marker)
-		}
-	}
-}
-
-func TestCompletionFish(t *testing.T) {
-	var buf bytes.Buffer
-	completionFish(&buf)
-	out := buf.String()
-
-	if out == "" {
-		t.Fatal("fish completion output is empty")
-	}
-
-	for _, marker := range []string{
-		"complete -c cloudstic -f",
-		"function __fish_cloudstic_query",
-		// Subcommands
-		"complete -c cloudstic -n __fish_use_subcommand -a init",
-		"complete -c cloudstic -n __fish_use_subcommand -a backup",
-		"complete -c cloudstic -n __fish_use_subcommand -a profile",
-		"complete -c cloudstic -n __fish_use_subcommand -a auth",
-		"complete -c cloudstic -n __fish_use_subcommand -a source",
-		"complete -c cloudstic -n __fish_use_subcommand -a setup",
-		"complete -c cloudstic -n __fish_use_subcommand -a tui",
-		"complete -c cloudstic -n __fish_use_subcommand -a key",
-		"complete -c cloudstic -n __fish_use_subcommand -a completion",
-		// Key subcommands
-		"-a list -d 'List all encryption key slots'",
-		"-a add-recovery -d 'Generate a 24-word recovery key'",
-		"-a passwd -d 'Change the repository password'",
-		"-l new-password",
-		// Global flags
-		"complete -c cloudstic -o store -l store -x",
-		"complete -c cloudstic -l verbose",
-		// Command-specific flags
-		"__fish_seen_subcommand_from init",
-		"__fish_seen_subcommand_from backup",
-		"__fish_seen_subcommand_from forget",
-		"__fish_seen_subcommand_from profile",
-		"-l dry-run",
-		"-l keep-last",
-		"-l profiles-file",
-		"-l profile",
-		"-l all-profiles",
-		"-l auth-ref",
-		"(__fish_cloudstic_query profile-names)",
-		"(__fish_cloudstic_query auth-names)",
-		"-l ignore-empty-snapshot",
-		"-a workstation -d 'Preview workstation onboarding plan'",
-		"-l store-ref",
-		"-a show -d 'Show one profile and resolved refs'",
-		"-a new -d 'Create or update backup profile'",
-		"-a login -d 'Run OAuth login flow for auth entry'",
-		"-l add-recovery-key",
-		// Value completions (source type list still present)
-		"'local: sftp:// gdrive gdrive-changes onedrive onedrive-changes'",
-		"'bash zsh fish'",
-	} {
-		if !strings.Contains(out, marker) {
-			t.Errorf("fish completion missing expected marker: %q", marker)
-		}
+	if got := completionProfilesPath([]string{"-profiles-file", "/flag/profiles.yaml"}); got != "/flag/profiles.yaml" {
+		t.Fatalf("flag profiles path = %q", got)
 	}
 }

--- a/cmd/cloudstic/config_tables.go
+++ b/cmd/cloudstic/config_tables.go
@@ -345,6 +345,8 @@ func secretDisplayRows(s cloudstic.ProfileStore) []table.Row {
 	}
 	appendRow("S3 Access Key Secret", s.S3AccessKeySecret, false)
 	appendRow("S3 Secret Key Secret", s.S3SecretKeySecret, false)
+	appendRow("B2 Key ID Secret", s.B2KeyIDSecret, false)
+	appendRow("B2 Application Key Secret", s.B2AppKeySecret, false)
 	appendRow("SFTP Password Secret", s.StoreSFTPPasswordSecret, false)
 	appendRow("SFTP Key Secret", s.StoreSFTPKeySecret, false)
 	appendRow("Password Secret", s.PasswordSecret, false)

--- a/cmd/cloudstic/flags.go
+++ b/cmd/cloudstic/flags.go
@@ -6,28 +6,27 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/cloudstic/cli/internal/ui"
 )
 
-func envDefault(key, fallback string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return fallback
-}
+type valueSource string
 
-func envBool(key string) bool {
-	v := os.Getenv(key)
-	return v == "1" || v == "true"
-}
+const (
+	valueSourceDefault     valueSource = "default"
+	valueSourceProfile     valueSource = "profile"
+	valueSourceEnvironment valueSource = "environment"
+	valueSourceFlag        valueSource = "flag"
+)
 
 type globalFlags struct {
 	store                             string
 	profile, profilesFile             string
 	s3Endpoint, s3Region, s3Profile   string
 	s3AccessKey, s3SecretKey          string
+	b2KeyID, b2AppKey                 string
 	sourceSFTPPassword, sourceSFTPKey string
 	sourceSFTPInsecure                bool
 	sourceSFTPKnownHosts              string
@@ -44,40 +43,128 @@ type globalFlags struct {
 	json                              bool
 	debugLog                          *ui.SafeLogWriter
 	flagSet                           *flag.FlagSet
+	sources                           map[string]valueSource
+}
+
+var globalFlagSpecs = []flagSpec{
+	storeFlag(),
+	valueFlag("profile", "name", "Backup profile name", completionProfile).withEnvironment(environment("CLOUDSTIC_PROFILE")),
+	profilesFileFlag(),
+	valueFlag("s3-endpoint", "url", "S3-compatible endpoint URL", completionNone).withEnvironment(environment("CLOUDSTIC_S3_ENDPOINT")),
+	valueFlag("s3-region", "region", "S3 region", completionNone).withEnvironment(environment("CLOUDSTIC_S3_REGION")),
+	valueFlag("s3-profile", "name", "AWS shared config profile", completionNone).withEnvironment(
+		environment("CLOUDSTIC_S3_PROFILE"), environment("AWS_PROFILE")),
+	valueFlag("s3-access-key", "key", "S3 access key ID", completionNone).withEnvironment(sensitiveEnvironment("AWS_ACCESS_KEY_ID")),
+	valueFlag("s3-secret-key", "secret", "S3 secret access key", completionNone).withEnvironment(sensitiveEnvironment("AWS_SECRET_ACCESS_KEY")),
+	valueFlag("b2-key-id", "key", "Backblaze B2 application key ID", completionNone).withEnvironment(sensitiveEnvironment("B2_KEY_ID")),
+	valueFlag("b2-app-key", "secret", "Backblaze B2 application key", completionNone).withEnvironment(sensitiveEnvironment("B2_APP_KEY")),
+	valueFlag("source-sftp-password", "password", "SFTP source password", completionNone).withEnvironment(sensitiveEnvironment("CLOUDSTIC_SOURCE_SFTP_PASSWORD")),
+	valueFlag("source-sftp-key", "path", "SSH private key for SFTP source", completionFile).withEnvironment(sensitiveEnvironment("CLOUDSTIC_SOURCE_SFTP_KEY")),
+	valueFlag("source-sftp-known-hosts", "path", "known_hosts file for SFTP source", completionFile).withEnvironment(environment("CLOUDSTIC_SOURCE_SFTP_KNOWN_HOSTS")),
+	boolFlag("source-sftp-insecure", "Skip host-key validation for SFTP source (INSECURE)").withEnvironment(environment("CLOUDSTIC_SOURCE_SFTP_INSECURE")),
+	valueFlag("store-sftp-password", "password", "SFTP store password", completionNone).withEnvironment(sensitiveEnvironment("CLOUDSTIC_STORE_SFTP_PASSWORD")),
+	valueFlag("store-sftp-key", "path", "SSH private key for SFTP store", completionFile).withEnvironment(sensitiveEnvironment("CLOUDSTIC_STORE_SFTP_KEY")),
+	valueFlag("store-sftp-known-hosts", "path", "known_hosts file for SFTP store", completionFile).withEnvironment(environment("CLOUDSTIC_STORE_SFTP_KNOWN_HOSTS")),
+	boolFlag("store-sftp-insecure", "Skip host-key validation for SFTP store (INSECURE)").withEnvironment(environment("CLOUDSTIC_STORE_SFTP_INSECURE")),
+	valueFlag("encryption-key", "hex", "Platform encryption key", completionNone).withEnvironment(sensitiveEnvironment("CLOUDSTIC_ENCRYPTION_KEY")).inSection(flagSectionEncryption),
+	valueFlag("password", "password", "Repository password", completionNone).withEnvironment(sensitiveEnvironment("CLOUDSTIC_PASSWORD")).inSection(flagSectionEncryption),
+	valueFlag("recovery-key", "words", "Recovery key mnemonic", completionNone).withEnvironment(sensitiveEnvironment("CLOUDSTIC_RECOVERY_KEY")).inSection(flagSectionEncryption),
+	valueFlag("kms-key-arn", "arn", "AWS KMS key ARN", completionNone).withEnvironment(environment("CLOUDSTIC_KMS_KEY_ARN")).inSection(flagSectionEncryption),
+	valueFlag("kms-region", "region", "AWS KMS region", completionNone).withEnvironment(environment("CLOUDSTIC_KMS_REGION")).inSection(flagSectionEncryption),
+	valueFlag("kms-endpoint", "url", "AWS KMS endpoint URL", completionNone).withEnvironment(environment("CLOUDSTIC_KMS_ENDPOINT")).inSection(flagSectionEncryption),
+	boolFlag("disable-packfile", "Disable small-object packfiles").withEnvironment(environment("CLOUDSTIC_DISABLE_PACKFILE")),
+	boolFlag("prompt", "Prompt for a repository password").inSection(flagSectionEncryption),
+	boolFlag("no-prompt", "Disable interactive prompts"),
+	boolFlag("verbose", "Log detailed operations"),
+	boolFlag("quiet", "Suppress progress bars"),
+	boolFlag("json", "Write command result as JSON"),
+	boolFlag("debug", "Log every store request"),
+}
+
+func storeFlag() flagSpec {
+	return storeURIFlag("store", "Storage backend URI").withEnvironment(environment("CLOUDSTIC_STORE"))
+}
+
+func profilesFileFlag() flagSpec {
+	return valueFlag("profiles-file", "path", "Path to profiles YAML file", completionFile).withEnvironment(environment("CLOUDSTIC_PROFILES_FILE"))
+}
+
+func sourceFlag() flagSpec {
+	return sourceURIFlag("source", "Source URI").withEnvironment(environment("CLOUDSTIC_SOURCE"))
+}
+
+func storeURIFlag(name, description string) flagSpec {
+	return valueFlag(name, "uri", description, completionNone).withCompletionValues("local:", "s3:", "b2:", "sftp://")
+}
+
+func sourceURIFlag(name, description string) flagSpec {
+	return valueFlag(name, "uri", description, completionNone).withCompletionValues(
+		"local:", "sftp://", "gdrive", "gdrive-changes", "onedrive", "onedrive-changes")
+}
+
+func volumeUUIDFlag() flagSpec {
+	return valueFlag("volume-uuid", "uuid", "Local volume UUID", completionNone).withEnvironment(hiddenEnvironment("CLOUDSTIC_VOLUME_UUID"))
+}
+
+func googleCredentialsFlag() flagSpec {
+	return valueFlag("google-credentials", "path", "Google credentials file", completionFile).withEnvironment(
+		sensitiveEnvironment("GOOGLE_APPLICATION_CREDENTIALS"))
+}
+
+func googleCredentialsJSONFlag() flagSpec {
+	return valueFlag("google-credentials-json", "json", "Inline Google credentials", completionNone).withEnvironment(
+		sensitiveEnvironment("GOOGLE_CREDENTIALS_JSON"))
+}
+
+func googleTokenFileFlag() flagSpec {
+	return valueFlag("google-token-file", "path", "Google OAuth token file", completionFile).withEnvironment(
+		sensitiveEnvironment("GOOGLE_TOKEN_FILE"))
+}
+
+func onedriveClientIDFlag() flagSpec {
+	return valueFlag("onedrive-client-id", "id", "OneDrive client ID", completionNone).withEnvironment(
+		environment("ONEDRIVE_CLIENT_ID"))
+}
+
+func onedriveTokenFileFlag() flagSpec {
+	return valueFlag("onedrive-token-file", "path", "OneDrive token file", completionFile).withEnvironment(
+		sensitiveEnvironment("ONEDRIVE_TOKEN_FILE"))
 }
 
 func addGlobalFlags(fs *flag.FlagSet) *globalFlags {
 	g := &globalFlags{flagSet: fs}
-	fs.StringVar(&g.store, "store", envDefault("CLOUDSTIC_STORE", "local:./backup_store"), "Storage backend URI: local:<path>, s3:<bucket>[/<prefix>], b2:<bucket>[/<prefix>], sftp://[user@]host[:port]/<path>")
+	fs.StringVar(&g.store, "store", "local:./backup_store", "Storage backend URI: local:<path>, s3:<bucket>[/<prefix>], b2:<bucket>[/<prefix>], sftp://[user@]host[:port]/<path>")
 	defaultProfilesPath, err := defaultProfilesPath()
 	if err != nil {
 		defaultProfilesPath = defaultProfilesFilename
 	}
-	fs.StringVar(&g.profile, "profile", envDefault("CLOUDSTIC_PROFILE", ""), "Profile name from profiles.yaml")
-	fs.StringVar(&g.profilesFile, "profiles-file", envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPath), "Path to profiles YAML file")
-	fs.StringVar(&g.s3Endpoint, "s3-endpoint", envDefault("CLOUDSTIC_S3_ENDPOINT", ""), "S3 compatible endpoint URL (for MinIO, R2, etc.)")
-	fs.StringVar(&g.s3Region, "s3-region", envDefault("CLOUDSTIC_S3_REGION", "us-east-1"), "S3 region")
-	fs.StringVar(&g.s3Profile, "s3-profile", envDefault("CLOUDSTIC_S3_PROFILE", envDefault("AWS_PROFILE", "")), "AWS shared config profile for S3 credentials")
-	fs.StringVar(&g.s3AccessKey, "s3-access-key", envDefault("AWS_ACCESS_KEY_ID", ""), "S3 access key ID")
-	fs.StringVar(&g.s3SecretKey, "s3-secret-key", envDefault("AWS_SECRET_ACCESS_KEY", ""), "S3 secret access key")
+	fs.StringVar(&g.profile, "profile", "", "Profile name from profiles.yaml")
+	fs.StringVar(&g.profilesFile, "profiles-file", defaultProfilesPath, "Path to profiles YAML file")
+	fs.StringVar(&g.s3Endpoint, "s3-endpoint", "", "S3 compatible endpoint URL (for MinIO, R2, etc.)")
+	fs.StringVar(&g.s3Region, "s3-region", "us-east-1", "S3 region")
+	fs.StringVar(&g.s3Profile, "s3-profile", "", "AWS shared config profile for S3 credentials")
+	fs.StringVar(&g.s3AccessKey, "s3-access-key", "", "S3 access key ID")
+	fs.StringVar(&g.s3SecretKey, "s3-secret-key", "", "S3 secret access key")
+	fs.StringVar(&g.b2KeyID, "b2-key-id", "", "Backblaze B2 application key ID")
+	fs.StringVar(&g.b2AppKey, "b2-app-key", "", "Backblaze B2 application key")
 
-	fs.StringVar(&g.sourceSFTPPassword, "source-sftp-password", envDefault("CLOUDSTIC_SOURCE_SFTP_PASSWORD", ""), "SFTP source password")
-	fs.StringVar(&g.sourceSFTPKey, "source-sftp-key", envDefault("CLOUDSTIC_SOURCE_SFTP_KEY", ""), "Path to SSH private key for SFTP source")
-	fs.BoolVar(&g.sourceSFTPInsecure, "source-sftp-insecure", envBool("CLOUDSTIC_SOURCE_SFTP_INSECURE"), "Skip host key validation for SFTP source (INSECURE)")
-	fs.StringVar(&g.sourceSFTPKnownHosts, "source-sftp-known-hosts", envDefault("CLOUDSTIC_SOURCE_SFTP_KNOWN_HOSTS", ""), "Path to known_hosts file for SFTP source")
+	fs.StringVar(&g.sourceSFTPPassword, "source-sftp-password", "", "SFTP source password")
+	fs.StringVar(&g.sourceSFTPKey, "source-sftp-key", "", "Path to SSH private key for SFTP source")
+	fs.BoolVar(&g.sourceSFTPInsecure, "source-sftp-insecure", false, "Skip host key validation for SFTP source (INSECURE)")
+	fs.StringVar(&g.sourceSFTPKnownHosts, "source-sftp-known-hosts", "", "Path to known_hosts file for SFTP source")
 
-	fs.StringVar(&g.storeSFTPPassword, "store-sftp-password", envDefault("CLOUDSTIC_STORE_SFTP_PASSWORD", ""), "SFTP store password")
-	fs.StringVar(&g.storeSFTPKey, "store-sftp-key", envDefault("CLOUDSTIC_STORE_SFTP_KEY", ""), "Path to SSH private key for SFTP store")
-	fs.BoolVar(&g.storeSFTPInsecure, "store-sftp-insecure", envBool("CLOUDSTIC_STORE_SFTP_INSECURE"), "Skip host key validation for SFTP store (INSECURE)")
-	fs.StringVar(&g.storeSFTPKnownHosts, "store-sftp-known-hosts", envDefault("CLOUDSTIC_STORE_SFTP_KNOWN_HOSTS", ""), "Path to known_hosts file for SFTP store")
+	fs.StringVar(&g.storeSFTPPassword, "store-sftp-password", "", "SFTP store password")
+	fs.StringVar(&g.storeSFTPKey, "store-sftp-key", "", "Path to SSH private key for SFTP store")
+	fs.BoolVar(&g.storeSFTPInsecure, "store-sftp-insecure", false, "Skip host key validation for SFTP store (INSECURE)")
+	fs.StringVar(&g.storeSFTPKnownHosts, "store-sftp-known-hosts", "", "Path to known_hosts file for SFTP store")
 
-	fs.StringVar(&g.encryptionKey, "encryption-key", envDefault("CLOUDSTIC_ENCRYPTION_KEY", ""), "Platform key (hex-encoded, 32 bytes)")
-	fs.StringVar(&g.password, "password", envDefault("CLOUDSTIC_PASSWORD", ""), "Repository password")
-	fs.StringVar(&g.recoveryKey, "recovery-key", envDefault("CLOUDSTIC_RECOVERY_KEY", ""), "Recovery key (BIP39 24-word mnemonic)")
-	fs.StringVar(&g.kmsKeyARN, "kms-key-arn", envDefault("CLOUDSTIC_KMS_KEY_ARN", ""), "AWS KMS key ARN for kms-platform slots")
-	fs.StringVar(&g.kmsRegion, "kms-region", envDefault("CLOUDSTIC_KMS_REGION", ""), "AWS KMS region (defaults to us-east-1)")
-	fs.StringVar(&g.kmsEndpoint, "kms-endpoint", envDefault("CLOUDSTIC_KMS_ENDPOINT", ""), "Custom AWS KMS endpoint URL")
-	fs.BoolVar(&g.disablePackfile, "disable-packfile", envBool("CLOUDSTIC_DISABLE_PACKFILE"), "Disable bundling small objects into 8MB packs")
+	fs.StringVar(&g.encryptionKey, "encryption-key", "", "Platform key (hex-encoded, 32 bytes)")
+	fs.StringVar(&g.password, "password", "", "Repository password")
+	fs.StringVar(&g.recoveryKey, "recovery-key", "", "Recovery key (BIP39 24-word mnemonic)")
+	fs.StringVar(&g.kmsKeyARN, "kms-key-arn", "", "AWS KMS key ARN for kms-platform slots")
+	fs.StringVar(&g.kmsRegion, "kms-region", "", "AWS KMS region (defaults to us-east-1)")
+	fs.StringVar(&g.kmsEndpoint, "kms-endpoint", "", "Custom AWS KMS endpoint URL")
+	fs.BoolVar(&g.disablePackfile, "disable-packfile", false, "Disable bundling small objects into 8MB packs")
 	fs.BoolVar(&g.prompt, "prompt", false, "Prompt for password interactively (use alongside --encryption-key or --kms-key-arn to add a password layer)")
 	fs.BoolVar(&g.noPrompt, "no-prompt", false, "Disable interactive prompts (for scripts and CI)")
 	fs.BoolVar(&g.verbose, "verbose", false, "Log detailed file-level operations")
@@ -91,26 +178,144 @@ func (g *globalFlags) jsonEnabled() bool {
 	return g != nil && g.json
 }
 
-func (g *globalFlags) flagProvided(name string) bool {
-	provided := false
-	g.flagSet.Visit(func(f *flag.Flag) {
-		provided = provided || f.Name == name
+func (g *globalFlags) valueSource(name string) valueSource {
+	if source := g.sources[name]; source != "" {
+		return source
+	}
+	return flagValueSource(g.flagSet, globalFlagByName(name))
+}
+
+func (g *globalFlags) setValueSource(name string, source valueSource) {
+	if g.sources == nil {
+		g.sources = make(map[string]valueSource)
+	}
+	g.sources[name] = source
+}
+
+func environmentValue(spec flagSpec) (string, bool) {
+	for _, environment := range spec.environment {
+		if value, ok := nonEmptyEnvironment(environment.name); ok {
+			return value, true
+		}
+	}
+	return "", false
+}
+
+func nonEmptyEnvironment(name string) (string, bool) {
+	value, ok := os.LookupEnv(name)
+	return value, ok && value != ""
+}
+
+func annotateEnvironmentUsage(fs *flag.FlagSet, specs []flagSpec) {
+	for _, spec := range specs {
+		f := fs.Lookup(spec.name)
+		if f == nil || len(spec.environment) == 0 || strings.Contains(f.Usage, "env: ") {
+			continue
+		}
+		names := make([]string, 0, len(spec.environment))
+		for _, environment := range spec.environment {
+			names = append(names, environment.name)
+		}
+		f.Usage += " (env: " + strings.Join(names, ", ") + ")"
+	}
+}
+
+func applyEnvironment(fs *flag.FlagSet, specs []flagSpec) error {
+	explicit := make(map[string]bool)
+	fs.Visit(func(f *flag.Flag) { explicit[f.Name] = true })
+	for _, spec := range specs {
+		if explicit[spec.name] || len(spec.environment) == 0 {
+			continue
+		}
+		f := fs.Lookup(spec.name)
+		if f == nil {
+			continue
+		}
+		for _, environment := range spec.environment {
+			raw, ok := nonEmptyEnvironment(environment.name)
+			if !ok {
+				continue
+			}
+			if isBooleanFlag(f) {
+				parsed, err := strconv.ParseBool(raw)
+				if err != nil {
+					return fmt.Errorf("invalid boolean value %q for %s: %w", raw, environment.name, err)
+				}
+				raw = strconv.FormatBool(parsed)
+			}
+			if err := f.Value.Set(raw); err != nil {
+				return fmt.Errorf("apply %s to -%s: %w", environment.name, spec.name, err)
+			}
+			break
+		}
+	}
+	return nil
+}
+
+func isBooleanFlag(f *flag.Flag) bool {
+	boolean, ok := f.Value.(interface{ IsBoolFlag() bool })
+	return ok && boolean.IsBoolFlag()
+}
+
+func flagValueSource(fs *flag.FlagSet, spec flagSpec) valueSource {
+	if fs == nil {
+		return valueSourceDefault
+	}
+	explicit := false
+	fs.Visit(func(f *flag.Flag) { explicit = explicit || f.Name == spec.name })
+	if explicit {
+		return valueSourceFlag
+	}
+	if _, ok := environmentValue(spec); ok {
+		return valueSourceEnvironment
+	}
+	return valueSourceDefault
+}
+
+func commandValueSources(fs *flag.FlagSet, command *commandSpec) map[string]valueSource {
+	sources := make(map[string]valueSource)
+	fs.VisitAll(func(f *flag.Flag) {
+		spec, ok := command.flag(f.Name)
+		if ok {
+			sources[f.Name] = flagValueSource(fs, spec)
+		}
 	})
-	return provided
+	return sources
+}
+
+func suppliedFlags(sources map[string]valueSource) map[string]bool {
+	flags := make(map[string]bool)
+	for name, source := range sources {
+		if source == valueSourceFlag || source == valueSourceEnvironment {
+			flags[name] = true
+		}
+	}
+	return flags
 }
 
 // parseFlags parses args into fs, reordering positional arguments after
 // flags so that flags can appear anywhere on the command line (e.g.
 // "cloudstic restore abc123 -output ./out.zip" works as well as the reverse).
 // Using this consistently means every command supports flexible argument ordering.
-func parseFlags(fs *flag.FlagSet, args []string) error {
+func parseFlags(fs *flag.FlagSet, args []string, command *commandSpec) error {
 	if fs.Lookup("no-prompt") == nil {
 		fs.Bool("no-prompt", false, "Disable interactive prompts (for scripts and CI)")
 	}
 	if hasGlobalFlag(args, "json") && !hasGlobalFlag(args, "h") {
 		fs.SetOutput(io.Discard)
 	}
-	return fs.Parse(reorderArgs(fs, args))
+	var specs []flagSpec
+	if command != nil {
+		specs = command.effectiveFlags()
+	}
+	annotateEnvironmentUsage(fs, specs)
+	if flagSetObserver != nil {
+		flagSetObserver(fs)
+	}
+	if err := fs.Parse(reorderArgs(fs, args)); err != nil {
+		return err
+	}
+	return applyEnvironment(fs, specs)
 }
 
 func (r *runner) parseError(err error) int {

--- a/cmd/cloudstic/flags_environment_test.go
+++ b/cmd/cloudstic/flags_environment_test.go
@@ -1,0 +1,609 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"flag"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+
+	cloudstic "github.com/cloudstic/cli"
+)
+
+func clearCommandEnvironment(t *testing.T) {
+	t.Helper()
+	for _, variable := range environmentVariables() {
+		t.Setenv(variable.Name, "")
+	}
+}
+
+func TestEnvironmentBindingsAreConsistentAcrossFlagSpecs(t *testing.T) {
+	type owner struct {
+		flag       string
+		sensitive  bool
+		documented bool
+	}
+	owners := make(map[string]owner)
+	visit := func(spec flagSpec) {
+		for _, environment := range spec.environment {
+			if environment.name == "" {
+				t.Errorf("flag -%s has an empty environment name", spec.name)
+				continue
+			}
+			current := owner{spec.name, environment.sensitive, environment.documented}
+			if previous, ok := owners[environment.name]; ok && previous != current {
+				t.Errorf("environment %s has inconsistent owners: %+v and %+v", environment.name, previous, current)
+			}
+			owners[environment.name] = current
+		}
+	}
+	for _, spec := range globalFlagSpecs {
+		visit(spec)
+	}
+	for _, command := range publicLeafCommands() {
+		for _, spec := range command.flags {
+			visit(spec)
+		}
+	}
+	for _, standalone := range standaloneEnvironmentVariables {
+		name := standalone.Name
+		if name == "" {
+			t.Error("standalone environment has an empty name")
+		} else if previous, ok := owners[name]; ok {
+			t.Errorf("standalone environment %s is already owned by flag -%s", name, previous.flag)
+		}
+	}
+}
+
+func TestFormerEnvironmentDefaultsAreOwnedByActiveSpecs(t *testing.T) {
+	global := map[string][]string{
+		"store":                   {"CLOUDSTIC_STORE"},
+		"profile":                 {"CLOUDSTIC_PROFILE"},
+		"profiles-file":           {"CLOUDSTIC_PROFILES_FILE"},
+		"s3-endpoint":             {"CLOUDSTIC_S3_ENDPOINT"},
+		"s3-region":               {"CLOUDSTIC_S3_REGION"},
+		"s3-profile":              {"CLOUDSTIC_S3_PROFILE", "AWS_PROFILE"},
+		"s3-access-key":           {"AWS_ACCESS_KEY_ID"},
+		"s3-secret-key":           {"AWS_SECRET_ACCESS_KEY"},
+		"source-sftp-password":    {"CLOUDSTIC_SOURCE_SFTP_PASSWORD"},
+		"source-sftp-key":         {"CLOUDSTIC_SOURCE_SFTP_KEY"},
+		"source-sftp-insecure":    {"CLOUDSTIC_SOURCE_SFTP_INSECURE"},
+		"source-sftp-known-hosts": {"CLOUDSTIC_SOURCE_SFTP_KNOWN_HOSTS"},
+		"store-sftp-password":     {"CLOUDSTIC_STORE_SFTP_PASSWORD"},
+		"store-sftp-key":          {"CLOUDSTIC_STORE_SFTP_KEY"},
+		"store-sftp-insecure":     {"CLOUDSTIC_STORE_SFTP_INSECURE"},
+		"store-sftp-known-hosts":  {"CLOUDSTIC_STORE_SFTP_KNOWN_HOSTS"},
+		"encryption-key":          {"CLOUDSTIC_ENCRYPTION_KEY"},
+		"password":                {"CLOUDSTIC_PASSWORD"},
+		"recovery-key":            {"CLOUDSTIC_RECOVERY_KEY"},
+		"kms-key-arn":             {"CLOUDSTIC_KMS_KEY_ARN"},
+		"kms-region":              {"CLOUDSTIC_KMS_REGION"},
+		"kms-endpoint":            {"CLOUDSTIC_KMS_ENDPOINT"},
+		"disable-packfile":        {"CLOUDSTIC_DISABLE_PACKFILE"},
+	}
+	for flagName, environmentNames := range global {
+		assertEnvironmentNames(t, "global", globalFlagByName(flagName), environmentNames...)
+	}
+
+	backup := backupCommandSpec()
+	for flagName, environmentName := range map[string]string{
+		"source":                  "CLOUDSTIC_SOURCE",
+		"volume-uuid":             "CLOUDSTIC_VOLUME_UUID",
+		"google-credentials":      "GOOGLE_APPLICATION_CREDENTIALS",
+		"google-credentials-json": "GOOGLE_CREDENTIALS_JSON",
+		"google-token-file":       "GOOGLE_TOKEN_FILE",
+		"onedrive-client-id":      "ONEDRIVE_CLIENT_ID",
+		"onedrive-token-file":     "ONEDRIVE_TOKEN_FILE",
+	} {
+		spec, ok := backup.flag(flagName)
+		if !ok {
+			t.Fatalf("backup spec is missing -%s", flagName)
+		}
+		assertEnvironmentNames(t, "backup", spec, environmentName)
+	}
+
+	for _, path := range []string{
+		"auth list", "auth show", "auth new", "auth login",
+		"profile list", "profile show", "profile new",
+		"store list", "store show", "store new", "store verify", "store init",
+		"__complete",
+	} {
+		command := commandByPath(t, path)
+		spec, ok := command.flag("profiles-file")
+		if !ok {
+			t.Fatalf("%s spec is missing -profiles-file", path)
+		}
+		assertEnvironmentNames(t, path, spec, "CLOUDSTIC_PROFILES_FILE")
+	}
+}
+
+func assertEnvironmentNames(t *testing.T, owner string, spec flagSpec, want ...string) {
+	t.Helper()
+	got := make([]string, 0, len(spec.environment))
+	for _, environment := range spec.environment {
+		got = append(got, environment.name)
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("%s -%s environments = %v, want %v", owner, spec.name, got, want)
+	}
+}
+
+func commandByPath(t *testing.T, path string) *commandSpec {
+	t.Helper()
+	parts := strings.Fields(path)
+	command := rootCommand(parts[0])
+	if command == nil {
+		t.Fatalf("command %q not found", path)
+	}
+	for _, part := range parts[1:] {
+		command = findCommand(command.children, part)
+		if command == nil {
+			t.Fatalf("command %q not found", path)
+		}
+	}
+	return command
+}
+
+func TestEnvironmentBindingsPreserveSupportedVariables(t *testing.T) {
+	want := map[string]string{
+		"CLOUDSTIC_STORE":                   "store",
+		"CLOUDSTIC_PROFILE":                 "profile",
+		"CLOUDSTIC_PROFILES_FILE":           "profiles-file",
+		"CLOUDSTIC_S3_ENDPOINT":             "s3-endpoint",
+		"CLOUDSTIC_S3_REGION":               "s3-region",
+		"CLOUDSTIC_S3_PROFILE":              "s3-profile",
+		"AWS_PROFILE":                       "s3-profile",
+		"AWS_ACCESS_KEY_ID":                 "s3-access-key",
+		"AWS_SECRET_ACCESS_KEY":             "s3-secret-key",
+		"B2_KEY_ID":                         "b2-key-id",
+		"B2_APP_KEY":                        "b2-app-key",
+		"CLOUDSTIC_SOURCE_SFTP_PASSWORD":    "source-sftp-password",
+		"CLOUDSTIC_SOURCE_SFTP_KEY":         "source-sftp-key",
+		"CLOUDSTIC_SOURCE_SFTP_KNOWN_HOSTS": "source-sftp-known-hosts",
+		"CLOUDSTIC_SOURCE_SFTP_INSECURE":    "source-sftp-insecure",
+		"CLOUDSTIC_STORE_SFTP_PASSWORD":     "store-sftp-password",
+		"CLOUDSTIC_STORE_SFTP_KEY":          "store-sftp-key",
+		"CLOUDSTIC_STORE_SFTP_KNOWN_HOSTS":  "store-sftp-known-hosts",
+		"CLOUDSTIC_STORE_SFTP_INSECURE":     "store-sftp-insecure",
+		"CLOUDSTIC_ENCRYPTION_KEY":          "encryption-key",
+		"CLOUDSTIC_PASSWORD":                "password",
+		"CLOUDSTIC_RECOVERY_KEY":            "recovery-key",
+		"CLOUDSTIC_KMS_KEY_ARN":             "kms-key-arn",
+		"CLOUDSTIC_KMS_REGION":              "kms-region",
+		"CLOUDSTIC_KMS_ENDPOINT":            "kms-endpoint",
+		"CLOUDSTIC_DISABLE_PACKFILE":        "disable-packfile",
+		"CLOUDSTIC_SOURCE":                  "source",
+		"GOOGLE_APPLICATION_CREDENTIALS":    "google-credentials",
+		"GOOGLE_CREDENTIALS_JSON":           "google-credentials-json",
+		"GOOGLE_TOKEN_FILE":                 "google-token-file",
+		"ONEDRIVE_CLIENT_ID":                "onedrive-client-id",
+		"ONEDRIVE_TOKEN_FILE":               "onedrive-token-file",
+		"CLOUDSTIC_CONFIG_DIR":              "",
+		"CLOUDSTIC_VOLUME_UUID":             "volume-uuid",
+	}
+	got := environmentVariables()
+	if len(got) != len(want) {
+		t.Fatalf("environment binding count = %d, want %d", len(got), len(want))
+	}
+	for _, variable := range got {
+		flagName, ok := want[variable.Name]
+		if !ok {
+			t.Errorf("unexpected environment variable %s", variable.Name)
+		} else if variable.Flag != flagName {
+			t.Errorf("%s flag = %q, want %q", variable.Name, variable.Flag, flagName)
+		}
+	}
+}
+
+func TestBuiltInDefaultsRemainIndependentFromFlagEnvironment(t *testing.T) {
+	clearCommandEnvironment(t)
+	configDir := t.TempDir()
+	t.Setenv("CLOUDSTIC_CONFIG_DIR", configDir)
+
+	a, err := parseBackupArgs(nil)
+	if err != nil {
+		t.Fatalf("parse backup defaults: %v", err)
+	}
+	wantProfilesFile := filepath.Join(configDir, defaultProfilesFilename)
+	for name, values := range map[string][2]string{
+		"store":                   {a.g.store, "local:./backup_store"},
+		"profile":                 {a.g.profile, ""},
+		"profiles-file":           {a.g.profilesFile, wantProfilesFile},
+		"s3-endpoint":             {a.g.s3Endpoint, ""},
+		"s3-region":               {a.g.s3Region, "us-east-1"},
+		"s3-profile":              {a.g.s3Profile, ""},
+		"s3-access-key":           {a.g.s3AccessKey, ""},
+		"s3-secret-key":           {a.g.s3SecretKey, ""},
+		"b2-key-id":               {a.g.b2KeyID, ""},
+		"b2-app-key":              {a.g.b2AppKey, ""},
+		"source-sftp-password":    {a.g.sourceSFTPPassword, ""},
+		"source-sftp-key":         {a.g.sourceSFTPKey, ""},
+		"source-sftp-known-hosts": {a.g.sourceSFTPKnownHosts, ""},
+		"store-sftp-password":     {a.g.storeSFTPPassword, ""},
+		"store-sftp-key":          {a.g.storeSFTPKey, ""},
+		"store-sftp-known-hosts":  {a.g.storeSFTPKnownHosts, ""},
+		"encryption-key":          {a.g.encryptionKey, ""},
+		"password":                {a.g.password, ""},
+		"recovery-key":            {a.g.recoveryKey, ""},
+		"kms-key-arn":             {a.g.kmsKeyARN, ""},
+		"kms-region":              {a.g.kmsRegion, ""},
+		"kms-endpoint":            {a.g.kmsEndpoint, ""},
+		"source":                  {a.sourceURI, "gdrive"},
+	} {
+		if values[0] != values[1] {
+			t.Errorf("-%s default = %q, want %q", name, values[0], values[1])
+		}
+	}
+	if a.g.sourceSFTPInsecure || a.g.storeSFTPInsecure || a.g.disablePackfile || a.g.prompt || a.g.noPrompt || a.g.verbose || a.g.quiet || a.g.json || a.g.debug {
+		t.Error("boolean global defaults must remain false")
+	}
+	if a.volumeUUID != "" || a.googleCreds != "" || a.googleCredsJSON != "" || a.googleTokenFile != "" || a.onedriveClientID != "" || a.onedriveTokenFile != "" {
+		t.Error("backup provider defaults must remain empty")
+	}
+}
+
+func TestSuppliedFlagsOnlyContainsOverrides(t *testing.T) {
+	flags := suppliedFlags(map[string]valueSource{
+		"default":     valueSourceDefault,
+		"profile":     valueSourceProfile,
+		"environment": valueSourceEnvironment,
+		"flag":        valueSourceFlag,
+	})
+	if len(flags) != 2 || !flags["environment"] || !flags["flag"] {
+		t.Fatalf("supplied flags = %#v", flags)
+	}
+}
+
+func TestEnvironmentBindingsFollowTheActiveCommandSpec(t *testing.T) {
+	clearCommandEnvironment(t)
+	t.Setenv("CLOUDSTIC_S3_REGION", "environment-region")
+
+	globalSet := flag.NewFlagSet("backup", flag.ContinueOnError)
+	global := addGlobalFlags(globalSet)
+	if err := parseFlags(globalSet, nil, backupCommandSpec()); err != nil {
+		t.Fatalf("parse global flags: %v", err)
+	}
+	if global.s3Region != "environment-region" {
+		t.Fatalf("global s3 region = %q, want environment-region", global.s3Region)
+	}
+
+	localSet := flag.NewFlagSet("store new", flag.ContinueOnError)
+	region := localSet.String("s3-region", "local-default", "S3 region")
+	if err := parseFlags(localSet, nil, storeNewCommandSpec()); err != nil {
+		t.Fatalf("parse store new flags: %v", err)
+	}
+	if *region != "local-default" {
+		t.Fatalf("store new s3 region = %q, want local-default", *region)
+	}
+}
+
+func TestEnvironmentFallbackOrderComesFromFlagSpec(t *testing.T) {
+	clearCommandEnvironment(t)
+	t.Setenv("AWS_PROFILE", "provider-profile")
+	t.Setenv("CLOUDSTIC_S3_PROFILE", "cloudstic-profile")
+
+	fs := flag.NewFlagSet("backup", flag.ContinueOnError)
+	global := addGlobalFlags(fs)
+	if err := parseFlags(fs, nil, backupCommandSpec()); err != nil {
+		t.Fatalf("parse global flags: %v", err)
+	}
+	if global.s3Profile != "cloudstic-profile" {
+		t.Fatalf("s3 profile = %q, want cloudstic-profile", global.s3Profile)
+	}
+
+	t.Setenv("CLOUDSTIC_S3_PROFILE", "")
+	fs = flag.NewFlagSet("backup", flag.ContinueOnError)
+	global = addGlobalFlags(fs)
+	if err := parseFlags(fs, nil, backupCommandSpec()); err != nil {
+		t.Fatalf("parse global flags with provider fallback: %v", err)
+	}
+	if global.s3Profile != "provider-profile" {
+		t.Fatalf("s3 profile = %q, want provider-profile", global.s3Profile)
+	}
+}
+
+func TestProfileNewEnvironmentValuesOverrideExistingProfile(t *testing.T) {
+	clearCommandEnvironment(t)
+	t.Setenv("CLOUDSTIC_SOURCE", "local:/environment")
+	t.Setenv("CLOUDSTIC_STORE", "s3:environment")
+	t.Setenv("GOOGLE_TOKEN_FILE", "/environment/token.json")
+
+	a, err := parseProfileNewArgs(nil)
+	if err != nil {
+		t.Fatalf("parse profile new: %v", err)
+	}
+	prefillProfileArgs(a, cloudstic.BackupProfile{
+		Source:          "local:/profile",
+		GoogleTokenFile: "/profile/token.json",
+	})
+	if a.source != "local:/environment" || a.googleTokenFile != "/environment/token.json" || a.store != "s3:environment" {
+		t.Fatalf("profile environment values were overwritten: source=%q token=%q store=%q", a.source, a.googleTokenFile, a.store)
+	}
+	for _, name := range []string{"source", "store", "google-token-file"} {
+		if !a.flagsSet[name] {
+			t.Errorf("environment-provided -%s was not marked as supplied", name)
+		}
+	}
+}
+
+func TestEnvironment_SecretValuesNeverAppearInHelp(t *testing.T) {
+	clearCommandEnvironment(t)
+	const secret = "sentinel-secret-that-must-not-appear"
+	for _, variable := range environmentVariables() {
+		if variable.Sensitive {
+			t.Setenv(variable.Name, secret)
+		}
+	}
+	fs := flag.NewFlagSet("secrets", flag.ContinueOnError)
+	var output bytes.Buffer
+	fs.SetOutput(&output)
+	command := backupCommandSpec()
+	for _, spec := range command.effectiveFlags() {
+		if len(spec.environment) == 0 {
+			continue
+		}
+		if spec.takesValue() {
+			fs.String(spec.name, "built-in", spec.description)
+		} else {
+			fs.Bool(spec.name, false, spec.description)
+		}
+	}
+	err := parseFlags(fs, []string{"-h"}, command)
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("parseFlags(-h) error = %v, want flag.ErrHelp", err)
+	}
+	if strings.Contains(output.String(), secret) {
+		t.Fatalf("help exposed a secret environment value:\n%s", output.String())
+	}
+	for _, variable := range environmentVariables() {
+		if variable.Sensitive && variable.Flag != "" && !strings.Contains(output.String(), variable.Name) {
+			t.Errorf("help does not name supported environment variable %s", variable.Name)
+		}
+	}
+}
+
+func TestEnvironment_GlobalHelpKeepsBuiltInDefaults(t *testing.T) {
+	clearCommandEnvironment(t)
+	t.Setenv("CLOUDSTIC_PASSWORD", "live-password")
+	t.Setenv("CLOUDSTIC_STORE", "s3:private-bucket")
+	fs := flag.NewFlagSet("backup", flag.ContinueOnError)
+	var output bytes.Buffer
+	fs.SetOutput(&output)
+	addGlobalFlags(fs)
+	err := parseFlags(fs, []string{"-h"}, backupCommandSpec())
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("parseFlags(-h) error = %v, want flag.ErrHelp", err)
+	}
+	if strings.Contains(output.String(), "live-password") || strings.Contains(output.String(), "s3:private-bucket") {
+		t.Fatalf("global help exposed live environment values:\n%s", output.String())
+	}
+	if !strings.Contains(output.String(), "local:./backup_store") || !strings.Contains(output.String(), "CLOUDSTIC_PASSWORD") {
+		t.Fatalf("global help does not show built-in defaults and environment names:\n%s", output.String())
+	}
+}
+
+func TestEnvironment_BooleanParsing(t *testing.T) {
+	for _, test := range []struct {
+		value string
+		want  bool
+	}{
+		{"1", true}, {"t", true}, {"TRUE", true}, {"True", true}, {"true", true},
+		{"0", false}, {"f", false}, {"FALSE", false}, {"False", false}, {"false", false},
+	} {
+		t.Run(test.value, func(t *testing.T) {
+			clearCommandEnvironment(t)
+			t.Setenv("CLOUDSTIC_DISABLE_PACKFILE", test.value)
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			g := addGlobalFlags(fs)
+			if err := parseFlags(fs, nil, breakLockCommandSpec()); err != nil {
+				t.Fatalf("parseFlags() error = %v", err)
+			}
+			if g.disablePackfile != test.want {
+				t.Fatalf("disablePackfile = %v, want %v", g.disablePackfile, test.want)
+			}
+		})
+	}
+}
+
+func TestEnvironment_InvalidBooleanIsActionable(t *testing.T) {
+	clearCommandEnvironment(t)
+	t.Setenv("CLOUDSTIC_DISABLE_PACKFILE", "enabled")
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	addGlobalFlags(fs)
+	err := parseFlags(fs, nil, breakLockCommandSpec())
+	if err == nil || !strings.Contains(err.Error(), "CLOUDSTIC_DISABLE_PACKFILE") || !strings.Contains(err.Error(), "invalid boolean") {
+		t.Fatalf("parseFlags() error = %v, want actionable environment-variable error", err)
+	}
+}
+
+func TestEnvironment_PrecedenceAndProvenance(t *testing.T) {
+	clearCommandEnvironment(t)
+	profilesPath := filepath.Join(t.TempDir(), "profiles.yaml")
+	if err := cloudstic.SaveProfilesFile(profilesPath, &cloudstic.ProfilesConfig{
+		Version: 1,
+		Stores: map[string]cloudstic.ProfileStore{
+			"remote": {URI: "s3:profile-bucket", S3Region: "profile-region"},
+		},
+		Profiles: map[string]cloudstic.BackupProfile{
+			"daily": {Source: "local:/data", Store: "remote"},
+		},
+	}); err != nil {
+		t.Fatalf("SaveProfilesFile: %v", err)
+	}
+	t.Setenv("CLOUDSTIC_S3_REGION", "environment-region")
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	g := addGlobalFlags(fs)
+	if err := parseFlags(fs, []string{"-profile", "daily", "-profiles-file", profilesPath}, backupCommandSpec()); err != nil {
+		t.Fatalf("parseFlags() error = %v", err)
+	}
+	if err := g.applyProfileStoreOverrides(); err != nil {
+		t.Fatalf("applyProfileStoreOverrides() error = %v", err)
+	}
+	if g.s3Region != "environment-region" || g.valueSource("s3-region") != valueSourceEnvironment {
+		t.Fatalf("environment precedence: region=%q source=%q", g.s3Region, g.valueSource("s3-region"))
+	}
+	if g.store != "s3:profile-bucket" || g.valueSource("store") != valueSourceProfile {
+		t.Fatalf("profile provenance: store=%q source=%q", g.store, g.valueSource("store"))
+	}
+	fs = flag.NewFlagSet("test", flag.ContinueOnError)
+	g = addGlobalFlags(fs)
+	if err := parseFlags(fs, []string{"-s3-region", "flag-region"}, backupCommandSpec()); err != nil {
+		t.Fatalf("parseFlags() error = %v", err)
+	}
+	if g.s3Region != "flag-region" || g.valueSource("s3-region") != valueSourceFlag {
+		t.Fatalf("flag precedence: region=%q source=%q", g.s3Region, g.valueSource("s3-region"))
+	}
+	if g.valueSource("store") != valueSourceDefault {
+		t.Fatalf("default provenance = %q", g.valueSource("store"))
+	}
+}
+
+func TestEnvironment_BackupSourceOverridesProfile(t *testing.T) {
+	clearCommandEnvironment(t)
+	t.Setenv("CLOUDSTIC_SOURCE", "local:/environment")
+	base, err := parseBackupArgs([]string{"-profile", "daily"})
+	if err != nil {
+		t.Fatalf("parseBackupArgs() error = %v", err)
+	}
+	cfg := &cloudstic.ProfilesConfig{
+		Stores: map[string]cloudstic.ProfileStore{},
+		Profiles: map[string]cloudstic.BackupProfile{
+			"daily": {Source: "local:/profile"},
+		},
+	}
+	effective, err := mergeProfileBackupArgs(base, "daily", cfg.Profiles["daily"], cfg)
+	if err != nil {
+		t.Fatalf("mergeProfileBackupArgs() error = %v", err)
+	}
+	if effective.sourceURI != "local:/environment" || effective.valueSource("source") != valueSourceEnvironment {
+		t.Fatalf("source = %q (%s), want environment value", effective.sourceURI, effective.valueSource("source"))
+	}
+
+	t.Setenv("CLOUDSTIC_SOURCE", "")
+	base, err = parseBackupArgs([]string{"-profile", "daily"})
+	if err != nil {
+		t.Fatalf("parseBackupArgs() error = %v", err)
+	}
+	effective, err = mergeProfileBackupArgs(base, "daily", cfg.Profiles["daily"], cfg)
+	if err != nil {
+		t.Fatalf("mergeProfileBackupArgs() error = %v", err)
+	}
+	if effective.sourceURI != "local:/profile" || effective.valueSource("source") != valueSourceProfile {
+		t.Fatalf("source = %q (%s), want profile value", effective.sourceURI, effective.valueSource("source"))
+	}
+}
+
+func TestB2Credentials_ProfileSecretReferences(t *testing.T) {
+	clearCommandEnvironment(t)
+	t.Setenv("PROFILE_B2_KEY_ID", "profile-key-id")
+	t.Setenv("PROFILE_B2_APP_KEY", "profile-app-key")
+	g, err := globalFlagsFromProfileStore(cloudstic.ProfileStore{
+		URI:            "b2:bucket",
+		B2KeyIDSecret:  "env://PROFILE_B2_KEY_ID",
+		B2AppKeySecret: "env://PROFILE_B2_APP_KEY",
+	})
+	if err != nil {
+		t.Fatalf("globalFlagsFromProfileStore() error = %v", err)
+	}
+	if g.b2KeyID != "profile-key-id" || g.b2AppKey != "profile-app-key" {
+		t.Fatalf("B2 credentials = (%q, %q)", g.b2KeyID, g.b2AppKey)
+	}
+}
+
+func TestB2Credentials_EnvironmentAndFlagPrecedence(t *testing.T) {
+	clearCommandEnvironment(t)
+	t.Setenv("B2_KEY_ID", "environment-key-id")
+	t.Setenv("B2_APP_KEY", "environment-app-key")
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	g := addGlobalFlags(fs)
+	if err := parseFlags(fs, []string{"-b2-key-id", "flag-key-id"}, backupCommandSpec()); err != nil {
+		t.Fatalf("parseFlags() error = %v", err)
+	}
+	if g.b2KeyID != "flag-key-id" || g.valueSource("b2-key-id") != valueSourceFlag {
+		t.Fatalf("B2 key ID = %q (%s)", g.b2KeyID, g.valueSource("b2-key-id"))
+	}
+	if g.b2AppKey != "environment-app-key" || g.valueSource("b2-app-key") != valueSourceEnvironment {
+		t.Fatalf("B2 app key = %q (%s)", g.b2AppKey, g.valueSource("b2-app-key"))
+	}
+}
+
+func TestB2Credentials_StoreNewPersistsFlagsAndSecretReferences(t *testing.T) {
+	clearCommandEnvironment(t)
+	profilesPath := filepath.Join(t.TempDir(), "profiles.yaml")
+	r := newRunner([]string{"new", "-no-prompt", "-profiles-file", profilesPath, "-name", "archive", "-uri", "b2:bucket/prefix", "-b2-key-id", "inline-key-id", "-b2-app-key-secret", "env://B2_APP_KEY"})
+	r.out = &bytes.Buffer{}
+	r.errOut = &bytes.Buffer{}
+	if code := runStore(r, context.Background()); code != 0 {
+		t.Fatalf("runStore() code = %d, stderr = %s", code, r.errOut)
+	}
+	cfg, err := cloudstic.LoadProfilesFile(profilesPath)
+	if err != nil {
+		t.Fatalf("LoadProfilesFile: %v", err)
+	}
+	store := cfg.Stores["archive"]
+	if store.B2KeyID != "inline-key-id" || store.B2AppKeySecret != "env://B2_APP_KEY" {
+		t.Fatalf("stored B2 credentials = %+v", store)
+	}
+}
+
+func TestEnvironmentDocumentationMatchesInventory(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join(repositoryRoot(t), "docs", "user-guide.md"))
+	if err != nil {
+		t.Fatalf("read user guide: %v", err)
+	}
+	want := environmentDocumentation() + "\n"
+	normalized := strings.ReplaceAll(string(raw), "\r\n", "\n")
+	for name, contents := range map[string][]byte{
+		"lf":   []byte(normalized),
+		"crlf": []byte(strings.ReplaceAll(normalized, "\n", "\r\n")),
+	} {
+		got, ok := generatedEnvironmentSection(contents)
+		if !ok {
+			t.Fatalf("%s user guide is missing generated environment-variable markers", name)
+		}
+		if got != want {
+			t.Fatalf("%s environment-variable documentation is stale; regenerate it from the command flag specs\n--- want ---\n%s--- got ---\n%s", name, want, got)
+		}
+	}
+}
+
+func generatedEnvironmentSection(raw []byte) (string, bool) {
+	text := strings.ReplaceAll(string(raw), "\r\n", "\n")
+	const begin = "<!-- BEGIN GENERATED ENVIRONMENT VARIABLES -->\n"
+	const end = "<!-- END GENERATED ENVIRONMENT VARIABLES -->"
+	start := strings.Index(text, begin)
+	finish := strings.Index(text, end)
+	if start < 0 || finish < 0 || finish < start {
+		return "", false
+	}
+	return text[start+len(begin) : finish], true
+}
+
+func repositoryRoot(t *testing.T) string {
+	t.Helper()
+	var candidates []string
+	if cwd, err := os.Getwd(); err == nil {
+		candidates = append(candidates, cwd)
+	}
+	if _, filename, _, ok := runtime.Caller(0); ok && filepath.IsAbs(filename) {
+		candidates = append(candidates, filepath.Dir(filename))
+	}
+	for _, candidate := range candidates {
+		for dir := candidate; ; dir = filepath.Dir(dir) {
+			if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+				return dir
+			}
+			parent := filepath.Dir(dir)
+			if parent == dir {
+				break
+			}
+		}
+	}
+	t.Fatal("locate repository root")
+	return ""
+}

--- a/cmd/cloudstic/flags_test.go
+++ b/cmd/cloudstic/flags_test.go
@@ -10,7 +10,7 @@ func TestReorderArgs_PreservesTerminator(t *testing.T) {
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	jsonOutput := fs.Bool("json", false, "")
 
-	if err := parseFlags(fs, []string{"object", "-json", "--", "-no-prompt"}); err != nil {
+	if err := parseFlags(fs, []string{"object", "-json", "--", "-no-prompt"}, nil); err != nil {
 		t.Fatalf("parseFlags() error = %v", err)
 	}
 	if !*jsonOutput {
@@ -51,17 +51,17 @@ func TestGlobalFlagScans_StopAtTerminator(t *testing.T) {
 
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	g := addGlobalFlags(fs)
-	if err := parseFlags(fs, []string{"--", "-store"}); err != nil {
+	if err := parseFlags(fs, []string{"--", "-store"}, nil); err != nil {
 		t.Fatalf("parseFlags() error = %v", err)
 	}
-	if g.flagProvided("store") {
-		t.Fatal("globalFlags.flagProvided() treated a positional argument as a flag")
+	if g.valueSource("store") != valueSourceDefault {
+		t.Fatal("globalFlags.valueSource() treated a positional argument as a flag")
 	}
 }
 
 func TestParseFlags_AcceptsNoPromptForNestedCommands(t *testing.T) {
 	fs := flag.NewFlagSet("nested", flag.ContinueOnError)
-	if err := parseFlags(fs, []string{"-no-prompt"}); err != nil {
+	if err := parseFlags(fs, []string{"-no-prompt"}, nil); err != nil {
 		t.Fatalf("parseFlags() error = %v", err)
 	}
 }

--- a/cmd/cloudstic/main.go
+++ b/cmd/cloudstic/main.go
@@ -42,61 +42,34 @@ func run() int {
 }
 
 func runCmd(r *runner, ctx context.Context, cmd string) int {
-	switch cmd {
-	case "version", "--version", "-v":
-		buildVersion, buildCommit, buildDate := buildMetadata()
-		_, _ = fmt.Fprintf(r.out, "cloudstic %s (commit %s, built %s)\n", buildVersion, buildCommit, buildDate)
-		return 0
-	case "init":
-		return runInit(r, ctx)
-	case "backup":
-		return runBackup(r, ctx)
-	case "restore":
-		return runRestore(r, ctx)
-	case "list":
-		return runList(r, ctx)
-	case "ls":
-		return runLsSnapshot(r, ctx)
-	case "prune":
-		return runPrune(r, ctx)
-	case "forget":
-		return runForget(r, ctx)
-	case "diff":
-		return runDiff(r, ctx)
-	case "break-lock":
-		return runBreakLock(r, ctx)
-	case "key":
-		return runKey(r, ctx)
-	case "check":
-		return runCheck(r, ctx)
-	case "cat":
-		return runCat(r, ctx)
-	case "profile":
-		return runProfile(r, ctx)
-	case "auth":
-		return runAuth(r, ctx)
-	case "store":
-		return runStore(r, ctx)
-	case "source":
-		return runSource(r, ctx)
-	case "setup":
-		return runSetup(r, ctx)
-	case "tui":
-		return runTUI(r, ctx)
-	case "completion":
-		return runCompletion(r)
-	case "__complete":
-		return runCompletionQuery(r, ctx)
-	case "help", "--help", "-h":
-		printUsage(r.out)
-		return 0
-	default:
+	command := rootCommand(cmd)
+	if command == nil {
 		exitCode := r.fail("Unknown command: %s", cmd)
 		if !r.jsonEnabled() {
 			printUsage(r.errOut)
 		}
 		return exitCode
 	}
+	return dispatchCommand(r, ctx, command)
+}
+
+func versionCommandSpec() *commandSpec {
+	return leafAliases("version", []string{"--version", "-v"}, "Display build version", "", runVersion).withoutFlagProbe()
+}
+
+func helpCommandSpec() *commandSpec {
+	return leafAliases("help", []string{"--help", "-h"}, "Display help", "", runHelp).hide().withoutFlagProbe()
+}
+
+func runVersion(r *runner, _ context.Context) int {
+	buildVersion, buildCommit, buildDate := buildMetadata()
+	_, _ = fmt.Fprintf(r.out, "cloudstic %s (commit %s, built %s)\n", buildVersion, buildCommit, buildDate)
+	return 0
+}
+
+func runHelp(r *runner, _ context.Context) int {
+	printUsage(r.out)
+	return 0
 }
 
 func buildMetadata() (string, string, string) {

--- a/cmd/cloudstic/store.go
+++ b/cmd/cloudstic/store.go
@@ -112,10 +112,12 @@ func (g *globalFlags) applyProfileStoreOverrides() error {
 	flagsSet := map[string]bool{}
 	for _, name := range []string{
 		"store", "s3-endpoint", "s3-region", "s3-profile", "s3-access-key", "s3-secret-key",
+		"b2-key-id", "b2-app-key",
 		"store-sftp-password", "store-sftp-key",
 		"password", "encryption-key", "recovery-key", "kms-key-arn", "kms-region", "kms-endpoint",
 	} {
-		flagsSet[name] = g.flagProvided(name)
+		source := g.valueSource(name)
+		flagsSet[name] = source == valueSourceFlag || source == valueSourceEnvironment
 	}
 	if err := applyProfileStoreToGlobalFlags(g, s, flagsSet); err != nil {
 		return fmt.Errorf("profile %q store %q: %w", g.profile, p.Store, err)
@@ -277,12 +279,10 @@ func (g *globalFlags) initObjectStore(ctx context.Context) (store.ObjectStore, e
 	case "local":
 		inner, err = store.NewLocalStore(uri.path)
 	case "b2":
-		keyID := os.Getenv("B2_KEY_ID")
-		appKey := os.Getenv("B2_APP_KEY")
-		if keyID == "" || appKey == "" {
-			return nil, fmt.Errorf("B2_KEY_ID and B2_APP_KEY env vars required for b2 store")
+		if g.b2KeyID == "" || g.b2AppKey == "" {
+			return nil, fmt.Errorf("B2 credentials required (use -b2-key-id and -b2-app-key or their environment variables)")
 		}
-		inner, err = store.NewB2Store(uri.bucket, store.WithCredentials(keyID, appKey), store.WithPrefix(uri.prefix))
+		inner, err = store.NewB2Store(uri.bucket, store.WithCredentials(g.b2KeyID, g.b2AppKey), store.WithPrefix(uri.prefix))
 	case "s3":
 		inner, err = store.NewS3Store(
 			ctx,

--- a/cmd/cloudstic/store_builder_helpers.go
+++ b/cmd/cloudstic/store_builder_helpers.go
@@ -11,6 +11,10 @@ type storeNewFlagPtrs struct {
 	s3SecretKey         *string
 	s3AccessKeySecret   *string
 	s3SecretKeySecret   *string
+	b2KeyID             *string
+	b2AppKey            *string
+	b2KeyIDSecret       *string
+	b2AppKeySecret      *string
 	sftpPassword        *string
 	sftpKey             *string
 	sftpPasswordSecret  *string
@@ -47,6 +51,18 @@ func applyExistingStoreDefaults(flagsSet map[string]bool, existing cloudstic.Pro
 	}
 	if !flagsSet["s3-secret-key-secret"] && existing.S3SecretKeySecret != "" {
 		*f.s3SecretKeySecret = existing.S3SecretKeySecret
+	}
+	if !flagsSet["b2-key-id"] && existing.B2KeyID != "" {
+		*f.b2KeyID = existing.B2KeyID
+	}
+	if !flagsSet["b2-app-key"] && existing.B2AppKey != "" {
+		*f.b2AppKey = existing.B2AppKey
+	}
+	if !flagsSet["b2-key-id-secret"] && existing.B2KeyIDSecret != "" {
+		*f.b2KeyIDSecret = existing.B2KeyIDSecret
+	}
+	if !flagsSet["b2-app-key-secret"] && existing.B2AppKeySecret != "" {
+		*f.b2AppKeySecret = existing.B2AppKeySecret
 	}
 	if !flagsSet["store-sftp-password"] && existing.StoreSFTPPassword != "" {
 		*f.sftpPassword = existing.StoreSFTPPassword
@@ -90,6 +106,10 @@ func buildProfileStoreFromFlags(f storeNewFlagPtrs) cloudstic.ProfileStore {
 		S3SecretKey:             *f.s3SecretKey,
 		S3AccessKeySecret:       *f.s3AccessKeySecret,
 		S3SecretKeySecret:       *f.s3SecretKeySecret,
+		B2KeyID:                 *f.b2KeyID,
+		B2AppKey:                *f.b2AppKey,
+		B2KeyIDSecret:           *f.b2KeyIDSecret,
+		B2AppKeySecret:          *f.b2AppKeySecret,
 		StoreSFTPPassword:       *f.sftpPassword,
 		StoreSFTPKey:            *f.sftpKey,
 		StoreSFTPPasswordSecret: *f.sftpPasswordSecret,

--- a/cmd/cloudstic/testdata/scripts/environment_help.txtar
+++ b/cmd/cloudstic/testdata/scripts/environment_help.txtar
@@ -1,0 +1,11 @@
+# Help names supported environment variables without exposing their live values.
+env CLOUDSTIC_PASSWORD=sentinel-repository-password
+env GOOGLE_CREDENTIALS_JSON=sentinel-google-credentials
+env B2_APP_KEY=sentinel-b2-application-key
+
+exec cloudstic backup -h
+! stdout 'sentinel-'
+! stderr 'sentinel-'
+stderr 'CLOUDSTIC_PASSWORD'
+stderr 'GOOGLE_CREDENTIALS_JSON'
+stderr 'B2_APP_KEY'

--- a/cmd/cloudstic/usage.go
+++ b/cmd/cloudstic/usage.go
@@ -3,9 +3,82 @@ package main
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/cloudstic/cli/internal/ui"
 )
+
+// environmentVariable is a documentation view derived from command flag
+// specs. Only variables without a flag need an entry of their own.
+type environmentVariable struct {
+	Name        string
+	Flag        string
+	Description string
+	Sensitive   bool
+	Documented  bool
+}
+
+var standaloneEnvironmentVariables = []environmentVariable{
+	{Name: "CLOUDSTIC_CONFIG_DIR", Description: "Cloudstic configuration directory", Documented: true},
+}
+
+func environmentVariables() []environmentVariable {
+	var variables []environmentVariable
+	seen := make(map[string]bool)
+	appendFlag := func(spec flagSpec) {
+		for _, environment := range spec.environment {
+			if seen[environment.name] {
+				continue
+			}
+			seen[environment.name] = true
+			variables = append(variables, environmentVariable{
+				Name:        environment.name,
+				Flag:        spec.name,
+				Description: spec.description,
+				Sensitive:   environment.sensitive,
+				Documented:  environment.documented,
+			})
+		}
+	}
+	for _, spec := range globalFlagSpecs {
+		appendFlag(spec)
+	}
+	for _, command := range publicLeafCommands() {
+		for _, spec := range command.flags {
+			appendFlag(spec)
+		}
+	}
+	for _, variable := range standaloneEnvironmentVariables {
+		if !seen[variable.Name] {
+			seen[variable.Name] = true
+			variables = append(variables, variable)
+		}
+	}
+	return variables
+}
+
+func environmentDocumentation() string {
+	var out strings.Builder
+	out.WriteString("Values resolve in this order: explicit CLI flag, environment variable, profile, built-in default.\n\n")
+	out.WriteString("Provider-oriented variables remain deliberately unprefixed for compatibility with their existing ecosystems. Sensitive values are never rendered in help output.\n\n")
+	out.WriteString("| Variable | Flag equivalent | Description |\n")
+	out.WriteString("| :--- | :--- | :--- |\n")
+	for _, variable := range environmentVariables() {
+		if !variable.Documented {
+			continue
+		}
+		flagName := "—"
+		if variable.Flag != "" {
+			flagName = "`-" + variable.Flag + "`"
+		}
+		description := variable.Description
+		if variable.Sensitive {
+			description += " (sensitive)"
+		}
+		_, _ = fmt.Fprintf(&out, "| `%s` | %s | %s |\n", variable.Name, flagName, description)
+	}
+	return out.String()
+}
 
 func printUsage(out io.Writer) {
 	t := ui.NewTermWriter(out)
@@ -16,62 +89,15 @@ func printUsage(out io.Writer) {
 	_, _ = fmt.Fprintf(t.W, "  cloudstic %s<command>%s [options]\n", ui.Cyan, ui.Reset)
 
 	t.Heading("COMMANDS")
-	t.Commands([][2]string{
-		{"init", "Initialize a new repository (must run before first backup)"},
-		{"backup", "Create a new backup snapshot from a source"},
-		{"auth new", "Create or update a reusable cloud auth entry"},
-		{"auth list", "List auth entries from profiles.yaml"},
-		{"auth show", "Show one auth entry"},
-		{"auth login", "Run OAuth login flow for one auth entry"},
-		{"store new", "Create or update a store entry in profiles.yaml"},
-		{"store list", "List configured stores"},
-		{"store show", "Show one store and its configuration"},
-		{"store verify", "Verify one store's credentials and connectivity"},
-		{"source discover", "Discover local source candidates for onboarding"},
-		{"setup workstation", "Guide workstation onboarding and profile scaffolding"},
-		{"tui", "Launch the interactive terminal dashboard"},
-		{"profile new", "Create or update a backup profile in profiles.yaml"},
-		{"profile list", "List stores, auth entries, and backup profiles"},
-		{"profile show", "Show one profile and resolved store/auth references"},
-		{"restore", "Restore files from a backup snapshot"},
-		{"list", "List all backup snapshots in the repository"},
-		{"ls", "List files within a specific snapshot"},
-		{"prune", "Remove unused data chunks from the repository"},
-		{"forget", "Remove a specific snapshot from history"},
-		{"diff", "Compare two snapshots or a snapshot against latest"},
-		{"break-lock", "Remove a stale repository lock left by a crashed process"},
-		{"key list", "List all encryption key slots in the repository"},
-		{"key add-recovery", "Generate a 24-word recovery key for an encrypted repository"},
-		{"key passwd", "Change the repository password"},
-		{"check", "Verify repository integrity (reference chain, objects, data)"},
-		{"cat", "Display raw JSON content of repository objects"},
-		{"completion", "Generate shell completion scripts (bash, zsh, fish)"},
-	})
+	commands := make([][2]string, 0, len(publicLeafCommands()))
+	for _, command := range publicLeafCommands() {
+		commands = append(commands, [2]string{command.path(), command.summary})
+	}
+	t.Commands(commands)
 
-	t.HeadingSub("GLOBAL OPTIONS", "(also settable via env vars)")
-	t.Flags([][2]string{
-		{"-store <uri>", ui.Env("Storage backend URI (see formats below)", "CLOUDSTIC_STORE")},
-		{"-profile <name>", ui.Env("Profile name from profiles.yaml", "CLOUDSTIC_PROFILE")},
-		{"-profiles-file <path>", ui.Env("Path to profiles YAML file", "CLOUDSTIC_PROFILES_FILE")},
-		{"-s3-endpoint <url>", ui.Env("S3 compatible endpoint (for MinIO, R2, etc.)", "CLOUDSTIC_S3_ENDPOINT")},
-		{"-s3-region <region>", ui.Env("S3 region", "CLOUDSTIC_S3_REGION")},
-		{"-s3-profile <name>", ui.Env("AWS shared config profile for S3 auth", "CLOUDSTIC_S3_PROFILE / AWS_PROFILE")},
-		{"-s3-access-key <key>", ui.Env("S3 Access Key ID", "AWS_ACCESS_KEY_ID")},
-		{"-s3-secret-key <secret>", ui.Env("S3 Secret Access Key", "AWS_SECRET_ACCESS_KEY")},
-		{"-source-sftp-password <pw>", ui.Env("SFTP source password", "CLOUDSTIC_SOURCE_SFTP_PASSWORD")},
-		{"-source-sftp-key <path>", ui.Env("Path to SSH private key for SFTP source", "CLOUDSTIC_SOURCE_SFTP_KEY")},
-		{"-source-sftp-known-hosts <path>", ui.Env("Path to known_hosts file for SFTP source", "CLOUDSTIC_SOURCE_SFTP_KNOWN_HOSTS")},
-		{"-source-sftp-insecure", ui.Env("Skip host key validation for SFTP source (INSECURE)", "CLOUDSTIC_SOURCE_SFTP_INSECURE")},
-		{"-store-sftp-password <pw>", ui.Env("SFTP store password", "CLOUDSTIC_STORE_SFTP_PASSWORD")},
-		{"-store-sftp-key <path>", ui.Env("Path to SSH private key for SFTP store", "CLOUDSTIC_STORE_SFTP_KEY")},
-		{"-store-sftp-known-hosts <path>", ui.Env("Path to known_hosts file for SFTP store", "CLOUDSTIC_STORE_SFTP_KNOWN_HOSTS")},
-		{"-store-sftp-insecure", ui.Env("Skip host key validation for SFTP store (INSECURE)", "CLOUDSTIC_STORE_SFTP_INSECURE")},
-		{"-no-prompt", "Disable interactive prompts (for scripts and CI)"},
-		{"-verbose", "Log detailed file-level operations"},
-		{"-quiet", "Suppress progress bars (keeps final summary)"},
-		{"-json", "Write command result as JSON to stdout"},
-		{"-debug", "Log every store request (network calls, timing, sizes)"},
-	})
+	general, encryption := splitGlobalFlagSpecs()
+	t.HeadingSub("GLOBAL OPTIONS", "(also settable via environment variables)")
+	t.Flags(usageFlags(general))
 	t.Blank()
 	t.Note(
 		"Store URI formats:",
@@ -82,15 +108,7 @@ func printUsage(out io.Writer) {
 	)
 
 	t.Heading("ENCRYPTION OPTIONS")
-	t.Flags([][2]string{
-		{"-password <pw>", ui.Env("Repository password", "CLOUDSTIC_PASSWORD")},
-		{"-prompt", "Prompt for password interactively (use alongside --encryption-key or --kms-key-arn)"},
-		{"-encryption-key <hex>", ui.Env("Platform key (64 hex chars = 32 bytes)", "CLOUDSTIC_ENCRYPTION_KEY")},
-		{"-recovery-key <words>", ui.Env("Recovery key (24-word seed phrase)", "CLOUDSTIC_RECOVERY_KEY")},
-		{"-kms-key-arn <arn>", ui.Env("AWS KMS key ARN for kms-platform slots", "CLOUDSTIC_KMS_KEY_ARN")},
-		{"-kms-region <region>", ui.Env("AWS KMS region", "CLOUDSTIC_KMS_REGION")},
-		{"-kms-endpoint <url>", ui.Env("AWS KMS endpoint URL", "CLOUDSTIC_KMS_ENDPOINT")},
-	})
+	t.Flags(usageFlags(encryption))
 	t.Blank()
 	t.Note(
 		"Encryption is required by default (AES-256-GCM). Provide -password",
@@ -99,300 +117,18 @@ func printUsage(out io.Writer) {
 	)
 
 	t.Heading("COMMAND DETAILS")
+	for _, command := range publicLeafCommands() {
+		t.Command(command.path(), command.args)
+		if len(command.flags) != 0 {
+			t.Flags(usageFlags(command.flags))
+		}
+		if len(command.notes) != 0 {
+			t.Note(command.notes...)
+		}
+		t.Blank()
+	}
 
-	t.Command("init", "")
-	t.Flags([][2]string{
-		{"-add-recovery-key", "Generate a 24-word recovery key during init"},
-		{"-no-encryption", "Create an unencrypted repository (not recommended)"},
-		{"-adopt-slots", "Initialize by adopting existing key slots if found"},
-	})
-	t.Blank()
-
-	t.Command("key list", "")
-	t.Note("  List all encryption key slots present in the repository.")
-	t.Blank()
-
-	t.Command("key add-recovery", "")
-	t.Note(
-		"  Generate a 24-word recovery key for an existing encrypted repository.",
-		"  Requires -encryption-key or -encryption-password to unlock the master key.",
-	)
-	t.Blank()
-
-	t.Command("key passwd", "")
-	t.Flags([][2]string{
-		{"-new-password <pw>", "New password (prompted interactively if not set)"},
-	})
-	t.Note(
-		"  Change the repository password. Provide current credentials via",
-		"  -password, -encryption-key, or -kms-key-arn to unlock.",
-	)
-	t.Blank()
-
-	t.Command("backup", "")
-	t.Flags([][2]string{
-		{"-source <uri>", ui.Env("Source URI: local:<path>, sftp://[user@]host[:port]/<path>, gdrive[://<Drive Name>][/<path>], gdrive-changes[://<Drive Name>][/<path>], onedrive[://<Drive Name>][/<path>], onedrive-changes[://<Drive Name>][/<path>]", "CLOUDSTIC_SOURCE")},
-		{"-profile <name>", "Run backup from a named profile"},
-		{"-all-profiles", "Run backup for all enabled profiles"},
-		{"-auth-ref <name>", "Use named auth entry from profiles.yaml for cloud credentials"},
-		{"-profiles-file <path>", ui.Env("Path to profiles YAML file", "CLOUDSTIC_PROFILES_FILE")},
-		{"-skip-native-files", "Exclude Google-native files (Docs, Sheets, Slides, etc.)"},
-		{"-google-credentials <path>", ui.Env("Path to Google service account credentials JSON", "GOOGLE_APPLICATION_CREDENTIALS")},
-		{"-google-credentials-ref <ref>", "Secret reference to Google service account credentials JSON"},
-		{"-google-credentials-json <json>", ui.Env("Inline Google credentials JSON (OAuth client or service account)", "GOOGLE_CREDENTIALS_JSON")},
-		{"-google-token-file <path>", ui.Env("Path to Google OAuth token file", "GOOGLE_TOKEN_FILE")},
-		{"-google-token-ref <ref>", "Secret reference to Google OAuth token"},
-		{"-onedrive-client-id <id>", ui.Env("OneDrive OAuth client ID", "ONEDRIVE_CLIENT_ID")},
-		{"-onedrive-token-file <path>", ui.Env("Path to OneDrive OAuth token file", "ONEDRIVE_TOKEN_FILE")},
-		{"-onedrive-token-ref <ref>", "Secret reference to OneDrive OAuth token"},
-		{"-tag <tag>", "Tag to apply to the snapshot (repeatable)"},
-		{"-exclude <pattern>", "Exclude pattern, gitignore syntax (repeatable)"},
-		{"-exclude-file <path>", "Load exclude patterns from file (one per line, gitignore syntax)"},
-		{"-ignore-empty-snapshot", "Skip creating a new snapshot when nothing changed"},
-		{"-dry-run", "Scan source and report changes without writing to the store"},
-		{"-skip-mode", "Skip POSIX mode, uid, gid, btime, and flags collection"},
-		{"-skip-flags", "Skip file flags collection"},
-		{"-skip-xattrs", "Skip extended attribute collection"},
-		{"-xattr-namespaces <prefixes>", "Restrict xattr collection to prefixes (comma-separated)"},
-	})
-	t.Blank()
-	t.Note(
-		"Source URI formats:",
-		"  local:<path>                       e.g. local:./documents",
-		"  sftp://[user@]host[:port]/<path>   e.g. sftp://backup@host.com/data",
-		"  gdrive                             Google Drive (full scan)",
-		"  gdrive-changes                     Google Drive (incremental via Changes API)",
-		"  onedrive                           OneDrive (full scan)",
-		"  onedrive-changes                   OneDrive (incremental via delta API)",
-	)
-
-	t.Command("store list", "")
-	t.Flags([][2]string{{"-profiles-file <path>", ui.Env("Path to profiles YAML file", "CLOUDSTIC_PROFILES_FILE")}})
-	t.Note("  List configured stores.")
-	t.Blank()
-
-	t.Command("store show", "<name>")
-	t.Flags([][2]string{{"-profiles-file <path>", ui.Env("Path to profiles YAML file", "CLOUDSTIC_PROFILES_FILE")}})
-	t.Note("  Show one store and its configuration.")
-	t.Blank()
-
-	t.Command("store verify", "<name>")
-	t.Flags([][2]string{{"-profiles-file <path>", ui.Env("Path to profiles YAML file", "CLOUDSTIC_PROFILES_FILE")}})
-	t.Note("  Resolve store credentials and verify connectivity.")
-	t.Blank()
-
-	t.Command("store init", "<name>")
-	t.Flags([][2]string{
-		{"-profiles-file <path>", ui.Env("Path to profiles YAML file", "CLOUDSTIC_PROFILES_FILE")},
-		{"-yes", "Initialize without confirmation prompt"},
-	})
-	t.Note("  Initialize a configured store by reference from profiles.yaml.")
-	t.Blank()
-
-	t.Command("store new", "")
-	t.Flags([][2]string{
-		{"-name <name>", "Store reference name"},
-		{"-uri <uri>", "Store URI (e.g. s3:bucket/path, local:/path, sftp://host/path)"},
-		{"-s3-region <region>", "S3 region"},
-		{"-s3-profile <name>", "AWS shared config profile"},
-		{"-s3-endpoint <url>", "S3-compatible endpoint URL"},
-		{"-s3-access-key <key>", "S3 static access key"},
-		{"-s3-secret-key <key>", "S3 static secret key"},
-		{"-s3-access-key-secret <ref>", "Secret reference for S3 access key (env://, keychain://)"},
-		{"-s3-secret-key-secret <ref>", "Secret reference for S3 secret key (env://, keychain://)"},
-		{"-store-sftp-password <pass>", "SFTP password"},
-		{"-store-sftp-key <path>", "Path to SFTP private key"},
-		{"-store-sftp-known-hosts <path>", "Path to SFTP known_hosts file"},
-		{"-store-sftp-insecure", "Skip SFTP host key validation (INSECURE)"},
-		{"-store-sftp-password-secret <ref>", "Secret reference for SFTP password (env://, keychain://)"},
-		{"-store-sftp-key-secret <ref>", "Secret reference for SFTP key path (env://, keychain://)"},
-		{"-password-secret <ref>", "Secret reference for repository password (env://, keychain://)"},
-		{"-encryption-key-secret <ref>", "Secret reference for platform key (env://, keychain://)"},
-		{"-recovery-key-secret <ref>", "Secret reference for recovery key mnemonic (env://, keychain://)"},
-		{"-kms-key-arn <arn>", "AWS KMS key ARN for envelope encryption"},
-		{"-kms-region <region>", "AWS KMS region"},
-		{"-kms-endpoint <url>", "Custom AWS KMS endpoint URL"},
-		{"-profiles-file <path>", ui.Env("Path to profiles YAML file", "CLOUDSTIC_PROFILES_FILE")},
-	})
-	t.Note("  Create or update a store entry in profiles.yaml.",
-		"  Prefer secret refs: -password-secret / -encryption-key-secret / -recovery-key-secret.",
-		"  KMS settings are stored directly (ARN is not a secret).",
-	)
-	t.Blank()
-
-	t.Command("source discover", "")
-	t.Flags([][2]string{
-		{"-portable-only", "Only show portable/external source candidates"},
-		{"-json", "Write discovered sources as JSON"},
-	})
-	t.Note(
-		"  Discover local source candidates with mount metadata and portable-drive hints.",
-		"  Intended for workstation onboarding and source selection workflows.",
-	)
-	t.Blank()
-
-	t.Command("setup workstation", "")
-	t.Flags([][2]string{
-		{"-dry-run", "Preview generated profiles without writing configuration"},
-		{"-yes", "Accept the proposed plan without confirmation"},
-		{"-profiles-file <path>", ui.Env("Path to profiles YAML file", "CLOUDSTIC_PROFILES_FILE")},
-		{"-store-ref <name>", "Existing store reference to attach to generated profiles"},
-		{"-json", "Write onboarding plan as JSON"},
-	})
-	t.Note(
-		"  Build a workstation onboarding flow using OS-aware folder suggestions and portable-drive discovery.",
-		"  Interactive by default. Use -dry-run to preview without writing, or -yes to save without confirmation.",
-	)
-	t.Blank()
-
-	t.Command("profile list", "")
-	t.Flags([][2]string{
-		{"-profiles-file <path>", ui.Env("Path to profiles YAML file", "CLOUDSTIC_PROFILES_FILE")},
-	})
-	t.Note("  List configured stores, auth entries, and backup profiles.")
-	t.Blank()
-
-	t.Command("profile show", "<name>")
-	t.Flags([][2]string{
-		{"-profiles-file <path>", ui.Env("Path to profiles YAML file", "CLOUDSTIC_PROFILES_FILE")},
-	})
-	t.Note("  Show one profile and resolved store/auth references.")
-	t.Blank()
-
-	t.Command("profile new", "")
-	t.Flags([][2]string{
-		{"-name <name>", "Profile name"},
-		{"-source <uri>", "Source URI for this profile"},
-		{"-store-ref <name>", "Store reference name to use from top-level stores"},
-		{"-store <uri>", "Optional store URI to create/update under -store-ref"},
-		{"-auth-ref <name>", "Auth reference name to use from top-level auth"},
-		{"-tag <tag>", "Tag for snapshots (repeatable)"},
-		{"-exclude <pattern>", "Exclude pattern (repeatable)"},
-		{"-exclude-file <path>", "Path to exclude file"},
-		{"-ignore-empty-snapshot", "Skip creating a new snapshot when nothing changed"},
-		{"-skip-native-files", "Exclude Google-native files"},
-		{"-volume-uuid <uuid>", "Override local source volume UUID"},
-		{"-google-credentials <path>", "Path to Google service account credentials JSON"},
-		{"-google-credentials-ref <ref>", "Secret reference to Google service account credentials JSON"},
-		{"-google-credentials-json <json>", "Inline Google credentials JSON (OAuth client or service account)"},
-		{"-google-token-file <path>", "Path to Google OAuth token file"},
-		{"-google-token-ref <ref>", "Secret reference to Google OAuth token"},
-		{"-onedrive-client-id <id>", "OneDrive OAuth client ID"},
-		{"-onedrive-token-file <path>", "Path to OneDrive OAuth token file"},
-		{"-onedrive-token-ref <ref>", "Secret reference to OneDrive OAuth token"},
-		{"-profiles-file <path>", ui.Env("Path to profiles YAML file", "CLOUDSTIC_PROFILES_FILE")},
-	})
-	t.Note(
-		"  Create or update a backup profile in profiles.yaml.",
-		"  Use -store-ref by itself to reference an existing store entry.",
-		"  Add -store to create or update that store entry in the same command.",
-		"  Use -auth-ref to reuse cloud OAuth settings across multiple profiles.",
-	)
-	t.Blank()
-
-	t.Command("auth list", "")
-	t.Flags([][2]string{{"-profiles-file <path>", ui.Env("Path to profiles YAML file", "CLOUDSTIC_PROFILES_FILE")}})
-	t.Note("  List configured auth entries.")
-	t.Blank()
-
-	t.Command("auth show", "<name>")
-	t.Flags([][2]string{{"-profiles-file <path>", ui.Env("Path to profiles YAML file", "CLOUDSTIC_PROFILES_FILE")}})
-	t.Note("  Show one auth entry.")
-	t.Blank()
-
-	t.Command("auth new", "")
-	t.Flags([][2]string{
-		{"-name <name>", "Auth reference name"},
-		{"-provider <google|onedrive>", "Cloud provider for this auth entry"},
-		{"-google-credentials <path>", "Google service account credentials JSON (optional)"},
-		{"-google-credentials-ref <ref>", "Secret reference to Google service account credentials JSON"},
-		{"-google-credentials-json <json>", "Inline Google credentials JSON (OAuth client or service account)"},
-		{"-google-token-file <path>", "Google OAuth token file path (required for provider=google)"},
-		{"-google-token-ref <ref>", "Secret reference to Google OAuth token"},
-		{"-onedrive-client-id <id>", "OneDrive OAuth client ID (optional)"},
-		{"-onedrive-token-file <path>", "OneDrive OAuth token file path (required for provider=onedrive)"},
-		{"-onedrive-token-ref <ref>", "Secret reference to OneDrive OAuth token"},
-		{"-profiles-file <path>", ui.Env("Path to profiles YAML file", "CLOUDSTIC_PROFILES_FILE")},
-	})
-	t.Note("  Create or update a reusable cloud auth entry.")
-	t.Blank()
-
-	t.Command("auth login", "")
-	t.Flags([][2]string{
-		{"-name <name>", "Auth reference name"},
-		{"-profiles-file <path>", ui.Env("Path to profiles YAML file", "CLOUDSTIC_PROFILES_FILE")},
-	})
-	t.Note("  Trigger OAuth login for an auth entry and save token to its configured file.")
-	t.Blank()
-
-	t.Command("restore", "[snapshot_id]")
-	t.Flags([][2]string{
-		{"-output <path>", "Output path (ZIP file for -format zip, directory for -format dir)"},
-		{"-format <zip|dir>", "Restore format (default: auto from -output)"},
-		{"-path <path>", "Restore only the given file or subtree (e.g. Documents/report.pdf or Documents/)"},
-		{"-dry-run", "Show what would be restored without writing output"},
-	})
-	t.Blank()
-
-	t.Command("list", "")
-	t.Flags([][2]string{
-		{"-group", "Group snapshots by source identity"},
-	})
-	t.Blank()
-
-	t.Command("ls", "[snapshot_id]")
-	t.Note("  List files in the specified snapshot (defaults to latest).")
-	t.Blank()
-
-	t.Command("prune", "")
-	t.Flags([][2]string{
-		{"-dry-run", "Show what would be deleted without deleting"},
-	})
-	t.Blank()
-
-	t.Command("forget", "<snapshot_id>")
-	t.Flags([][2]string{
-		{"-prune", "Run prune immediately after forgetting"},
-		{"-dry-run", "Show what would be removed without acting"},
-		{"-keep-last N", "Keep the N most recent snapshots"},
-		{"-keep-daily N", "Keep N daily snapshots"},
-		{"-keep-weekly N", "Keep N weekly snapshots"},
-		{"-keep-monthly N", "Keep N monthly snapshots"},
-		{"-keep-yearly N", "Keep N yearly snapshots"},
-		{"-source <uri>", "Filter by source URI (e.g. local:./docs, gdrive, sftp://host/path)"},
-		{"-account <id>", "Filter by account"},
-		{"-tag <tag>", "Filter by tag (repeatable)"},
-		{"-group-by <fields>", "Group snapshots by fields (default: source,account,path)"},
-	})
-	t.Blank()
-
-	t.Command("diff", "<snapshot_1> <snapshot_2>")
-	t.Note("  Compare two snapshots. Use 'latest' as an alias for the most recent.")
-	t.Blank()
-
-	t.Command("break-lock", "")
-	t.Note("  Remove a stale repository lock left by a crashed or killed process.",
-		"  Only use this if you are sure no other operation is running.")
-	t.Blank()
-
-	t.Command("check", "[snapshot_id]")
-	t.Flags([][2]string{
-		{"-read-data", "Re-hash all chunk data for full byte-level verification"},
-	})
-	t.Note("  Verify the integrity of the repository by walking the full reference",
-		"  chain: index/latest → snapshot → HAMT nodes → filemeta → content → chunks.",
-		"  Defaults to the latest snapshot. Reports missing, corrupt, or unreadable objects.")
-	t.Blank()
-
-	t.Command("cat", "<object_key> [object_key...]")
-	t.Note("  Display raw JSON for one or more repository objects.",
-		"  Object keys: snapshot/<hash>, filemeta/<hash>, content/<hash>,",
-		"  node/<hash>, chunk/<hash>, config, index/latest, keys/<slot>")
-
-	t.Command("completion", "<shell>")
-	t.Note("  Generate completion scripts for bash, zsh, or fish.",
-		"  See 'cloudstic completion --help' or the user guide for setup instructions.")
-	t.Blank()
+	printEnvironmentUsage(t)
 
 	t.Heading("EXAMPLES")
 	t.Examples(
@@ -411,4 +147,60 @@ func printUsage(out io.Writer) {
 		"cloudstic prune -dry-run -verbose",
 	)
 	t.Blank()
+}
+
+func splitGlobalFlagSpecs() (general, encryption []flagSpec) {
+	for _, spec := range globalFlagSpecs {
+		if spec.section == flagSectionEncryption {
+			encryption = append(encryption, spec)
+		} else {
+			general = append(general, spec)
+		}
+	}
+	return general, encryption
+}
+
+func usageFlags(specs []flagSpec) [][2]string {
+	flags := make([][2]string, 0, len(specs))
+	for _, spec := range specs {
+		label := "-" + spec.name
+		if spec.takesValue() {
+			label += " <" + spec.value + ">"
+		}
+		description := spec.description
+		if names := documentedEnvironmentNames(spec); len(names) != 0 {
+			description = ui.Env(description, strings.Join(names, ", "))
+		}
+		flags = append(flags, [2]string{label, description})
+	}
+	return flags
+}
+
+func documentedEnvironmentNames(spec flagSpec) []string {
+	var names []string
+	for _, environment := range spec.environment {
+		if !environment.documented {
+			continue
+		}
+		names = append(names, environment.name)
+	}
+	return names
+}
+
+func printEnvironmentUsage(t ui.TermWriter) {
+	t.Heading("ENVIRONMENT")
+	t.Note(
+		"Values resolve in this order: explicit CLI flag, environment variable, profile, built-in default.",
+		"Provider-standard variables remain unprefixed; sensitive values are never rendered in help output.",
+	)
+	var standalone [][2]string
+	for _, variable := range standaloneEnvironmentVariables {
+		if variable.Documented {
+			standalone = append(standalone, [2]string{variable.Name, variable.Description})
+		}
+	}
+	if len(standalone) != 0 {
+		t.Blank()
+		t.Flags(standalone)
+	}
 }

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -487,11 +487,6 @@ New snapshots are tagged `hamt_version: 2`. Snapshots without this field default
 
 ## Environment Variables
 
-| Variable                         | Used by   | Description                          |
-|----------------------------------|-----------|--------------------------------------|
-| `GOOGLE_APPLICATION_CREDENTIALS` | `gdrive`  | Path to OAuth client credentials     |
-| `ONEDRIVE_CLIENT_ID`            | `onedrive`| Azure app client ID                  |
-| `ONEDRIVE_CLIENT_SECRET`        | `onedrive`| Azure app client secret              |
-| `ONEDRIVE_TOKEN_FILE`           | `onedrive`| Path to cached OAuth token (default: `onedrive_token.json`) |
-| `B2_KEY_ID`                     | `b2`      | Backblaze B2 application key ID      |
-| `B2_APP_KEY`                    | `b2`      | Backblaze B2 application key         |
+The canonical environment-variable inventory, including flag mappings,
+precedence, and sensitivity, is generated from the CLI declarations into the
+[user guide](user-guide.md#environment-variables).

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1589,6 +1589,10 @@ cloudstic init -store b2:my-bucket-name -password "passphrase"
 cloudstic backup -store b2:my-bucket-name -source local:~/Documents
 ```
 
+Credentials may also be passed explicitly with `-b2-key-id` and
+`-b2-app-key`. Stored profiles support `b2_key_id` / `b2_app_key` and the
+preferred `b2_key_id_secret` / `b2_app_key_secret` secret-reference fields.
+
 Use a prefix to namespace objects within a bucket:
 
 ```bash
@@ -1597,10 +1601,10 @@ cloudstic init -store b2:my-bucket/laptop/ -password "passphrase"
 
 **Environment variables:**
 
-| Variable | Description |
-|----------|-------------|
-| `B2_KEY_ID` | Backblaze B2 application key ID |
-| `B2_APP_KEY` | Backblaze B2 application key |
+| Variable | Flag | Description |
+|----------|------|-------------|
+| `B2_KEY_ID` | `-b2-key-id` | Backblaze B2 application key ID |
+| `B2_APP_KEY` | `-b2-app-key` | Backblaze B2 application key |
 
 ### Amazon S3
 
@@ -1790,31 +1794,45 @@ cloudstic forget -keep-daily 7 -keep-monthly 12 -dry-run
 
 ## Environment Variables
 
+<!-- BEGIN GENERATED ENVIRONMENT VARIABLES -->
+Values resolve in this order: explicit CLI flag, environment variable, profile, built-in default.
+
+Provider-oriented variables remain deliberately unprefixed for compatibility with their existing ecosystems. Sensitive values are never rendered in help output.
+
 | Variable | Flag equivalent | Description |
 | :--- | :--- | :--- |
-| `CLOUDSTIC_STORE` | `-store` | Storage backend URI: `local:<path>`, `s3:<bucket>[/<prefix>]`, `b2:<bucket>[/<prefix>]`, `sftp://[user@]host[:port]/<path>` |
-| `CLOUDSTIC_S3_ENDPOINT` | `-s3-endpoint` | S3 compatible endpoint (for MinIO, R2, etc.) |
-| `CLOUDSTIC_S3_REGION` | `-s3-region` | S3 Region |
-| `CLOUDSTIC_S3_PROFILE` | `-s3-profile` | AWS shared config profile for S3 auth |
-| `AWS_ACCESS_KEY_ID` | `-s3-access-key` | S3 Access Key ID |
-| `AWS_SECRET_ACCESS_KEY` | `-s3-secret-key` | S3 Secret Access Key |
-| `CLOUDSTIC_STORE_SFTP_PASSWORD` | `-store-sftp-password` | SFTP password for the store |
-| `CLOUDSTIC_STORE_SFTP_KEY` | `-store-sftp-key` | Path to SSH private key for the store |
-| `CLOUDSTIC_SOURCE` | `-source` | Source URI: `local:<path>`, `sftp://[user@]host[:port]/<path>`, `gdrive[://<Drive Name>][/<path>]`, `gdrive-changes[://<Drive Name>][/<path>]`, `onedrive[://<Drive Name>][/<path>]`, `onedrive-changes[://<Drive Name>][/<path>]` |
-| `CLOUDSTIC_SOURCE_SFTP_PASSWORD` | `-source-sftp-password` | SFTP password for the source |
-| `CLOUDSTIC_SOURCE_SFTP_KEY` | `-source-sftp-key` | Path to SSH private key for the source |
-| `CLOUDSTIC_ENCRYPTION_KEY` | `-encryption-key` | Platform key (hex) |
-| `CLOUDSTIC_PASSWORD` | `-password` | Encryption password |
-| `CLOUDSTIC_RECOVERY_KEY` | `-recovery-key` | Recovery seed phrase |
-| `CLOUDSTIC_KMS_KEY_ARN` | `-kms-key-arn` | AWS KMS key ARN for kms-platform slots |
-| `CLOUDSTIC_KMS_REGION` | `-kms-region` | AWS KMS region |
-| `CLOUDSTIC_KMS_ENDPOINT` | `-kms-endpoint` | Custom AWS KMS endpoint URL |
+| `CLOUDSTIC_STORE` | `-store` | Storage backend URI |
+| `CLOUDSTIC_PROFILE` | `-profile` | Backup profile name |
 | `CLOUDSTIC_PROFILES_FILE` | `-profiles-file` | Path to profiles YAML file |
-| `CLOUDSTIC_CONFIG_DIR` | — | Override config directory path |
-| `GOOGLE_APPLICATION_CREDENTIALS` | `-google-credentials` | Path to your own Google OAuth credentials file (optional, overrides built-in) |
-| `GOOGLE_CREDENTIALS_JSON` | `-google-credentials-json` | Inline Google credentials JSON (OAuth client or service account) |
-| `GOOGLE_TOKEN_FILE` | `-google-token-file` | Override Google OAuth token path |
-| `ONEDRIVE_CLIENT_ID` | — | Microsoft app client ID (optional, overrides built-in) |
-| `ONEDRIVE_TOKEN_FILE` | — | Override OneDrive token path |
-| `B2_KEY_ID` | — | Backblaze B2 key ID |
-| `B2_APP_KEY` | — | Backblaze B2 application key |
+| `CLOUDSTIC_S3_ENDPOINT` | `-s3-endpoint` | S3-compatible endpoint URL |
+| `CLOUDSTIC_S3_REGION` | `-s3-region` | S3 region |
+| `CLOUDSTIC_S3_PROFILE` | `-s3-profile` | AWS shared config profile |
+| `AWS_PROFILE` | `-s3-profile` | AWS shared config profile |
+| `AWS_ACCESS_KEY_ID` | `-s3-access-key` | S3 access key ID (sensitive) |
+| `AWS_SECRET_ACCESS_KEY` | `-s3-secret-key` | S3 secret access key (sensitive) |
+| `B2_KEY_ID` | `-b2-key-id` | Backblaze B2 application key ID (sensitive) |
+| `B2_APP_KEY` | `-b2-app-key` | Backblaze B2 application key (sensitive) |
+| `CLOUDSTIC_SOURCE_SFTP_PASSWORD` | `-source-sftp-password` | SFTP source password (sensitive) |
+| `CLOUDSTIC_SOURCE_SFTP_KEY` | `-source-sftp-key` | SSH private key for SFTP source (sensitive) |
+| `CLOUDSTIC_SOURCE_SFTP_KNOWN_HOSTS` | `-source-sftp-known-hosts` | known_hosts file for SFTP source |
+| `CLOUDSTIC_SOURCE_SFTP_INSECURE` | `-source-sftp-insecure` | Skip host-key validation for SFTP source (INSECURE) |
+| `CLOUDSTIC_STORE_SFTP_PASSWORD` | `-store-sftp-password` | SFTP store password (sensitive) |
+| `CLOUDSTIC_STORE_SFTP_KEY` | `-store-sftp-key` | SSH private key for SFTP store (sensitive) |
+| `CLOUDSTIC_STORE_SFTP_KNOWN_HOSTS` | `-store-sftp-known-hosts` | known_hosts file for SFTP store |
+| `CLOUDSTIC_STORE_SFTP_INSECURE` | `-store-sftp-insecure` | Skip host-key validation for SFTP store (INSECURE) |
+| `CLOUDSTIC_ENCRYPTION_KEY` | `-encryption-key` | Platform encryption key (sensitive) |
+| `CLOUDSTIC_PASSWORD` | `-password` | Repository password (sensitive) |
+| `CLOUDSTIC_RECOVERY_KEY` | `-recovery-key` | Recovery key mnemonic (sensitive) |
+| `CLOUDSTIC_KMS_KEY_ARN` | `-kms-key-arn` | AWS KMS key ARN |
+| `CLOUDSTIC_KMS_REGION` | `-kms-region` | AWS KMS region |
+| `CLOUDSTIC_KMS_ENDPOINT` | `-kms-endpoint` | AWS KMS endpoint URL |
+| `CLOUDSTIC_DISABLE_PACKFILE` | `-disable-packfile` | Disable small-object packfiles |
+| `CLOUDSTIC_SOURCE` | `-source` | Source URI |
+| `GOOGLE_APPLICATION_CREDENTIALS` | `-google-credentials` | Google credentials file (sensitive) |
+| `GOOGLE_CREDENTIALS_JSON` | `-google-credentials-json` | Inline Google credentials (sensitive) |
+| `GOOGLE_TOKEN_FILE` | `-google-token-file` | Google OAuth token file (sensitive) |
+| `ONEDRIVE_CLIENT_ID` | `-onedrive-client-id` | OneDrive client ID |
+| `ONEDRIVE_TOKEN_FILE` | `-onedrive-token-file` | OneDrive token file (sensitive) |
+| `CLOUDSTIC_CONFIG_DIR` | — | Cloudstic configuration directory |
+
+<!-- END GENERATED ENVIRONMENT VARIABLES -->

--- a/e2e/feature_completion_runtime_test.go
+++ b/e2e/feature_completion_runtime_test.go
@@ -170,16 +170,9 @@ _cloudstic_query profile-names
 `
 	case len(words) >= 3 && words[1] == "-store" && words[2] == "":
 		scriptBody = `
-compadd() {
-    local arg
-    for arg in "$@"; do
-        case "$arg" in
-            -*) ;;
-            *) print -r -- "$arg" ;;
-        esac
-    done
-}
-_cloudstic_store_prefixes
+_describe() { return 0 }
+_arguments() { print -l -- "$@" }
+_cloudstic
 `
 	}
 	return runShell(t, "zsh", append(append([]string{}, rt.env...), zshHomeEnv(t)...), `

--- a/internal/engine/profiles.go
+++ b/internal/engine/profiles.go
@@ -25,6 +25,8 @@ type ProfileStore struct {
 	S3Profile         string `yaml:"s3_profile,omitempty"`
 	S3AccessKey       string `yaml:"s3_access_key,omitempty"`
 	S3SecretKey       string `yaml:"s3_secret_key,omitempty"`
+	B2KeyID           string `yaml:"b2_key_id,omitempty"`
+	B2AppKey          string `yaml:"b2_app_key,omitempty"`
 	StoreSFTPPassword string `yaml:"store_sftp_password,omitempty"`
 	StoreSFTPKey      string `yaml:"store_sftp_key,omitempty"`
 
@@ -34,6 +36,8 @@ type ProfileStore struct {
 	RecoveryKeySecret       string `yaml:"recovery_key_secret,omitempty"`
 	S3AccessKeySecret       string `yaml:"s3_access_key_secret,omitempty"`
 	S3SecretKeySecret       string `yaml:"s3_secret_key_secret,omitempty"`
+	B2KeyIDSecret           string `yaml:"b2_key_id_secret,omitempty"`
+	B2AppKeySecret          string `yaml:"b2_app_key_secret,omitempty"`
 	StoreSFTPPasswordSecret string `yaml:"store_sftp_password_secret,omitempty"`
 	StoreSFTPKeySecret      string `yaml:"store_sftp_key_secret,omitempty"`
 	KMSKeyARN               string `yaml:"kms_key_arn,omitempty"`
@@ -118,6 +122,12 @@ func validateProfilesConfig(cfg *ProfilesConfig) error {
 			return err
 		}
 		if err := validateSecretRef("store", storeName, "s3_secret_key_secret", s.S3SecretKeySecret); err != nil {
+			return err
+		}
+		if err := validateSecretRef("store", storeName, "b2_key_id_secret", s.B2KeyIDSecret); err != nil {
+			return err
+		}
+		if err := validateSecretRef("store", storeName, "b2_app_key_secret", s.B2AppKeySecret); err != nil {
 			return err
 		}
 		if err := validateSecretRef("store", storeName, "store_sftp_password_secret", s.StoreSFTPPasswordSecret); err != nil {


### PR DESCRIPTION
## Summary
- Drive recursive command dispatch, usage, flags, notes, environment bindings, and completion metadata from command specs
- Keep built-in defaults in executable flag registrations while resolving environment overrides uniformly with explicit provenance
- Generate Bash, Zsh, and Fish completion from spec-owned static choices and generic dynamic completers
- Preserve B2 profile credentials and source/store-specific SFTP security settings through the migration
- Add registry parity, historical environment binding, default preservation, generated documentation, and completion runtime coverage

Closes #260

## Verification
- env -u AWS_PROFILE -u CLOUDSTIC_ENCRYPTION_KEY -u CLOUDSTIC_KMS_KEY_ARN -u CLOUDSTIC_SOURCE -u CLOUDSTIC_STORE -u GOOGLE_APPLICATION_CREDENTIALS GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./...
- env -u AWS_PROFILE -u CLOUDSTIC_ENCRYPTION_KEY -u CLOUDSTIC_KMS_KEY_ARN -u CLOUDSTIC_SOURCE -u CLOUDSTIC_STORE -u GOOGLE_APPLICATION_CREDENTIALS GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./cmd/cloudstic
- env -u AWS_PROFILE -u CLOUDSTIC_ENCRYPTION_KEY -u CLOUDSTIC_KMS_KEY_ARN -u CLOUDSTIC_SOURCE -u CLOUDSTIC_STORE -u GOOGLE_APPLICATION_CREDENTIALS GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./...