### PR TITLE
test(e2e): isolate completion runtime harness from the ambient PATH

### DIFF
--- a/e2e/feature_completion_runtime_test.go
+++ b/e2e/feature_completion_runtime_test.go
@@ -107,13 +107,28 @@ func newCompletionRuntime(t *testing.T) completionRuntime {
 	return completionRuntime{bin: bin, env: env}
 }
 
+// pathPrelude re-prepends the freshly built binary's directory to PATH from
+// inside the script. The generated completion scripts call the runtime query
+// helper as a bare `cloudstic`, so any cloudstic installed elsewhere on PATH
+// would answer instead of the build under test — and an older one silently
+// returns nothing for `__complete`. Shell startup files (notably macOS'
+// path_helper) reorder PATH, so setting it in the process environment alone is
+// not enough to guarantee the build under test wins.
+func (rt completionRuntime) pathPrelude(shell string) string {
+	dir := shellQuote(filepath.Dir(rt.bin))
+	if shell == "fish" {
+		return "set -gx PATH " + dir + " $PATH\n"
+	}
+	return "export PATH=" + dir + "${PATH:+:$PATH}\n"
+}
+
 func (rt completionRuntime) runBash(t *testing.T, words []string) string {
 	t.Helper()
 	var quoted []string
 	for _, word := range words {
 		quoted = append(quoted, shellQuote(word))
 	}
-	return runShell(t, "bash", rt.env, `
+	return runShell(t, "bash", rt.env, rt.pathPrelude("bash")+`
 completion_file="$(mktemp)"
 "`+rt.bin+`" completion bash > "$completion_file"
 source "$completion_file"
@@ -132,7 +147,7 @@ printf '%s\n' "${COMPREPLY[@]}"
 
 func (rt completionRuntime) runFish(t *testing.T, line string) string {
 	t.Helper()
-	return runShell(t, "fish", rt.env, `
+	return runShell(t, "fish", rt.env, rt.pathPrelude("fish")+`
 source ("`+rt.bin+`" completion fish | psub)
 complete --do-complete `+shellQuote(line)+`
 `)
@@ -182,7 +197,7 @@ compadd() {
 _cloudstic_store_prefixes
 `
 	}
-	return runShell(t, "zsh", append(append([]string{}, rt.env...), zshHomeEnv(t)...), `
+	return runShell(t, "zsh", append(append([]string{}, rt.env...), zshHomeEnv(t)...), rt.pathPrelude("zsh")+`
 autoload -Uz compinit
 compinit -i -d "$HOME/.zcompdump"
 source <("`+rt.bin+`" completion zsh)
@@ -221,7 +236,10 @@ func assertCompletionContains(t *testing.T, out string, values ...string) {
 
 func runShell(t *testing.T, shell string, env []string, script string) string {
 	t.Helper()
-	cmd := exec.Command(shell, "-lc", script)
+	// Deliberately not a login shell: startup files are user-specific (and on
+	// macOS path_helper rewrites PATH), which makes the harness depend on the
+	// developer's machine rather than on the build under test.
+	cmd := exec.Command(shell, "-c", script)
 	cmd.Env = env
 	out, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
## Summary

- Run the completion runtime scripts under a non-login shell (`-c` instead of `-lc`) so user startup files cannot influence a hermetic e2e test.
- Re-prepend the build-under-test's directory to `PATH` from inside each script (`pathPrelude`), so it wins over any startup file that still runs. Fish gets `set -gx`, which has no `export` builtin.

### Why

`TestCLI_Feature_CompletionRuntime_ProfileValues` failed on a clean checkout of `main` on macOS, in both the bash and zsh subtests, with an empty completion result.

The generated completion scripts were not at fault. The harness ran each script through a *login* shell; on macOS `/etc/profile` and `/etc/zprofile` invoke `path_helper`, which rebuilds `PATH` with the `/etc/paths` entries first and so demotes the temp bin dir the test prepends in `newCompletionRuntime`. The scripts generate themselves from an absolute binary path, but their `_cloudstic_query` helper invokes a bare `cloudstic` — which then resolved to whatever cloudstic happened to be installed on the developer's machine. An older release has no `__complete` subcommand and prints nothing, and the script's `2>/dev/null` swallowed the error.

That is why only `ProfileValues` failed: it is the sole scenario served by the runtime `__complete` query rather than by the static script text. Fish passed throughout because `fish -lc` does not get the `path_helper` reordering.

### Reviewer notes

- No assertion was weakened, skipped, or removed — the tests now genuinely exercise the build under test.
- Verified against the exact triggering condition: the stale `cloudstic 1.14.0` that caused the failure is still installed at `/opt/homebrew/bin` on the machine where these runs passed, so this is not a green result from a cleaned-up environment.
- Unrelated but worth knowing: `cloudstic 1.14.0`'s generated bash completion script has a real syntax error (`bash -n` fails at the nested `case` in `_cloudstic`), so `_cloudstic` never gets defined for anyone on that release. The current build's script is clean, so it is already fixed on `main`.

## Verification

- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./e2e -run TestCLI_Feature_CompletionRuntime_ -v` — all 4 tests x 3 shells (bash/zsh/fish) pass
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./e2e/...` — 0 issues