### PR TITLE
refactor(cli): drive dispatch, usage, and completion from a command registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Docker-based hermetic tests (MinIO store, SFTP source/store) are automatically s
 ### Package Layout
 
 - `client.go` (root) — Public `Client` API. Re-exports types from internal packages using Go type aliases. This is the library entry point for programmatic use.
-- `cmd/cloudstic/` — CLI entry point (`package main`). `main.go`'s `runCmd()` dispatches each subcommand to a `run*()` function that lives in its own `cmd_*.go` file (e.g. `cmd_backup.go`, `cmd_key.go`). Subcommands: `init`, `backup`, `restore`, `list`, `ls`, `prune`, `forget`, `diff`, `break-lock`, `key` (with `list`/`add-recovery`/`passwd`), `check`, `cat`, `profile`, `auth`, `store`, `source`, `setup`, `tui`, `completion`. Uses Go's `flag` package (no cobra/viper); `reorderArgs()` in `flags.go` allows flags after positional args. The interactive terminal UI lives in `cmd_tui*.go`.
+- `cmd/cloudstic/` — CLI entry point (`package main`). `commands.go` holds `commandRegistry()`, the single source of truth for the command surface: `main.go`'s `runCmd()` dispatches from it, `printUsage()` renders its `COMMANDS` listing from it, and the shell-completion command lists are generated from it. Each command's `run*()` function lives in its own `cmd_*.go` file (e.g. `cmd_backup.go`, `cmd_key.go`). Subcommands: `init`, `backup`, `restore`, `list`, `ls`, `prune`, `forget`, `diff`, `break-lock`, `key` (with `list`/`add-recovery`/`passwd`), `check`, `cat`, `profile`, `auth`, `store`, `source`, `setup`, `tui`, `completion`. Uses Go's `flag` package (no cobra/viper); `reorderArgs()` in `flags.go` allows flags after positional args. The interactive terminal UI lives in `cmd_tui*.go`.
   - Commands are free functions taking the dependency container first: `run<Name>(r *runner, ctx, ...)` (and `exec<Name>(r, ctx, ...)` for testable sub-steps). The `runner` struct (`runner.go`) carries `out`/`errOut` writers and the client, so command output is capturable in tests; only I/O primitives (`fail`, `writeJSON`, `openClient`, `prompt*`) remain methods on it.
   - Presentation is separate from orchestration: `print*`/`render*` helpers are free functions taking an `io.Writer` first (`printBackupSummary(out, res)`), so result formatting cannot reach the client or command flow.
   - `cloudsticClient` (`client_iface.go`) is the interface `runner` depends on — satisfied by the real `*Client` and by `stubClient` (`stub_client_test.go`) in unit tests.
@@ -179,8 +179,9 @@ When implementing new functionality, always consider the following:
 
 4. **CLI Integration** — For new commands:
    - Add a `cmd_<name>.go` file with a `run<Name>(r *runner, ctx context.Context) int` free function (plus `exec<Name>(r, ctx, ...)` for testable sub-steps — see existing `cmd_*.go` for the pattern).
-   - Add the command to the switch in `runCmd()` in `main.go`.
-   - Add command documentation to `printUsage()` in `usage.go`.
+   - Split flag construction from parsing: a `new<Name>FlagSet() (*flag.FlagSet, *<name>Args)` builder plus a `parse<Name>Args(args []string)` that calls it. The builder lets the registry and drift tests introspect the real flags.
+   - Register the command in `commandRegistry()` (`commands.go`). That single declaration drives dispatch in `runCmd()`, the `COMMANDS` listing in `printUsage()`, and the shell-completion command lists — do **not** edit `main.go` or `usage.go` for a new command.
+   - Add the command's own flags to the per-command lists in `completion.go` (global flags and command names are generated; per-command flag lists are still hand-written). `TestCommandFlagsAppearInBashCompletion` fails if you forget.
    - Use the `reorderArgs()` helper (`flags.go`) so flags may follow positional args.
    - Write output via `r.out`/`r.errOut` (not `fmt.Print`) so it is capturable, and unit-test against `stubClient`.
    - Keep result rendering in `print*`/`render*` free functions that take an `io.Writer` first — never give presentation code access to `runner`.

--- a/cmd/cloudstic/cmd_backup.go
+++ b/cmd/cloudstic/cmd_backup.go
@@ -49,57 +49,42 @@ type backupArgs struct {
 	flagsSet          map[string]bool
 }
 
