### PR TITLE
fix(keychain): stop key add-recovery from silently invalidating a recovery key

### DIFF
--- a/client.go
+++ b/client.go
@@ -140,10 +140,24 @@ func ChangePassword(ctx context.Context, rawStore store.ObjectStore, kc keychain
 	return keychain.ChangePasswordSlot(ctx, rawStore, masterKey, newPassword)
 }
 
+// AddRecoveryKeyOptions controls which recovery slot AddRecoveryKey writes.
+type AddRecoveryKeyOptions struct {
+	// Label names the slot (object key keys/recovery-<label>). Empty means the
+	// default slot. Distinct labels let a repository hold several recovery keys,
+	// all of which stay valid.
+	Label string
+	// Replace permits overwriting an existing slot with the same label, which
+	// invalidates the mnemonic that slot was issued for.
+	Replace bool
+}
+
 // AddRecoveryKey generates a BIP39 recovery key for the repository,
 // authenticating with kc to obtain the master key.
 // Returns the 24-word mnemonic phrase.
-func AddRecoveryKey(ctx context.Context, rawStore store.ObjectStore, kc keychain.Chain) (string, error) {
+//
+// If a recovery slot with the requested label already exists and opts.Replace
+// is false, it returns a *keychain.SlotExistsError and writes nothing.
+func AddRecoveryKey(ctx context.Context, rawStore store.ObjectStore, kc keychain.Chain, opts AddRecoveryKeyOptions) (string, error) {
 	if err := requireEncryptedRepo(ctx, rawStore); err != nil {
 		return "", err
 	}
@@ -155,7 +169,7 @@ func AddRecoveryKey(ctx context.Context, rawStore store.ObjectStore, kc keychain
 	if err != nil {
 		return "", fmt.Errorf("unlock repository: %w", err)
 	}
-	return keychain.AddRecoverySlot(ctx, rawStore, masterKey)
+	return keychain.AddRecoverySlot(ctx, rawStore, masterKey, opts.Label, opts.Replace)
 }
 
 // LoadRepoConfig reads the repository marker from a raw (undecorated) store.

--- a/client_test.go
+++ b/client_test.go
@@ -180,7 +180,7 @@ func TestAddRecoveryKey(t *testing.T) {
 		t.Fatalf("InitRepo: %v", err)
 	}
 
-	mnemonic, err := AddRecoveryKey(ctx, s, keychain.Chain{keychain.WithPassword("test-pass")})
+	mnemonic, err := AddRecoveryKey(ctx, s, keychain.Chain{keychain.WithPassword("test-pass")}, AddRecoveryKeyOptions{})
 	if err != nil {
 		t.Fatalf("AddRecoveryKey: %v", err)
 	}
@@ -211,7 +211,7 @@ func TestAddRecoveryKey_WrongCredentials(t *testing.T) {
 	if _, err := InitRepo(ctx, s, WithInitCredentials(keychain.Chain{keychain.WithPassword("correct-pass")})); err != nil {
 		t.Fatalf("InitRepo: %v", err)
 	}
-	if _, err := AddRecoveryKey(ctx, s, keychain.Chain{keychain.WithPassword("wrong-pass")}); err == nil {
+	if _, err := AddRecoveryKey(ctx, s, keychain.Chain{keychain.WithPassword("wrong-pass")}, AddRecoveryKeyOptions{}); err == nil {
 		t.Error("expected error with wrong credentials")
 	}
 }

--- a/cmd/cloudstic/cmd_key.go
+++ b/cmd/cloudstic/cmd_key.go
@@ -9,6 +9,7 @@ import (
 
 	cloudstic "github.com/cloudstic/cli"
 	"github.com/cloudstic/cli/internal/ui"
+	"github.com/cloudstic/cli/pkg/keychain"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/moby/term"
 )
@@ -118,10 +119,17 @@ func runKeyPasswd(r *runner, ctx context.Context, a *keyPasswdArgs) int {
 
 type addRecoveryKeyArgs struct {
 	*globalFlags
+	label string
+	force bool
 }
 
 func declareAddRecoveryKeyArgs(g *globalFlags) (*addRecoveryKeyArgs, commandInput) {
-	return &addRecoveryKeyArgs{globalFlags: g}, commandInput{}
+	a := &addRecoveryKeyArgs{globalFlags: g}
+	return a, commandInput{flags: []flagSpec{
+		stringFlag(&a.label, "label", keychain.DefaultSlotLabel, "Label for the new recovery key slot",
+			withPlaceholder("<name>")),
+		boolFlag(&a.force, "force", false, "Replace an existing slot with the same label (invalidates its recovery key)"),
+	}}
 }
 
 func runAddRecoveryKey(r *runner, ctx context.Context, a *addRecoveryKeyArgs) int {
@@ -139,7 +147,15 @@ func runAddRecoveryKey(r *runner, ctx context.Context, a *addRecoveryKeyArgs) in
 		return r.fail("%v", err)
 	}
 
-	mnemonic, err := cloudstic.AddRecoveryKey(ctx, raw, kc)
+	mnemonic, err := cloudstic.AddRecoveryKey(ctx, raw, kc, cloudstic.AddRecoveryKeyOptions{
+		Label:   a.label,
+		Replace: a.force,
+	})
+	var exists *keychain.SlotExistsError
+	if errors.As(err, &exists) {
+		return r.fail("%v.\nReplacing it invalidates the recovery key it was issued for.\n"+
+			"Use -label <name> to add a second recovery key, or -force to replace this one.", err)
+	}
 	if err != nil {
 		return r.fail("Failed to create recovery key: %v", err)
 	}

--- a/cmd/cloudstic/testdata/scripts/key_add_recovery.txtar
+++ b/cmd/cloudstic/testdata/scripts/key_add_recovery.txtar
@@ -1,0 +1,32 @@
+# A recovery mnemonic is a last-resort credential: adding one must never
+# silently invalidate a mnemonic the user already wrote down.
+
+exec cloudstic init -store local:$WORK/repo -password hunter2 -no-prompt
+stderr 'Repository initialized \(encrypted: true\)'
+
+exec cloudstic key add-recovery -store local:$WORK/repo -password hunter2 -no-prompt
+stderr 'Recovery key slot has been added'
+
+# A second run with the same label refuses instead of overwriting.
+! exec cloudstic key add-recovery -store local:$WORK/repo -password hunter2 -no-prompt
+stderr 'already exists'
+stderr '-label'
+stderr '-force'
+
+# The existing slot is untouched.
+exec cloudstic key list -store local:$WORK/repo -no-prompt
+stdout 'recovery *. default'
+
+# A different label adds a second recovery key alongside the first.
+exec cloudstic key add-recovery -store local:$WORK/repo -password hunter2 -label offsite -no-prompt
+stderr 'Recovery key slot has been added'
+exec cloudstic key list -store local:$WORK/repo -no-prompt
+stdout 'recovery *. offsite'
+
+# -force replaces a slot deliberately.
+exec cloudstic key add-recovery -store local:$WORK/repo -password hunter2 -force -no-prompt
+stderr 'Recovery key slot has been added'
+
+# An invalid label is rejected before anything is written.
+! exec cloudstic key add-recovery -store local:$WORK/repo -password hunter2 -label 'bad/label' -no-prompt
+stderr 'invalid key slot label'

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -311,8 +311,14 @@ cloudstic init --encryption-password <pw> --recovery
 Or add a recovery key to an existing repository:
 
 ```
-cloudstic add-recovery-key --encryption-password <pw>
+cloudstic key add-recovery -password <pw>
 ```
+
+Recovery slots are addressed as `keys/recovery-<label>`, so a repository can
+hold several of them and every issued mnemonic stays valid. `key add-recovery`
+refuses to overwrite an existing slot, since that would silently invalidate the
+mnemonic the user wrote down; pass `-label <name>` to add another key, or
+`-force` to replace one.
 
 Open a repository using the recovery key:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1108,9 +1108,23 @@ cloudstic key add-recovery -password "my secret passphrase"
 
 # For KMS-managed repositories
 cloudstic key add-recovery -kms-key-arn arn:aws:kms:us-east-1:123:key/abc
+
+# A second, separately labelled recovery key — the first one keeps working
+cloudstic key add-recovery -label offsite
 ```
 
+| Flag | Description |
+|------|-------------|
+| `-label <name>` | Label for the new slot, stored as `keys/recovery-<label>` (default `default`) |
+| `-force` | Replace an existing slot with the same label |
+
 The recovery key is displayed once. Write it down immediately.
+
+A repository can hold several recovery slots, one per label, and every issued
+mnemonic keeps working until its slot is replaced. Because replacing a slot
+invalidates the mnemonic it was issued for — a loss you would only discover
+during an actual recovery — `key add-recovery` refuses to overwrite an existing
+slot. Use `-label` to add another key, or `-force` to replace one deliberately.
 
 > The legacy `add-recovery-key` command is still accepted but deprecated.
 

--- a/internal/engine/init.go
+++ b/internal/engine/init.go
@@ -174,7 +174,9 @@ func (m *InitManager) addRecoverySlot(ctx context.Context, cfg initConfig) (stri
 	if err != nil {
 		return "", fmt.Errorf("extract master key for recovery slot: %w", err)
 	}
-	mnemonic, err := keychain.AddRecoverySlot(ctx, m.store, masterKey)
+	// The repository is being created here, so there is no earlier mnemonic to
+	// invalidate: write the default slot unconditionally.
+	mnemonic, err := keychain.AddRecoverySlot(ctx, m.store, masterKey, keychain.DefaultSlotLabel, true)
 	if err != nil {
 		return "", fmt.Errorf("create recovery key: %w", err)
 	}

--- a/pkg/keychain/keychain.go
+++ b/pkg/keychain/keychain.go
@@ -17,8 +17,28 @@ func DeriveEncryptionKey(masterKey []byte) ([]byte, error) {
 }
 
 // AddRecoverySlot generates a recovery key, wraps the given master key with
-// it, stores the recovery slot, and returns the BIP39 24-word mnemonic.
-func AddRecoverySlot(ctx context.Context, s store.ObjectStore, masterKey []byte) (mnemonic string, err error) {
+// it, stores the recovery slot under the given label, and returns the BIP39
+// 24-word mnemonic.
+//
+// A recovery mnemonic is a last-resort credential, so an existing slot with the
+// same label is never replaced silently: overwriting it invalidates the
+// mnemonic the user wrote down. Callers must pass replace=true to do so
+// deliberately, or use a different label to add a second recovery key that
+// leaves the first one working.
+func AddRecoverySlot(ctx context.Context, s store.ObjectStore, masterKey []byte, label string, replace bool) (mnemonic string, err error) {
+	label, err = NormalizeSlotLabel(label)
+	if err != nil {
+		return "", err
+	}
+	if !replace {
+		exists, err := s.Exists(ctx, slotObjectKey(SlotTypeRecovery, label))
+		if err != nil {
+			return "", fmt.Errorf("check existing recovery key slot: %w", err)
+		}
+		if exists {
+			return "", &SlotExistsError{SlotType: SlotTypeRecovery, Label: label}
+		}
+	}
 	mnemonic, recoveryKey, err := crypto.GenerateRecoveryMnemonic()
 	if err != nil {
 		return "", err
@@ -27,6 +47,7 @@ func AddRecoverySlot(ctx context.Context, s store.ObjectStore, masterKey []byte)
 	if err != nil {
 		return "", err
 	}
+	slot.Label = label
 	if err := WriteKeySlot(ctx, s, slot); err != nil {
 		return "", err
 	}
@@ -117,9 +138,9 @@ func CreatePlatformSlot(masterKey, platformKey []byte) (KeySlot, error) {
 		return KeySlot{}, fmt.Errorf("wrap master key with platform key: %w", err)
 	}
 	return KeySlot{
-		SlotType:   "platform",
+		SlotType:   SlotTypePlatform,
 		WrappedKey: base64.StdEncoding.EncodeToString(wrapped),
-		Label:      "default",
+		Label:      DefaultSlotLabel,
 	}, nil
 }
 
@@ -135,9 +156,9 @@ func CreatePasswordSlot(masterKey []byte, password string) (KeySlot, error) {
 		return KeySlot{}, fmt.Errorf("wrap master key with password: %w", err)
 	}
 	return KeySlot{
-		SlotType:   "password",
+		SlotType:   SlotTypePassword,
 		WrappedKey: base64.StdEncoding.EncodeToString(wrapped),
-		Label:      "default",
+		Label:      DefaultSlotLabel,
 		KDFParams: &KDFParams{
 			Algorithm: "argon2id",
 			Salt:      base64.StdEncoding.EncodeToString(salt),
@@ -154,9 +175,9 @@ func CreateRecoverySlot(masterKey, recoveryKey []byte) (KeySlot, error) {
 		return KeySlot{}, fmt.Errorf("wrap master key with recovery key: %w", err)
 	}
 	return KeySlot{
-		SlotType:   "recovery",
+		SlotType:   SlotTypeRecovery,
 		WrappedKey: base64.StdEncoding.EncodeToString(wrapped),
-		Label:      "default",
+		Label:      DefaultSlotLabel,
 	}, nil
 }
 
@@ -298,7 +319,7 @@ func (c kmsClientCred) Wrap(ctx context.Context, masterKey []byte) (KeySlot, err
 	}
 	return KeySlot{
 		SlotType:   "kms-platform",
-		Label:      "default",
+		Label:      DefaultSlotLabel,
 		WrappedKey: base64.StdEncoding.EncodeToString(ciphertext),
 	}, nil
 }
@@ -349,7 +370,7 @@ func (c kmsARNCred) Wrap(ctx context.Context, masterKey []byte) (KeySlot, error)
 	}
 	return KeySlot{
 		SlotType:   "kms-platform",
-		Label:      "default",
+		Label:      DefaultSlotLabel,
 		WrappedKey: base64.StdEncoding.EncodeToString(ciphertext),
 	}, nil
 }

--- a/pkg/keychain/keyslot.go
+++ b/pkg/keychain/keyslot.go
@@ -9,6 +9,45 @@ import (
 	"github.com/cloudstic/cli/pkg/store"
 )
 
+// Slot types, as stored in KeySlot.SlotType.
+const (
+	SlotTypePlatform    = "platform"
+	SlotTypePassword    = "password"
+	SlotTypeRecovery    = "recovery"
+	SlotTypeKMSPlatform = "kms-platform"
+)
+
+// DefaultSlotLabel is the label used when a caller does not name a slot.
+const DefaultSlotLabel = "default"
+
+// SlotExistsError reports that a key slot already occupies the object key a
+// caller asked to write, and that overwriting it was not requested.
+type SlotExistsError struct {
+	SlotType string
+	Label    string
+}
+
+func (e *SlotExistsError) Error() string {
+	return fmt.Sprintf("a %s key slot labelled %q already exists", e.SlotType, e.Label)
+}
+
+// NormalizeSlotLabel validates a slot label and returns it, substituting
+// DefaultSlotLabel for the empty string. A label becomes part of the slot's
+// object key, so it may not be blank or contain separator characters.
+func NormalizeSlotLabel(label string) (string, error) {
+	label = strings.TrimSpace(label)
+	if label == "" {
+		return DefaultSlotLabel, nil
+	}
+	if strings.ContainsAny(label, "/\\ \t\r\n") {
+		return "", fmt.Errorf("invalid key slot label %q: must not contain whitespace or path separators", label)
+	}
+	if label == "." || label == ".." {
+		return "", fmt.Errorf("invalid key slot label %q", label)
+	}
+	return label, nil
+}
+
 // KeySlot is the JSON representation of an encryption key slot stored in B2.
 type KeySlot struct {
 	SlotType   string     `json:"slot_type"`

--- a/pkg/keychain/keyslot_test.go
+++ b/pkg/keychain/keyslot_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -270,7 +271,7 @@ func TestAddAndOpenRecoveryKey(t *testing.T) {
 		t.Fatalf("Resolve with platform key: %v", err)
 	}
 
-	mnemonic, err := AddRecoverySlot(context.Background(), inner, masterKey)
+	mnemonic, err := AddRecoverySlot(context.Background(), inner, masterKey, "", false)
 	if err != nil {
 		t.Fatalf("AddRecoverySlot: %v", err)
 	}
@@ -311,7 +312,7 @@ func TestOpenWithWrongRecoveryKey(t *testing.T) {
 
 	slots, _ := LoadKeySlots(context.Background(), inner)
 	mk, _ := (Chain{WithPlatformKey(platformKey)}).Resolve(context.Background(), slots)
-	_, _ = AddRecoverySlot(context.Background(), inner, mk)
+	_, _ = AddRecoverySlot(context.Background(), inner, mk, "", false)
 
 	slots, _ = LoadKeySlots(context.Background(), inner)
 
@@ -378,5 +379,118 @@ func TestHasKeySlots(t *testing.T) {
 	_, _ = initEncryptionKey(inner, key, "")
 	if !HasKeySlots(context.Background(), inner) {
 		t.Fatal("store should have key slots after init")
+	}
+}
+
+// setupRecoveryTestStore returns a store with a platform slot and its master key.
+func setupRecoveryTestStore(t *testing.T) (*mockStore, []byte) {
+	t.Helper()
+	inner := newMemStore()
+	platformKey, _ := crypto.GenerateKey()
+	if _, err := initEncryptionKey(inner, platformKey, ""); err != nil {
+		t.Fatal(err)
+	}
+	slots, _ := LoadKeySlots(context.Background(), inner)
+	masterKey, err := (Chain{WithPlatformKey(platformKey)}).Resolve(context.Background(), slots)
+	if err != nil {
+		t.Fatalf("Resolve with platform key: %v", err)
+	}
+	return inner, masterKey
+}
+
+func TestAddRecoverySlot_RefusesToOverwriteExistingSlot(t *testing.T) {
+	ctx := context.Background()
+	inner, masterKey := setupRecoveryTestStore(t)
+
+	first, err := AddRecoverySlot(ctx, inner, masterKey, "", false)
+	if err != nil {
+		t.Fatalf("AddRecoverySlot: %v", err)
+	}
+
+	_, err = AddRecoverySlot(ctx, inner, masterKey, "", false)
+	var exists *SlotExistsError
+	if !errors.As(err, &exists) {
+		t.Fatalf("expected *SlotExistsError, got %v", err)
+	}
+	if exists.Label != DefaultSlotLabel || exists.SlotType != SlotTypeRecovery {
+		t.Fatalf("unexpected error detail: %+v", exists)
+	}
+
+	// The first mnemonic must still open the repository.
+	slots, _ := LoadKeySlots(ctx, inner)
+	if _, err := (Chain{WithRecoveryKey(first)}).Resolve(ctx, slots); err != nil {
+		t.Fatalf("first mnemonic no longer resolves: %v", err)
+	}
+}
+
+func TestAddRecoverySlot_DistinctLabelsCoexist(t *testing.T) {
+	ctx := context.Background()
+	inner, masterKey := setupRecoveryTestStore(t)
+
+	first, err := AddRecoverySlot(ctx, inner, masterKey, "", false)
+	if err != nil {
+		t.Fatalf("AddRecoverySlot default: %v", err)
+	}
+	second, err := AddRecoverySlot(ctx, inner, masterKey, "offsite", false)
+	if err != nil {
+		t.Fatalf("AddRecoverySlot offsite: %v", err)
+	}
+	if first == second {
+		t.Fatal("expected two distinct mnemonics")
+	}
+
+	slots, _ := LoadKeySlots(ctx, inner)
+	for _, m := range []string{first, second} {
+		if _, err := (Chain{WithRecoveryKey(m)}).Resolve(ctx, slots); err != nil {
+			t.Fatalf("mnemonic does not resolve: %v", err)
+		}
+	}
+}
+
+func TestAddRecoverySlot_ReplaceInvalidatesPreviousMnemonic(t *testing.T) {
+	ctx := context.Background()
+	inner, masterKey := setupRecoveryTestStore(t)
+
+	first, err := AddRecoverySlot(ctx, inner, masterKey, "", false)
+	if err != nil {
+		t.Fatalf("AddRecoverySlot: %v", err)
+	}
+	second, err := AddRecoverySlot(ctx, inner, masterKey, "", true)
+	if err != nil {
+		t.Fatalf("AddRecoverySlot replace: %v", err)
+	}
+
+	slots, _ := LoadKeySlots(ctx, inner)
+	if _, err := (Chain{WithRecoveryKey(second)}).Resolve(ctx, slots); err != nil {
+		t.Fatalf("replacement mnemonic does not resolve: %v", err)
+	}
+	if _, err := (Chain{WithRecoveryKey(first)}).Resolve(ctx, slots); err == nil {
+		t.Fatal("expected the replaced mnemonic to stop resolving")
+	}
+}
+
+func TestAddRecoverySlot_RejectsInvalidLabel(t *testing.T) {
+	ctx := context.Background()
+	inner, masterKey := setupRecoveryTestStore(t)
+
+	for _, label := range []string{"../escape", "with space", "sub/dir", "."} {
+		if _, err := AddRecoverySlot(ctx, inner, masterKey, label, false); err == nil {
+			t.Fatalf("label %q: expected an error", label)
+		}
+	}
+	for key := range inner.data {
+		if strings.Contains(key, "escape") || strings.Contains(key, "dir") {
+			t.Fatalf("invalid label produced object key %q", key)
+		}
+	}
+}
+
+func TestNormalizeSlotLabel(t *testing.T) {
+	got, err := NormalizeSlotLabel("  ")
+	if err != nil || got != DefaultSlotLabel {
+		t.Fatalf("blank label: got %q, %v", got, err)
+	}
+	if got, err := NormalizeSlotLabel("offsite"); err != nil || got != "offsite" {
+		t.Fatalf("plain label: got %q, %v", got, err)
 	}
 }


### PR DESCRIPTION
## Summary

- Refuse to overwrite an existing recovery key slot: `keychain.AddRecoverySlot`
  now takes a label and an explicit `replace` flag and returns a typed
  `*SlotExistsError` instead of clobbering `keys/recovery-default`. Previously a
  second `cloudstic key add-recovery` silently invalidated the mnemonic the user
  had written down, discoverable only during an actual disaster recovery.
- Add `-label` to `key add-recovery` so a repository can hold several recovery
  slots that all keep working, and `-force` for a deliberate replacement. The
  refusal message names both.
- Validate slot labels (`NormalizeSlotLabel`) so they cannot be blank or contain
  path separators/whitespace and escape the `keys/` prefix; nothing is written
  when a label is rejected.
- Thread the choice through `Client.AddRecoveryKey` via `AddRecoveryKeyOptions`;
  `init` keeps writing the default slot unconditionally, since it is creating
  the repository and has no earlier mnemonic to invalidate.
- Name the slot types as constants and document the new behaviour in
  `docs/user-guide.md` and `docs/encryption.md`.

No repository format change: labelled slots already round-trip through the
existing `KeySlot.Label` field and `keys/<type>-<label>` object key, and older
builds read a `recovery-offsite` slot exactly like any other recovery slot.

Closes #315

## Verification

- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./... ` — passes except
  the pre-existing `TestCLI_Feature_CompletionRuntime_ProfileValues` failure in
  `./e2e`, confirmed to fail identically on the base commit.
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./cmd/cloudstic/... ./pkg/keychain/... . ./internal/engine/...`
- `npx markdownlint-cli2 docs/user-guide.md docs/encryption.md`

New coverage: four unit tests in `pkg/keychain` (refusal leaves the first
mnemonic valid, distinct labels coexist, `-force` replaces, invalid labels
write nothing) and an end-to-end
`cmd/cloudstic/testdata/scripts/key_add_recovery.txtar` driving the real
command against a local encrypted repository.