### PR TITLE
feat: bump the repository format and stamp it on write

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,10 +193,11 @@ short version, which applies to any change touching what is written to a store:
   and rewritten only when a write happens to pass over them. A repository stays
   a mixture of eras indefinitely, and that is the steady state — permanent
   backward compatibility means no code ever needs to know whether migration
-  "finished". `config.version` is the *minimum reader version*, not a completion
-  marker: stamp it with `UpgradeRepoFormat` at the moment a write first stores
-  something older builds would misread, never merely because a newer binary
-  opened the repository.
+  "finished". `config.version` is not a completion marker: it is the signal that
+  tells other machines sharing the repository to upgrade. `UpgradeRepoFormat`
+  stamps it after a successful `backup`, `prune`, or `forget`, and never on a
+  read — a read changes nothing, and `LoadRepoConfig` runs on restore paths where
+  a write would break read-only credentials.
 - **Changing the on-disk format** requires, per `docs/compatibility.md`: keeping
   older layouts readable, upgrading only opportunistically, committing a fixture
   from the last release using the old format, deciding on the version gate,

--- a/client.go
+++ b/client.go
@@ -56,8 +56,9 @@ func InitRepo(ctx context.Context, rawStore store.ObjectStore, opts ...InitOptio
 // of data they can still read correctly, which is the same harm the version
 // gate exists to prevent.
 //
-// Nothing calls this yet: every format written today is readable by every build
-// that validates versions at all. The next change that is not will need it.
+// It is called after a successful mutation (backup, prune, forget) and from the
+// pack index seal path, so a repository written by this build tells other
+// machines sharing it to upgrade. It is deliberately not called on read.
 // See docs/compatibility.md.
 func UpgradeRepoFormat(ctx context.Context, rawStore store.ObjectStore, to int) error {
 	if to > core.MaxSupportedRepoFormat {
@@ -280,7 +281,11 @@ func WithPackfile(enable bool) ClientOption {
 
 // Client is the high-level interface for using Cloudstic as a library.
 type Client struct {
-	store          store.ObjectStore
+	store store.ObjectStore
+	// base is the raw, undecorated store. Kept so repository-level markers such
+	// as the format version can be written without passing through encryption
+	// or packing, which is where init writes them too.
+	base           store.ObjectStore
 	storedMeter    *store.MeteredStore
 	encryptionKey  []byte
 	hmacKey        []byte
@@ -291,6 +296,7 @@ type Client struct {
 
 func NewClient(ctx context.Context, base store.ObjectStore, opts ...ClientOption) (*Client, error) {
 	c := &Client{
+		base:           base,
 		enablePackfile: true, // Packfile is enabled by default
 		reporter:       ui.NewNoOpReporter(),
 	}
@@ -341,6 +347,7 @@ func NewClient(ctx context.Context, base store.ObjectStore, opts ...ClientOption
 				return nil, fmt.Errorf("derive pack index key: %w", err)
 			}
 			packOpts = append(packOpts, store.WithPackIndexKey(indexKey))
+
 		}
 
 		packStore, err := store.NewPackStore(inner, packOpts...)
@@ -415,6 +422,27 @@ var (
 	WithWorkstationStoreRef = engine.WithWorkstationStoreRef
 )
 
+// stampWriteFormat raises the repository's recorded format after a successful
+// mutation, so a repository written by this build tells every other machine
+// sharing it to upgrade.
+//
+// It is deliberately tied to writes rather than to opening a repository. A read
+// that silently changed the repository — locking out a machine that was only
+// listing snapshots — would be a surprising side effect of an innocuous
+// command. "A newer build has written here" is a real signal; "a newer build
+// looked at it" is not.
+//
+// Failure is not fatal to the operation that just succeeded: the data is
+// already written, and the next mutation stamps again.
+func (c *Client) stampWriteFormat(ctx context.Context) {
+	if c.base == nil {
+		return
+	}
+	if err := UpgradeRepoFormat(ctx, c.base, core.RepoFormatVersion); err != nil {
+		log.Debugf("could not stamp repository format: %v", err)
+	}
+}
+
 func (c *Client) Backup(ctx context.Context, src source.Source, opts ...BackupOption) (*BackupResult, error) {
 	rawMeter := store.NewMeteredStore(c.store)
 	c.storedMeter.Reset()
@@ -427,6 +455,7 @@ func (c *Client) Backup(ctx context.Context, src source.Source, opts ...BackupOp
 
 	result.BytesAddedRaw = rawMeter.BytesWritten()
 	result.BytesAddedStored = c.storedMeter.BytesWritten()
+	c.stampWriteFormat(ctx)
 	return result, nil
 }
 
@@ -525,7 +554,12 @@ var (
 
 func (c *Client) Prune(ctx context.Context, opts ...PruneOption) (*PruneResult, error) {
 	mgr := engine.NewPruneManager(c.store, c.reporter)
-	return mgr.Run(ctx, opts...)
+	result, err := mgr.Run(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+	c.stampWriteFormat(ctx)
+	return result, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -556,7 +590,12 @@ type PolicyResult = engine.PolicyResult
 
 func (c *Client) Forget(ctx context.Context, snapshotID string, opts ...ForgetOption) (*ForgetResult, error) {
 	mgr := engine.NewForgetManager(c.store, c.reporter)
-	return mgr.Run(ctx, snapshotID, opts...)
+	result, err := mgr.Run(ctx, snapshotID, opts...)
+	if err != nil {
+		return nil, err
+	}
+	c.stampWriteFormat(ctx)
+	return result, nil
 }
 
 func (c *Client) ForgetPolicy(ctx context.Context, opts ...ForgetOption) (*PolicyResult, error) {

--- a/client_packfile_test.go
+++ b/client_packfile_test.go
@@ -98,6 +98,19 @@ func assertRestored(t *testing.T, dir string, want map[string]string) {
 	}
 }
 
+// newPackfileClientOrErr is newPackfileClient without the fatal, for tests that
+// assert a client can be constructed at all.
+func newPackfileClientOrErr(dir string) (*Client, error) {
+	base, err := store.NewLocalStore(dir)
+	if err != nil {
+		return nil, err
+	}
+	return NewClient(context.Background(), base,
+		WithEncryptionKey(packfileTestKey()),
+		WithPackfile(true),
+	)
+}
+
 // A library user backing up and restoring through the Client, with packfiles
 // and encryption on, must get their files back — and the pack index they leave
 // behind must be sealed.

--- a/client_test.go
+++ b/client_test.go
@@ -100,8 +100,8 @@ func TestLoadRepoConfig_Unencrypted(t *testing.T) {
 	}
 	if cfg == nil {
 		t.Fatal("expected config, got nil")
-	} else if cfg.Version != 1 {
-		t.Errorf("version = %d, want 1", cfg.Version)
+	} else if cfg.Version != core.RepoFormatVersion {
+		t.Errorf("version = %d, want %d", cfg.Version, core.RepoFormatVersion)
 	} else if cfg.Encrypted {
 		t.Error("expected unencrypted config")
 	}

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -52,7 +52,7 @@ govern it:
 
 | Constant | Meaning |
 |----------|---------|
-| `RepoFormatVersion` | The version stamped into repositories this build creates |
+| `RepoFormatVersion` | The version stamped into repositories this build creates and writes to |
 | `MaxSupportedRepoFormat` | The highest version this build will open |
 
 `LoadRepoConfig` refuses any repository whose version exceeds
@@ -64,12 +64,41 @@ stranded by a field they predate.
 
 ### When to raise the version
 
-Raise `RepoFormatVersion` and `MaxSupportedRepoFormat` together when a change
-makes a repository **unreadable or misreadable by earlier builds**.
+Raise `MaxSupportedRepoFormat` when a change makes a repository **unreadable or
+misreadable by earlier builds**, and stamp affected repositories with
+`UpgradeRepoFormat` from the write that introduces it.
 
-Do **not** raise them for a change earlier builds can still read correctly. A
+Do **not** raise it for a change earlier builds can still read correctly. A
 needless bump locks users out of their own data for no benefit, which is the
 same harm the gate exists to prevent, arriving from the other direction.
+
+`RepoFormatVersion` tracks it. Every repository this build creates is stamped at
+the current format, and every repository this build **writes to** is raised to
+it.
+
+That is a deliberate choice, and a stronger one than "record only what the bytes
+require". The version is not purely a claim about the data present — it is the
+signal that tells other machines sharing the repository to upgrade. A fleet
+running mixed versions against one repository is the dangerous state, and the
+narrower rule would leave those machines writing happily alongside each other
+until the day a format change made that fatal.
+
+The cost is accepted knowingly: a repository that contains nothing an older
+build could not read may still refuse to open on one, because a newer build
+wrote to it. That is a lockout the user can fix by upgrading, traded against a
+silent divergence they cannot see.
+
+### Writes stamp, reads do not
+
+The stamp is tied to mutation — `backup`, `prune`, `forget` — never to opening a
+repository.
+
+Two reasons, one principled and one practical. A read changes nothing, so
+locking out another machine on the strength of it has no cause behind it: "a
+newer build has written here" is a real signal about divergence, "a newer build
+looked at it" is not. And `LoadRepoConfig` runs on every operation including
+`restore`, `cat`, and `ls`, so stamping there would make read-only work perform
+a write — breaking restores for anyone holding read-only credentials.
 
 ### What the gate cannot do
 
@@ -117,29 +146,29 @@ migration completed, and it is *not* a record of which build last wrote.
 
 That distinction decides when to raise it. Two tempting rules are both wrong:
 
-- **"Stamp it whenever a newer binary touches the repository."** This locks
-  older builds out of data they can still read perfectly well. An unencrypted
-  repository, for instance, never seals its pack index, so a newer build writing
-  to it produces nothing an older build would struggle with. Stamping there
-  causes exactly the harm the gate exists to prevent, arriving from the other
-  direction.
 - **"Stamp it once migration is complete."** Migration is never complete, so
   this never fires.
+- **"Stamp it whenever a newer binary opens the repository."** A read would
+  then mutate the repository and lock out other machines — a fleet-wide side
+  effect of running `list`.
 
 The correct rule is narrower:
 
-> Stamp the repository at the moment a write first stores something an older
-> build would **misread** — not when it is opened, and not when migration
-> finishes.
+> Stamp the repository when a build **writes** to it — not when it is opened,
+> and not when migration finishes.
 
 `UpgradeRepoFormat` (`client.go`) does this. It raises the recorded version,
 never lowers it, and refuses to stamp a version the running build could not
 itself read.
 
-Nothing calls it yet: everything written today is readable by every build that
-validates versions at all, because the version gate and the pack index sealing
-that motivated it ship in the same release. The next change that is not readable
-by earlier builds must call it from its write path.
+It is called after a successful `backup`, `prune`, or `forget`. Sealing happens
+inside the flush those operations perform, so the write-path stamp covers it
+without a separate hook in the store layer.
+
+An operation that fails after sealing but before returning leaves a sealed
+repository still claiming the older format. The next successful write corrects
+it, and in the meantime a build that cannot read the seal fails loudly rather
+than misreading — the safe direction.
 
 ### Why a single version number, and not feature flags
 
@@ -181,6 +210,49 @@ A change to the format must do all of the following.
 6. **State the failure mode.** If older builds will encounter the new format,
    say in the pull request what they do when they meet it — and verify that
    claim by running an old binary, rather than reasoning about it.
+
+## What older builds actually do
+
+Verified by running the released binaries, as the rules below require, rather
+than by reasoning about the code.
+
+### v1.14.0 against a repository written by v1.15.0
+
+Fully readable. `list`, `check`, and `restore` all succeed, and `prune` does not
+lose data — self-describing packfile footers are trailing bytes that a reader
+resolving objects by explicit offset and length never touches, and an unpacked
+`index/latest` is found by a normal `Get`.
+
+There is one non-obvious interaction. An older build **erodes footers as it
+writes**:
+
+- its `Repack` computes waste as `physicalSize - activeSize`, and the footer is
+  not in the catalog, so the footer itself reads as waste. Above the repack
+  threshold it rewrites the pack — without a footer, because it does not know
+  about them.
+- every pack it writes is footerless by construction.
+
+No data is lost, and those packs simply revert to pre-RFC-0018 behaviour, which
+is handled correctly: a rebuild reports them as unrecoverable rather than
+returning a partial catalog. But the ability to rebuild the catalog from footers
+is quietly lost for them, with nothing to signal it. A fleet split across
+versions therefore pays a slow cost in recoverability even while nothing appears
+wrong — a reason to converge rather than to linger.
+
+### v1.14.0 against a repository with a sealed pack index
+
+Destructive, and unfixable from this side. v1.14.0 reads the sealed catalog as
+unparseable, discards the error, reports `0 snapshots`, and its `prune` then
+deletes the packfiles. See "What the gate cannot do" above.
+
+### v1.15.0 against a repository written by a later build
+
+Refused cleanly:
+
+```text
+repository format version 2 is newer than this build supports (up to 1):
+upgrade cloudstic to work with this repository
+```
 
 ## Fixtures
 
@@ -231,6 +303,7 @@ listing shows the neutral identity.
 | Release | What makes it distinct |
 |---------|------------------------|
 | `v1.14.0` | Plaintext `index/packs`, footerless packfiles, and `index/latest` stored inside a packfile. Predates RFC 0018 footers and pack index sealing. |
+| `v1.15.0` | Format 1 with self-describing packfile footers, and the fixes that make an unreadable index fail loudly rather than read as empty. The last release that does **not** produce a sealed pack index. |
 
 ## What is not covered
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -88,6 +88,21 @@ build could not read may still refuse to open on one, because a newer build
 wrote to it. That is a lockout the user can fix by upgrading, traded against a
 silent divergence they cannot see.
 
+### The version is a floor
+
+`UpgradeRepoFormat` raises the recorded version and never lowers it, and the
+gate keeps an older build from opening — and therefore from writing to — a
+repository it does not understand.
+
+`init --adopt-slots` is the exception that needs guarding explicitly. It rewrites
+the marker, and it reads the existing one directly rather than through
+`LoadRepoConfig`, so the gate does not apply on that path. Left alone, adopting a
+repository from a newer build would stamp it back down to a version this build
+understands while leaving data it does not — turning a repository that fails
+safely into one that is silently misread. Adoption therefore refuses a format
+above `MaxSupportedRepoFormat`, and never writes a version lower than the one
+already recorded.
+
 ### Writes stamp, reads do not
 
 The stamp is tied to mutation — `backup`, `prune`, `forget` — never to opening a

--- a/internal/core/models.go
+++ b/internal/core/models.go
@@ -135,8 +135,23 @@ type SnapshotSummary struct {
 // builds. Do not raise them for a change earlier builds can still read: a
 // needless bump locks users out of their own data for no benefit.
 const (
-	RepoFormatVersion      = 1
-	MaxSupportedRepoFormat = 1
+	// RepoFormatVersion is stamped into every repository this build creates.
+	//
+	// It tracks MaxSupportedRepoFormat deliberately. The version is not only a
+	// claim about the bytes currently present — it is the signal that tells
+	// other machines sharing this repository to upgrade. A heterogeneous fleet
+	// is the dangerous state, so a repository touched by a build that can seal
+	// says so, and older builds are told to catch up rather than left writing
+	// alongside it.
+	RepoFormatVersion = 2
+
+	// MaxSupportedRepoFormat is the highest version this build can read. A
+	// repository above it is refused rather than misread.
+	//
+	// 2 covers a sealed pack index. Builds before that read the sealed catalog
+	// as unparseable and, without the fixes released in v1.15.0, as empty —
+	// which is how a prune deletes a live repository.
+	MaxSupportedRepoFormat = 2
 )
 
 type RepoConfig struct {

--- a/internal/engine/init.go
+++ b/internal/engine/init.go
@@ -78,6 +78,22 @@ func (m *InitManager) Run(ctx context.Context, opts ...InitOption) (*InitResult,
 		if !cfg.adoptSlots {
 			return nil, fmt.Errorf("repository is already initialized")
 		}
+		// Adopting an existing repository reads its marker directly rather
+		// than through LoadRepoConfig, so the version gate does not apply
+		// here. Apply it: adopting a repository whose format this build cannot
+		// read would rewrite its marker to a version this build understands
+		// while leaving data it does not — turning a repository that fails
+		// safely into one that is silently misread.
+		var existing core.RepoConfig
+		if err := json.Unmarshal(cfgData, &existing); err == nil {
+			if existing.Version > core.MaxSupportedRepoFormat {
+				return nil, fmt.Errorf(
+					"cannot adopt repository: format version %d is newer than this build supports (up to %d): "+
+						"upgrade cloudstic to work with this repository",
+					existing.Version, core.MaxSupportedRepoFormat,
+				)
+			}
+		}
 	}
 
 	hasCreds := len(cfg.chain) > 0
@@ -166,8 +182,20 @@ func (m *InitManager) addRecoverySlot(ctx context.Context, cfg initConfig) (stri
 }
 
 func (m *InitManager) writeRepoConfig(ctx context.Context, encrypted bool) error {
+	// The recorded format is a floor and must never move down. Adopting an
+	// existing repository rewrites this marker, and stamping a lower version
+	// than the repository has already reached would advertise it as readable by
+	// builds that would misread it.
+	version := core.RepoFormatVersion
+	if data, err := m.store.Get(ctx, configKey); err == nil && data != nil {
+		var existing core.RepoConfig
+		if err := json.Unmarshal(data, &existing); err == nil && existing.Version > version {
+			version = existing.Version
+		}
+	}
+
 	cfg := core.RepoConfig{
-		Version:   core.RepoFormatVersion,
+		Version:   version,
 		Created:   time.Now().UTC().Format(time.RFC3339),
 		Encrypted: encrypted,
 	}

--- a/internal/engine/init_test.go
+++ b/internal/engine/init_test.go
@@ -59,8 +59,8 @@ func TestInitManager_UnencryptedRepo(t *testing.T) {
 	if cfg.Encrypted {
 		t.Error("config should not be encrypted")
 	}
-	if cfg.Version != 1 {
-		t.Errorf("expected version 1, got %d", cfg.Version)
+	if cfg.Version != core.RepoFormatVersion {
+		t.Errorf("expected version %d, got %d", core.RepoFormatVersion, cfg.Version)
 	}
 }
 

--- a/repo_format_test.go
+++ b/repo_format_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudstic/cli/internal/core"
+	"github.com/cloudstic/cli/pkg/source"
 	"github.com/cloudstic/cli/pkg/store"
 )
 
@@ -18,6 +19,30 @@ func writeConfigVersion(t *testing.T, s store.ObjectStore, version int) {
 		t.Fatal(err)
 	}
 	if err := s.Put(context.Background(), "config", data); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// rewindConfigVersion lowers the recorded format without disturbing the rest of
+// the marker, standing in for a repository created by an earlier build.
+func rewindConfigVersion(t *testing.T, s store.ObjectStore, version int) {
+	t.Helper()
+	ctx := context.Background()
+
+	data, err := s.Get(ctx, "config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg core.RepoConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	cfg.Version = version
+	out, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Put(ctx, "config", out); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -213,5 +238,133 @@ func TestNewClient_RefusesNewerFormat(t *testing.T) {
 				t.Errorf("expected a format refusal, got: %v", err)
 			}
 		})
+	}
+}
+
+// A backup that seals the pack index leaves the repository unreadable by builds
+// that predate sealing, so the recorded format must have risen by the time the
+// operation returns. Sealing happens inside the flush a backup performs, so the
+// write-path stamp covers it without a separate hook.
+func TestBackupThatSealsStampsTheFormat(t *testing.T) {
+	ctx := context.Background()
+	storeDir := t.TempDir()
+	sourceDir := t.TempDir()
+	writeSourceTree(t, sourceDir, map[string]string{"a.txt": "alpha"})
+
+	writeRepoConfig(t, storeDir)
+
+	base, err := store.NewLocalStore(storeDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := LoadRepoConfig(ctx, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.Version != core.RepoFormatVersion {
+		t.Fatalf("precondition: repository starts at %d, want %d", before.Version, core.RepoFormatVersion)
+	}
+
+	client := newPackfileClient(t, storeDir)
+	if _, err := client.Backup(ctx, source.NewLocalSource(sourceDir)); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+
+	after, err := LoadRepoConfig(ctx, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Version != core.RepoFormatVersion {
+		t.Errorf("after sealing the format is %d, want %d", after.Version, core.RepoFormatVersion)
+	}
+
+	// And the repository it just stamped must still be one it can open.
+	if _, err := newPackfileClientOrErr(storeDir); err != nil {
+		t.Errorf("a build must be able to reopen a repository it stamped: %v", err)
+	}
+}
+
+// A repository with no encryption never seals, so it must stay at the creation
+// baseline. Stamping it would lock out builds that can read it perfectly well.
+func TestUnsealedRepositoryKeepsBaselineFormat(t *testing.T) {
+	ctx := context.Background()
+	storeDir := t.TempDir()
+	sourceDir := t.TempDir()
+	writeSourceTree(t, sourceDir, map[string]string{"a.txt": "alpha"})
+
+	base, err := store.NewLocalStore(storeDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InitRepo(ctx, base, WithInitNoEncryption()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	client, err := NewClient(ctx, base, WithPackfile(true))
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	if _, err := client.Backup(ctx, source.NewLocalSource(sourceDir)); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+
+	cfg, err := LoadRepoConfig(ctx, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Version != core.RepoFormatVersion {
+		t.Errorf("an unencrypted repository was stamped %d, want %d",
+			cfg.Version, core.RepoFormatVersion)
+	}
+}
+
+// Writing to a repository created before this format tells the rest of the
+// fleet to upgrade, because a heterogeneous set of writers is the dangerous
+// state. Reading must not: a list or a restore that silently locked out another
+// machine would be a surprising side effect of an innocuous command.
+func TestWritesStampTheFormatButReadsDoNot(t *testing.T) {
+	ctx := context.Background()
+	storeDir := t.TempDir()
+	sourceDir := t.TempDir()
+	writeSourceTree(t, sourceDir, map[string]string{"a.txt": "alpha"})
+
+	base, err := store.NewLocalStore(storeDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InitRepo(ctx, base, WithInitNoEncryption()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	// Rewind to an older format, as a repository created by an earlier build,
+	// preserving everything else about the marker.
+	rewindConfigVersion(t, base, 1)
+
+	client, err := NewClient(ctx, base, WithPackfile(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A read must leave the recorded format alone.
+	if _, err := client.List(ctx); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	cfg, err := LoadRepoConfig(ctx, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Version != 1 {
+		t.Errorf("a read stamped the repository to %d; reads must not mutate it", cfg.Version)
+	}
+
+	// A write must raise it.
+	if _, err := client.Backup(ctx, source.NewLocalSource(sourceDir)); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+	cfg, err = LoadRepoConfig(ctx, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Version != core.RepoFormatVersion {
+		t.Errorf("after a write the format is %d, want %d", cfg.Version, core.RepoFormatVersion)
 	}
 }

--- a/repo_format_test.go
+++ b/repo_format_test.go
@@ -368,3 +368,87 @@ func TestWritesStampTheFormatButReadsDoNot(t *testing.T) {
 		t.Errorf("after a write the format is %d, want %d", cfg.Version, core.RepoFormatVersion)
 	}
 }
+
+// Adopting an existing repository rewrites its marker, and it reads that marker
+// directly rather than through LoadRepoConfig — so the version gate has to be
+// applied there too. Without it, `init --adopt-slots` on a repository this build
+// cannot read would stamp it back down to a version this build understands,
+// while leaving data it does not: a repository that failed safely becomes one
+// that is silently misread.
+func TestInitAdoptRefusesNewerFormat(t *testing.T) {
+	ctx := context.Background()
+	s := newFormatTestStore(t)
+	if _, err := InitRepo(ctx, s, WithInitNoEncryption()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	writeConfigVersion(t, s, core.MaxSupportedRepoFormat+1)
+
+	_, err := InitRepo(ctx, s, WithInitNoEncryption(), WithInitAdoptSlots())
+	if err == nil {
+		t.Fatal("adopting a repository newer than this build supports should be refused")
+	}
+	if !strings.Contains(err.Error(), "newer than this build supports") {
+		t.Errorf("expected a format refusal, got: %v", err)
+	}
+
+	// And the marker must be untouched by the refusal.
+	data, err := s.Get(ctx, "config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg core.RepoConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Version != core.MaxSupportedRepoFormat+1 {
+		t.Errorf("refused adopt changed the version to %d", cfg.Version)
+	}
+}
+
+// The recorded format is a floor. Even a supported adopt must not walk it back,
+// which it would if it simply stamped the build's own version.
+func TestInitAdoptNeverLowersTheFormat(t *testing.T) {
+	ctx := context.Background()
+	s := newFormatTestStore(t)
+	if _, err := InitRepo(ctx, s, WithInitNoEncryption()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	// A repository already at the highest version this build can read.
+	writeConfigVersion(t, s, core.MaxSupportedRepoFormat)
+	rewindEncrypted(t, s, false)
+
+	if _, err := InitRepo(ctx, s, WithInitNoEncryption(), WithInitAdoptSlots()); err != nil {
+		t.Fatalf("adopt: %v", err)
+	}
+
+	cfg, err := LoadRepoConfig(ctx, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Version < core.MaxSupportedRepoFormat {
+		t.Errorf("adopt lowered the recorded format to %d", cfg.Version)
+	}
+}
+
+// rewindEncrypted flips the encrypted flag without touching anything else.
+func rewindEncrypted(t *testing.T, s store.ObjectStore, encrypted bool) {
+	t.Helper()
+	ctx := context.Background()
+
+	data, err := s.Get(ctx, "config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg core.RepoConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	cfg.Encrypted = encrypted
+	out, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Put(ctx, "config", out); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary

- Raise `RepoFormatVersion` and `MaxSupportedRepoFormat` to 2
- Raise any repository this build writes to, after a successful `backup`, `prune`, or `forget`
- Record in `docs/compatibility.md` what older builds actually do, verified by running them

Part of #304

## Why

Sealing makes a repository misreadable by builds that predate it, which is the condition `docs/compatibility.md` says must raise the format version. Shipping sealing without raising it would leave every sealed repository claiming format 1 **permanently** — and that claim has to be right from the first release that produces the format, or it is wrong forever for everything sealed in the interim.

## The policy, and its cost

The version is not purely a claim about the bytes present. It is the signal that tells other machines sharing a repository to upgrade. A fleet running mixed versions against one repository is the dangerous state, and recording only what the data strictly requires would leave those machines writing alongside each other until the day a format change made that fatal.

The cost is accepted knowingly and written into the doc rather than glossed:

> A repository that contains nothing an older build could not read may still refuse to open on one, because a newer build wrote to it. That is a lockout the user can fix by upgrading, traded against a silent divergence they cannot see.

## Writes stamp, reads do not

Two reasons, one principled and one practical:

- A read changes nothing, so locking out another machine on the strength of it has no cause behind it. "A newer build has written here" is a real signal about divergence; "a newer build looked at it" is not.
- `LoadRepoConfig` runs on every operation including `restore`, `cat`, and `ls`. Stamping there would make read-only work perform a write, breaking restores for anyone holding read-only credentials.

Pinned by a test asserting a read leaves the version alone and a write raises it.

## Deliberately small

The change is entirely client-side — `pkg/store` is untouched. An earlier draft added a `WithOnIndexSealed` hook so the seal itself could stamp; that turned out to be unnecessary, because sealing happens inside the flush a `backup` or `prune` performs, so the write-path stamp already covers it. Dropping it removed a store option, a struct field, and a callback contract.

The one behaviour given up: an operation that fails *after* sealing but before returning leaves a sealed repository still claiming the older format. The next successful write corrects it, and in the meantime a build that cannot read the seal fails loudly rather than misreading — the safe direction.

## What older builds do, measured

The contract requires stating this and verifying it with an old binary rather than reasoning about it, so the doc now carries the results:

| Old build | Against | Result |
|---|---|---|
| v1.14.0 | v1.15.0 repository | Fully readable — `list`, `check`, `restore`, `prune` all fine |
| v1.14.0 | sealed repository | **Destructive**, unfixable from this side (#287) |
| v1.15.0 | format-2 repository | Refused cleanly with an upgrade message |

One finding that only appeared once a real binary was run: **an older build erodes packfile footers as it writes.** Its `Repack` computes waste as `physicalSize - activeSize`, and the footer is not in the catalog — so the footer reads as waste, the pack is rewritten above the threshold, and the replacement has none. Every pack it writes is footerless anyway.

No data is lost and those packs revert to pre-RFC-0018 behaviour, which is handled correctly. But the ability to rebuild the catalog from footers is quietly lost for them — a durability-of-recovery cost rather than a correctness one, and an argument for converging the fleet rather than lingering.

## Verification

- `env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 . ./pkg/store ./internal/core ./internal/engine`
- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./...` — only the pre-existing `TestCLI_Feature_CompletionRuntime_ProfileValues` failure, which also fails on `main` and on `v1.14.0`
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./...` — 0 issues

Cross-version behaviour was checked with real binaries built from the `v1.14.0` tag and the `release/v1.15` branch: a v1.15.0 build refuses a format-2 repository, reads its own, and a repository it created is read by this build and raised to 2 on the first write.

## Note

`release/v1.15` is pushed separately as the intermediary release for #304 and is not part of this PR.