-func parseBackupArgs(args []string) (*backupArgs, error) {
+func newBackupFlagSet() (*flag.FlagSet, *backupArgs) {
 	fs := flag.NewFlagSet("backup", flag.ContinueOnError)
 	a := &backupArgs{}
 	a.g = addGlobalFlags(fs)
-	sourceURI := fs.String("source", envDefault("CLOUDSTIC_SOURCE", "gdrive"), "Source URI: local:<path>, sftp://[user@]host[:port]/<path>, gdrive[://<Drive Name>][/<path>], gdrive-changes[://<Drive Name>][/<path>], onedrive[://<Drive Name>][/<path>], onedrive-changes[://<Drive Name>][/<path>]")
-	allProfiles := fs.Bool("all-profiles", false, "Run backup for all enabled profiles from profiles.yaml")
-	authRef := fs.String("auth-ref", "", "Use named auth entry from profiles.yaml for cloud source credentials")
-	dryRun := fs.Bool("dry-run", false, "Scan source and report changes without writing to the store")
-	ignoreEmpty := fs.Bool("ignore-empty-snapshot", false, "Skip creating a new snapshot when nothing changed")
-	skipNativeFiles := fs.Bool("skip-native-files", false, "Exclude Google-native files (Docs, Sheets, Slides, etc.) from the backup")
-	excludeFile := fs.String("exclude-file", "", "Path to file with exclude patterns (one per line, gitignore syntax)")
-	volumeUUID := fs.String("volume-uuid", envDefault("CLOUDSTIC_VOLUME_UUID", ""), "Override volume UUID for local source (enables cross-machine incremental backup)")
-	googleCreds := fs.String("google-credentials", envDefault("GOOGLE_APPLICATION_CREDENTIALS", ""), "Path to Google service account credentials JSON file")
-	googleCredsRef := fs.String("google-credentials-ref", "", "Secret reference to Google service account credentials JSON")
-	googleCredsJSON := fs.String("google-credentials-json", envDefault("GOOGLE_CREDENTIALS_JSON", ""), "Inline Google credentials JSON (OAuth client or service account)")
-	googleTokenFile := fs.String("google-token-file", envDefault("GOOGLE_TOKEN_FILE", ""), "Path to Google OAuth token file")
-	googleTokenRef := fs.String("google-token-ref", "", "Secret reference to Google OAuth token")
-	onedriveClientID := fs.String("onedrive-client-id", envDefault("ONEDRIVE_CLIENT_ID", ""), "OneDrive OAuth client ID")
-	onedriveTokenFile := fs.String("onedrive-token-file", envDefault("ONEDRIVE_TOKEN_FILE", ""), "Path to OneDrive OAuth token file")
-	onedriveTokenRef := fs.String("onedrive-token-ref", "", "Secret reference to OneDrive OAuth token")
-	skipMode := fs.Bool("skip-mode", false, "Skip POSIX mode, uid, gid, btime, and flags collection")
-	skipFlags := fs.Bool("skip-flags", false, "Skip file flags collection")
-	skipXattrs := fs.Bool("skip-xattrs", false, "Skip extended attribute collection")
-	xattrNamespaces := fs.String("xattr-namespaces", "", "Restrict xattr collection to these prefixes (comma-separated, e.g. \"user.,com.apple.\")")
+	fs.StringVar(&a.sourceURI, "source", envDefault("CLOUDSTIC_SOURCE", "gdrive"), "Source URI: local:<path>, sftp://[user@]host[:port]/<path>, gdrive[://<Drive Name>][/<path>], gdrive-changes[://<Drive Name>][/<path>], onedrive[://<Drive Name>][/<path>], onedrive-changes[://<Drive Name>][/<path>]")
+	fs.BoolVar(&a.allProfiles, "all-profiles", false, "Run backup for all enabled profiles from profiles.yaml")
+	fs.StringVar(&a.authRef, "auth-ref", "", "Use named auth entry from profiles.yaml for cloud source credentials")
+	fs.BoolVar(&a.dryRun, "dry-run", false, "Scan source and report changes without writing to the store")
+	fs.BoolVar(&a.ignoreEmpty, "ignore-empty-snapshot", false, "Skip creating a new snapshot when nothing changed")
+	fs.BoolVar(&a.skipNativeFiles, "skip-native-files", false, "Exclude Google-native files (Docs, Sheets, Slides, etc.) from the backup")
+	fs.StringVar(&a.excludeFile, "exclude-file", "", "Path to file with exclude patterns (one per line, gitignore syntax)")
+	fs.StringVar(&a.volumeUUID, "volume-uuid", envDefault("CLOUDSTIC_VOLUME_UUID", ""), "Override volume UUID for local source (enables cross-machine incremental backup)")
+	fs.StringVar(&a.googleCreds, "google-credentials", envDefault("GOOGLE_APPLICATION_CREDENTIALS", ""), "Path to Google service account credentials JSON file")
+	fs.StringVar(&a.googleCredsRef, "google-credentials-ref", "", "Secret reference to Google service account credentials JSON")
+	fs.StringVar(&a.googleCredsJSON, "google-credentials-json", envDefault("GOOGLE_CREDENTIALS_JSON", ""), "Inline Google credentials JSON (OAuth client or service account)")
+	fs.StringVar(&a.googleTokenFile, "google-token-file", envDefault("GOOGLE_TOKEN_FILE", ""), "Path to Google OAuth token file")
+	fs.StringVar(&a.googleTokenRef, "google-token-ref", "", "Secret reference to Google OAuth token")
+	fs.StringVar(&a.onedriveClientID, "onedrive-client-id", envDefault("ONEDRIVE_CLIENT_ID", ""), "OneDrive OAuth client ID")
+	fs.StringVar(&a.onedriveTokenFile, "onedrive-token-file", envDefault("ONEDRIVE_TOKEN_FILE", ""), "Path to OneDrive OAuth token file")
+	fs.StringVar(&a.onedriveTokenRef, "onedrive-token-ref", "", "Secret reference to OneDrive OAuth token")
+	fs.BoolVar(&a.skipMode, "skip-mode", false, "Skip POSIX mode, uid, gid, btime, and flags collection")
+	fs.BoolVar(&a.skipFlags, "skip-flags", false, "Skip file flags collection")
+	fs.BoolVar(&a.skipXattrs, "skip-xattrs", false, "Skip extended attribute collection")
+	fs.StringVar(&a.xattrNamespaces, "xattr-namespaces", "", "Restrict xattr collection to these prefixes (comma-separated, e.g. \"user.,com.apple.\")")
 	fs.Var(&a.tags, "tag", "Tag to apply to the snapshot (can be specified multiple times)")
 	fs.Var(&a.excludes, "exclude", "Exclude pattern (gitignore syntax, repeatable)")
+	return fs, a
+}
+
+func parseBackupArgs(args []string) (*backupArgs, error) {
+	fs, a := newBackupFlagSet()
 	if err := parseFlags(fs, args); err != nil {
 		return nil, err
 	}
-	a.sourceURI = *sourceURI
 	a.profile = a.g.profile
-	a.allProfiles = *allProfiles
-	a.authRef = *authRef
 	a.profilesFile = a.g.profilesFile
-	a.dryRun = *dryRun
-	a.ignoreEmpty = *ignoreEmpty
-	a.skipNativeFiles = *skipNativeFiles
-	a.excludeFile = *excludeFile
-	a.volumeUUID = *volumeUUID
-	a.googleCreds = *googleCreds
-	a.googleCredsRef = *googleCredsRef
-	a.googleCredsJSON = *googleCredsJSON
-	a.googleTokenFile = *googleTokenFile
-	a.googleTokenRef = *googleTokenRef
-	a.onedriveClientID = *onedriveClientID
-	a.onedriveTokenFile = *onedriveTokenFile
-	a.onedriveTokenRef = *onedriveTokenRef
-	a.skipMode = *skipMode
-	a.skipFlags = *skipFlags
-	a.skipXattrs = *skipXattrs
-	a.xattrNamespaces = *xattrNamespaces
 	a.flagsSet = map[string]bool{}
 	fs.Visit(func(f *flag.Flag) {
 		a.flagsSet[f.Name] = true

--- a/cmd/cloudstic/cmd_breaklock.go
+++ b/cmd/cloudstic/cmd_breaklock.go
@@ -13,9 +13,13 @@ type breakLockArgs struct {
 	g *globalFlags
 }
 
-func parseBreakLockArgs(args []string) (*breakLockArgs, error) {
+func newBreakLockFlagSet() (*flag.FlagSet, *breakLockArgs) {
 	fs := flag.NewFlagSet("break-lock", flag.ContinueOnError)
-	a := &breakLockArgs{g: addGlobalFlags(fs)}
+	return fs, &breakLockArgs{g: addGlobalFlags(fs)}
+}
+
+func parseBreakLockArgs(args []string) (*breakLockArgs, error) {
+	fs, a := newBreakLockFlagSet()
 	if err := parseFlags(fs, args); err != nil {
 		return nil, err
 	}

--- a/cmd/cloudstic/cmd_cat.go
+++ b/cmd/cloudstic/cmd_cat.go
@@ -18,18 +18,22 @@ type catArgs struct {
 	raw  bool
 }
 
-func parseCatArgs(args []string) (*catArgs, error) {
+func newCatFlagSet() (*flag.FlagSet, *catArgs) {
 	fs := flag.NewFlagSet("cat", flag.ContinueOnError)
 	a := &catArgs{}
 	a.g = addGlobalFlags(fs)
-	rawFlag := fs.Bool("raw", false, "Output raw, unformatted data (useful for hashing)")
+	fs.BoolVar(&a.raw, "raw", false, "Output raw, unformatted data (useful for hashing)")
+	return fs, a
+}
+
+func parseCatArgs(args []string) (*catArgs, error) {
+	fs, a := newCatFlagSet()
 	if err := parseFlags(fs, args); err != nil {
 		return nil, err
 	}
 	if fs.NArg() < 1 {
 		return nil, fmt.Errorf("at least one object key is required")
 	}
-	a.raw = *rawFlag
 	a.keys = fs.Args()
 	return a, nil
 }

--- a/cmd/cloudstic/cmd_check.go
+++ b/cmd/cloudstic/cmd_check.go
@@ -15,15 +15,19 @@ type checkArgs struct {
 	snapshotRef string
 }
 
-func parseCheckArgs(args []string) (*checkArgs, error) {
+func newCheckFlagSet() (*flag.FlagSet, *checkArgs) {
 	fs := flag.NewFlagSet("check", flag.ContinueOnError)
 	a := &checkArgs{}
 	a.g = addGlobalFlags(fs)
-	readData := fs.Bool("read-data", false, "Re-hash all chunk data for full byte-level verification")
+	fs.BoolVar(&a.readData, "read-data", false, "Re-hash all chunk data for full byte-level verification")
+	return fs, a
+}
+
+func parseCheckArgs(args []string) (*checkArgs, error) {
+	fs, a := newCheckFlagSet()
 	if err := parseFlags(fs, args); err != nil {
 		return nil, err
 	}
-	a.readData = *readData
 	a.snapshotRef = fs.Arg(0)
 	if a.snapshotRef == "" {
 		a.snapshotRef = "latest"

--- a/cmd/cloudstic/cmd_diff.go
+++ b/cmd/cloudstic/cmd_diff.go
@@ -16,10 +16,15 @@ type diffArgs struct {
 	snap2 string
 }
 
-func parseDiffArgs(args []string) (*diffArgs, error) {
+func newDiffFlagSet() (*flag.FlagSet, *diffArgs) {
 	fs := flag.NewFlagSet("diff", flag.ContinueOnError)
 	a := &diffArgs{}
 	a.g = addGlobalFlags(fs)
+	return fs, a
+}
+
+func parseDiffArgs(args []string) (*diffArgs, error) {
+	fs, a := newDiffFlagSet()
 	if err := parseFlags(fs, args); err != nil {
 		return nil, err
 	}

--- a/cmd/cloudstic/cmd_forget.go
+++ b/cmd/cloudstic/cmd_forget.go
@@ -31,24 +31,33 @@ type forgetArgs struct {
 	snapshotID    string
 	hasFilters    bool
 	hasPolicy     bool
+
+	// rawFilterSource holds the -source flag verbatim; parseForgetArgs splits
+	// it into filterSource/filterPath after parsing.
+	rawFilterSource string
 }
 
-func parseForgetArgs(args []string) (*forgetArgs, error) {
+func newForgetFlagSet() (*flag.FlagSet, *forgetArgs) {
 	fs := flag.NewFlagSet("forget", flag.ContinueOnError)
 	a := &forgetArgs{}
 	a.g = addGlobalFlags(fs)
-	prune := fs.Bool("prune", false, "Run prune after forgetting")
-	dryRun := fs.Bool("dry-run", false, "Only show what would be removed")
-	keepLast := fs.Int("keep-last", 0, "Keep the last n snapshots")
-	keepHourly := fs.Int("keep-hourly", 0, "Keep n hourly snapshots")
-	keepDaily := fs.Int("keep-daily", 0, "Keep n daily snapshots")
-	keepWeekly := fs.Int("keep-weekly", 0, "Keep n weekly snapshots")
-	keepMonthly := fs.Int("keep-monthly", 0, "Keep n monthly snapshots")
-	keepYearly := fs.Int("keep-yearly", 0, "Keep n yearly snapshots")
+	fs.BoolVar(&a.prune, "prune", false, "Run prune after forgetting")
+	fs.BoolVar(&a.dryRun, "dry-run", false, "Only show what would be removed")
+	fs.IntVar(&a.keepLast, "keep-last", 0, "Keep the last n snapshots")
+	fs.IntVar(&a.keepHourly, "keep-hourly", 0, "Keep n hourly snapshots")
+	fs.IntVar(&a.keepDaily, "keep-daily", 0, "Keep n daily snapshots")
+	fs.IntVar(&a.keepWeekly, "keep-weekly", 0, "Keep n weekly snapshots")
+	fs.IntVar(&a.keepMonthly, "keep-monthly", 0, "Keep n monthly snapshots")
+	fs.IntVar(&a.keepYearly, "keep-yearly", 0, "Keep n yearly snapshots")
 	fs.Var(&a.filterTags, "tag", "Filter by tag (can be specified multiple times)")
-	filterSource := fs.String("source", "", "Filter by source URI (e.g. local:./docs, gdrive)")
-	filterAccount := fs.String("account", "", "Filter by account")
-	groupBy := fs.String("group-by", "source,account,path", "Group snapshots by fields (comma-separated)")
+	fs.StringVar(&a.rawFilterSource, "source", "", "Filter by source URI (e.g. local:./docs, gdrive)")
+	fs.StringVar(&a.filterAccount, "account", "", "Filter by account")
+	fs.StringVar(&a.groupBy, "group-by", "source,account,path", "Group snapshots by fields (comma-separated)")
+	return fs, a
+}
+
+func parseForgetArgs(args []string) (*forgetArgs, error) {
+	fs, a := newForgetFlagSet()
 	if err := parseFlags(fs, args); err != nil {
 		return nil, err
 	}
@@ -57,23 +66,13 @@ func parseForgetArgs(args []string) (*forgetArgs, error) {
 			a.groupBySet = true
 		}
 	})
-	a.prune = *prune
-	a.dryRun = *dryRun
-	a.keepLast = *keepLast
-	a.keepHourly = *keepHourly
-	a.keepDaily = *keepDaily
-	a.keepWeekly = *keepWeekly
-	a.keepMonthly = *keepMonthly
-	a.keepYearly = *keepYearly
-	a.filterAccount = *filterAccount
-	a.groupBy = *groupBy
-	if *filterSource != "" {
+	if a.rawFilterSource != "" {
 		// Allow bare source type keywords (e.g. "local", "sftp") without a path for type-only filtering.
-		switch *filterSource {
+		switch a.rawFilterSource {
 		case "local", "sftp", "gdrive", "gdrive-changes", "onedrive", "onedrive-changes":
-			a.filterSource = *filterSource
+			a.filterSource = a.rawFilterSource
 		default:
-			parts, err := parseSourceURI(*filterSource)
+			parts, err := parseSourceURI(a.rawFilterSource)
 			if err != nil {
 				return nil, fmt.Errorf("invalid -source filter: %w", err)
 			}

--- a/cmd/cloudstic/cmd_init.go
+++ b/cmd/cloudstic/cmd_init.go
@@ -20,19 +20,21 @@ type initArgs struct {
 	adoptSlots   bool
 }
 
-func parseInitArgs(args []string) (*initArgs, error) {
+func newInitFlagSet() (*flag.FlagSet, *initArgs) {
 	fs := flag.NewFlagSet("init", flag.ContinueOnError)
 	a := &initArgs{}
 	a.g = addGlobalFlags(fs)
-	recovery := fs.Bool("add-recovery-key", false, "Generate a recovery key (24-word seed phrase) during init")
-	noEncryption := fs.Bool("no-encryption", false, "Create an unencrypted repository (NOT recommended)")
-	adoptSlots := fs.Bool("adopt-slots", false, "Initialize by adopting existing key slots if found (prevents error if already has slots)")
+	fs.BoolVar(&a.recovery, "add-recovery-key", false, "Generate a recovery key (24-word seed phrase) during init")
+	fs.BoolVar(&a.noEncryption, "no-encryption", false, "Create an unencrypted repository (NOT recommended)")
+	fs.BoolVar(&a.adoptSlots, "adopt-slots", false, "Initialize by adopting existing key slots if found (prevents error if already has slots)")
+	return fs, a
+}
+
+func parseInitArgs(args []string) (*initArgs, error) {
+	fs, a := newInitFlagSet()
 	if err := parseFlags(fs, args); err != nil {
 		return nil, err
 	}
-	a.recovery = *recovery
-	a.noEncryption = *noEncryption
-	a.adoptSlots = *adoptSlots
 	return a, nil
 }
 

--- a/cmd/cloudstic/cmd_key.go
+++ b/cmd/cloudstic/cmd_key.go
@@ -44,9 +44,13 @@ type keyListArgs struct {
 	g *globalFlags
 }
 
-func parseKeyListArgs(args []string) (*keyListArgs, error) {
+func newKeyListFlagSet() (*flag.FlagSet, *keyListArgs) {
 	fs := flag.NewFlagSet("key list", flag.ContinueOnError)
-	a := &keyListArgs{g: addGlobalFlags(fs)}
+	return fs, &keyListArgs{g: addGlobalFlags(fs)}
+}
+
+func parseKeyListArgs(args []string) (*keyListArgs, error) {
+	fs, a := newKeyListFlagSet()
 	if err := parseFlags(fs, args); err != nil {
 		return nil, err
 	}
@@ -100,15 +104,19 @@ type keyPasswdArgs struct {
 	newPassword string
 }
 
-func parseKeyPasswdArgs(args []string) (*keyPasswdArgs, error) {
+func newKeyPasswdFlagSet() (*flag.FlagSet, *keyPasswdArgs) {
 	fs := flag.NewFlagSet("key passwd", flag.ContinueOnError)
 	a := &keyPasswdArgs{}
 	a.g = addGlobalFlags(fs)
-	newPassword := fs.String("new-password", "", "New repository password (prompted interactively if not set)")
+	fs.StringVar(&a.newPassword, "new-password", "", "New repository password (prompted interactively if not set)")
+	return fs, a
+}
+
+func parseKeyPasswdArgs(args []string) (*keyPasswdArgs, error) {
+	fs, a := newKeyPasswdFlagSet()
 	if err := parseFlags(fs, args); err != nil {
 		return nil, err
 	}
-	a.newPassword = *newPassword
 	return a, nil
 }
 
@@ -158,9 +166,13 @@ type addRecoveryKeyArgs struct {
 	g *globalFlags
 }
 
-func parseAddRecoveryKeyArgs(args []string) (*addRecoveryKeyArgs, error) {
+func newAddRecoveryKeyFlagSet() (*flag.FlagSet, *addRecoveryKeyArgs) {
 	fs := flag.NewFlagSet("add-recovery-key", flag.ContinueOnError)
-	a := &addRecoveryKeyArgs{g: addGlobalFlags(fs)}
+	return fs, &addRecoveryKeyArgs{g: addGlobalFlags(fs)}
+}
+
+func parseAddRecoveryKeyArgs(args []string) (*addRecoveryKeyArgs, error) {
+	fs, a := newAddRecoveryKeyFlagSet()
 	if err := parseFlags(fs, args); err != nil {
 		return nil, err
 	}

--- a/cmd/cloudstic/cmd_list.go
+++ b/cmd/cloudstic/cmd_list.go
@@ -14,12 +14,15 @@ type listArgs struct {
 	group *bool
 }
 
-func parseListArgs(args []string) (*listArgs, error) {
+func newListFlagSet() (*flag.FlagSet, *listArgs) {
 	fs := flag.NewFlagSet("list", flag.ContinueOnError)
-	a := &listArgs{
-		g:     addGlobalFlags(fs),
-		group: fs.Bool("group", false, "Group snapshots by source identity"),
-	}
+	a := &listArgs{g: addGlobalFlags(fs)}
+	a.group = fs.Bool("group", false, "Group snapshots by source identity")
+	return fs, a
+}
+
+func parseListArgs(args []string) (*listArgs, error) {
+	fs, a := newListFlagSet()
 	if err := parseFlags(fs, args); err != nil {
 		return nil, err
 	}

--- a/cmd/cloudstic/cmd_ls.go
+++ b/cmd/cloudstic/cmd_ls.go
@@ -19,10 +19,15 @@ type lsArgs struct {
 	snapshotID string
 }
 
-func parseLsArgs(args []string) (*lsArgs, error) {
+func newLsFlagSet() (*flag.FlagSet, *lsArgs) {
 	fs := flag.NewFlagSet("ls", flag.ContinueOnError)
 	a := &lsArgs{}
 	a.g = addGlobalFlags(fs)
+	return fs, a
+}
+
+func parseLsArgs(args []string) (*lsArgs, error) {
+	fs, a := newLsFlagSet()
 	if err := parseFlags(fs, args); err != nil {
 		return nil, err
 	}

--- a/cmd/cloudstic/cmd_prune.go
+++ b/cmd/cloudstic/cmd_prune.go
@@ -15,15 +15,19 @@ type pruneArgs struct {
 	dryRun bool
 }
 
-func parsePruneArgs(args []string) (*pruneArgs, error) {
+func newPruneFlagSet() (*flag.FlagSet, *pruneArgs) {
 	fs := flag.NewFlagSet("prune", flag.ContinueOnError)
 	a := &pruneArgs{}
 	a.g = addGlobalFlags(fs)
-	dryRun := fs.Bool("dry-run", false, "Show what would be deleted without deleting")
+	fs.BoolVar(&a.dryRun, "dry-run", false, "Show what would be deleted without deleting")
+	return fs, a
+}
+
+func parsePruneArgs(args []string) (*pruneArgs, error) {
+	fs, a := newPruneFlagSet()
 	if err := parseFlags(fs, args); err != nil {
 		return nil, err
 	}
-	a.dryRun = *dryRun
 	return a, nil
 }
 

--- a/cmd/cloudstic/cmd_restore.go
+++ b/cmd/cloudstic/cmd_restore.go
@@ -21,21 +21,23 @@ type restoreArgs struct {
 	snapshotRef string
 }
 
-func parseRestoreArgs(args []string) (*restoreArgs, error) {
+func newRestoreFlagSet() (*flag.FlagSet, *restoreArgs) {
 	fs := flag.NewFlagSet("restore", flag.ContinueOnError)
 	a := &restoreArgs{}
 	a.g = addGlobalFlags(fs)
-	output := fs.String("output", "./restore.zip", "Output path (ZIP file for -format zip, directory for -format dir)")
-	format := fs.String("format", "", "Restore format: zip or dir (default: auto from -output)")
-	dryRun := fs.Bool("dry-run", false, "Show what would be restored without writing output")
-	pathFilter := fs.String("path", "", "Restore only the given file or subtree (e.g. Documents/report.pdf or Documents/)")
+	fs.StringVar(&a.output, "output", "./restore.zip", "Output path (ZIP file for -format zip, directory for -format dir)")
+	fs.StringVar(&a.format, "format", "", "Restore format: zip or dir (default: auto from -output)")
+	fs.BoolVar(&a.dryRun, "dry-run", false, "Show what would be restored without writing output")
+	fs.StringVar(&a.pathFilter, "path", "", "Restore only the given file or subtree (e.g. Documents/report.pdf or Documents/)")
+	return fs, a
+}
+
+func parseRestoreArgs(args []string) (*restoreArgs, error) {
+	fs, a := newRestoreFlagSet()
 	if err := parseFlags(fs, args); err != nil {
 		return nil, err
 	}
-	a.output = *output
-	a.format = strings.TrimSpace(strings.ToLower(*format))
-	a.dryRun = *dryRun
-	a.pathFilter = *pathFilter
+	a.format = strings.TrimSpace(strings.ToLower(a.format))
 	a.snapshotRef = "latest"
 	if fs.NArg() > 0 {
 		a.snapshotRef = fs.Arg(0)

--- a/cmd/cloudstic/cmd_tui.go
+++ b/cmd/cloudstic/cmd_tui.go
@@ -12,11 +12,16 @@ type tuiArgs struct {
 	profilesFile string
 }
 
-func parseTUIArgs(args []string) (*tuiArgs, error) {
+func newTUIFlagSet() (*flag.FlagSet, *tuiArgs) {
 	fs := flag.NewFlagSet("tui", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	a := &tuiArgs{}
 	fs.StringVar(&a.profilesFile, "profiles-file", defaultProfilesPathNoCreate(), "Path to profiles YAML file")
+	return fs, a
+}
+
+func parseTUIArgs(args []string) (*tuiArgs, error) {
+	fs, a := newTUIFlagSet()
 	if err := parseFlags(fs, args); err != nil {
 		return nil, err
 	}

--- a/cmd/cloudstic/commands.go
+++ b/cmd/cloudstic/commands.go
@@ -1,0 +1,252 @@
+package main
+
+import (
+	"context"
+	"flag"
+)
+
+// command describes one CLI command. The registry below is the single source
+// of truth for the command surface: dispatch (main.go), the usage listing
+// (usage.go), and the shell-completion command lists (completion.go) are all
+// derived from it, so adding a command is one declaration rather than three
+// edits that can silently drift apart.
+type command struct {
+	// name is the token typed on the command line, e.g. "backup".
+	name string
+	// summary is the one-line description shown in usage and zsh completion.
+	summary string
+	// subcommands lists the nested verbs for grouped commands such as
+	// "key list" or "store new". Empty for leaf commands.
+	subcommands []subcommand
+	// newFlagSet builds this command's flag set without parsing it, so tests
+	// can introspect the real flags. Nil for commands that take no flags of
+	// their own (grouped commands delegate to their subcommands).
+	newFlagSet func() *flag.FlagSet
+	// run executes the command.
+	run func(r *runner, ctx context.Context) int
+	// hidden keeps internal commands out of usage and completion output.
+	hidden bool
+}
+
+// subcommand describes one nested verb of a grouped command.
+//
+// Subcommands currently declare only their name and summary. Their flag sets
+// are still built inline inside each run function, so they are not yet
+// introspectable; extracting them is follow-up work tracked separately.
+type subcommand struct {
+	name    string
+	summary string
+}
+
+// commandRegistry declares every command the CLI accepts. Order determines the
+// order commands appear in `cloudstic help`.
+func commandRegistry() []command {
+	return []command{
+		{
+			name:       "init",
+			summary:    "Initialize a new repository (must run before first backup)",
+			newFlagSet: func() *flag.FlagSet { fs, _ := newInitFlagSet(); return fs },
+			run:        runInit,
+		},
+		{
+			name:       "backup",
+			summary:    "Create a new backup snapshot from a source",
+			newFlagSet: func() *flag.FlagSet { fs, _ := newBackupFlagSet(); return fs },
+			run:        runBackup,
+		},
+		{
+			name:    "auth",
+			summary: "Manage reusable cloud auth entries",
+			subcommands: []subcommand{
+				{name: "new", summary: "Create or update a reusable cloud auth entry"},
+				{name: "list", summary: "List auth entries from profiles.yaml"},
+				{name: "show", summary: "Show one auth entry"},
+				{name: "login", summary: "Run OAuth login flow for one auth entry"},
+			},
+			run: runAuth,
+		},
+		{
+			name:    "store",
+			summary: "Manage store entries in profiles.yaml",
+			subcommands: []subcommand{
+				{name: "new", summary: "Create or update a store entry in profiles.yaml"},
+				{name: "list", summary: "List configured stores"},
+				{name: "show", summary: "Show one store and its configuration"},
+				{name: "verify", summary: "Verify one store's credentials and connectivity"},
+				{name: "init", summary: "Initialize a configured store by reference"},
+			},
+			run: runStore,
+		},
+		{
+			name:    "source",
+			summary: "Discover source candidates for onboarding",
+			subcommands: []subcommand{
+				{name: "discover", summary: "Discover local source candidates for onboarding"},
+			},
+			run: runSource,
+		},
+		{
+			name:    "setup",
+			summary: "Guided setup and onboarding flows",
+			subcommands: []subcommand{
+				{name: "workstation", summary: "Guide workstation onboarding and profile scaffolding"},
+			},
+			run: runSetup,
+		},
+		{
+			name:       "tui",
+			summary:    "Launch the interactive terminal dashboard",
+			newFlagSet: func() *flag.FlagSet { fs, _ := newTUIFlagSet(); return fs },
+			run:        runTUI,
+		},
+		{
+			name:    "profile",
+			summary: "Manage backup profiles",
+			subcommands: []subcommand{
+				{name: "new", summary: "Create or update a backup profile in profiles.yaml"},
+				{name: "list", summary: "List stores, auth entries, and backup profiles"},
+				{name: "show", summary: "Show one profile and resolved store/auth references"},
+			},
+			run: runProfile,
+		},
+		{
+			name:       "restore",
+			summary:    "Restore files from a backup snapshot",
+			newFlagSet: func() *flag.FlagSet { fs, _ := newRestoreFlagSet(); return fs },
+			run:        runRestore,
+		},
+		{
+			name:       "list",
+			summary:    "List all backup snapshots in the repository",
+			newFlagSet: func() *flag.FlagSet { fs, _ := newListFlagSet(); return fs },
+			run:        runList,
+		},
+		{
+			name:       "ls",
+			summary:    "List files within a specific snapshot",
+			newFlagSet: func() *flag.FlagSet { fs, _ := newLsFlagSet(); return fs },
+			run:        runLsSnapshot,
+		},
+		{
+			name:       "prune",
+			summary:    "Remove unused data chunks from the repository",
+			newFlagSet: func() *flag.FlagSet { fs, _ := newPruneFlagSet(); return fs },
+			run:        runPrune,
+		},
+		{
+			name:       "forget",
+			summary:    "Remove a specific snapshot from history",
+			newFlagSet: func() *flag.FlagSet { fs, _ := newForgetFlagSet(); return fs },
+			run:        runForget,
+		},
+		{
+			name:       "diff",
+			summary:    "Compare two snapshots or a snapshot against latest",
+			newFlagSet: func() *flag.FlagSet { fs, _ := newDiffFlagSet(); return fs },
+			run:        runDiff,
+		},
+		{
+			name:       "break-lock",
+			summary:    "Remove a stale repository lock left by a crashed process",
+			newFlagSet: func() *flag.FlagSet { fs, _ := newBreakLockFlagSet(); return fs },
+			run:        runBreakLock,
+		},
+		{
+			name:    "key",
+			summary: "Manage encryption key slots",
+			subcommands: []subcommand{
+				{name: "list", summary: "List all encryption key slots in the repository"},
+				{name: "add-recovery", summary: "Generate a 24-word recovery key for an encrypted repository"},
+				{name: "passwd", summary: "Change the repository password"},
+			},
+			run: runKey,
+		},
+		{
+			name:       "check",
+			summary:    "Verify repository integrity (reference chain, objects, data)",
+			newFlagSet: func() *flag.FlagSet { fs, _ := newCheckFlagSet(); return fs },
+			run:        runCheck,
+		},
+		{
+			name:       "cat",
+			summary:    "Display raw JSON content of repository objects",
+			newFlagSet: func() *flag.FlagSet { fs, _ := newCatFlagSet(); return fs },
+			run:        runCat,
+		},
+		{
+			name:    "completion",
+			summary: "Generate shell completion scripts (bash, zsh, fish)",
+			run:     func(r *runner, _ context.Context) int { return runCompletion(r) },
+		},
+		{
+			name:    "__complete",
+			summary: "Internal dynamic completion helper",
+			run:     runCompletionQuery,
+			hidden:  true,
+		},
+	}
+}
+
+// lookupCommand resolves a command by name, including its aliases.
+func lookupCommand(name string) (command, bool) {
+	for _, c := range commandRegistry() {
+		if c.name == name {
+			return c, true
+		}
+	}
+	return command{}, false
+}
+
+// visibleCommands returns the registry entries that appear in user-facing
+// usage and completion output.
+func visibleCommands() []command {
+	var out []command
+	for _, c := range commandRegistry() {
+		if !c.hidden {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// commandNames returns the visible command names, plus the built-in verbs that
+// are handled directly by dispatch rather than by a registry entry.
+func commandNames() []string {
+	names := make([]string, 0, len(visibleCommands())+2)
+	for _, c := range visibleCommands() {
+		names = append(names, c.name)
+	}
+	return append(names, "version", "help")
+}
+
+// usageCommandRows renders the registry as the rows shown under the usage
+// COMMANDS heading, expanding grouped commands into "<group> <sub>" entries.
+func usageCommandRows() [][2]string {
+	var rows [][2]string
+	for _, c := range visibleCommands() {
+		if len(c.subcommands) == 0 {
+			rows = append(rows, [2]string{c.name, c.summary})
+			continue
+		}
+		for _, sub := range c.subcommands {
+			rows = append(rows, [2]string{c.name + " " + sub.name, sub.summary})
+		}
+	}
+	return rows
+}
+
+// flagNames returns the sorted flag names declared by fs.
+func flagNames(fs *flag.FlagSet) []string {
+	var names []string
+	fs.VisitAll(func(f *flag.Flag) {
+		names = append(names, f.Name)
+	})
+	return names
+}
+
+// isBoolFlag reports whether f is a boolean flag, which shells must not treat
+// as consuming a following value.
+func isBoolFlag(f *flag.Flag) bool {
+	bf, ok := f.Value.(interface{ IsBoolFlag() bool })
+	return ok && bf.IsBoolFlag()
+}

--- a/cmd/cloudstic/commands_test.go
+++ b/cmd/cloudstic/commands_test.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestRegistryEntriesAreWellFormed guards the registry's own invariants.
+func TestRegistryEntriesAreWellFormed(t *testing.T) {
+	seen := map[string]bool{}
+	for _, c := range commandRegistry() {
+		if c.name == "" {
+			t.Error("registry entry with empty name")
+		}
+		if seen[c.name] {
+			t.Errorf("duplicate command %q in registry", c.name)
+		}
+		seen[c.name] = true
+		if c.summary == "" {
+			t.Errorf("command %q has no summary", c.name)
+		}
+		if c.run == nil {
+			t.Errorf("command %q has no run function", c.name)
+		}
+		subSeen := map[string]bool{}
+		for _, sub := range c.subcommands {
+			if subSeen[sub.name] {
+				t.Errorf("duplicate subcommand %q under %q", sub.name, c.name)
+			}
+			subSeen[sub.name] = true
+			if sub.summary == "" {
+				t.Errorf("subcommand %q %q has no summary", c.name, sub.name)
+			}
+		}
+	}
+}
+
+// TestUsageListsEveryRegisteredCommand ensures the usage output cannot drift
+// from the registry, since both are now derived from it.
+func TestUsageListsEveryRegisteredCommand(t *testing.T) {
+	var buf bytes.Buffer
+	printUsage(&buf)
+	got := buf.String()
+
+	for _, c := range visibleCommands() {
+		if len(c.subcommands) == 0 {
+			if !strings.Contains(got, c.name) {
+				t.Errorf("usage output is missing command %q", c.name)
+			}
+			continue
+		}
+		for _, sub := range c.subcommands {
+			if !strings.Contains(got, c.name+" "+sub.name) {
+				t.Errorf("usage output is missing %q", c.name+" "+sub.name)
+			}
+		}
+	}
+
+	for _, c := range commandRegistry() {
+		if c.hidden && strings.Contains(got, c.name) {
+			t.Errorf("usage output should not mention hidden command %q", c.name)
+		}
+	}
+}
+
+// completionScripts renders each shell script once for the drift checks below.
+func completionScripts(t *testing.T) map[string]string {
+	t.Helper()
+	scripts := map[string]string{}
+	for name, gen := range map[string]func(w *bytes.Buffer){
+		"bash": func(w *bytes.Buffer) { completionBash(w) },
+		"zsh":  func(w *bytes.Buffer) { completionZsh(w) },
+		"fish": func(w *bytes.Buffer) { completionFish(w) },
+	} {
+		var buf bytes.Buffer
+		gen(&buf)
+		scripts[name] = buf.String()
+	}
+	return scripts
+}
+
+// TestCompletionListsEveryRegisteredCommand is the drift guard: a command added
+// to the registry but missing from any shell script fails here. This is the
+// regression test for `check` and `store`, which were previously absent from
+// the hand-maintained bash/zsh/fish command lists.
+func TestCompletionListsEveryRegisteredCommand(t *testing.T) {
+	for shell, script := range completionScripts(t) {
+		for _, c := range visibleCommands() {
+			if !strings.Contains(script, c.name) {
+				t.Errorf("%s completion is missing command %q", shell, c.name)
+			}
+		}
+	}
+
+	// Hidden commands must not be offered to the user. The scripts still
+	// *invoke* `cloudstic __complete` to fetch dynamic values, so assert on the
+	// generated list of offered names rather than the whole script.
+	for _, c := range commandRegistry() {
+		if !c.hidden {
+			continue
+		}
+		for _, offered := range commandNames() {
+			if offered == c.name {
+				t.Errorf("hidden command %q must not be offered for completion", c.name)
+			}
+		}
+	}
+}
+
+// TestCompletionGlobalFlagsMatchFlagSet ensures the completion global-flag
+// lists match the flags actually registered by addGlobalFlags.
+func TestCompletionGlobalFlagsMatchFlagSet(t *testing.T) {
+	scripts := completionScripts(t)
+
+	for _, name := range globalFlagNames() {
+		if !strings.Contains(scripts["bash"], "-"+name) {
+			t.Errorf("bash completion is missing global flag -%s", name)
+		}
+	}
+
+	// The bash global_flags list must be exactly the registered global flags:
+	// no extras, no omissions, no duplicates.
+	line := ""
+	for _, l := range strings.Split(scripts["bash"], "\n") {
+		if strings.Contains(l, "local global_flags=") {
+			line = l
+			break
+		}
+	}
+	if line == "" {
+		t.Fatal("could not find global_flags declaration in bash completion")
+	}
+	got := strings.Fields(strings.Trim(strings.SplitN(line, "=", 2)[1], `"`))
+	want := strings.Fields(dashPrefixed(globalFlagNames(), " "))
+	if len(got) != len(want) {
+		t.Errorf("bash global_flags has %d entries, registry has %d", len(got), len(want))
+	}
+	seen := map[string]bool{}
+	for _, f := range got {
+		if seen[f] {
+			t.Errorf("bash global_flags lists %s more than once", f)
+		}
+		seen[f] = true
+	}
+	for _, f := range want {
+		if !seen[f] {
+			t.Errorf("bash global_flags is missing %s", f)
+		}
+	}
+}
+
+// TestCompletionValueFlagsExcludeBooleans ensures boolean flags are never
+// listed as value-taking, which would make shells swallow the next word.
+func TestCompletionValueFlagsExcludeBooleans(t *testing.T) {
+	valueFlags := map[string]bool{}
+	for _, n := range globalValueFlagNames() {
+		valueFlags[n] = true
+	}
+	fs := globalFlagSet()
+	for _, name := range globalFlagNames() {
+		f := fs.Lookup(name)
+		if isBoolFlag(f) && valueFlags[name] {
+			t.Errorf("boolean flag -%s must not be listed as value-taking", name)
+		}
+		if !isBoolFlag(f) && !valueFlags[name] {
+			t.Errorf("value flag -%s is missing from the value-taking list", name)
+		}
+	}
+}
+
+// TestCommandFlagSetsAreIntrospectable ensures every command that declares a
+// flag-set builder produces a usable, non-empty flag set. This is what lets the
+// completion drift checks reason about real flags rather than a hand-copied list.
+func TestCommandFlagSetsAreIntrospectable(t *testing.T) {
+	for _, c := range commandRegistry() {
+		if c.newFlagSet == nil {
+			continue
+		}
+		fs := c.newFlagSet()
+		if fs == nil {
+			t.Errorf("command %q returned a nil flag set", c.name)
+			continue
+		}
+		if len(flagNames(fs)) == 0 {
+			t.Errorf("command %q declared a flag set with no flags", c.name)
+		}
+	}
+}
+
+// TestCommandFlagsAppearInBashCompletion checks that every flag a command
+// actually declares is offered by the bash completion for that command.
+func TestCommandFlagsAppearInBashCompletion(t *testing.T) {
+	script := completionScripts(t)["bash"]
+	globals := map[string]bool{}
+	for _, n := range globalFlagNames() {
+		globals[n] = true
+	}
+
+	for _, c := range commandRegistry() {
+		if c.newFlagSet == nil || c.hidden {
+			continue
+		}
+		for _, name := range flagNames(c.newFlagSet()) {
+			if globals[name] {
+				continue // covered by the global_flags list
+			}
+			if !strings.Contains(script, "-"+name) {
+				t.Errorf("bash completion for %q is missing flag -%s", c.name, name)
+			}
+		}
+	}
+}

--- a/cmd/cloudstic/completion.go
+++ b/cmd/cloudstic/completion.go
@@ -34,7 +34,7 @@ func runCompletion(r *runner) int {
 
 // completionBash writes a bash completion script to w.
 func completionBash(w io.Writer) {
-	_, _ = fmt.Fprint(w, `# bash completion for cloudstic
+	_, _ = fmt.Fprint(w, renderCompletion(`# bash completion for cloudstic
 
 _cloudstic_query() {
     local kind="$1"
@@ -47,9 +47,9 @@ _cloudstic() {
     local cur prev words cword
     _init_completion || return
 
-    local commands="init backup auth profile store source setup tui restore list ls prune forget diff break-lock key cat completion version help"
+    local commands="@@COMMAND_NAMES@@"
 
-    local global_flags="-store -profile -profiles-file -s3-endpoint -s3-region -s3-profile -s3-access-key -s3-secret-key -source-sftp-password -source-sftp-key -source-sftp-known-hosts -source-sftp-insecure -store-sftp-password -store-sftp-key -store-sftp-known-hosts -store-sftp-insecure -encryption-key -password -recovery-key -kms-key-arn -kms-region -kms-endpoint -disable-packfile -prompt -no-prompt -verbose -quiet -json -debug"
+    local global_flags="@@GLOBAL_FLAGS@@"
 
     # Identify the subcommand
     local cmd=""
@@ -59,7 +59,7 @@ _cloudstic() {
             -*)
                 # skip flags and their values
                 case "${words[i]}" in
-					-store|-profile|-profiles-file|-s3-endpoint|-s3-region|-s3-profile|-s3-access-key|-s3-secret-key|-source-sftp-password|-source-sftp-key|-source-sftp-known-hosts|-store|-store-sftp-password|-store-sftp-key|-store-sftp-known-hosts|-encryption-key|-password|-recovery-key|-kms-key-arn|-kms-region|-kms-endpoint|-source|-all-profiles|-auth-ref|-google-credentials|-google-credentials-ref|-google-credentials-json|-google-token-file|-google-token-ref|-onedrive-client-id|-onedrive-token-file|-onedrive-token-ref|-tag|-output|-keep-last|-keep-hourly|-keep-daily|-keep-weekly|-keep-monthly|-keep-yearly|-group-by|-account|-xattr-namespaces)
+					@@GLOBAL_VALUE_FLAGS@@|-source|-auth-ref|-google-credentials|-google-credentials-ref|-google-credentials-json|-google-token-file|-google-token-ref|-onedrive-client-id|-onedrive-token-file|-onedrive-token-ref|-tag|-output|-format|-path|-keep-last|-keep-hourly|-keep-daily|-keep-weekly|-keep-monthly|-keep-yearly|-group-by|-account|-xattr-namespaces|-exclude|-exclude-file|-new-password|-name|-provider|-uri|-store-ref)
 						((i++)) ;;
 				esac
                 ;;
@@ -279,12 +279,12 @@ _cloudstic() {
 }
 
 complete -F _cloudstic cloudstic
-`)
+`))
 }
 
 // completionZsh writes a zsh completion script to w.
 func completionZsh(w io.Writer) {
-	_, _ = fmt.Fprint(w, `#compdef cloudstic
+	_, _ = fmt.Fprint(w, renderCompletion(`#compdef cloudstic
 
 # zsh completion for cloudstic
 
@@ -321,25 +321,7 @@ _cloudstic_store_prefixes() {
 _cloudstic() {
     local -a commands
     commands=(
-        'init:Initialize a new repository'
-        'backup:Create a new backup snapshot from a source'
-        'auth:Manage reusable cloud auth entries'
-        'profile:Manage backup profiles'
-        'source:Discover source candidates for onboarding'
-        'setup:Guided setup and onboarding flows'
-        'tui:Launch the interactive terminal dashboard'
-        'restore:Restore files from a backup snapshot'
-        'list:List all backup snapshots in the repository'
-        'ls:List files within a specific snapshot'
-        'prune:Remove unused data chunks from the repository'
-        'forget:Remove a specific snapshot from history'
-        'diff:Compare two snapshots or a snapshot against latest'
-        'break-lock:Remove a stale repository lock'
-        'key:Manage encryption key slots'
-        'cat:Display raw JSON content of repository objects'
-        'completion:Generate shell completion scripts'
-        'version:Print version information'
-        'help:Show usage information'
+@@ZSH_COMMANDS@@
     )
 
     local prev_word="${words[CURRENT-1]}"
@@ -398,7 +380,7 @@ _cloudstic() {
 
     if [[ -z "$cmd" ]]; then
         case "$prev_word" in
-            -store|-profile|-profiles-file|-s3-endpoint|-s3-region|-s3-profile|-s3-access-key|-s3-secret-key|-source-sftp-password|-source-sftp-key|-source-sftp-known-hosts|-store-sftp-password|-store-sftp-key|-store-sftp-known-hosts|-encryption-key|-password|-recovery-key|-kms-key-arn|-kms-region|-kms-endpoint)
+            @@GLOBAL_VALUE_FLAGS@@)
                 _arguments $global_flags
                 return
                 ;;
@@ -754,12 +736,12 @@ _cloudstic() {
 }
 
 compdef _cloudstic cloudstic
-`)
+`))
 }
 
 // completionFish writes a fish completion script to w.
 func completionFish(w io.Writer) {
-	_, _ = fmt.Fprint(w, `# fish completion for cloudstic
+	_, _ = fmt.Fprint(w, renderCompletion(`# fish completion for cloudstic
 
 function __fish_cloudstic_query
     set -l kind $argv[1]
@@ -770,25 +752,7 @@ end
 complete -c cloudstic -f
 
 # Subcommands
-complete -c cloudstic -n __fish_use_subcommand -a init -d 'Initialize a new repository'
-complete -c cloudstic -n __fish_use_subcommand -a backup -d 'Create a new backup snapshot'
-complete -c cloudstic -n __fish_use_subcommand -a auth -d 'Manage reusable cloud auth entries'
-complete -c cloudstic -n __fish_use_subcommand -a profile -d 'Manage backup profiles'
-complete -c cloudstic -n __fish_use_subcommand -a source -d 'Discover source candidates for onboarding'
-complete -c cloudstic -n __fish_use_subcommand -a setup -d 'Guided setup and onboarding flows'
-complete -c cloudstic -n __fish_use_subcommand -a tui -d 'Launch the interactive terminal dashboard'
-complete -c cloudstic -n __fish_use_subcommand -a restore -d 'Restore files from a snapshot'
-complete -c cloudstic -n __fish_use_subcommand -a list -d 'List all backup snapshots'
-complete -c cloudstic -n __fish_use_subcommand -a ls -d 'List files within a snapshot'
-complete -c cloudstic -n __fish_use_subcommand -a prune -d 'Remove unused data chunks'
-complete -c cloudstic -n __fish_use_subcommand -a forget -d 'Remove a snapshot from history'
-complete -c cloudstic -n __fish_use_subcommand -a diff -d 'Compare two snapshots'
-complete -c cloudstic -n __fish_use_subcommand -a break-lock -d 'Remove a stale repository lock'
-complete -c cloudstic -n __fish_use_subcommand -a key -d 'Manage encryption key slots'
-complete -c cloudstic -n __fish_use_subcommand -a cat -d 'Display raw JSON of repository objects'
-complete -c cloudstic -n __fish_use_subcommand -a completion -d 'Generate shell completion scripts'
-complete -c cloudstic -n __fish_use_subcommand -a version -d 'Print version information'
-complete -c cloudstic -n __fish_use_subcommand -a help -d 'Show usage information'
+@@FISH_COMMANDS@@
 
 # Global flags (available for all subcommands)
 complete -c cloudstic -o store -l store -x -a 'local: s3: b2: sftp://' -d 'Storage backend URI (local:<path>, s3:<bucket>[/<prefix>], b2:<bucket>[/<prefix>], sftp://[user@]host[:port]/<path>)'
@@ -962,5 +926,5 @@ complete -c cloudstic -n '__fish_seen_subcommand_from cat' -l raw -d 'Output raw
 
 # completion
 complete -c cloudstic -n '__fish_seen_subcommand_from completion' -a 'bash zsh fish' -d 'Shell type'
-`)
+`))
 }

--- a/cmd/cloudstic/completion_generated.go
+++ b/cmd/cloudstic/completion_generated.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+)
+
+// The shell completion scripts embed a handful of lists that must match the
+// command registry and the real flag definitions. Rather than maintaining them
+// by hand in three shell dialects, the scripts carry placeholders that are
+// substituted here at generation time.
+const (
+	placeholderCommandNames     = "@@COMMAND_NAMES@@"
+	placeholderGlobalFlags      = "@@GLOBAL_FLAGS@@"
+	placeholderGlobalValueFlags = "@@GLOBAL_VALUE_FLAGS@@"
+	placeholderZshCommands      = "@@ZSH_COMMANDS@@"
+	placeholderFishCommands     = "@@FISH_COMMANDS@@"
+)
+
+// globalFlagSet builds a flag set containing only the global flags, for
+// introspection by completion generation and drift tests.
+func globalFlagSet() *flag.FlagSet {
+	fs := flag.NewFlagSet("global", flag.ContinueOnError)
+	addGlobalFlags(fs)
+	return fs
+}
+
+// globalFlagNames returns every global flag name in declaration order.
+func globalFlagNames() []string {
+	return flagNames(globalFlagSet())
+}
+
+// globalValueFlagNames returns the global flags that take a value, i.e. every
+// non-boolean flag. Shells use this to know which flags consume the next word.
+func globalValueFlagNames() []string {
+	var names []string
+	globalFlagSet().VisitAll(func(f *flag.Flag) {
+		if !isBoolFlag(f) {
+			names = append(names, f.Name)
+		}
+	})
+	return names
+}
+
+// dashPrefixed renders names as shell flag tokens joined by sep.
+func dashPrefixed(names []string, sep string) string {
+	dashed := make([]string, 0, len(names))
+	for _, n := range names {
+		dashed = append(dashed, "-"+n)
+	}
+	return strings.Join(dashed, sep)
+}
+
+// completionCommandNames lists the commands offered as the first argument.
+func completionCommandNames() string {
+	return strings.Join(commandNames(), " ")
+}
+
+// zshCommandLines renders the registry as zsh `name:description` entries.
+func zshCommandLines() string {
+	var b strings.Builder
+	for _, c := range visibleCommands() {
+		fmt.Fprintf(&b, "        '%s:%s'\n", c.name, escapeZsh(c.summary))
+	}
+	fmt.Fprintf(&b, "        '%s:%s'\n", "version", "Print version information")
+	fmt.Fprintf(&b, "        '%s:%s'", "help", "Show usage information")
+	return b.String()
+}
+
+// fishCommandLines renders the registry as fish subcommand completions.
+func fishCommandLines() string {
+	var b strings.Builder
+	for _, c := range visibleCommands() {
+		fmt.Fprintf(&b, "complete -c cloudstic -n __fish_use_subcommand -a %s -d '%s'\n", c.name, escapeFish(c.summary))
+	}
+	fmt.Fprintf(&b, "complete -c cloudstic -n __fish_use_subcommand -a %s -d '%s'\n", "version", "Print version information")
+	fmt.Fprintf(&b, "complete -c cloudstic -n __fish_use_subcommand -a %s -d '%s'", "help", "Show usage information")
+	return b.String()
+}
+
+// escapeZsh escapes a description for a single-quoted zsh `name:desc` entry.
+func escapeZsh(s string) string {
+	s = strings.ReplaceAll(s, `'`, `'\''`)
+	return strings.ReplaceAll(s, ":", `\:`)
+}
+
+// escapeFish escapes a description for a single-quoted fish argument.
+func escapeFish(s string) string {
+	return strings.ReplaceAll(s, `'`, `\'`)
+}
+
+// renderCompletion substitutes the generated lists into a shell script template.
+func renderCompletion(script string) string {
+	return strings.NewReplacer(
+		placeholderCommandNames, completionCommandNames(),
+		placeholderGlobalFlags, dashPrefixed(globalFlagNames(), " "),
+		placeholderGlobalValueFlags, dashPrefixed(globalValueFlagNames(), "|"),
+		placeholderZshCommands, zshCommandLines(),
+		placeholderFishCommands, fishCommandLines(),
+	).Replace(script)
+}

--- a/cmd/cloudstic/main.go
+++ b/cmd/cloudstic/main.go
@@ -47,56 +47,20 @@ func runCmd(r *runner, ctx context.Context, cmd string) int {
 		buildVersion, buildCommit, buildDate := buildMetadata()
 		_, _ = fmt.Fprintf(r.out, "cloudstic %s (commit %s, built %s)\n", buildVersion, buildCommit, buildDate)
 		return 0
-	case "init":
-		return runInit(r, ctx)
-	case "backup":
-		return runBackup(r, ctx)
-	case "restore":
-		return runRestore(r, ctx)
-	case "list":
-		return runList(r, ctx)
-	case "ls":
-		return runLsSnapshot(r, ctx)
-	case "prune":
-		return runPrune(r, ctx)
-	case "forget":
-		return runForget(r, ctx)
-	case "diff":
-		return runDiff(r, ctx)
-	case "break-lock":
-		return runBreakLock(r, ctx)
-	case "key":
-		return runKey(r, ctx)
-	case "check":
-		return runCheck(r, ctx)
-	case "cat":
-		return runCat(r, ctx)
-	case "profile":
-		return runProfile(r, ctx)
-	case "auth":
-		return runAuth(r, ctx)
-	case "store":
-		return runStore(r, ctx)
-	case "source":
-		return runSource(r, ctx)
-	case "setup":
-		return runSetup(r, ctx)
-	case "tui":
-		return runTUI(r, ctx)
-	case "completion":
-		return runCompletion(r)
-	case "__complete":
-		return runCompletionQuery(r, ctx)
 	case "help", "--help", "-h":
 		printUsage(r.out)
 		return 0
-	default:
-		exitCode := r.fail("Unknown command: %s", cmd)
-		if !r.jsonEnabled() {
-			printUsage(r.errOut)
-		}
-		return exitCode
 	}
+
+	if c, ok := lookupCommand(cmd); ok {
+		return c.run(r, ctx)
+	}
+
+	exitCode := r.fail("Unknown command: %s", cmd)
+	if !r.jsonEnabled() {
+		printUsage(r.errOut)
+	}
+	return exitCode
 }
 
 func buildMetadata() (string, string, string) {

--- a/cmd/cloudstic/usage.go
+++ b/cmd/cloudstic/usage.go
@@ -16,37 +16,9 @@ func printUsage(out io.Writer) {
 	_, _ = fmt.Fprintf(t.W, "  cloudstic %s<command>%s [options]\n", ui.Cyan, ui.Reset)
 
 	t.Heading("COMMANDS")
-	t.Commands([][2]string{
-		{"init", "Initialize a new repository (must run before first backup)"},
-		{"backup", "Create a new backup snapshot from a source"},
-		{"auth new", "Create or update a reusable cloud auth entry"},
-		{"auth list", "List auth entries from profiles.yaml"},
-		{"auth show", "Show one auth entry"},
-		{"auth login", "Run OAuth login flow for one auth entry"},
-		{"store new", "Create or update a store entry in profiles.yaml"},
-		{"store list", "List configured stores"},
-		{"store show", "Show one store and its configuration"},
-		{"store verify", "Verify one store's credentials and connectivity"},
-		{"source discover", "Discover local source candidates for onboarding"},
-		{"setup workstation", "Guide workstation onboarding and profile scaffolding"},
-		{"tui", "Launch the interactive terminal dashboard"},
-		{"profile new", "Create or update a backup profile in profiles.yaml"},
-		{"profile list", "List stores, auth entries, and backup profiles"},
-		{"profile show", "Show one profile and resolved store/auth references"},
-		{"restore", "Restore files from a backup snapshot"},
-		{"list", "List all backup snapshots in the repository"},
-		{"ls", "List files within a specific snapshot"},
-		{"prune", "Remove unused data chunks from the repository"},
-		{"forget", "Remove a specific snapshot from history"},
-		{"diff", "Compare two snapshots or a snapshot against latest"},
-		{"break-lock", "Remove a stale repository lock left by a crashed process"},
-		{"key list", "List all encryption key slots in the repository"},
-		{"key add-recovery", "Generate a 24-word recovery key for an encrypted repository"},
-		{"key passwd", "Change the repository password"},
-		{"check", "Verify repository integrity (reference chain, objects, data)"},
-		{"cat", "Display raw JSON content of repository objects"},
-		{"completion", "Generate shell completion scripts (bash, zsh, fish)"},
-	})
+	// Generated from the command registry so the listing cannot drift from
+	// what dispatch actually accepts.
+	t.Commands(usageCommandRows())
 
 	t.HeadingSub("GLOBAL OPTIONS", "(also settable via env vars)")
 	t.Flags([][2]string{


### PR DESCRIPTION
## Summary

- Added `commands.go` with `commandRegistry()` — name, summary, subcommands, flag-set builder, and run function for every command.
- `runCmd()` now dispatches from the registry instead of a hand-written switch; `printUsage()` renders its `COMMANDS` listing from it.
- The command lists and global-flag lists embedded in the bash, zsh, and fish completion scripts are now **generated** from the registry and the real flag sets, via placeholders substituted in `completion_generated.go`.
- Split flag construction from parsing for top-level commands (`new<Name>FlagSet` + `parse<Name>Args`) so the real flags are introspectable, binding with `StringVar`/`BoolVar`/`IntVar` instead of pointer locals.
- Added drift tests: registry invariants, usage coverage, completion coverage, global-flag list exactness (no extras/omissions/duplicates), bool-vs-value flag classification, and per-command flag coverage in bash completion.

### Drift this actually fixes

Verified against the built binary, not just inspection:

- **`check` was missing from the bash, zsh, and fish command lists**, and **`store` from the zsh and fish lists** — neither command completed at all.
- **`store init` was missing from the usage listing.**
- The bash value-taking-flags list contained a **duplicate `-store`**.

Command lists and global flags are now generated, which makes that class of drift *structurally impossible* rather than merely tested.

### Correction to the issue description

#260 also described `-source-sftp-insecure`/`-store-sftp-insecure` as wrongly omitted from the value-taking-flags list. That omission was **correct** — both are boolean flags and must not consume the next word. The generated list now derives this from the flag types, and `TestCommandFlagsExcludeBooleans` asserts booleans are never classified as value-taking.

### Deliberately out of scope

Per-command flag lists in the completion scripts remain hand-written (the zsh/fish entries carry per-flag descriptions and completer hints like `_files`/`_cloudstic_auth_names` that flag introspection cannot supply). `TestCommandFlagsAppearInBashCompletion` covers the resulting gap — it fails if a command gains a flag its completion entry does not offer, which I verified by temporarily adding a probe flag.

Grouped subcommands (auth/store/profile/key/source/setup) still build their flag sets inline in their run functions, so they are not yet introspectable; extracting them (`store new` alone has 22 flags) would have roughly doubled this diff. Both are noted as follow-ups in `commands.go` and `AGENTS.md`.

Closes #260

## Verification

- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./cmd/cloudstic` passes
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./cmd/cloudstic/...` → 0 issues
- `npx markdownlint-cli2 "AGENTS.md"` → 0 issues; `gofmt -l` clean; `go build ./...` and `go vet ./...` clean
- Generated scripts parse as valid shell: `bash -n` and `zsh -n` both OK (fish not installed locally)
- Drift guards proven to fire: temporarily added an undocumented flag to `check` → `TestCommandFlagsAppearInBashCompletion` failed as intended, then reverted
- Manual: every registry command dispatches (`-h` on all 20), unknown command still exits 1 with usage, and init → backup → check works end-to-end