### PR TITLE
fix: verify content hashes during restore

### DIFF
--- a/client.go
+++ b/client.go
@@ -489,9 +489,10 @@ type RestoreOption = engine.RestoreOption
 type RestoreResult = engine.RestoreResult
 
 var (
-	WithRestoreDryRun  = engine.WithRestoreDryRun
-	WithRestoreVerbose = engine.WithRestoreVerbose
-	WithRestorePath    = engine.WithRestorePath
+	WithRestoreDryRun   = engine.WithRestoreDryRun
+	WithRestoreVerbose  = engine.WithRestoreVerbose
+	WithRestorePath     = engine.WithRestorePath
+	WithRestoreNoVerify = engine.WithRestoreNoVerify
 )
 
 // Restore writes the snapshot's file tree as a ZIP archive to w.

--- a/cmd/cloudstic/cmd_restore.go
+++ b/cmd/cloudstic/cmd_restore.go
@@ -17,6 +17,7 @@ type restoreArgs struct {
 	format      string
 	dryRun      bool
 	pathFilter  string
+	noVerify    bool
 	snapshotRef string
 }
 
@@ -31,6 +32,7 @@ func declareRestoreArgs(g *globalFlags) (*restoreArgs, commandInput) {
 			boolFlag(&a.dryRun, "dry-run", false, "Show what would be restored without writing output"),
 			stringFlag(&a.pathFilter, "path", "", "Restore only the given file or subtree (e.g. Documents/report.pdf or Documents/)",
 				withPlaceholder("<path>")),
+			boolFlag(&a.noVerify, "no-verify", false, "Skip the content-hash check on each restored file (not recommended)"),
 		},
 		positionals: []positionalSpec{optionalPositional(&a.snapshotRef, "snapshot ID", "latest")},
 	}
@@ -106,6 +108,9 @@ func buildRestoreOpts(a *restoreArgs) []cloudstic.RestoreOption {
 	}
 	if a.pathFilter != "" {
 		restoreOpts = append(restoreOpts, engine.WithRestorePath(a.pathFilter))
+	}
+	if a.noVerify {
+		restoreOpts = append(restoreOpts, engine.WithRestoreNoVerify())
 	}
 	return restoreOpts
 }

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -851,8 +851,21 @@ cloudstic restore -dry-run
 | `-format` | auto | Restore format: `zip` or `dir` (auto-detected from `-output` when omitted) |
 | `-path` | | Restore only the given file or subtree. Use a trailing `/` to select an entire directory (e.g. `Documents/`). Without a trailing slash, the exact file path is matched (e.g. `Documents/report.pdf`). |
 | `-dry-run` | `false` | Show what would be restored without writing output |
+| `-no-verify` | `false` | Skip the content-hash check on each restored file (not recommended) |
 
 The snapshot ID is a positional argument (defaults to latest if omitted).
+
+**Integrity verification.** Every restored file is hashed as it is written and
+compared against the content hash recorded when the snapshot was taken. If they
+disagree — because an object was corrupted, truncated, or replaced in the
+storage backend — that file is reported as an error and **removed**, so a
+known-bad file is never left behind under its original name. The rest of the
+restore continues, and the command exits non-zero.
+
+`-no-verify` disables this. It exists as an escape hatch for the rare case where
+a snapshot records a hash that disagrees with its own content, so that the data
+can still be recovered; in ZIP mode a failed entry cannot be retracted from the
+archive, so treat an archive that reported errors as suspect.
 
 > **Locking:** `restore` always acquires a **shared lock** at the start of the run (including `-dry-run`). The lock is released when the command exits.
 

