### PR TITLE
test(crypto): make the bad-checksum mnemonic test deterministic

### DIFF
--- a/pkg/crypto/mnemonic_test.go
+++ b/pkg/crypto/mnemonic_test.go
@@ -46,17 +46,24 @@ func TestMnemonicToKey_InvalidMnemonic(t *testing.T) {
 	}
 }
 
+// canonicalMnemonic is the BIP39 vector for 256 bits of zero entropy. Its last
+// word carries the checksum, so replacing that word alone yields a mnemonic
+// that is well-formed but fails validation.
+const (
+	canonicalMnemonic   = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art"
+	badChecksumMnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon"
+)
+
 func TestMnemonicToKey_BadChecksum(t *testing.T) {
-	mnemonic, _, _ := GenerateRecoveryMnemonic()
-	words := strings.Fields(mnemonic)
-	// Swap the last word to break the checksum.
-	if words[23] == "abandon" {
-		words[23] = "ability"
-	} else {
-		words[23] = "abandon"
+	// Both halves are asserted so the test cannot quietly become vacuous: if the
+	// baseline stopped being valid, a rejection of the corrupted one would prove
+	// nothing about checksums.
+	if _, err := MnemonicToKey(canonicalMnemonic); err != nil {
+		t.Fatalf("the canonical BIP39 vector should be valid: %v", err)
 	}
-	bad := strings.Join(words, " ")
-	if _, err := MnemonicToKey(bad); err == nil {
+
+	// The two differ only in the final, checksum-bearing word.
+	if _, err := MnemonicToKey(badChecksumMnemonic); err == nil {
 		t.Fatal("expected error for bad checksum")
 	}
 }


### PR DESCRIPTION
## Summary

- Replace the randomly generated mnemonic with the canonical BIP39 vector and a corrupted sibling differing only in the final, checksum-bearing word
- Assert both halves, so the test cannot become vacuous if the baseline ever stops being valid

Closes #309

## Why

The test generated a random 24-word mnemonic and swapped the last word, expecting the checksum to break. In a 24-word mnemonic that word carries the last 3 entropy bits plus an 8-bit checksum, so given the preceding entropy exactly 8 of the 2048 words are valid in that position. A fixed replacement lands on one about 1 time in 256, the mnemonic stays valid, and the test fails.

Measured on this repository:

```console
before: 8 failures in 3000 runs
after:  0 failures in 5000 runs
```

It had already taken down `Test (macos-latest)` and `Test (ubuntu-latest)` on an unrelated pull request (#308), where it passed on re-run — the usual way this kind of flake costs time without ever looking like a real defect.

## Verification

- `env GOCACHE=/tmp/cloudstic-gocache go test -count=5000 -run TestMnemonicToKey_BadChecksum ./pkg/crypto`
- `env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./pkg/crypto`
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./pkg/crypto/...`
