### PR TITLE
docs(cli): make env-vs-profile precedence explicit and guard doc drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,7 @@ Routes metadata objects to PostgreSQL (with RLS tenant isolation via `SET LOCAL 
 
 - **Config directory** — resolved by `internal/paths.ConfigDir()`: `CLOUDSTIC_CONFIG_DIR` if set, else `os.UserConfigDir()/cloudstic` (e.g. `~/.config/cloudstic`), created `0700`. Holds the profiles file, OAuth tokens, etc.
 - **Profiles** — a profile bundles a named source + store (+ secret refs) so users run `cloudstic backup -profile <name>` instead of re-specifying flags. Persisted via `LoadProfilesFile`/`SaveProfilesFile` (root package, implemented in `internal/engine/profiles.go`). Managed from the CLI (`cmd_profile.go`, `cmd_setup.go`) and the TUI. See RFC `rfcs/0010-backup-profiles.md`. The active profile / file come from `CLOUDSTIC_PROFILE` / `CLOUDSTIC_PROFILES_FILE`.
+- **Resolution precedence** — `resolveClientConfig` (`config.go`) resolves a command's store configuration as: explicit CLI flag > selected profile's store field > environment variable > built-in default. A profile is a named choice the user invoked with `-profile`, so once selected it overrides ambient environment variables the same way it overrides built-in defaults — only an explicit flag beats it. `applyProfileStore` decides this per field via `flagProvided`, which only recognizes `originFlag`; `originEnv` values are treated the same as `originDefault` and are eligible to be overridden. See `TestResolveClientConfig_ProfileOverridesEnvironment` (`config_test.go`).
 
 ### Secret References
 
@@ -140,9 +141,17 @@ Backends expose `Load`/`Save`/`Delete`; unsupported operations return a typed `s
 | `CLOUDSTIC_CONFIG_DIR` | Override the config/state directory (default `~/.config/cloudstic`). |
 | `CLOUDSTIC_{STORE,SOURCE}_SFTP_{PASSWORD,KEY,KNOWN_HOSTS,INSECURE}` | SFTP auth/host-key config for the store and source backends. |
 | `CLOUDSTIC_DISABLE_PACKFILE` | Disable the `PackStore` small-object bundling layer. |
+| `CLOUDSTIC_VOLUME_UUID` | Override the volume UUID for a local source (cross-machine incremental backup for portable drives). |
 | `CLOUDSTIC_E2E_MODE` | E2E test mode: `hermetic` (default), `live`, or `all` (see below). |
 
-`CLOUDSTIC_TEST_*` and `CLOUDSTIC_VOLUME_UUID` are test-only knobs, not user-facing.
+This table is a curated subset (`CLOUDSTIC_*` vars only) for orientation. The
+exhaustive, one-row-per-variable inventory — including provider-standard vars
+like `AWS_ACCESS_KEY_ID` and `B2_KEY_ID` that are deliberately unprefixed — is
+the "Environment Variables" table in `docs/user-guide.md`, kept complete by
+`TestUserGuideDocumentsEveryEnvVar` (`cmd/cloudstic/flagspec_test.go`), which
+fails if a flag's `env` binding has no matching row.
+
+`CLOUDSTIC_TEST_*` are test-only knobs, not user-facing.
 
 ## Documentation Map
 

--- a/cmd/cloudstic/config_test.go
+++ b/cmd/cloudstic/config_test.go
@@ -11,6 +11,46 @@ import (
 	cloudstic "github.com/cloudstic/cli"
 )
 
+// TestResolveClientConfig_ProfileOverridesEnvironment documents and locks in
+// the precedence #266 asked to make explicit: a selected profile is a named
+// choice the user invoked with -profile, so it overrides an ambient
+// environment variable the same way it overrides a built-in default. Only an
+// explicit CLI flag (TestApplyProfileStore_CLIFlagOverrides) beats it.
+func TestResolveClientConfig_ProfileOverridesEnvironment(t *testing.T) {
+	t.Setenv("CLOUDSTIC_S3_REGION", "env-region")
+	g := newTestGlobalFlags()
+	if g.s3Region != "env-region" {
+		t.Fatalf("s3Region=%q want env-region (environment should win over default)", g.s3Region)
+	}
+	if g.origins["s3-region"] != originEnv {
+		t.Fatalf("origins[s3-region]=%v want originEnv", g.origins["s3-region"])
+	}
+
+	profilesPath := filepath.Join(t.TempDir(), "profiles.yaml")
+	err := cloudstic.SaveProfilesFile(profilesPath, &cloudstic.ProfilesConfig{
+		Version: 1,
+		Stores: map[string]cloudstic.ProfileStore{
+			"s": {URI: "s3:bucket", S3Region: "profile-region"},
+		},
+		Profiles: map[string]cloudstic.BackupProfile{
+			"p": {Source: "local:/data", Store: "s"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SaveProfilesFile: %v", err)
+	}
+	g.profile = "p"
+	g.profilesFile = profilesPath
+
+	resolved, err := resolveClientConfig(g)
+	if err != nil {
+		t.Fatalf("resolveClientConfig: %v", err)
+	}
+	if resolved.store.s3.region != "profile-region" {
+		t.Fatalf("store.s3.region=%q want profile-region (profile should win over environment)", resolved.store.s3.region)
+	}
+}
+
 func TestResolveClientConfig_AppliesProfileStore(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")

--- a/cmd/cloudstic/flagspec_test.go
+++ b/cmd/cloudstic/flagspec_test.go
@@ -3,6 +3,9 @@ package main
 import (
 	"bytes"
 	"flag"
+	"os"
+	"path/filepath"
+	"regexp"
 	"slices"
 	"strings"
 	"testing"
@@ -254,6 +257,50 @@ func TestHelpNamesEnvironmentVariables(t *testing.T) {
 			t.Errorf("help output should name the environment variable %s", want)
 		}
 	}
+}
+
+// TestUserGuideDocumentsEveryEnvVar guards against the environment-variable
+// documentation drifting from the actual command surface (#266): every flag
+// declared with an environment binding, anywhere in the command tree, must
+// have a row in docs/user-guide.md's "Environment Variables" table.
+func TestUserGuideDocumentsEveryEnvVar(t *testing.T) {
+	path := filepath.Join("..", "..", "docs", "user-guide.md")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	const heading = "## Environment Variables"
+	start := bytes.Index(raw, []byte(heading))
+	if start < 0 {
+		t.Fatalf("%s has no %q section", path, heading)
+	}
+	section := raw[start+len(heading):]
+	if end := bytes.Index(section, []byte("\n## ")); end >= 0 {
+		section = section[:end]
+	}
+
+	documented := map[string]bool{}
+	for _, m := range regexp.MustCompile("`([A-Z0-9_]+)`").FindAllSubmatch(section, -1) {
+		documented[string(m[1])] = true
+	}
+
+	seen := map[string]bool{}
+	walk(commandRegistry(), func(cmdPath string, c command) {
+		if c.flags == nil {
+			return
+		}
+		for _, spec := range c.flags().specs() {
+			if spec.env == "" || seen[spec.env] {
+				continue
+			}
+			seen[spec.env] = true
+			if !documented[spec.env] {
+				t.Errorf("%s: flag -%s binds env %s, which has no row in docs/user-guide.md's Environment Variables table",
+					cmdPath, spec.name, spec.env)
+			}
+		}
+	})
 }
 
 func lookupCommandForTest(t *testing.T, name string) command {

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1809,6 +1809,7 @@ cloudstic forget -keep-daily 7 -keep-monthly 12 -dry-run
 | Variable | Flag equivalent | Description |
 | :--- | :--- | :--- |
 | `CLOUDSTIC_STORE` | `-store` | Storage backend URI: `local:<path>`, `s3:<bucket>[/<prefix>]`, `b2:<bucket>[/<prefix>]`, `sftp://[user@]host[:port]/<path>` |
+| `CLOUDSTIC_PROFILE` | `-profile` | Active profile name from profiles.yaml |
 | `CLOUDSTIC_S3_ENDPOINT` | `-s3-endpoint` | S3 compatible endpoint (for MinIO, R2, etc.) |
 | `CLOUDSTIC_S3_REGION` | `-s3-region` | S3 Region |
 | `CLOUDSTIC_S3_PROFILE` | `-s3-profile` | AWS shared config profile for S3 auth |
@@ -1816,11 +1817,17 @@ cloudstic forget -keep-daily 7 -keep-monthly 12 -dry-run
 | `AWS_SECRET_ACCESS_KEY` | `-s3-secret-key` | S3 Secret Access Key |
 | `B2_KEY_ID` | `-b2-key-id` | Backblaze B2 application key ID |
 | `B2_APP_KEY` | `-b2-app-key` | Backblaze B2 application key |
+| `CLOUDSTIC_DISABLE_PACKFILE` | `-disable-packfile` | Disable bundling small objects into packs |
 | `CLOUDSTIC_STORE_SFTP_PASSWORD` | `-store-sftp-password` | SFTP password for the store |
 | `CLOUDSTIC_STORE_SFTP_KEY` | `-store-sftp-key` | Path to SSH private key for the store |
+| `CLOUDSTIC_STORE_SFTP_INSECURE` | `-store-sftp-insecure` | Skip host key validation for the store (INSECURE) |
+| `CLOUDSTIC_STORE_SFTP_KNOWN_HOSTS` | `-store-sftp-known-hosts` | Path to known_hosts file for the store |
 | `CLOUDSTIC_SOURCE` | `-source` | Source URI: `local:<path>`, `sftp://[user@]host[:port]/<path>`, `gdrive[://<Drive Name>][/<path>]`, `gdrive-changes[://<Drive Name>][/<path>]`, `onedrive[://<Drive Name>][/<path>]`, `onedrive-changes[://<Drive Name>][/<path>]` |
+| `CLOUDSTIC_VOLUME_UUID` | `-volume-uuid` | Override volume UUID for local source (see [Portable drives](#portable-drives)) |
 | `CLOUDSTIC_SOURCE_SFTP_PASSWORD` | `-source-sftp-password` | SFTP password for the source |
 | `CLOUDSTIC_SOURCE_SFTP_KEY` | `-source-sftp-key` | Path to SSH private key for the source |
+| `CLOUDSTIC_SOURCE_SFTP_INSECURE` | `-source-sftp-insecure` | Skip host key validation for the source (INSECURE) |
+| `CLOUDSTIC_SOURCE_SFTP_KNOWN_HOSTS` | `-source-sftp-known-hosts` | Path to known_hosts file for the source |
 | `CLOUDSTIC_ENCRYPTION_KEY` | `-encryption-key` | Platform key (hex) |
 | `CLOUDSTIC_PASSWORD` | `-password` | Encryption password |
 | `CLOUDSTIC_RECOVERY_KEY` | `-recovery-key` | Recovery seed phrase |
@@ -1832,5 +1839,8 @@ cloudstic forget -keep-daily 7 -keep-monthly 12 -dry-run
 | `GOOGLE_APPLICATION_CREDENTIALS` | `-google-credentials` | Path to your own Google OAuth credentials file (optional, overrides built-in) |
 | `GOOGLE_CREDENTIALS_JSON` | `-google-credentials-json` | Inline Google credentials JSON (OAuth client or service account) |
 | `GOOGLE_TOKEN_FILE` | `-google-token-file` | Override Google OAuth token path |
-| `ONEDRIVE_CLIENT_ID` | — | Microsoft app client ID (optional, overrides built-in) |
-| `ONEDRIVE_TOKEN_FILE` | — | Override OneDrive token path |
+| `ONEDRIVE_CLIENT_ID` | `-onedrive-client-id` | Microsoft app client ID (optional, overrides built-in) |
+| `ONEDRIVE_TOKEN_FILE` | `-onedrive-token-file` | Override OneDrive token path |
+
+This table is kept complete by an automated test: any flag declared with an
+environment binding must have a row here, or `go test ./cmd/cloudstic` fails.


### PR DESCRIPTION
## Summary
- Document the resolution precedence (`flag > profile > env > default`) in `AGENTS.md`'s Configuration & Profiles section, explaining *why* a selected profile overrides an ambient environment variable (it's a named choice the user invoked with `-profile`, same as it overrides a built-in default) — only an explicit CLI flag beats it
- Add `TestResolveClientConfig_ProfileOverridesEnvironment` to lock that precedence in with a regression test (previously only "flag beats profile" and "flag/env beats default" were tested; "profile beats env" was neither documented nor tested)
- Fix real drift already present in the docs:
  - `docs/user-guide.md`'s Environment Variables table was missing `CLOUDSTIC_PROFILE`, `CLOUDSTIC_DISABLE_PACKFILE`, `CLOUDSTIC_VOLUME_UUID`, and the four `*_SFTP_INSECURE`/`*_SFTP_KNOWN_HOSTS` variables
  - it also listed `ONEDRIVE_CLIENT_ID`/`ONEDRIVE_TOKEN_FILE` as having no flag equivalent, even though `-onedrive-client-id`/`-onedrive-token-file` exist
  - `AGENTS.md` separately claimed `CLOUDSTIC_VOLUME_UUID` was a test-only, non-user-facing knob — it isn't; it backs a real, documented flag (cross-machine incremental backup for portable drives)
- Add `TestUserGuideDocumentsEveryEnvVar`, which walks the entire command tree and fails if any flag's `env` binding has no row in `user-guide.md`'s table — verified it actually fires by temporarily deleting a row (against a scratch copy, not committed)

Closes #266

## Verification
- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 -race ./cmd/cloudstic ./internal/engine .`
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./cmd/cloudstic/...`
- `npx markdownlint-cli2 docs/user-guide.md AGENTS.md` — 0 issues