### PR TITLE
fix(engine): abort prune when no snapshots are found but objects remain

### DIFF
--- a/internal/engine/prune.go
+++ b/internal/engine/prune.go
@@ -125,6 +125,25 @@ func (pm *PruneManager) mark(ctx context.Context, phase ui.Phase) (map[string]bo
 		return nil, err
 	}
 
+	// A repository holding objects but no listable snapshots would make the
+	// sweep below delete everything. That is never a legitimate state: it means
+	// the snapshot listing is incomplete, most often because an index could not
+	// be read. Refuse rather than act on it.
+	if len(snapRefs) == 0 {
+		orphan, err := pm.firstObject(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if orphan != "" {
+			return nil, fmt.Errorf(
+				"prune aborted: no snapshots found, but the repository still contains objects (e.g. %s). "+
+					"This usually means a repository index could not be read; "+
+					"re-run once the store is reachable, or run 'cloudstic check' to inspect the repository",
+				orphan,
+			)
+		}
+	}
+
 	phase.Log(fmt.Sprintf("Found %d unique snapshots", len(snapRefs)))
 
 	for ref := range snapRefs {
@@ -135,6 +154,22 @@ func (pm *PruneManager) mark(ctx context.Context, phase ui.Phase) (map[string]bo
 	}
 
 	return reachable, nil
+}
+
+// firstObject returns any one key under the sweepable prefixes, or "" when the
+// repository holds none. Errors are propagated: an unreadable listing must not
+// be mistaken for an empty repository.
+func (pm *PruneManager) firstObject(ctx context.Context) (string, error) {
+	for _, prefix := range objectPrefixes {
+		keys, err := pm.store.List(ctx, prefix)
+		if err != nil {
+			return "", fmt.Errorf("list %s: %w", prefix, err)
+		}
+		if len(keys) > 0 {
+			return keys[0], nil
+		}
+	}
+	return "", nil
 }
 
 func (pm *PruneManager) collectSnapshots(ctx context.Context, reachable map[string]bool) (map[string]bool, error) {

--- a/internal/engine/prune_guard_test.go
+++ b/internal/engine/prune_guard_test.go
@@ -1,0 +1,68 @@
+package engine
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cloudstic/cli/internal/ui"
+	"github.com/cloudstic/cli/pkg/store"
+)
+
+// hiddenSnapshotStore reports no snapshots while the rest of the repository is
+// intact, reproducing what an unreadable index looks like to the mark phase.
+type hiddenSnapshotStore struct {
+	store.ObjectStore
+}
+
+func (h *hiddenSnapshotStore) List(ctx context.Context, prefix string) ([]string, error) {
+	if strings.HasPrefix(prefix, "snapshot/") {
+		return nil, nil
+	}
+	return h.ObjectStore.List(ctx, prefix)
+}
+
+// Prune must never interpret "no snapshots" as "everything is garbage" while
+// the repository still holds objects.
+func TestPruneManager_AbortsWhenSnapshotsVanishButObjectsRemain(t *testing.T) {
+	ctx := context.Background()
+	mockStore := NewMockStore()
+
+	if err := mockStore.Put(ctx, "chunk/live", []byte("data")); err != nil {
+		t.Fatalf("put chunk: %v", err)
+	}
+	if err := mockStore.Put(ctx, "filemeta/live", []byte("{}")); err != nil {
+		t.Fatalf("put filemeta: %v", err)
+	}
+
+	metered := store.NewMeteredStore(&hiddenSnapshotStore{ObjectStore: mockStore})
+	pm := NewPruneManager(metered, ui.NewNoOpReporter())
+
+	result, err := pm.Run(ctx)
+	if err == nil {
+		t.Fatalf("prune succeeded and deleted %d objects; want an abort", result.ObjectsDeleted)
+	}
+	if !strings.Contains(err.Error(), "no snapshots found") {
+		t.Errorf("error should explain the abort, got: %v", err)
+	}
+
+	assertExists(t, ctx, mockStore, "chunk/live")
+	assertExists(t, ctx, mockStore, "filemeta/live")
+}
+
+// A genuinely empty repository is a legitimate state and must still prune.
+func TestPruneManager_EmptyRepositorySucceeds(t *testing.T) {
+	ctx := context.Background()
+	mockStore := NewMockStore()
+
+	metered := store.NewMeteredStore(mockStore)
+	pm := NewPruneManager(metered, ui.NewNoOpReporter())
+
+	result, err := pm.Run(ctx)
+	if err != nil {
+		t.Fatalf("prune on an empty repository: %v", err)
+	}
+	if result.ObjectsDeleted != 0 {
+		t.Errorf("expected 0 deletions, got %d", result.ObjectsDeleted)
+	}
+}


### PR DESCRIPTION
## Summary

- Abort `prune` when the mark phase finds zero snapshots while the repository still holds objects under the sweepable prefixes
- Add `firstObject`, which propagates listing errors rather than letting an unreadable listing pass as an empty repository
- Point the error at the likely cause (an unreadable index) instead of just reporting "no snapshots"

## Why

`PruneManager.mark` builds the reachable set from `List("snapshot/")`. When that returns nothing, `sweep` treats every `chunk/`, `content/`, `filemeta/`, `node/`, and `snapshot/` object as unreachable and deletes the entire repository.

An unreadable pack catalog produces exactly that empty list today; that specific cause is fixed in #293. But "mark found nothing, so delete everything" is a dangerous shape regardless of what makes a listing incomplete, so this guards the sweep directly rather than only fixing the one known trigger.

A genuinely empty repository still prunes normally.

Part of #287
Closes #289

## Verification

- `env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./internal/engine`
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./internal/engine/...`

Two new tests: one asserting `prune` aborts and deletes nothing when snapshots are unlistable but objects remain, one asserting an empty repository still succeeds. Verified independently of #293 — this branch is based on `main` and does not depend on it.