### PR TITLE
feat(cli): promote B2 credentials to flags, profiles, and secret refs

### DIFF
--- a/cmd/cloudstic/cmd_backup_profile_test.go
+++ b/cmd/cloudstic/cmd_backup_profile_test.go
@@ -352,6 +352,8 @@ func TestApplyProfileStore_AllFields(t *testing.T) {
 		S3Profile:           "prod",
 		S3AccessKey:         "AKIATEST",
 		S3SecretKey:         "SECRETTEST",
+		B2KeyID:             "b2-key-id",
+		B2AppKey:            "b2-app-key",
 		StoreSFTPPassword:   "sftp-pw",
 		StoreSFTPKey:        "/tmp/sftp.key",
 		PasswordSecret:      "env://TEST_PASSWORD",
@@ -376,6 +378,8 @@ func TestApplyProfileStore_AllFields(t *testing.T) {
 		{"s3.profile", cfg.store.s3.profile, "prod"},
 		{"s3.accessKey", cfg.store.s3.accessKey, "AKIATEST"},
 		{"s3.secretKey", cfg.store.s3.secretKey, "SECRETTEST"},
+		{"b2.keyID", cfg.store.b2.keyID, "b2-key-id"},
+		{"b2.appKey", cfg.store.b2.appKey, "b2-app-key"},
 		{"sftp.password", cfg.store.sftp.password, "sftp-pw"},
 		{"sftp.key", cfg.store.sftp.key, "/tmp/sftp.key"},
 		{"unlock.password", cfg.unlock.password, "secret-pw"},
@@ -417,6 +421,25 @@ func TestApplyProfileStore_SecretRef(t *testing.T) {
 	}
 	if cfg.unlock.password != "from-secret-ref" {
 		t.Fatalf("unlock.password=%q want from-secret-ref", cfg.unlock.password)
+	}
+}
+
+func TestApplyProfileStore_B2SecretRef(t *testing.T) {
+	t.Setenv("SECRET_B2_KEY_ID", "b2-id-from-env")
+	t.Setenv("SECRET_B2_APP_KEY", "b2-key-from-env")
+
+	cfg, err := applyTestProfileStore(t, cloudstic.ProfileStore{
+		B2KeyIDSecret:  "env://SECRET_B2_KEY_ID",
+		B2AppKeySecret: "env://SECRET_B2_APP_KEY",
+	})
+	if err != nil {
+		t.Fatalf("applyProfileStore: %v", err)
+	}
+	if cfg.store.b2.keyID != "b2-id-from-env" {
+		t.Fatalf("b2.keyID=%q want b2-id-from-env", cfg.store.b2.keyID)
+	}
+	if cfg.store.b2.appKey != "b2-key-from-env" {
+		t.Fatalf("b2.appKey=%q want b2-key-from-env", cfg.store.b2.appKey)
 	}
 }
 

--- a/cmd/cloudstic/cmd_profile.go
+++ b/cmd/cloudstic/cmd_profile.go
@@ -67,6 +67,9 @@ func profileStoreAuthMode(s cloudstic.ProfileStore) string {
 	if s.S3Profile != "" {
 		return "aws-shared-profile"
 	}
+	if s.B2KeyID != "" || s.B2AppKey != "" || s.B2KeyIDSecret != "" || s.B2AppKeySecret != "" {
+		return "b2-keys"
+	}
 	if s.StoreSFTPPassword != "" || s.StoreSFTPKey != "" || s.StoreSFTPPasswordSecret != "" || s.StoreSFTPKeySecret != "" {
 		return "sftp"
 	}

--- a/cmd/cloudstic/cmd_profile_test.go
+++ b/cmd/cloudstic/cmd_profile_test.go
@@ -362,6 +362,8 @@ func TestProfileStoreAuthMode(t *testing.T) {
 	}{
 		{"s3_access_key", cloudstic.ProfileStore{S3AccessKey: "x"}, "static-keys"},
 		{"s3_profile", cloudstic.ProfileStore{S3Profile: "x"}, "aws-shared-profile"},
+		{"b2_key_id", cloudstic.ProfileStore{B2KeyID: "x"}, "b2-keys"},
+		{"b2_app_key_secret", cloudstic.ProfileStore{B2AppKeySecret: "env://B2_APP_KEY"}, "b2-keys"},
 		{"sftp_password", cloudstic.ProfileStore{StoreSFTPPassword: "x"}, "sftp"},
 		{"sftp_key", cloudstic.ProfileStore{StoreSFTPKey: "x"}, "sftp"},
 		{"empty", cloudstic.ProfileStore{}, "default-chain"},

--- a/cmd/cloudstic/cmd_store.go
+++ b/cmd/cloudstic/cmd_store.go
@@ -79,6 +79,8 @@ type storeNewArgs struct {
 	s3Region, s3Profile, s3Endpoint                        string
 	s3AccessKey, s3SecretKey                               string
 	s3AccessKeySecret, s3SecretKeySecret                   string
+	b2KeyID, b2AppKey                                      string
+	b2KeyIDSecret, b2AppKeySecret                          string
 	sftpPassword, sftpKey                                  string
 	sftpPasswordSecret, sftpKeySecret                      string
 	passwordSecret, encryptionKeySecret, recoveryKeySecret string
@@ -98,6 +100,10 @@ func declareStoreNewArgs(g *globalFlags) (*storeNewArgs, commandInput) {
 		stringFlag(&a.s3SecretKey, "s3-secret-key", "", "S3 static secret key", withPlaceholder("<secret>"), asSecret()),
 		stringFlag(&a.s3AccessKeySecret, "s3-access-key-secret", "", "Secret reference for S3 access key (e.g. env://..., keychain://...)", withPlaceholder("<ref>")),
 		stringFlag(&a.s3SecretKeySecret, "s3-secret-key-secret", "", "Secret reference for S3 secret key (e.g. env://..., keychain://...)", withPlaceholder("<ref>")),
+		stringFlag(&a.b2KeyID, "b2-key-id", "", "Backblaze B2 application key ID", withPlaceholder("<key-id>"), asSecret()),
+		stringFlag(&a.b2AppKey, "b2-app-key", "", "Backblaze B2 application key", withPlaceholder("<key>"), asSecret()),
+		stringFlag(&a.b2KeyIDSecret, "b2-key-id-secret", "", "Secret reference for B2 key ID (e.g. env://..., keychain://...)", withPlaceholder("<ref>")),
+		stringFlag(&a.b2AppKeySecret, "b2-app-key-secret", "", "Secret reference for B2 application key (e.g. env://..., keychain://...)", withPlaceholder("<ref>")),
 		stringFlag(&a.sftpPassword, "store-sftp-password", "", "SFTP password", withPlaceholder("<pass>"), asSecret()),
 		stringFlag(&a.sftpKey, "store-sftp-key", "", "Path to SFTP private key", withPlaceholder("<path>"), withCompleter("_files")),
 		stringFlag(&a.sftpPasswordSecret, "store-sftp-password-secret", "", "Secret reference for SFTP password (e.g. env://..., keychain://...)", withPlaceholder("<ref>")),
@@ -116,6 +122,8 @@ func (a *storeNewArgs) flagPtrs() storeNewFlagPtrs {
 		uri: &a.uri, s3Region: &a.s3Region, s3Profile: &a.s3Profile, s3Endpoint: &a.s3Endpoint,
 		s3AccessKey: &a.s3AccessKey, s3SecretKey: &a.s3SecretKey,
 		s3AccessKeySecret: &a.s3AccessKeySecret, s3SecretKeySecret: &a.s3SecretKeySecret,
+		b2KeyID: &a.b2KeyID, b2AppKey: &a.b2AppKey,
+		b2KeyIDSecret: &a.b2KeyIDSecret, b2AppKeySecret: &a.b2AppKeySecret,
 		sftpPassword: &a.sftpPassword, sftpKey: &a.sftpKey,
 		sftpPasswordSecret: &a.sftpPasswordSecret, sftpKeySecret: &a.sftpKeySecret,
 		passwordSecret: &a.passwordSecret, encryptionKeySecret: &a.encryptionKeySecret,

--- a/cmd/cloudstic/cmd_store_test.go
+++ b/cmd/cloudstic/cmd_store_test.go
@@ -723,6 +723,39 @@ func TestRunStoreNew_WithAllS3Options(t *testing.T) {
 	}
 }
 
+func TestRunStoreNew_WithB2Options(t *testing.T) {
+	tmpDir := t.TempDir()
+	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
+
+	args := []string{"new",
+		"-profiles-file", profilesPath,
+		"-name", "full-b2",
+		"-uri", "b2:bucket",
+		"-b2-key-id", "direct-key-id",
+		"-b2-app-key-secret", "env://B2_APP_KEY",
+	}
+	var out strings.Builder
+	var errOut strings.Builder
+	r := &runner{out: &out, errOut: &errOut}
+	if code := storeCommand().execute(r.withArgs(args), context.Background(), "store"); code != 0 {
+		t.Fatalf("store new failed: %s", errOut.String())
+	}
+
+	raw, err := os.ReadFile(profilesPath)
+	if err != nil {
+		t.Fatalf("read profiles: %v", err)
+	}
+	yaml := string(raw)
+	for _, want := range []string{
+		"b2_key_id: direct-key-id",
+		"b2_app_key_secret: env://B2_APP_KEY",
+	} {
+		if !strings.Contains(yaml, want) {
+			t.Fatalf("expected %q in YAML:\n%s", want, yaml)
+		}
+	}
+}
+
 func TestRunStoreNew_WithSecretRefFlags(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")

--- a/cmd/cloudstic/config.go
+++ b/cmd/cloudstic/config.go
@@ -29,6 +29,12 @@ type s3Config struct {
 	secretKey string
 }
 
+// b2Config holds Backblaze B2 application key credentials.
+type b2Config struct {
+	keyID  string
+	appKey string
+}
+
 // sftpConfig holds SFTP authentication and host-key settings. The same shape
 // serves both a store and a backup source, which are configured independently.
 type sftpConfig struct {
@@ -49,6 +55,7 @@ type kmsConfig struct {
 type storeConfig struct {
 	uri   string
 	s3    s3Config
+	b2    b2Config
 	sftp  sftpConfig
 	debug bool
 }
@@ -86,6 +93,10 @@ func clientConfigFromFlags(g *globalFlags) clientConfig {
 				profile:   g.s3Profile,
 				accessKey: g.s3AccessKey,
 				secretKey: g.s3SecretKey,
+			},
+			b2: b2Config{
+				keyID:  g.b2KeyID,
+				appKey: g.b2AppKey,
 			},
 			sftp: sftpConfig{
 				password:   g.storeSFTPPassword,
@@ -223,6 +234,8 @@ func applyProfileStore(cfg *clientConfig, s cloudstic.ProfileStore, provided fun
 		{"s3-profile", "s3_profile", s.S3Profile, "", &cfg.store.s3.profile},
 		{"s3-access-key", "s3_access_key", s.S3AccessKey, s.S3AccessKeySecret, &cfg.store.s3.accessKey},
 		{"s3-secret-key", "s3_secret_key", s.S3SecretKey, s.S3SecretKeySecret, &cfg.store.s3.secretKey},
+		{"b2-key-id", "b2_key_id", s.B2KeyID, s.B2KeyIDSecret, &cfg.store.b2.keyID},
+		{"b2-app-key", "b2_app_key", s.B2AppKey, s.B2AppKeySecret, &cfg.store.b2.appKey},
 		{"store-sftp-password", "store_sftp_password", s.StoreSFTPPassword, s.StoreSFTPPasswordSecret, &cfg.store.sftp.password},
 		{"store-sftp-key", "store_sftp_key", s.StoreSFTPKey, s.StoreSFTPKeySecret, &cfg.store.sftp.key},
 		{"password", "password", "", s.PasswordSecret, &cfg.unlock.password},

--- a/cmd/cloudstic/config_tables.go
+++ b/cmd/cloudstic/config_tables.go
@@ -345,6 +345,8 @@ func secretDisplayRows(s cloudstic.ProfileStore) []table.Row {
 	}
 	appendRow("S3 Access Key Secret", s.S3AccessKeySecret, false)
 	appendRow("S3 Secret Key Secret", s.S3SecretKeySecret, false)
+	appendRow("B2 Key ID Secret", s.B2KeyIDSecret, false)
+	appendRow("B2 App Key Secret", s.B2AppKeySecret, false)
 	appendRow("SFTP Password Secret", s.StoreSFTPPasswordSecret, false)
 	appendRow("SFTP Key Secret", s.StoreSFTPKeySecret, false)
 	appendRow("Password Secret", s.PasswordSecret, false)

--- a/cmd/cloudstic/flags.go
+++ b/cmd/cloudstic/flags.go
@@ -17,6 +17,7 @@ type globalFlags struct {
 	profile, profilesFile             string
 	s3Endpoint, s3Region, s3Profile   string
 	s3AccessKey, s3SecretKey          string
+	b2KeyID, b2AppKey                 string
 	sourceSFTPPassword, sourceSFTPKey string
 	sourceSFTPInsecure                bool
 	sourceSFTPKnownHosts              string
@@ -65,6 +66,10 @@ func repoFlagSpecs(g *globalFlags) []flagSpec {
 			withEnv("AWS_ACCESS_KEY_ID"), withPlaceholder("<key>"), asSecret()),
 		stringFlag(&g.s3SecretKey, "s3-secret-key", "", "S3 secret access key",
 			withEnv("AWS_SECRET_ACCESS_KEY"), withPlaceholder("<secret>"), asSecret()),
+		stringFlag(&g.b2KeyID, "b2-key-id", "", "Backblaze B2 application key ID",
+			withEnv("B2_KEY_ID"), withPlaceholder("<key-id>"), asSecret()),
+		stringFlag(&g.b2AppKey, "b2-app-key", "", "Backblaze B2 application key",
+			withEnv("B2_APP_KEY"), withPlaceholder("<key>"), asSecret()),
 		boolFlag(&g.disablePackfile, "disable-packfile", false, "Disable bundling small objects into 8MB packs",
 			withEnv("CLOUDSTIC_DISABLE_PACKFILE"), withShortUsage("Disable bundling small objects into packs")),
 	}

--- a/cmd/cloudstic/flagspec_test.go
+++ b/cmd/cloudstic/flagspec_test.go
@@ -154,7 +154,7 @@ func TestSecretFlagsWithEnvAreConsistent(t *testing.T) {
 		if s.env != "" && !strings.HasPrefix(s.env, "CLOUDSTIC_") {
 			// Provider-standard names are deliberate; record them explicitly.
 			switch s.env {
-			case "AWS_PROFILE", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY":
+			case "AWS_PROFILE", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "B2_KEY_ID", "B2_APP_KEY":
 			default:
 				t.Errorf("flag -%s uses unprefixed env %q; add it to the documented provider-standard list", s.name, s.env)
 			}

--- a/cmd/cloudstic/store_builder_helpers.go
+++ b/cmd/cloudstic/store_builder_helpers.go
@@ -11,6 +11,10 @@ type storeNewFlagPtrs struct {
 	s3SecretKey         *string
 	s3AccessKeySecret   *string
 	s3SecretKeySecret   *string
+	b2KeyID             *string
+	b2AppKey            *string
+	b2KeyIDSecret       *string
+	b2AppKeySecret      *string
 	sftpPassword        *string
 	sftpKey             *string
 	sftpPasswordSecret  *string
@@ -47,6 +51,18 @@ func applyExistingStoreDefaults(g *globalFlags, existing cloudstic.ProfileStore,
 	}
 	if !g.flagProvided("s3-secret-key-secret") && existing.S3SecretKeySecret != "" {
 		*f.s3SecretKeySecret = existing.S3SecretKeySecret
+	}
+	if !g.flagProvided("b2-key-id") && existing.B2KeyID != "" {
+		*f.b2KeyID = existing.B2KeyID
+	}
+	if !g.flagProvided("b2-app-key") && existing.B2AppKey != "" {
+		*f.b2AppKey = existing.B2AppKey
+	}
+	if !g.flagProvided("b2-key-id-secret") && existing.B2KeyIDSecret != "" {
+		*f.b2KeyIDSecret = existing.B2KeyIDSecret
+	}
+	if !g.flagProvided("b2-app-key-secret") && existing.B2AppKeySecret != "" {
+		*f.b2AppKeySecret = existing.B2AppKeySecret
 	}
 	if !g.flagProvided("store-sftp-password") && existing.StoreSFTPPassword != "" {
 		*f.sftpPassword = existing.StoreSFTPPassword
@@ -90,6 +106,10 @@ func buildProfileStoreFromFlags(f storeNewFlagPtrs) cloudstic.ProfileStore {
 		S3SecretKey:             *f.s3SecretKey,
 		S3AccessKeySecret:       *f.s3AccessKeySecret,
 		S3SecretKeySecret:       *f.s3SecretKeySecret,
+		B2KeyID:                 *f.b2KeyID,
+		B2AppKey:                *f.b2AppKey,
+		B2KeyIDSecret:           *f.b2KeyIDSecret,
+		B2AppKeySecret:          *f.b2AppKeySecret,
 		StoreSFTPPassword:       *f.sftpPassword,
 		StoreSFTPKey:            *f.sftpKey,
 		StoreSFTPPasswordSecret: *f.sftpPasswordSecret,

--- a/cmd/cloudstic/storebuild.go
+++ b/cmd/cloudstic/storebuild.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/cloudstic/cli/internal/logger"
 	"github.com/cloudstic/cli/internal/ui"
@@ -53,12 +52,10 @@ func newObjectStore(ctx context.Context, cfg storeConfig) (store.ObjectStore, er
 	case "local":
 		inner, err = store.NewLocalStore(uri.path)
 	case "b2":
-		keyID := os.Getenv("B2_KEY_ID")
-		appKey := os.Getenv("B2_APP_KEY")
-		if keyID == "" || appKey == "" {
-			return nil, fmt.Errorf("B2_KEY_ID and B2_APP_KEY env vars required for b2 store")
+		if cfg.b2.keyID == "" || cfg.b2.appKey == "" {
+			return nil, fmt.Errorf("B2 credentials required: pass -b2-key-id/-b2-app-key (or set B2_KEY_ID/B2_APP_KEY)")
 		}
-		inner, err = store.NewB2Store(uri.bucket, store.WithCredentials(keyID, appKey), store.WithPrefix(uri.prefix))
+		inner, err = store.NewB2Store(uri.bucket, store.WithCredentials(cfg.b2.keyID, cfg.b2.appKey), store.WithPrefix(uri.prefix))
 	case "s3":
 		inner, err = store.NewS3Store(
 			ctx,

--- a/cmd/cloudstic/storebuild_test.go
+++ b/cmd/cloudstic/storebuild_test.go
@@ -70,3 +70,19 @@ func TestNewObjectStore_UnknownScheme(t *testing.T) {
 		t.Fatal("expected error for unknown store scheme")
 	}
 }
+
+// B2 credentials come from the resolved b2Config, not from raw os.Getenv
+// calls, so a missing credential is caught before any network dial is
+// attempted.
+func TestNewObjectStore_B2_RequiresCredentials(t *testing.T) {
+	cases := []storeConfig{
+		{uri: "b2:my-bucket"},
+		{uri: "b2:my-bucket", b2: b2Config{keyID: "id-only"}},
+		{uri: "b2:my-bucket", b2: b2Config{appKey: "key-only"}},
+	}
+	for _, cfg := range cases {
+		if _, err := newObjectStore(context.Background(), cfg); err == nil {
+			t.Fatalf("expected error for incomplete B2 credentials: %+v", cfg.b2)
+		}
+	}
+}

--- a/cmd/cloudstic/testdata/help_check.golden
+++ b/cmd/cloudstic/testdata/help_check.golden
@@ -20,6 +20,8 @@ GLOBAL OPTIONS (also settable via environment variables)
     -s3-profile <name>             AWS shared config profile for S3 credentials  [env: CLOUDSTIC_S3_PROFILE]
     -s3-access-key <key>           S3 access key ID  [env: AWS_ACCESS_KEY_ID]
     -s3-secret-key <secret>        S3 secret access key  [env: AWS_SECRET_ACCESS_KEY]
+    -b2-key-id <key-id>            Backblaze B2 application key ID  [env: B2_KEY_ID]
+    -b2-app-key <key>              Backblaze B2 application key  [env: B2_APP_KEY]
     -disable-packfile              Disable bundling small objects into 8MB packs  [env: CLOUDSTIC_DISABLE_PACKFILE]
     -store-sftp-password <pw>      SFTP store password  [env: CLOUDSTIC_STORE_SFTP_PASSWORD]
     -store-sftp-key <path>         Path to SSH private key for SFTP store  [env: CLOUDSTIC_STORE_SFTP_KEY]

--- a/cmd/cloudstic/testdata/help_list.golden
+++ b/cmd/cloudstic/testdata/help_list.golden
@@ -17,6 +17,8 @@ GLOBAL OPTIONS (also settable via environment variables)
     -s3-profile <name>             AWS shared config profile for S3 credentials  [env: CLOUDSTIC_S3_PROFILE]
     -s3-access-key <key>           S3 access key ID  [env: AWS_ACCESS_KEY_ID]
     -s3-secret-key <secret>        S3 secret access key  [env: AWS_SECRET_ACCESS_KEY]
+    -b2-key-id <key-id>            Backblaze B2 application key ID  [env: B2_KEY_ID]
+    -b2-app-key <key>              Backblaze B2 application key  [env: B2_APP_KEY]
     -disable-packfile              Disable bundling small objects into 8MB packs  [env: CLOUDSTIC_DISABLE_PACKFILE]
     -store-sftp-password <pw>      SFTP store password  [env: CLOUDSTIC_STORE_SFTP_PASSWORD]
     -store-sftp-key <path>         Path to SSH private key for SFTP store  [env: CLOUDSTIC_STORE_SFTP_KEY]

--- a/cmd/cloudstic/testdata/usage_root.golden
+++ b/cmd/cloudstic/testdata/usage_root.golden
@@ -44,6 +44,8 @@ GLOBAL OPTIONS (also settable via environment variables)
     -s3-profile <name>              AWS shared config profile for S3 credentials  [env: CLOUDSTIC_S3_PROFILE]
     -s3-access-key <key>            S3 access key ID  [env: AWS_ACCESS_KEY_ID]
     -s3-secret-key <secret>         S3 secret access key  [env: AWS_SECRET_ACCESS_KEY]
+    -b2-key-id <key-id>             Backblaze B2 application key ID  [env: B2_KEY_ID]
+    -b2-app-key <key>               Backblaze B2 application key  [env: B2_APP_KEY]
     -disable-packfile               Disable bundling small objects into 8MB packs  [env: CLOUDSTIC_DISABLE_PACKFILE]
     -store-sftp-password <pw>       SFTP store password  [env: CLOUDSTIC_STORE_SFTP_PASSWORD]
     -store-sftp-key <path>          Path to SSH private key for SFTP store  [env: CLOUDSTIC_STORE_SFTP_KEY]

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1579,14 +1579,22 @@ cloudstic init -store local:/mnt/external/backups -password "passphrase"
 
 ### Backblaze B2
 
-Store backups in a Backblaze B2 bucket. Requires B2 application keys.
+Store backups in a Backblaze B2 bucket. Requires B2 application keys, supplied
+as flags, environment variables, or (for a saved store) a profile field or
+secret reference.
+
+```bash
+cloudstic init -store b2:my-bucket-name -b2-key-id your-key-id -b2-app-key your-app-key -password "passphrase"
+cloudstic backup -store b2:my-bucket-name -source local:~/Documents
+```
+
+Or via the environment:
 
 ```bash
 export B2_KEY_ID=your-key-id
 export B2_APP_KEY=your-app-key
 
 cloudstic init -store b2:my-bucket-name -password "passphrase"
-cloudstic backup -store b2:my-bucket-name -source local:~/Documents
 ```
 
 Use a prefix to namespace objects within a bucket:
@@ -1595,12 +1603,20 @@ Use a prefix to namespace objects within a bucket:
 cloudstic init -store b2:my-bucket/laptop/ -password "passphrase"
 ```
 
-**Environment variables:**
+To save B2 credentials in a store entry, use `cloudstic store new` with a
+secret reference rather than an inline key:
 
-| Variable | Description |
-|----------|-------------|
-| `B2_KEY_ID` | Backblaze B2 application key ID |
-| `B2_APP_KEY` | Backblaze B2 application key |
+```bash
+cloudstic store new -name b2-store -uri b2:my-bucket-name \
+  -b2-key-id-secret env://B2_KEY_ID -b2-app-key-secret env://B2_APP_KEY
+```
+
+**Flags and environment variables:**
+
+| Variable | Flag equivalent | Description |
+|----------|------------------|-------------|
+| `B2_KEY_ID` | `-b2-key-id` | Backblaze B2 application key ID |
+| `B2_APP_KEY` | `-b2-app-key` | Backblaze B2 application key |
 
 ### Amazon S3
 
@@ -1798,6 +1814,8 @@ cloudstic forget -keep-daily 7 -keep-monthly 12 -dry-run
 | `CLOUDSTIC_S3_PROFILE` | `-s3-profile` | AWS shared config profile for S3 auth |
 | `AWS_ACCESS_KEY_ID` | `-s3-access-key` | S3 Access Key ID |
 | `AWS_SECRET_ACCESS_KEY` | `-s3-secret-key` | S3 Secret Access Key |
+| `B2_KEY_ID` | `-b2-key-id` | Backblaze B2 application key ID |
+| `B2_APP_KEY` | `-b2-app-key` | Backblaze B2 application key |
 | `CLOUDSTIC_STORE_SFTP_PASSWORD` | `-store-sftp-password` | SFTP password for the store |
 | `CLOUDSTIC_STORE_SFTP_KEY` | `-store-sftp-key` | Path to SSH private key for the store |
 | `CLOUDSTIC_SOURCE` | `-source` | Source URI: `local:<path>`, `sftp://[user@]host[:port]/<path>`, `gdrive[://<Drive Name>][/<path>]`, `gdrive-changes[://<Drive Name>][/<path>]`, `onedrive[://<Drive Name>][/<path>]`, `onedrive-changes[://<Drive Name>][/<path>]` |
@@ -1816,5 +1834,3 @@ cloudstic forget -keep-daily 7 -keep-monthly 12 -dry-run
 | `GOOGLE_TOKEN_FILE` | `-google-token-file` | Override Google OAuth token path |
 | `ONEDRIVE_CLIENT_ID` | — | Microsoft app client ID (optional, overrides built-in) |
 | `ONEDRIVE_TOKEN_FILE` | — | Override OneDrive token path |
-| `B2_KEY_ID` | — | Backblaze B2 key ID |
-| `B2_APP_KEY` | — | Backblaze B2 application key |

--- a/internal/engine/profiles.go
+++ b/internal/engine/profiles.go
@@ -25,6 +25,8 @@ type ProfileStore struct {
 	S3Profile         string `yaml:"s3_profile,omitempty"`
 	S3AccessKey       string `yaml:"s3_access_key,omitempty"`
 	S3SecretKey       string `yaml:"s3_secret_key,omitempty"`
+	B2KeyID           string `yaml:"b2_key_id,omitempty"`
+	B2AppKey          string `yaml:"b2_app_key,omitempty"`
 	StoreSFTPPassword string `yaml:"store_sftp_password,omitempty"`
 	StoreSFTPKey      string `yaml:"store_sftp_key,omitempty"`
 
@@ -34,6 +36,8 @@ type ProfileStore struct {
 	RecoveryKeySecret       string `yaml:"recovery_key_secret,omitempty"`
 	S3AccessKeySecret       string `yaml:"s3_access_key_secret,omitempty"`
 	S3SecretKeySecret       string `yaml:"s3_secret_key_secret,omitempty"`
+	B2KeyIDSecret           string `yaml:"b2_key_id_secret,omitempty"`
+	B2AppKeySecret          string `yaml:"b2_app_key_secret,omitempty"`
 	StoreSFTPPasswordSecret string `yaml:"store_sftp_password_secret,omitempty"`
 	StoreSFTPKeySecret      string `yaml:"store_sftp_key_secret,omitempty"`
 	KMSKeyARN               string `yaml:"kms_key_arn,omitempty"`
@@ -118,6 +122,12 @@ func validateProfilesConfig(cfg *ProfilesConfig) error {
 			return err
 		}
 		if err := validateSecretRef("store", storeName, "s3_secret_key_secret", s.S3SecretKeySecret); err != nil {
+			return err
+		}
+		if err := validateSecretRef("store", storeName, "b2_key_id_secret", s.B2KeyIDSecret); err != nil {
+			return err
+		}
+		if err := validateSecretRef("store", storeName, "b2_app_key_secret", s.B2AppKeySecret); err != nil {
 			return err
 		}
 		if err := validateSecretRef("store", storeName, "store_sftp_password_secret", s.StoreSFTPPasswordSecret); err != nil {

--- a/internal/engine/profiles_test.go
+++ b/internal/engine/profiles_test.go
@@ -45,6 +45,8 @@ func TestSaveProfilesFile_RoundTrip(t *testing.T) {
 				RecoveryKeySecret:       "keychain://cloudstic/recovery",
 				S3AccessKeySecret:       "env://AWS_ACCESS_KEY_ID",
 				S3SecretKeySecret:       "env://AWS_SECRET_ACCESS_KEY",
+				B2KeyIDSecret:           "env://B2_KEY_ID",
+				B2AppKeySecret:          "env://B2_APP_KEY",
 				StoreSFTPPasswordSecret: "env://STORE_SFTP_PASSWORD",
 				StoreSFTPKeySecret:      "env://STORE_SFTP_KEY",
 			},
@@ -72,6 +74,12 @@ func TestSaveProfilesFile_RoundTrip(t *testing.T) {
 	}
 	if cfg.Stores["s"].S3SecretKeySecret != "env://AWS_SECRET_ACCESS_KEY" {
 		t.Fatalf("unexpected s3 secret ref: %q", cfg.Stores["s"].S3SecretKeySecret)
+	}
+	if cfg.Stores["s"].B2KeyIDSecret != "env://B2_KEY_ID" {
+		t.Fatalf("unexpected b2 key id ref: %q", cfg.Stores["s"].B2KeyIDSecret)
+	}
+	if cfg.Stores["s"].B2AppKeySecret != "env://B2_APP_KEY" {
+		t.Fatalf("unexpected b2 app key ref: %q", cfg.Stores["s"].B2AppKeySecret)
 	}
 }
 
@@ -116,6 +124,25 @@ func TestSaveProfilesFile_InvalidSecretRef(t *testing.T) {
 		t.Fatal("SaveProfilesFile: expected validation error")
 	}
 	if !strings.Contains(err.Error(), `store "prod" field "store_sftp_key_secret"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSaveProfilesFile_InvalidB2SecretRef(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "profiles.yaml")
+	err := SaveProfilesFile(path, &ProfilesConfig{
+		Stores: map[string]ProfileStore{
+			"b2store": {
+				URI:            "b2:bucket",
+				B2AppKeySecret: "env:/bad-format",
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("SaveProfilesFile: expected validation error")
+	}
+	if !strings.Contains(err.Error(), `store "b2store" field "b2_app_key_secret"`) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Add `-b2-key-id`/`-b2-app-key` global flags (env `B2_KEY_ID`/`B2_APP_KEY`, both `asSecret()`), alongside the existing S3 flags in `repoFlagSpecs`
- Add `ProfileStore.B2KeyID`/`B2AppKey` (direct) and `B2KeyIDSecret`/`B2AppKeySecret` (secret ref) fields to `internal/engine/profiles.go`, validated through `validateSecretRef` the same way as the S3 fields
- `storeConfig` gains a `b2Config{keyID, appKey}` field; `clientConfigFromFlags`/`applyProfileStore` fold B2 credentials in like every other credential, so `newObjectStore`'s `b2` case in `storebuild.go` takes a resolved value instead of calling `os.Getenv` directly — B2 store construction is now unit-testable without env mutation (`TestNewObjectStore_B2_RequiresCredentials`)
- `cloudstic store new` gets `-b2-key-id[-secret]`/`-b2-app-key[-secret]` flags, mirroring the S3 flags already on that command
- `store show`/`profile show` credential display and `profileStoreAuthMode` (used for the store health/auth-mode columns) recognize B2 credentials the same way they recognize S3/SFTP ones
- Updated `docs/user-guide.md`'s B2 section and environment-variable table to document the new flags and removed the now-stale "Flag equivalent: —" rows

Part of #266 (env-var centralization epic — this is the "B2 has no equivalent registered flags, profile fields, or secret-reference support" scope item)

## Verification
- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 -race ./cmd/cloudstic ./internal/engine .`
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./cmd/cloudstic/... ./internal/engine/...`
- Regenerated `usage_root.golden`/`help_check.golden`/`help_list.golden` and reviewed the diff (two new lines each, no drift)