### PR TITLE
fix: honour --dry-run in forget, and stop previews from stamping the format

### DIFF
--- a/client.go
+++ b/client.go
@@ -558,7 +558,9 @@ func (c *Client) Prune(ctx context.Context, opts ...PruneOption) (*PruneResult, 
 	if err != nil {
 		return nil, err
 	}
-	c.stampWriteFormat(ctx)
+	if !result.DryRun {
+		c.stampWriteFormat(ctx)
+	}
 	return result, nil
 }
 
@@ -594,13 +596,22 @@ func (c *Client) Forget(ctx context.Context, snapshotID string, opts ...ForgetOp
 	if err != nil {
 		return nil, err
 	}
-	c.stampWriteFormat(ctx)
+	if !result.DryRun {
+		c.stampWriteFormat(ctx)
+	}
 	return result, nil
 }
 
 func (c *Client) ForgetPolicy(ctx context.Context, opts ...ForgetOption) (*PolicyResult, error) {
 	mgr := engine.NewForgetManager(c.store, c.reporter)
-	return mgr.RunPolicy(ctx, opts...)
+	result, err := mgr.RunPolicy(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+	if !result.DryRun {
+		c.stampWriteFormat(ctx)
+	}
+	return result, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/cloudstic/cmd_forget.go
+++ b/cmd/cloudstic/cmd_forget.go
@@ -160,6 +160,9 @@ func execForgetSingle(r *runner, ctx context.Context, a *forgetArgs) int {
 	if a.prune {
 		forgetOpts = append(forgetOpts, cloudstic.WithPrune())
 	}
+	if a.dryRun {
+		forgetOpts = append(forgetOpts, cloudstic.WithDryRun())
+	}
 	if a.verbose {
 		forgetOpts = append(forgetOpts, cloudstic.WithForgetVerbose())
 	}
@@ -174,7 +177,11 @@ func execForgetSingle(r *runner, ctx context.Context, a *forgetArgs) int {
 		})
 	}
 	_, _ = fmt.Fprintln(r.out)
-	_, _ = fmt.Fprintln(r.out, "Snapshot removed.")
+	if a.dryRun {
+		_, _ = fmt.Fprintln(r.out, "Would remove snapshot (dry run; nothing was changed).")
+	} else {
+		_, _ = fmt.Fprintln(r.out, "Snapshot removed.")
+	}
 	if result.Prune != nil {
 		printPruneStats(r.out, result.Prune)
 	}

--- a/internal/engine/forget.go
+++ b/internal/engine/forget.go
@@ -97,6 +97,11 @@ func WithFilterPath(path string) ForgetOption {
 // ForgetResult holds the outcome of a forget operation.
 type ForgetResult struct {
 	Prune *PruneResult // nil when prune was not requested
+
+	// DryRun reports that nothing was written. Callers need this to tell a
+	// preview from a real mutation — stamping the repository format after a
+	// dry run would make a read-only command lock other machines out.
+	DryRun bool
 }
 
 // ForgetManager removes a snapshot and its index pointers, optionally pruning
@@ -135,6 +140,14 @@ func (fm *ForgetManager) Run(ctx context.Context, snapshotID string, opts ...For
 		phase.Log(fmt.Sprintf("Forgetting %s", targetRef))
 	}
 
+	// A dry run resolves the snapshot so the caller learns what would go, and
+	// stops before touching anything. Deleting here regardless — which is what
+	// this did — turns a preview of a destructive command into the command.
+	if cfg.dryRun {
+		phase.Done()
+		return &ForgetResult{DryRun: true}, nil
+	}
+
 	if err := fm.store.Delete(ctx, targetRef); err != nil {
 		phase.Error()
 		return nil, fmt.Errorf("delete snapshot %s: %w", targetRef, err)
@@ -154,7 +167,7 @@ func (fm *ForgetManager) Run(ctx context.Context, snapshotID string, opts ...For
 		return nil, fmt.Errorf("flush store: %w", err)
 	}
 
-	result := &ForgetResult{}
+	result := &ForgetResult{DryRun: cfg.dryRun}
 	if cfg.prune {
 		pruneResult, err := fm.pruner.Run(ctx)
 		if err != nil {
@@ -230,6 +243,9 @@ type PolicyGroupResult struct {
 type PolicyResult struct {
 	Groups []PolicyGroupResult
 	Prune  *PruneResult
+
+	// DryRun reports that nothing was written. See ForgetResult.DryRun.
+	DryRun bool
 }
 
 // RunPolicy applies a retention policy to all snapshots and removes those not
@@ -274,7 +290,7 @@ func (fm *ForgetManager) RunPolicy(ctx context.Context, opts ...ForgetOption) (*
 	})
 
 	// Apply policy per group
-	result := &PolicyResult{}
+	result := &PolicyResult{DryRun: cfg.dryRun}
 	var toRemove []SnapshotEntry
 
 	for _, key := range keys {

--- a/internal/engine/forget_test.go
+++ b/internal/engine/forget_test.go
@@ -118,3 +118,36 @@ func TestForgetManager_RunPolicy_FilterOnlyAllowed(t *testing.T) {
 		t.Fatalf("expected 1 snapshot to be removed by filter-only policy, got %d", len(result.Groups[0].Remove))
 	}
 }
+
+// A dry run must resolve the snapshot and stop. Deleting anyway — which is what
+// this did — turns a preview of a destructive command into the command itself,
+// and the CLI even reported "Snapshot removed."
+func TestForgetManager_DryRunRemovesNothing(t *testing.T) {
+	ctx := context.Background()
+	s := NewMockStore()
+
+	snap := core.Snapshot{Seq: 1, Root: "node/1"}
+	snapRef := saveSnapshot(ctx, s, &snap)
+	_ = s.Put(ctx, "index/latest", createIndex(snapRef, 1))
+
+	fm := NewForgetManager(s, ui.NewNoOpReporter())
+	result, err := fm.Run(ctx, snapRef, WithDryRun())
+	if err != nil {
+		t.Fatalf("dry run: %v", err)
+	}
+	if !result.DryRun {
+		t.Error("the result should report that it was a dry run")
+	}
+
+	if exists, _ := s.Exists(ctx, snapRef); !exists {
+		t.Error("a dry run deleted the snapshot")
+	}
+
+	// And without the flag it really goes.
+	if _, err := fm.Run(ctx, snapRef); err != nil {
+		t.Fatalf("forget: %v", err)
+	}
+	if exists, _ := s.Exists(ctx, snapRef); exists {
+		t.Error("a real forget left the snapshot behind")
+	}
+}

--- a/repo_format_test.go
+++ b/repo_format_test.go
@@ -452,3 +452,96 @@ func rewindEncrypted(t *testing.T, s store.ObjectStore, encrypted bool) {
 		t.Fatal(err)
 	}
 }
+
+// A preview must not mutate. Stamping the format on a dry run would make a
+// read-only command lock other machines out of the repository — the exact harm
+// the "writes stamp, reads do not" rule exists to prevent, arriving through an
+// operation the user asked not to change anything.
+func TestDryRunsDoNotStampTheFormat(t *testing.T) {
+	ctx := context.Background()
+	storeDir := t.TempDir()
+	sourceDir := t.TempDir()
+	writeSourceTree(t, sourceDir, map[string]string{"a.txt": "alpha"})
+
+	base, err := store.NewLocalStore(storeDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InitRepo(ctx, base, WithInitNoEncryption()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	client, err := NewClient(ctx, base, WithPackfile(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Backup(ctx, source.NewLocalSource(sourceDir)); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+
+	// Rewind, as a repository written by an earlier build.
+	rewindConfigVersion(t, base, 1)
+
+	t.Run("prune", func(t *testing.T) {
+		if _, err := client.Prune(ctx, WithPruneDryRun()); err != nil {
+			t.Fatalf("prune dry run: %v", err)
+		}
+		assertFormatVersion(t, base, 1)
+	})
+
+	t.Run("forget", func(t *testing.T) {
+		if _, err := client.Forget(ctx, "latest", WithDryRun()); err != nil {
+			t.Fatalf("forget dry run: %v", err)
+		}
+		assertFormatVersion(t, base, 1)
+	})
+
+	// And a real mutation still stamps, so the guard is not simply disabling it.
+	t.Run("a real prune still stamps", func(t *testing.T) {
+		if _, err := client.Prune(ctx); err != nil {
+			t.Fatalf("prune: %v", err)
+		}
+		assertFormatVersion(t, base, core.RepoFormatVersion)
+	})
+}
+
+// ForgetPolicy mutates like Forget does, so it has to stamp like Forget does.
+// It was missed when the other write paths were wired up.
+func TestForgetPolicyStampsTheFormat(t *testing.T) {
+	ctx := context.Background()
+	storeDir := t.TempDir()
+	sourceDir := t.TempDir()
+	writeSourceTree(t, sourceDir, map[string]string{"a.txt": "alpha"})
+
+	base, err := store.NewLocalStore(storeDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InitRepo(ctx, base, WithInitNoEncryption()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	client, err := NewClient(ctx, base, WithPackfile(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Backup(ctx, source.NewLocalSource(sourceDir)); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+	rewindConfigVersion(t, base, 1)
+
+	if _, err := client.ForgetPolicy(ctx, WithKeepLast(1)); err != nil {
+		t.Fatalf("forget policy: %v", err)
+	}
+	assertFormatVersion(t, base, core.RepoFormatVersion)
+}
+
+func assertFormatVersion(t *testing.T, s store.ObjectStore, want int) {
+	t.Helper()
+	cfg, err := LoadRepoConfig(context.Background(), s)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.Version != want {
+		t.Errorf("recorded format is %d, want %d", cfg.Version, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Return early from `ForgetManager.Run` on a dry run, once the snapshot is resolved and before any write
- Pass `-dry-run` through from `execForgetSingle`, and report a preview rather than `Snapshot removed.`
- Expose `DryRun` on `ForgetResult` and `PolicyResult`, as `PruneResult` already did
- Gate format stamping on the result, so a dry run no longer mutates the repository
- Stamp on `ForgetPolicy`, which was missed when the other write paths were wired up

Closes #312

## The main bug

`cloudstic forget <snapshot> --dry-run` **deleted the snapshot**, and printed `Snapshot removed.` while doing it:

```console
$ cloudstic forget latest ... -dry-run -no-prompt
Snapshot removed.
$ cloudstic list ...
0 snapshots
```

Two independent faults, either of which alone would cause it:

1. `execForgetSingle` never passed the flag through. It is declared and honoured on the retention-policy path, but the single-snapshot path built its options without it.
2. `ForgetManager.Run` read `cfg.dryRun` into its result and never checked it — the delete, the catalog update, and the `index/latest` fixup all ran regardless. So even a library caller passing `WithDryRun()` lost the snapshot.

The retention path was unaffected: `RunPolicy` does check the flag.

This is pre-existing and unrelated to the recent format work — I found it while auditing which write paths stamp the repository version.

## The stamping bugs, which are mine

The format stamping added in #308 ran after `prune` and `forget` regardless of dry-run, so **`prune --dry-run` mutated the repository**, bumping its recorded format and potentially locking other machines out. Measured before the fix:

```console
$ # repository at format 1
$ cloudstic prune ... -dry-run
$ # recorded format: 2
```

That is exactly the harm the *"writes stamp, reads do not"* rule in `docs/compatibility.md` exists to prevent, reached through an operation the user explicitly asked not to change anything.

`ForgetPolicy` had the opposite problem: it mutates like `Forget` does but was never stamped at all.

## Verification

- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./...` — only the pre-existing `TestCLI_Feature_CompletionRuntime_ProfileValues` failure, which also fails on `main`
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./...` — 0 issues

Checked against a real binary before and after: a dry run leaves the snapshot and the format alone, a real forget removes it, and a real prune still stamps. `TestForgetManager_DryRunRemovesNothing` covers the engine, `TestDryRunsDoNotStampTheFormat` and `TestForgetPolicyStampsTheFormat` cover the client.
