### PR TITLE
fix(store): stop treating an unreadable pack catalog as an empty one

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ CompressedStore → EncryptedStore → MeteredStore → [PackStore] → KeyCache
 - `CompressedStore` — zstd compression on write, auto-detects zstd/gzip/raw on read.
 - `EncryptedStore` — AES-256-GCM. Passes through objects under `keys/` prefix unencrypted (key slots).
 - `MeteredStore` — Tracks bytes written for reporting.
-- `PackStore` (optional) — Bundles small objects (<512KB) into 8MB packfiles to reduce API calls. Uses a bbolt-backed catalog.
+- `PackStore` (optional) — Bundles small objects (<512KB) into 8MB packfiles to reduce API calls. Only content-addressed prefixes (`filemeta/`, `node/`, `snapshot/`, `chunk/`, `content/`) are packed; mutable keys such as `index/latest` are never bundled. The `index/packs` JSON catalog is the only record of an object's offset within its pack and cannot be rebuilt by listing the store, so a failed catalog load fails the calling operation instead of degrading to an empty catalog, and `Flush` refuses to overwrite a catalog it has not first merged with the stored copy.
 - `KeyCacheStore` — Caches key existence in a temporary bbolt database to avoid redundant `Exists`/`List` calls against remote backends. Uses `singleflight` to deduplicate concurrent writes for the same key.
 - Backend: `LocalStore`, `S3Store`, `B2Store`, `SFTPStore`, or `HybridStore` (PostgreSQL for metadata + B2 for chunks).
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -298,7 +298,19 @@ A catalog of lightweight snapshot summaries used to avoid fetching each full sna
 
 #### index/packs
 
-When packfiles are enabled, a bbolt database mapping logical object keys to their byte offset and length within a packfile. Rebuilt automatically if stale.
+When packfiles are enabled, a JSON object mapping logical object keys to the packfile, byte offset, and length where their bytes actually live:
+
+```json
+{
+  "filemeta/<hash>": { "p": "packs/<hash>", "o": 0, "l": 412 }
+}
+```
+
+Unlike `index/snapshots`, this catalog **cannot** be rebuilt by listing the store. Packfiles are a bare concatenation of object bytes with no framing, so the boundary between two objects exists nowhere except in this catalog. A packed object has no object of its own at its logical key — the key is resolvable only through `index/packs`.
+
+That makes it the one index in the repository whose loss is unrecoverable: the bytes remain intact and correctly hashed in their packfile, but nothing can locate them. Consequently a failed read of this catalog fails the operation that needed it rather than degrading to an empty catalog, and it is never written back before the stored copy has been merged in.
+
+RFC 0018 proposes a self-describing packfile format that adds a footer index to each packfile, which would demote `index/packs` to a rebuildable cache.
 
 ---
 

--- a/docs/storage-model.md
+++ b/docs/storage-model.md
@@ -47,10 +47,19 @@ or modify an object that was already stored.
 | HAMT Flush                     | Orphaned node + blob objects          | None        |
 | Snapshot write                 | Orphaned snapshot + all its objects    | None        |
 | `index/latest` update          | New snapshot exists but isn't "latest" | None        |
-| `index/packs` catalog          | Catalog stale; rebuilt on next load    | None        |
+| `index/packs` catalog          | Entries written since the last flush are unaddressable | **Data loss** |
 
-In every case the previous `index/latest` still points at a fully valid
-snapshot with a complete, consistent tree.
+For every row but the last, the previous `index/latest` still points at a fully
+valid snapshot with a complete, consistent tree.
+
+`index/packs` is the exception. Packfiles carry no framing or footer, so the
+catalog is the *only* record of an object's offset and length within its pack —
+it cannot be rebuilt by listing the store the way `index/snapshots` can. A lost
+or truncated catalog leaves the bytes physically present but permanently
+unaddressable. Because of this, an unreadable catalog fails the operation that
+needs it rather than degrading to an empty one, and a catalog is never written
+back before the stored copy has been merged in. See RFC 0018 for the
+self-describing packfile format that removes this single point of failure.
 
 ### Individual object atomicity
 