--- a/internal/engine/restore.go
+++ b/internal/engine/restore.go
@@ -3,6 +3,8 @@ package engine
 import (
 	"archive/zip"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -25,6 +27,7 @@ type restoreConfig struct {
 	dryRun     bool
 	verbose    bool
 	pathFilter string
+	noVerify   bool
 }
 
 type restorePlan struct {
@@ -43,6 +46,14 @@ func WithRestoreDryRun() RestoreOption {
 // WithRestoreVerbose logs each file/dir being written.
 func WithRestoreVerbose() RestoreOption {
 	return func(cfg *restoreConfig) { cfg.verbose = true }
+}
+
+// WithRestoreNoVerify skips the content-hash check that restore normally runs
+// over every file it writes. Verification is on by default; this exists as an
+// escape hatch for the case where a snapshot records a hash that disagrees with
+// its own content, so that the data can still be recovered.
+func WithRestoreNoVerify() RestoreOption {
+	return func(cfg *restoreConfig) { cfg.noVerify = true }
 }
 
 // WithRestorePath limits the restore to files matching the given path.
@@ -148,7 +159,7 @@ func (rm *RestoreManager) runWithWriter(ctx context.Context, plan restorePlan, w
 		}
 
 		if err := writer.WriteFile(rel, meta, func(out io.Writer) error {
-			return rm.writeFileContent(ctx, out, meta)
+			return rm.writeFileContent(ctx, out, meta, !plan.cfg.noVerify)
 		}); err != nil {
 			if err == errRestoreSkipped {
 				phase.Increment(1)
@@ -366,9 +377,14 @@ func (w *fsRestoreWriter) WriteFile(relPath string, meta core.FileMeta, writeCon
 	writeErr := writeContent(cw)
 	closeErr := f.Close()
 	if writeErr != nil {
+		// Never leave known-bad bytes behind under the user's own filename.
+		// This covers a failed content-hash check as well as a stream that
+		// died partway, which previously left a truncated file on disk.
+		_ = os.Remove(fullPath)
 		return writeErr
 	}
 	if closeErr != nil {
+		_ = os.Remove(fullPath)
 		return closeErr
 	}
 
@@ -475,7 +491,7 @@ func (cw *countingWriter) Write(p []byte) (int, error) {
 	return n, err
 }
 
-func (rm *RestoreManager) writeFileContent(ctx context.Context, w io.Writer, meta core.FileMeta) error {
+func (rm *RestoreManager) writeFileContent(ctx context.Context, w io.Writer, meta core.FileMeta, verify bool) error {
 	contentKey := meta.ContentRef
 	if contentKey == "" {
 		contentKey = meta.ContentHash
@@ -485,14 +501,34 @@ func (rm *RestoreManager) writeFileContent(ctx context.Context, w io.Writer, met
 	if err != nil {
 		return err
 	}
+
+	// Hash the reconstructed stream as it is written. meta.ContentHash is a
+	// SHA-256 over the whole plaintext for both storage paths — the chunked
+	// path accumulates it in Chunker.ProcessStream, the inline path computes it
+	// directly — so one digest of the output is directly comparable. Nothing
+	// below this line authenticates the bytes otherwise: an object replaced in
+	// the backing store is returned by the store stack without complaint.
+	hasher := sha256.New()
+	out := w
+	if verify {
+		out = io.MultiWriter(w, hasher)
+	}
+
 	for _, chunkRef := range content.Chunks {
-		if err := rm.writeChunk(ctx, w, chunkRef); err != nil {
+		if err := rm.writeChunk(ctx, out, chunkRef); err != nil {
 			return err
 		}
 	}
 	if len(content.DataInlineB64) > 0 {
-		if _, err := w.Write(content.DataInlineB64); err != nil {
+		if _, err := out.Write(content.DataInlineB64); err != nil {
 			return err
+		}
+	}
+
+	if verify {
+		got := hex.EncodeToString(hasher.Sum(nil))
+		if got != meta.ContentHash {
+			return fmt.Errorf("content hash mismatch: expected %s, got %s", meta.ContentHash, got)
 		}
 	}
 	return nil

--- a/internal/engine/restore_verify_test.go
+++ b/internal/engine/restore_verify_test.go
@@ -1,0 +1,195 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cloudstic/cli/internal/core"
+	"github.com/cloudstic/cli/internal/ui"
+	"github.com/cloudstic/cli/pkg/store"
+)
+
+// setupBackupForRestoreLarge backs up one file that is large enough to take the
+// chunked path (over inlineThreshold) but small enough to land in exactly one
+// chunk (under cdcMinSize * 2), so a test can replace that chunk wholesale.
+func setupBackupForRestoreLarge(t *testing.T) *MockStore {
+	t.Helper()
+	src := NewMockSource()
+	dest := NewMockStore()
+
+	content := bytes.Repeat([]byte("cloudstic restore integrity test payload\n"), 15000) // ~600 KiB
+	if len(content) <= 512*1024 {
+		t.Fatalf("test payload %d bytes is not above the inline threshold", len(content))
+	}
+	src.AddFile("big.txt", "id_big", content)
+
+	bkMgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil)
+	if _, err := bkMgr.Run(context.Background()); err != nil {
+		t.Fatalf("Backup setup failed: %v", err)
+	}
+	return dest
+}
+
+// tamperChunk replaces the single stored chunk object with attacker-chosen
+// bytes, simulating write access to the storage backend. It returns the key it
+// replaced so a test can assert it found one.
+func tamperChunk(t *testing.T, dest *MockStore, replacement []byte) string {
+	t.Helper()
+	dest.mu.Lock()
+	defer dest.mu.Unlock()
+	for key := range dest.Data {
+		if strings.HasPrefix(key, "chunk/") {
+			dest.Data[key] = replacement
+			return key
+		}
+	}
+	t.Fatalf("no chunk/ object found in store; test setup no longer produces chunks")
+	return ""
+}
+
+// A backend that can write to the repository can replace a chunk with
+// unencrypted plaintext of its choosing. EncryptedStore does not recognise it
+// as ciphertext, so GCM authentication never runs. The content hash is what
+// catches it.
+func TestRestore_RejectsTamperedChunk(t *testing.T) {
+	dest := setupBackupForRestoreLarge(t)
+	tamperChunk(t, dest, []byte("attacker controlled content"))
+
+	rsMgr := NewRestoreManager(store.NewCompressedStore(dest), ui.NewNoOpReporter())
+	outDir := filepath.Join(t.TempDir(), "restored")
+	writer, err := NewFSRestoreWriter(outDir)
+	if err != nil {
+		t.Fatalf("NewFSRestoreWriter failed: %v", err)
+	}
+
+	result, err := rsMgr.Run(context.Background(), writer, "")
+	if err != nil {
+		t.Fatalf("Run returned a hard error, expected a per-file error: %v", err)
+	}
+	if result.Errors == 0 {
+		t.Fatal("restore reported no errors after a chunk was replaced with attacker bytes")
+	}
+
+	// The corrupted file must not be left on disk under the user's filename.
+	got, err := os.ReadFile(filepath.Join(outDir, "big.txt"))
+	if err == nil {
+		t.Fatalf("corrupt file was left on disk with %d bytes", len(got))
+	}
+	if !os.IsNotExist(err) {
+		t.Fatalf("unexpected error stating restored file: %v", err)
+	}
+}
+
+// The escape hatch must still hand the bytes over, so that a snapshot with a
+// disagreeing hash never leaves a user unable to recover anything at all.
+func TestRestore_NoVerifyStillWritesTamperedChunk(t *testing.T) {
+	dest := setupBackupForRestoreLarge(t)
+	tamperChunk(t, dest, []byte("attacker controlled content"))
+
+	rsMgr := NewRestoreManager(store.NewCompressedStore(dest), ui.NewNoOpReporter())
+	outDir := filepath.Join(t.TempDir(), "restored")
+	writer, err := NewFSRestoreWriter(outDir)
+	if err != nil {
+		t.Fatalf("NewFSRestoreWriter failed: %v", err)
+	}
+
+	result, err := rsMgr.Run(context.Background(), writer, "", WithRestoreNoVerify())
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if result.Errors != 0 {
+		t.Fatalf("-no-verify should not report hash errors, got %d", result.Errors)
+	}
+	got, err := os.ReadFile(filepath.Join(outDir, "big.txt"))
+	if err != nil {
+		t.Fatalf("expected the file to be written with -no-verify: %v", err)
+	}
+	if string(got) != "attacker controlled content" {
+		t.Fatalf("unexpected content with -no-verify: %q", got)
+	}
+}
+
+// Verification must not fire on healthy data.
+func TestRestore_VerifiesCleanRestore(t *testing.T) {
+	dest := setupBackupForRestore(t)
+	rsMgr := NewRestoreManager(store.NewCompressedStore(dest), ui.NewNoOpReporter())
+
+	outDir := filepath.Join(t.TempDir(), "restored")
+	writer, err := NewFSRestoreWriter(outDir)
+	if err != nil {
+		t.Fatalf("NewFSRestoreWriter failed: %v", err)
+	}
+	result, err := rsMgr.Run(context.Background(), writer, "")
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if result.Errors != 0 {
+		t.Fatalf("clean restore reported %d verification errors", result.Errors)
+	}
+	b, err := os.ReadFile(filepath.Join(outDir, "restore_me.txt"))
+	if err != nil {
+		t.Fatalf("read restore_me.txt: %v", err)
+	}
+	if string(b) != "restore content" {
+		t.Fatalf("restore_me.txt content=%q", string(b))
+	}
+}
+
+// Inline (small) files bypass the chunker entirely; their hash is computed on a
+// different code path, so cover it separately.
+func TestRestore_VerifiesInlineContent(t *testing.T) {
+	dest := setupBackupForRestore(t)
+
+	// Only entries whose source reported a non-zero size take the inline path,
+	// so find the content object that actually carries an inline payload rather
+	// than assuming the first one does.
+	var contentKey string
+	var c core.Content
+	dest.mu.Lock()
+	for key, raw := range dest.Data {
+		if !strings.HasPrefix(key, "content/") {
+			continue
+		}
+		var candidate core.Content
+		if err := json.Unmarshal(raw, &candidate); err != nil {
+			continue
+		}
+		if len(candidate.DataInlineB64) > 0 {
+			contentKey, c = key, candidate
+			break
+		}
+	}
+	dest.mu.Unlock()
+	if contentKey == "" {
+		t.Fatal("no content/ object with an inline payload found in store")
+	}
+
+	c.DataInlineB64 = bytes.Repeat([]byte("X"), len(c.DataInlineB64))
+	tampered, err := json.Marshal(&c)
+	if err != nil {
+		t.Fatalf("marshal tampered content: %v", err)
+	}
+
+	dest.mu.Lock()
+	dest.Data[contentKey] = tampered
+	dest.mu.Unlock()
+
+	rsMgr := NewRestoreManager(store.NewCompressedStore(dest), ui.NewNoOpReporter())
+	outDir := filepath.Join(t.TempDir(), "restored")
+	writer, err := NewFSRestoreWriter(outDir)
+	if err != nil {
+		t.Fatalf("NewFSRestoreWriter failed: %v", err)
+	}
+	result, err := rsMgr.Run(context.Background(), writer, "")
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if result.Errors == 0 {
+		t.Fatal("restore reported no errors after inline content was tampered with")
+	}
+}


### PR DESCRIPTION
## Summary

- Hash the reconstructed stream while `writeFileContent` copies it, and compare against `meta.ContentHash` once the content is complete
- On mismatch, fail that file and remove the partial output — the run continues and exits non-zero
- Add `-no-verify` as an escape hatch for snapshots whose recorded hash disagrees with their own content
- Document both in `docs/user-guide.md`

Closes #322.
Part of #317.

## The problem

Restore wrote store bytes straight to the output file and never compared the result against `meta.ContentHash`. `writeChunk` (`internal/engine/restore.go:697`) was the whole write path, and there was no hash check anywhere on it.

Nothing else on that path authenticates the bytes. `EncryptedStore.Get` returns any payload it does not recognise as ciphertext verbatim (`pkg/store/encrypted.go:54`), and `crypto.IsEncrypted` is a single-byte test — so an attacker with write access to the storage backend bypasses GCM entirely by simply not encrypting. `check -read-data` would catch it; no normal restore runs it. That storage-layer hole is tracked separately in #320.

## Why this shape

`meta.ContentHash` is a SHA-256 over the whole plaintext for both storage paths — the chunked path accumulates it in `Chunker.ProcessStream`, the inline path computes it directly — so a single digest of the output is directly comparable with no special-casing, and costs essentially nothing since the bytes are already being copied.

**On mismatch: fail that file and remove the partial output.** Aborting the whole run is wrong for a disaster-recovery tool — one poisoned object must not block recovery of every other file — but leaving known-bad bytes on disk under the user's original filename is worse than leaving nothing.

Removing on error also fixes a smaller pre-existing problem: a stream that died partway previously left a truncated file behind.

**`-no-verify`** is the escape hatch. A false positive under the policy above costs the user a file they could otherwise have recovered, and a backup tool must never leave someone with no way to get their bytes out. The known false-positive risk is the Google Drive source, which populates `ContentHash` from the API's `sha256Checksum` (`pkg/source/gdrive.go:834`) rather than computing it locally — that value is a genuine SHA-256 and should agree, but it is supplied rather than derived.

## Limitations

`zipRestoreWriter` cannot retract an entry it has already streamed. The error is still reported and still exits non-zero, but the archive should be treated as suspect. Fixing that properly means buffering per entry; out of scope here.

## Compatibility

No on-disk format change and no version bump. `RepoFormatVersion` and `MaxSupportedRepoFormat` are untouched, so older builds are entirely unaffected — there is no new format for them to meet.

This is deliberately the part of #317 that ships alone and first: it is the **only** part that protects bytes already sitting in a repository. The framing work in #319 and #320 hardens future writes but cannot be made retroactive, because a v3-stamped repo will contain unframed v2 objects indefinitely under the "permanently partial" upgrade contract.

## Verification

New `internal/engine/restore_verify_test.go`:

- `TestRestore_RejectsTamperedChunk` — replaces a `chunk/<hash>` object with attacker-chosen plaintext; asserts the restore reports an error and leaves **no file** on disk
- `TestRestore_NoVerifyStillWritesTamperedChunk` — asserts the escape hatch still hands the bytes over
- `TestRestore_VerifiesCleanRestore` — asserts no false positives on healthy data
- `TestRestore_VerifiesInlineContent` — covers the inline path, whose hash is computed on a different code path from the chunked one

Commands run:

- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./internal/engine ./cmd/cloudstic .` passes
- `go test -race -count=1 ./...` passes. The two `TestCLI_Feature_CompletionRuntime_ProfileValues` e2e failures reproduce on a clean `main` and are unrelated to this change.
- `golangci-lint run` reports 0 issues