--- a/pkg/store/pack.go
+++ b/pkg/store/pack.go
@@ -107,22 +107,31 @@ func (s *PackStore) Put(ctx context.Context, key string, data []byte) error {
 	return nil
 }
 
+// packablePrefixes are the content-addressed namespaces safe to bundle into a
+// packfile. Every key under them is immutable and named by its own hash, so a
+// packed copy can never go stale.
+//
+// The index/ namespace is deliberately absent: those keys are mutable pointers
+// (index/latest), rebuildable catalogs (index/packs, index/snapshots), or locks.
+// Packing a mutable key ties its freshness to catalog-flush ordering and leaves
+// every superseded copy behind as pack waste.
+var packablePrefixes = []string{
+	"filemeta/",
+	"node/",
+	"snapshot/",
+	"chunk/",
+	"content/",
+}
+
 // isSmallObject determines if a key/data pair should be bundled into a packfile.
 func (s *PackStore) isSmallObject(key string, data []byte) bool {
-	// Don't pack the pack index itself, lock files, or the snapshot catalog
-	// (mutable indexes that are read on every operation).
-	if key == indexPacksKey || key == "index/snapshots" || strings.HasPrefix(key, "index/lock") {
+	// We only pack metadata and small blobs to keep large data files randomly
+	// accessible natively.
+	if len(data) > maxObjectSize {
 		return false
 	}
-	// We only pack metadata to keep data files randomly accessible natively.
-	// Specifically: filemeta, nodes, snapshots, index, and small chunks/contents (up to 512KB)
-	if len(data) <= maxObjectSize {
-		if strings.HasPrefix(key, "filemeta/") ||
-			strings.HasPrefix(key, "node/") ||
-			strings.HasPrefix(key, "snapshot/") ||
-			strings.HasPrefix(key, "chunk/") ||
-			strings.HasPrefix(key, "content/") ||
-			strings.HasPrefix(key, "index/") {
+	for _, prefix := range packablePrefixes {
+		if strings.HasPrefix(key, prefix) {
 			return true
 		}
 	}
@@ -184,13 +193,12 @@ func (s *PackStore) Get(ctx context.Context, key string) ([]byte, error) {
 	// or it's just a normal large object.
 	if !inCatalog {
 		if key != indexPacksKey && !strings.HasPrefix(key, packPrefix) {
-			s.mu.Lock()
-			// Another thread might have loaded it while we waited for lock
-			if !s.catalogLoaded {
-				_ = s.loadCatalogLocked(ctx)
+			if err := s.ensureCatalogLoaded(ctx); err != nil {
+				return nil, err
 			}
+			s.mu.RLock()
 			entry, inCatalog = s.catalog[key]
-			s.mu.Unlock()
+			s.mu.RUnlock()
 		}
 
 		if !inCatalog {
@@ -253,20 +261,16 @@ func (s *PackStore) List(ctx context.Context, prefix string) ([]string, error) {
 		return nil, err
 	}
 
-	// 2. Add keys from catalog and active buffer matching prefix
-	s.mu.RLock()
-	var packedKeys []string
-	if !s.catalogLoaded {
-		// Try to load catalog if not loaded
-		s.mu.RUnlock()
-		s.mu.Lock()
-		if !s.catalogLoaded {
-			_ = s.loadCatalogLocked(ctx)
-		}
-		s.mu.Unlock()
-		s.mu.RLock()
+	// 2. Add keys from catalog and active buffer matching prefix.
+	// An unreadable catalog must fail the listing rather than silently omit
+	// every packed key: callers such as prune's mark phase treat a short list
+	// as "these objects are unreachable".
+	if err := s.ensureCatalogLoaded(ctx); err != nil {
+		return nil, err
 	}
 
+	s.mu.RLock()
+	var packedKeys []string
 	for key := range s.catalog {
 		if strings.HasPrefix(key, prefix) {
 			packedKeys = append(packedKeys, key)
@@ -301,6 +305,14 @@ func (s *PackStore) List(ctx context.Context, prefix string) ([]string, error) {
 // Flush ensures any pending small objects are written to a packfile,
 // and uploads the latest JSON catalog.
 func (s *PackStore) Flush(ctx context.Context) error {
+	// The catalog is written back wholesale, so it must first be merged with
+	// whatever is already stored. Flushing a catalog that was never loaded
+	// would replace the full history with only this session's entries and
+	// strand every previously packed object.
+	if err := s.ensureCatalogLoaded(ctx); err != nil {
+		return fmt.Errorf("refusing to overwrite %s: %w", indexPacksKey, err)
+	}
+
 	s.mu.Lock()
 	packRef, packData := s.prepareFlushLocked()
 
@@ -342,6 +354,15 @@ func (s *PackStore) Flush(ctx context.Context) error {
 }
 
 // loadCatalogLocked fetches the index/packs file from the inner store and populates the catalog.
+//
+// The catalog is the only record of where a packed object lives, so a failure
+// to read it must never be mistaken for "there are no packed objects". Callers
+// are required to propagate the error: silently continuing with an empty
+// catalog makes every packed object look absent, which is indistinguishable
+// from deletion to prune's mark-and-sweep.
+//
+// s.catalogLoaded is set only when the catalog was read successfully or proven
+// absent, and is the invariant Flush relies on before overwriting index/packs.
 func (s *PackStore) loadCatalogLocked(ctx context.Context) error {
 	// If it was already loaded or proven missing (noted by dirty flag or some other state), we wouldn't be here,
 	// but we need to track if we've already attempted loading so we don't spam 404s.
@@ -350,14 +371,29 @@ func (s *PackStore) loadCatalogLocked(ctx context.Context) error {
 	}
 
 	debugf("loading pack catalog from %s", indexPacksKey)
+
+	// A fresh repository legitimately has no catalog. Establish that up front so
+	// a missing object is never conflated with an unreadable one; backends do
+	// not expose a typed not-found error, so an existence check is the only
+	// reliable way to tell the two apart.
+	exists, err := s.ObjectStore.Exists(ctx, indexPacksKey)
+	if err != nil {
+		return fmt.Errorf("check pack catalog %s: %w", indexPacksKey, err)
+	}
+	if !exists {
+		s.catalogLoaded = true // We checked, it doesn't exist, stop checking
+		return nil
+	}
+
 	data, err := s.ObjectStore.Get(ctx, indexPacksKey)
 	if err != nil {
-		// It's normal for index/packs to not exist on a fresh repository
-		if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "no such file") || strings.Contains(err.Error(), "NoSuchKey") {
-			s.catalogLoaded = true // We checked, it doesn't exist, stop checking
+		// Tolerate a backend that reports absence only on read (or that raced
+		// with a concurrent write), but treat every other error as fatal.
+		if isNotFoundErr(err) {
+			s.catalogLoaded = true
 			return nil
 		}
-		return err
+		return fmt.Errorf("load pack catalog %s: %w", indexPacksKey, err)
 	}
 
 	if err := json.Unmarshal(data, &s.catalog); err != nil {
@@ -368,9 +404,44 @@ func (s *PackStore) loadCatalogLocked(ctx context.Context) error {
 	return nil
 }
 
+// isNotFoundErr reports whether err indicates a missing object. Backends do not
+// share a typed error, so this matches the shapes they produce in practice.
+func isNotFoundErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "not found") ||
+		strings.Contains(msg, "no such file") ||
+		strings.Contains(msg, "NoSuchKey")
+}
+
+// ensureCatalogLoaded loads the catalog if it has not been read yet, taking the
+// write lock only when a load is actually needed.
+func (s *PackStore) ensureCatalogLoaded(ctx context.Context) error {
+	s.mu.RLock()
+	loaded := s.catalogLoaded
+	s.mu.RUnlock()
+	if loaded {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Another goroutine may have loaded it while we waited for the lock.
+	return s.loadCatalogLocked(ctx)
+}
+
 // Delete removes an object. For packed objects, it just removes it from the catalog.
 // The actual packfile is not currently garbage collected.
 func (s *PackStore) Delete(ctx context.Context, key string) error {
+	// Without the catalog a packed key looks unpacked, and the delete would be
+	// forwarded to the backend where the object does not physically exist —
+	// reporting success while the entry survives the next flush.
+	if err := s.ensureCatalogLoaded(ctx); err != nil {
+		return err
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -412,12 +483,11 @@ func (s *PackStore) Size(ctx context.Context, key string) (int64, error) {
 // For example, 0.3 means a pack is repacked if it is more than 30% empty.
 // Returns the number of bytes reclaimed, number of packs deleted, and error.
 func (s *PackStore) Repack(ctx context.Context, maxWastedRatio float64) (int64, int, error) {
-	// Ensure catalog is loaded
-	s.mu.Lock()
-	if !s.catalogLoaded {
-		_ = s.loadCatalogLocked(ctx)
+	// Ensure catalog is loaded. Repack deletes packfiles whose entries are all
+	// gone from the catalog, so an empty catalog would condemn every pack.
+	if err := s.ensureCatalogLoaded(ctx); err != nil {
+		return 0, 0, err
 	}
-	s.mu.Unlock()
 
 	s.mu.RLock()
 	// Calculate active bytes per pack and map keys to packs
@@ -437,6 +507,16 @@ func (s *PackStore) Repack(ctx context.Context, maxWastedRatio float64) (int64, 
 
 	var bytesReclaimed int64
 	var packsDeleted int
+
+	// Packs whose live objects have been re-inserted but not yet made durable.
+	// They are deleted only after the replacement pack and the updated catalog
+	// have been flushed, so an interruption leaves recoverable orphans rather
+	// than losing the objects.
+	type retiredPack struct {
+		ref    string
+		wasted int64
+	}
+	var retired []retiredPack
 
 	for _, packRef := range packRefs {
 		activeSize := packActiveSizes[packRef]
@@ -502,20 +582,27 @@ func (s *PackStore) Repack(ctx context.Context, maxWastedRatio float64) (int64, 
 				}
 			}
 
-			// Delete the old packfile
-			if err := s.ObjectStore.Delete(ctx, packRef); err != nil {
-				return bytesReclaimed, packsDeleted, fmt.Errorf("delete old repacked pack %s: %w", packRef, err)
-			}
-
-			bytesReclaimed += wasted
-			packsDeleted++
-			s.packCache.Remove(packRef)
+			// The old packfile is retired, not deleted: its contents only become
+			// durable at the flush below.
+			retired = append(retired, retiredPack{ref: packRef, wasted: wasted})
 		}
 	}
 
-	// Ensure any final repacked objects are flushed
+	// Make the replacement packs and the updated catalog durable before
+	// anything they replace is removed.
 	if err := s.Flush(ctx); err != nil {
 		return bytesReclaimed, packsDeleted, fmt.Errorf("flush after repack: %w", err)
+	}
+
+	// Only now is it safe to drop the originals. An error here leaves a
+	// superseded pack behind, which the orphan pass above reclaims next run.
+	for _, pack := range retired {
+		if err := s.ObjectStore.Delete(ctx, pack.ref); err != nil {
+			return bytesReclaimed, packsDeleted, fmt.Errorf("delete old repacked pack %s: %w", pack.ref, err)
+		}
+		bytesReclaimed += pack.wasted
+		packsDeleted++
+		s.packCache.Remove(pack.ref)
 	}
 
 	return bytesReclaimed, packsDeleted, nil

--- a/pkg/store/pack_catalog_test.go
+++ b/pkg/store/pack_catalog_test.go
@@ -1,0 +1,220 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+// faultyCatalogStore fails reads of the pack catalog a bounded number of times,
+// standing in for a transient backend error (throttling, reset connection).
+type faultyCatalogStore struct {
+	ObjectStore
+	failsLeft int
+	injected  int
+}
+
+var errCatalogUnavailable = errors.New("RequestError: connection reset by peer")
+
+func (f *faultyCatalogStore) Get(ctx context.Context, key string) ([]byte, error) {
+	if key == indexPacksKey && f.failsLeft > 0 {
+		f.failsLeft--
+		f.injected++
+		return nil, errCatalogUnavailable
+	}
+	return f.ObjectStore.Get(ctx, key)
+}
+
+func (f *faultyCatalogStore) Exists(ctx context.Context, key string) (bool, error) {
+	if key == indexPacksKey && f.failsLeft > 0 {
+		f.failsLeft--
+		f.injected++
+		return false, errCatalogUnavailable
+	}
+	return f.ObjectStore.Exists(ctx, key)
+}
+
+func newCatalogTestStore(t *testing.T) (*faultyCatalogStore, ObjectStore) {
+	t.Helper()
+
+	tmpDir, err := os.MkdirTemp("", "cloudstic-pack-catalog-*")
+	if err != nil {
+		t.Fatalf("create temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	localStore, err := NewLocalStore(tmpDir)
+	if err != nil {
+		t.Fatalf("create local store: %v", err)
+	}
+	return &faultyCatalogStore{ObjectStore: localStore}, localStore
+}
+
+func newPackStoreT(t *testing.T, inner ObjectStore) *PackStore {
+	t.Helper()
+	ps, err := NewPackStore(inner)
+	if err != nil {
+		t.Fatalf("init pack store: %v", err)
+	}
+	return ps
+}
+
+// seedPackedRepo writes keys through a healthy PackStore and flushes them.
+func seedPackedRepo(t *testing.T, inner ObjectStore, keys ...string) {
+	t.Helper()
+	ctx := context.Background()
+	ps := newPackStoreT(t, inner)
+	for _, key := range keys {
+		if err := ps.Put(ctx, key, []byte("payload for "+key)); err != nil {
+			t.Fatalf("put %s: %v", key, err)
+		}
+	}
+	if err := ps.Flush(ctx); err != nil {
+		t.Fatalf("seed flush: %v", err)
+	}
+}
+
+// A catalog that cannot be read must fail the listing. Returning a short list
+// tells prune's mark phase that every packed object is unreachable.
+func TestPackStore_ListFailsWhenCatalogUnreadable(t *testing.T) {
+	ctx := context.Background()
+	faulty, inner := newCatalogTestStore(t)
+	seedPackedRepo(t, inner, "snapshot/aaa", "snapshot/bbb")
+
+	faulty.failsLeft = 1
+	ps := newPackStoreT(t, faulty)
+
+	keys, err := ps.List(ctx, "snapshot/")
+	if err == nil {
+		t.Fatalf("List succeeded with %d keys; want an error when the catalog is unreadable", len(keys))
+	}
+	if faulty.injected == 0 {
+		t.Fatal("fault was never injected")
+	}
+	if !strings.Contains(err.Error(), "index/packs") {
+		t.Errorf("error should name the catalog, got: %v", err)
+	}
+}
+
+// The same guarantee for point reads: a packed object must not be reported
+// missing just because the catalog could not be consulted.
+func TestPackStore_GetFailsWhenCatalogUnreadable(t *testing.T) {
+	ctx := context.Background()
+	faulty, inner := newCatalogTestStore(t)
+	seedPackedRepo(t, inner, "filemeta/a")
+
+	faulty.failsLeft = 1
+	ps := newPackStoreT(t, faulty)
+
+	if _, err := ps.Get(ctx, "filemeta/a"); err == nil {
+		t.Fatal("Get succeeded; want an error when the catalog is unreadable")
+	}
+}
+
+// Repack condemns packs whose entries are absent from the catalog, so it must
+// refuse to run at all rather than treat an unreadable catalog as empty.
+func TestPackStore_RepackFailsWhenCatalogUnreadable(t *testing.T) {
+	ctx := context.Background()
+	faulty, inner := newCatalogTestStore(t)
+	seedPackedRepo(t, inner, "filemeta/a", "filemeta/b")
+
+	packsBefore, _ := inner.List(ctx, packPrefix)
+
+	faulty.failsLeft = 1
+	ps := newPackStoreT(t, faulty)
+
+	if _, _, err := ps.Repack(ctx, 0.3); err == nil {
+		t.Fatal("Repack succeeded; want an error when the catalog is unreadable")
+	}
+
+	packsAfter, _ := inner.List(ctx, packPrefix)
+	if len(packsAfter) != len(packsBefore) {
+		t.Errorf("Repack deleted packs despite an unreadable catalog: %d -> %d", len(packsBefore), len(packsAfter))
+	}
+}
+
+// Flush writes the catalog back wholesale. If the stored catalog was never
+// merged in, flushing would strand every previously packed object.
+func TestPackStore_FlushDoesNotOverwriteUnloadedCatalog(t *testing.T) {
+	ctx := context.Background()
+	faulty, inner := newCatalogTestStore(t)
+	seedPackedRepo(t, inner, "filemeta/old1", "filemeta/old2", "snapshot/old")
+
+	// A session whose catalog load fails, which then writes and flushes.
+	faulty.failsLeft = 99
+	ps := newPackStoreT(t, faulty)
+	if err := ps.Put(ctx, "filemeta/new", []byte("new run")); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if err := ps.Flush(ctx); err == nil {
+		t.Fatal("Flush succeeded; want a refusal to overwrite an unloaded catalog")
+	}
+
+	// A healthy session must still see the historical entries.
+	recovered := newPackStoreT(t, inner)
+	keys, err := recovered.List(ctx, "filemeta/")
+	if err != nil {
+		t.Fatalf("List after recovery: %v", err)
+	}
+	if len(keys) != 2 {
+		t.Errorf("expected 2 historical filemeta entries, got %v", keys)
+	}
+	if _, err := recovered.Get(ctx, "filemeta/old1"); err != nil {
+		t.Errorf("historical entry became unreadable: %v", err)
+	}
+	if _, err := recovered.Get(ctx, "snapshot/old"); err != nil {
+		t.Errorf("historical snapshot became unreadable: %v", err)
+	}
+}
+
+// Once the backend recovers, the catalog loads and the merged flush keeps both
+// the historical and the new entries.
+func TestPackStore_FlushMergesAfterTransientFailure(t *testing.T) {
+	ctx := context.Background()
+	faulty, inner := newCatalogTestStore(t)
+	seedPackedRepo(t, inner, "filemeta/old1")
+
+	faulty.failsLeft = 1
+	ps := newPackStoreT(t, faulty)
+	if err := ps.Put(ctx, "filemeta/new", []byte("new run")); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if err := ps.Flush(ctx); err == nil {
+		t.Fatal("first Flush should fail while the catalog is unreadable")
+	}
+	// Backend has recovered; the retry must succeed and preserve history.
+	if err := ps.Flush(ctx); err != nil {
+		t.Fatalf("retry Flush: %v", err)
+	}
+
+	recovered := newPackStoreT(t, inner)
+	for _, key := range []string{"filemeta/old1", "filemeta/new"} {
+		if _, err := recovered.Get(ctx, key); err != nil {
+			t.Errorf("get %s after merged flush: %v", key, err)
+		}
+	}
+}
+
+// A fresh repository legitimately has no catalog; that must not be an error.
+func TestPackStore_FreshRepositoryFlushSucceeds(t *testing.T) {
+	ctx := context.Background()
+	_, inner := newCatalogTestStore(t)
+
+	ps := newPackStoreT(t, inner)
+	if err := ps.Put(ctx, "filemeta/a", []byte("first")); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if err := ps.Flush(ctx); err != nil {
+		t.Fatalf("flush on fresh repository: %v", err)
+	}
+
+	keys, err := ps.List(ctx, "filemeta/")
+	if err != nil {
+		t.Fatalf("list on fresh repository: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Errorf("expected 1 key, got %v", keys)
+	}
+}

--- a/pkg/store/pack_durability_test.go
+++ b/pkg/store/pack_durability_test.go
@@ -1,0 +1,146 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+// index/latest is a mutable pointer, not content-addressed. Packing it ties its
+// freshness to catalog-flush ordering and strands stale copies inside packs.
+func TestPackStore_DoesNotPackMutableIndexKeys(t *testing.T) {
+	ctx := context.Background()
+	_, inner := newCatalogTestStore(t)
+	ps := newPackStoreT(t, inner)
+
+	mutable := []string{"index/latest", "index/packs", "index/snapshots", "index/lock/abc"}
+	for _, key := range mutable {
+		if ps.isSmallObject(key, []byte("snapshot/aaa")) {
+			t.Errorf("%s must not be packed", key)
+		}
+	}
+
+	for _, key := range []string{"filemeta/a", "node/b", "snapshot/c", "chunk/d", "content/e"} {
+		if !ps.isSmallObject(key, []byte("small")) {
+			t.Errorf("%s should still be packed", key)
+		}
+	}
+
+	// index/latest must land in the backend directly, addressable without the catalog.
+	if err := ps.Put(ctx, "index/latest", []byte("snapshot/aaa")); err != nil {
+		t.Fatalf("put index/latest: %v", err)
+	}
+	if exists, err := inner.Exists(ctx, "index/latest"); err != nil || !exists {
+		t.Errorf("index/latest should exist in the backend directly (exists=%v, err=%v)", exists, err)
+	}
+}
+
+// Repositories written before the fix have index/latest inside a pack; those
+// reads must keep working through the catalog.
+func TestPackStore_LegacyPackedIndexLatestStaysReadable(t *testing.T) {
+	ctx := context.Background()
+	_, inner := newCatalogTestStore(t)
+
+	// Simulate the legacy layout by packing the key explicitly.
+	legacy := newPackStoreT(t, inner)
+	legacy.mu.Lock()
+	offset := int64(legacy.packBuffer.Len())
+	legacy.packBuffer.Write([]byte("snapshot/legacy"))
+	legacy.packKeys["index/latest"] = PackEntry{Offset: offset, Length: int64(len("snapshot/legacy"))}
+	legacy.mu.Unlock()
+	if err := legacy.Flush(ctx); err != nil {
+		t.Fatalf("legacy flush: %v", err)
+	}
+
+	fresh := newPackStoreT(t, inner)
+	data, err := fresh.Get(ctx, "index/latest")
+	if err != nil {
+		t.Fatalf("legacy packed index/latest unreadable: %v", err)
+	}
+	if string(data) != "snapshot/legacy" {
+		t.Errorf("got %q, want %q", data, "snapshot/legacy")
+	}
+}
+
+// deleteBlockingStore fails deletes of packfiles, standing in for a process
+// interrupted after the replacement pack was flushed but before cleanup.
+type deleteBlockingStore struct {
+	ObjectStore
+	blocked bool
+}
+
+func (d *deleteBlockingStore) Delete(ctx context.Context, key string) error {
+	if d.blocked && strings.HasPrefix(key, packPrefix) {
+		return errors.New("interrupted")
+	}
+	return d.ObjectStore.Delete(ctx, key)
+}
+
+// A repack interrupted around the deletion of the original pack must leave the
+// data readable. Before the fix the objects existed only in memory at that
+// point, so the interruption lost them.
+func TestPackStore_RepackInterruptedBeforeDeleteLosesNothing(t *testing.T) {
+	ctx := context.Background()
+
+	tmpDir, err := os.MkdirTemp("", "cloudstic-repack-durability-*")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	localStore, err := NewLocalStore(tmpDir)
+	if err != nil {
+		t.Fatalf("local store: %v", err)
+	}
+	blocking := &deleteBlockingStore{ObjectStore: localStore}
+
+	// Build a pack that is mostly waste so it qualifies for repacking.
+	ps := newPackStoreT(t, blocking)
+	survivor := "filemeta/survivor"
+	if err := ps.Put(ctx, survivor, []byte("keep me")); err != nil {
+		t.Fatalf("put survivor: %v", err)
+	}
+	for _, key := range []string{"filemeta/waste1", "filemeta/waste2", "filemeta/waste3"} {
+		if err := ps.Put(ctx, key, []byte(strings.Repeat("x", 400))); err != nil {
+			t.Fatalf("put %s: %v", key, err)
+		}
+	}
+	if err := ps.Flush(ctx); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	for _, key := range []string{"filemeta/waste1", "filemeta/waste2", "filemeta/waste3"} {
+		if err := ps.Delete(ctx, key); err != nil {
+			t.Fatalf("delete %s: %v", key, err)
+		}
+	}
+	if err := ps.Flush(ctx); err != nil {
+		t.Fatalf("flush after deletes: %v", err)
+	}
+
+	// Interrupt at the point where the old pack would be removed.
+	blocking.blocked = true
+	if _, _, err := ps.Repack(ctx, 0.3); err == nil {
+		t.Fatal("expected the blocked delete to surface as an error")
+	}
+	blocking.blocked = false
+
+	// A fresh session, reading only what reached storage, must still find it.
+	recovered := newPackStoreT(t, localStore)
+	data, err := recovered.Get(ctx, survivor)
+	if err != nil {
+		t.Fatalf("survivor lost after interrupted repack: %v", err)
+	}
+	if string(data) != "keep me" {
+		t.Errorf("got %q, want %q", data, "keep me")
+	}
+
+	// The superseded pack is a recoverable orphan; a later repack reclaims it.
+	if _, _, err := recovered.Repack(ctx, 0.3); err != nil {
+		t.Fatalf("cleanup repack: %v", err)
+	}
+	if _, err := recovered.Get(ctx, survivor); err != nil {
+		t.Errorf("survivor lost after cleanup repack: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Propagate pack catalog load errors from `Get`, `List`, `Repack`, and `Delete` instead of discarding them with `_ =`
- Distinguish a missing catalog from an unreadable one with an existence check, since backends expose no typed not-found error
- Make `Flush` merge the stored catalog before overwriting `index/packs`, or refuse to write it
- Reorder `Repack` to flush replacement packs before deleting the packs they supersede
- Restrict packing to content-addressed prefixes, so the mutable `index/latest` pointer is no longer bundled
- Correct the `AGENTS.md`, `docs/storage-model.md`, and `docs/spec.md` claims that a lost `index/packs` is rebuildable

## Why

`index/packs` is the only record of where a packed object lives, and packfiles carry no framing that would let it be rebuilt. Every `loadCatalogLocked` call site discarded its error, so a transient backend failure degraded silently into "there are no packed objects" — and snapshots, being small JSON blobs, are always packed.

`List("snapshot/")` therefore returned zero keys **with a nil error**, which `PruneManager.mark` reads as "nothing is reachable". Sweep then deletes the repository, and `Repack` — swallowing the same error — deletes every packfile as orphaned. Reproduced with a fault-injecting `ObjectStore` that fails `Get("index/packs")` exactly once.

`Flush` compounded it by writing the in-memory catalog back wholesale with no invariant that the stored copy had been merged in, so a run that failed its load replaced the full history with only its own entries.

Two smaller defects found in the same area: `Delete` on an unloaded catalog forwarded a packed key to the backend and reported success while the entry survived the next flush; and `index/latest` was admitted by the blanket `index/` prefix match despite the adjacent exclusions for other mutable keys.

No on-disk format change. Repositories with a previously packed `index/latest` stay readable.

Part of #287
Closes #288
Closes #290
Closes #291

## Verification

- `env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./pkg/store ./internal/engine .`
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./pkg/store/...`
- `npx markdownlint-cli2 AGENTS.md docs/storage-model.md docs/spec.md`

Nine new tests cover the catalog-failure paths, the flush invariant, the fresh-repository path, legacy packed `index/latest` reads, and an interrupted repack. Note: `TestCLI_Feature_CompletionRuntime_ProfileValues` in `./e2e` fails on `main` as well and is unrelated to this change.