### PR TITLE
refactor(hamt): verify node hashes on load and bound recursive descent

### DIFF
--- a/internal/hamt/hamt.go
+++ b/internal/hamt/hamt.go
@@ -19,7 +19,21 @@ const (
 	maxLeafSize  = 32
 
 	nodePrefix = "node/"
+
+	// maxTreeDepth bounds every recursive descent. Routing consumes 5 bits per
+	// level out of a 32-bit prefix, so a well-formed tree cannot nest deeper
+	// than maxDepth internal levels plus its leaves. Going past it means the
+	// structure is not a tree: a child ref reaching back into its own ancestry
+	// would otherwise recurse until the stack runs out. Hash verification in
+	// NodeStore.load makes such a cycle hard to build, but this guard costs one
+	// comparison and turns a hang into an error.
+	maxTreeDepth = maxDepth + 2
 )
+
+// errTooDeep reports a descent past maxTreeDepth.
+func errTooDeep(depth int) error {
+	return fmt.Errorf("hamt node nesting exceeds %d levels at depth %d: tree is cyclic or corrupt", maxTreeDepth, depth)
+}
 
 // DiffEntry represents a single change between two trees.
 // OldValue is empty for additions; NewValue is empty for deletions.
@@ -88,7 +102,7 @@ func (t *Tree) Walk(ctx context.Context, root string, fn func(key, value string)
 	if root == "" {
 		return nil
 	}
-	return walk(ctx, t.nodes, child{ref: root}, fn)
+	return walk(ctx, t.nodes, child{ref: root}, 0, fn)
 }
 
 // Diff structurally compares two persisted trees and calls fn for every entry
@@ -107,7 +121,7 @@ func (t *Tree) NodeRefs(ctx context.Context, root string, fn func(ref string) er
 	if root == "" {
 		return nil
 	}
-	return nodeRefs(ctx, t.nodes, root, fn)
+	return nodeRefs(ctx, t.nodes, root, 0, fn)
 }
 
 // ---------------------------------------------------------------------------
@@ -194,7 +208,7 @@ func (tx *Txn) Walk(ctx context.Context, fn func(key, value string) error) error
 	if tx.root.isZero() {
 		return nil
 	}
-	return walk(ctx, tx.nodes, tx.root, fn)
+	return walk(ctx, tx.nodes, tx.root, 0, fn)
 }
 
 // DiffFrom compares a persisted tree against the working tree, reporting what
@@ -485,7 +499,7 @@ func lookup(ctx context.Context, ns *NodeStore, c child, routingKey, key string)
 	if err != nil {
 		return "", err
 	}
-	for level := 0; ; level++ {
+	for level := 0; level <= maxTreeDepth; level++ {
 		n, err := resolve(ctx, ns, c)
 		if err != nil {
 			return "", err
@@ -510,11 +524,12 @@ func lookup(ctx context.Context, ns *NodeStore, c child, routingKey, key string)
 		}
 		c = n.children[pos]
 	}
+	return "", errTooDeep(maxTreeDepth)
 }
 
 func lookupByKey(ctx context.Context, ns *NodeStore, root child, key string) (string, error) {
 	var found string
-	err := walk(ctx, ns, root, func(k, value string) error {
+	err := walk(ctx, ns, root, 0, func(k, value string) error {
 		if k == key {
 			found = value
 			return errFoundSentinel
@@ -527,7 +542,10 @@ func lookupByKey(ctx context.Context, ns *NodeStore, root child, key string) (st
 	return "", err
 }
 
-func walk(ctx context.Context, ns *NodeStore, c child, fn func(key, value string) error) error {
+func walk(ctx context.Context, ns *NodeStore, c child, depth int, fn func(key, value string) error) error {
+	if depth > maxTreeDepth {
+		return errTooDeep(depth)
+	}
 	n, err := resolve(ctx, ns, c)
 	if err != nil {
 		return err
@@ -541,14 +559,17 @@ func walk(ctx context.Context, ns *NodeStore, c child, fn func(key, value string
 		return nil
 	}
 	for _, cc := range n.children {
-		if err := walk(ctx, ns, cc, fn); err != nil {
+		if err := walk(ctx, ns, cc, depth+1, fn); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func nodeRefs(ctx context.Context, ns *NodeStore, ref string, fn func(string) error) error {
+func nodeRefs(ctx context.Context, ns *NodeStore, ref string, depth int, fn func(string) error) error {
+	if depth > maxTreeDepth {
+		return errTooDeep(depth)
+	}
 	if err := fn(ref); err != nil {
 		return err
 	}
@@ -560,7 +581,7 @@ func nodeRefs(ctx context.Context, ns *NodeStore, ref string, fn func(string) er
 		return nil
 	}
 	for _, cc := range n.children {
-		if err := nodeRefs(ctx, ns, cc.ref, fn); err != nil {
+		if err := nodeRefs(ctx, ns, cc.ref, depth+1, fn); err != nil {
 			return err
 		}
 	}
@@ -589,6 +610,9 @@ func diff(ctx context.Context, ns *NodeStore, c1, c2 child, fn func(DiffEntry) e
 }
 
 func diffNodes(ctx context.Context, ns *NodeStore, n1, n2 *node, level int, fn func(DiffEntry) error) error {
+	if level > maxTreeDepth {
+		return errTooDeep(level)
+	}
 	if n1.leaf && n2.leaf {
 		return diffLeaves(n1, n2, fn)
 	}
@@ -607,11 +631,11 @@ func diffNodes(ctx context.Context, ns *NodeStore, n1, n2 *node, level int, fn f
 		case c1 == nil && c2 == nil:
 			continue
 		case c1 == nil:
-			if err := collectAll(ctx, ns, c2, func(k, v string) error { return fn(DiffEntry{Key: k, NewValue: v}) }); err != nil {
+			if err := collectAll(ctx, ns, c2, level, func(k, v string) error { return fn(DiffEntry{Key: k, NewValue: v}) }); err != nil {
 				return err
 			}
 		case c2 == nil:
-			if err := collectAll(ctx, ns, c1, func(k, v string) error { return fn(DiffEntry{Key: k, OldValue: v}) }); err != nil {
+			if err := collectAll(ctx, ns, c1, level, func(k, v string) error { return fn(DiffEntry{Key: k, OldValue: v}) }); err != nil {
 				return err
 			}
 		default:
@@ -685,7 +709,10 @@ func diffLeaves(n1, n2 *node, fn func(DiffEntry) error) error {
 	return nil
 }
 
-func collectAll(ctx context.Context, ns *NodeStore, n *node, fn func(key, value string) error) error {
+func collectAll(ctx context.Context, ns *NodeStore, n *node, depth int, fn func(key, value string) error) error {
+	if depth > maxTreeDepth {
+		return errTooDeep(depth)
+	}
 	if n.leaf {
 		for _, e := range n.entries {
 			if err := fn(e.Key, e.Value); err != nil {
@@ -699,7 +726,7 @@ func collectAll(ctx context.Context, ns *NodeStore, n *node, fn func(key, value 
 		if err != nil {
 			return err
 		}
-		if err := collectAll(ctx, ns, child, fn); err != nil {
+		if err := collectAll(ctx, ns, child, depth+1, fn); err != nil {
 			return err
 		}
 	}

--- a/internal/hamt/hamt_test.go
+++ b/internal/hamt/hamt_test.go
@@ -691,9 +691,12 @@ func TestNodeCacheLRUEviction(t *testing.T) {
 	n := nodeCacheSize + 100
 	refs := make([]string, n)
 	for i := 0; i < n; i++ {
-		ref := fmt.Sprintf("node/test-%04d", i)
+		// Refs are content addresses, so they have to be computed, not made up:
+		// NodeStore verifies every node it loads against its own ref.
+		data := []byte(fmt.Sprintf(`{"type":"leaf","entries":[{"key":"k%d","filemeta":"v%d"}]}`, i, i))
+		ref := nodePrefix + core.ComputeHash(data)
 		refs[i] = ref
-		_ = persistent.inner.Put(ctx, ref, []byte(fmt.Sprintf(`{"type":"leaf","entries":[{"key":"k%d","filemeta":"v%d"}]}`, i, i)))
+		_ = persistent.inner.Put(ctx, ref, data)
 	}
 	persistent.reset()
 
@@ -751,5 +754,137 @@ func TestInternalNodeType(t *testing.T) {
 	}
 	if n.leaf {
 		t.Fatal("expected an internal node at the root once the leaf has split")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integrity
+// ---------------------------------------------------------------------------
+
+// A node ref is a content address, so a node that does not hash to the ref it
+// was fetched under is corrupt or substituted. Every reader must refuse it
+// rather than serve whatever it decoded.
+func TestLoadRejectsTamperedNode(t *testing.T) {
+	persistent := newInMemoryStore()
+	tree := NewTree(persistent)
+
+	root := ""
+	var err error
+	for i := 0; i < 60; i++ {
+		key := fmt.Sprintf("k%02d", i)
+		root, err = insertCommit(tree, root, routingKey("", key), key, "filemeta/v"+key)
+		if err != nil {
+			t.Fatalf("insert %d: %v", i, err)
+		}
+	}
+
+	// Pick a node that is actually reachable from the final root — the store
+	// also holds superseded nodes from the intermediate commits.
+	var victim string
+	if err := tree.NodeRefs(ctx, root, func(ref string) error {
+		if ref != root && victim == "" {
+			victim = ref
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("NodeRefs: %v", err)
+	}
+	if victim == "" {
+		t.Fatal("no non-root node to tamper with")
+	}
+
+	// Rewrite its contents in place, leaving the ref untouched — exactly what a
+	// compromised or bit-rotted backend would produce.
+	persistent.data[victim] = []byte(`{"type":"leaf","entries":[{"key":"evil","filemeta":"filemeta/attacker"}]}`)
+
+	// A fresh Tree, so the tampered node is re-read rather than served from the
+	// cache populated while building.
+	reader := NewTree(persistent)
+	err = reader.Walk(ctx, root, func(string, string) error { return nil })
+	if err == nil {
+		t.Fatal("Walk accepted a tampered node")
+	}
+	if !strings.Contains(err.Error(), "integrity check") {
+		t.Fatalf("expected an integrity error, got: %v", err)
+	}
+}
+
+// buildOverDeepChain writes a chain of internal nodes ending in a leaf, nested
+// deeper than routing can address. Every node is written under its true content
+// address, so this passes the integrity check and isolates the depth guard: it
+// is what a valid-looking but malformed tree looks like.
+func buildOverDeepChain(t *testing.T, s *inMemoryStore, depth int) string {
+	t.Helper()
+
+	put := func(hn *core.HAMTNode) string {
+		hash, data, err := core.ComputeJSONHash(hn)
+		if err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+		ref := nodePrefix + hash
+		if err := s.Put(ctx, ref, data); err != nil {
+			t.Fatalf("put: %v", err)
+		}
+		return ref
+	}
+
+	ref := put(&core.HAMTNode{
+		Type:    core.ObjectTypeLeaf,
+		Entries: []core.LeafEntry{{Key: "deep", PathKey: routingKey("", "deep"), Value: "filemeta/deep"}},
+	})
+	for i := 0; i < depth; i++ {
+		ref = put(&core.HAMTNode{Type: core.ObjectTypeInternal, Bitmap: 1, Children: []string{ref}})
+	}
+	return ref
+}
+
+func TestTraversalRefusesUnboundedNesting(t *testing.T) {
+	persistent := newInMemoryStore()
+	root := buildOverDeepChain(t, persistent, maxTreeDepth+3)
+	nodes := NewNodeStore(persistent)
+
+	t.Run("walk", func(t *testing.T) {
+		assertTooDeep(t, walk(ctx, nodes, child{ref: root}, 0, func(string, string) error { return nil }))
+	})
+	t.Run("nodeRefs", func(t *testing.T) {
+		assertTooDeep(t, nodeRefs(ctx, nodes, root, 0, func(string) error { return nil }))
+	})
+	t.Run("collectAll", func(t *testing.T) {
+		n, err := nodes.load(ctx, root)
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		assertTooDeep(t, collectAll(ctx, nodes, n, 0, func(string, string) error { return nil }))
+	})
+	t.Run("diffNodes", func(t *testing.T) {
+		n, err := nodes.load(ctx, root)
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		assertTooDeep(t, diffNodes(ctx, nodes, n, n, 0, func(DiffEntry) error { return nil }))
+	})
+
+	// Lookup is bounded independently, and more tightly: it consumes 5 routing
+	// bits per level, so a 32-bit prefix runs out at level 6 — before the depth
+	// guard is ever reached. "00000000" routes to bucket 0 at every level,
+	// following this chain as far as it can go.
+	t.Run("lookup", func(t *testing.T) {
+		_, err := lookup(ctx, nodes, child{ref: root}, "00000000", "deep")
+		if err == nil {
+			t.Fatal("expected Lookup to refuse an over-deep tree")
+		}
+		if !strings.Contains(err.Error(), "too deep") {
+			t.Fatalf("expected a depth error, got: %v", err)
+		}
+	})
+}
+
+func assertTooDeep(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected a depth-limit error, got nil")
+	}
+	if !strings.Contains(err.Error(), "cyclic or corrupt") {
+		t.Fatalf("expected a depth-limit error, got: %v", err)
 	}
 }

--- a/internal/hamt/nodestore.go
+++ b/internal/hamt/nodestore.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	lru "github.com/hashicorp/golang-lru/v2"
 	"golang.org/x/sync/errgroup"
@@ -16,8 +17,8 @@ import (
 var log = logger.New("hamt", logger.ColorCyan)
 
 const (
-	nodeCacheSize        = 4096
-	defaultWriteWorkers  = 20
+	nodeCacheSize       = 4096
+	defaultWriteWorkers = 20
 )
 
 // NodeStore is the only part of this package that knows HAMT nodes are bytes.
@@ -49,6 +50,9 @@ func (ns *NodeStore) load(ctx context.Context, ref string) (*node, error) {
 	}
 	data, err := ns.store.Get(ctx, ref)
 	if err != nil {
+		return nil, err
+	}
+	if err := verifyNodeRef(ref, data); err != nil {
 		return nil, err
 	}
 	var hn core.HAMTNode
@@ -97,4 +101,22 @@ func (ns *NodeStore) putAll(ctx context.Context, batch map[string][]byte) error 
 		})
 	}
 	return g.Wait()
+}
+
+// verifyNodeRef checks that data is what ref names.
+//
+// A node ref is its own checksum: "node/" + SHA-256 of the bytes written under
+// it. Checking it on the way in means every consumer of the tree — restore,
+// ls, diff, prune, check — detects a corrupted or substituted node, not just
+// `check -read-data`. It also closes the recursion hole: a node cannot claim a
+// child that hashes to one of its own ancestors without failing this check.
+func verifyNodeRef(ref string, data []byte) error {
+	want, ok := strings.CutPrefix(ref, nodePrefix)
+	if !ok {
+		return fmt.Errorf("node ref %q is missing the %q prefix", ref, nodePrefix)
+	}
+	if got := core.ComputeHash(data); got != want {
+		return fmt.Errorf("node %s failed its integrity check: %d bytes hashing to %s", ref, len(data), got)
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

- **Verify every node on load.** A node ref is its own checksum — `node/` + SHA-256 of the bytes stored under it — but nothing checked that on the way in, so a corrupted or substituted node was decoded and served as genuine. `NodeStore.load` now verifies it, which means `restore`, `ls`, `diff`, `prune` and `check` all detect corruption, not just `check -read-data`.
- **Bound every recursive descent.** `walk`, `nodeRefs`, `collectAll` and `diffNodes` now carry a depth and refuse to go past `maxTreeDepth`. Routing consumes 5 bits per level out of a 32-bit prefix, so a well-formed tree cannot nest that deep; exceeding it means the structure is not a tree, and what was an unbounded recursion is now an error.
- `Lookup` was already bounded more tightly — it runs out of routing bits at level 6 — and now states that explicitly rather than relying on it.

Verification is the primary fix and the depth guard is belt-and-braces: a node cannot name a child that hashes back into its own ancestry without failing the hash check first.

Completes #324, after #325 and #327.

## Compatibility

This is the part worth scrutiny, since it adds a check to a read path that legacy repositories go through. Legacy node refs are hashes of the stored bytes, so verifying them costs old repositories nothing — and that is verified, not assumed. Both committed baselines pass every subtest:

```
--- PASS: TestCLI_Feature_ReadsLegacyRepositories/legacy-repo-v1.14.0  (list, check, restore, backup_onto_it)
--- PASS: TestCLI_Feature_ReadsLegacyRepositories/legacy-repo-v1.15.0  (list, check, restore, backup_onto_it)
```

Verification is deliberately against the **raw stored bytes**, not a re-marshalled node. Re-marshalling would be fragile if any older encoder produced different whitespace or field ordering; hashing what was actually stored is what the ref has always meant.

No format change: `core.RepoFormatVersion` and `core.MaxSupportedRepoFormat` are untouched, and root hashes are unchanged (`TestRootHashGolden` still matches the golden generated from the pre-refactor implementation).

## New tests

- `TestLoadRejectsTamperedNode` — rewrites a reachable node's contents in place, leaving its ref intact, and asserts `Walk` refuses it. It tampers with a node reached via `NodeRefs` rather than an arbitrary node in the store, since the store also holds superseded nodes from earlier commits.
- `TestTraversalRefusesUnboundedNesting` — builds a chain nested deeper than routing can address, with **every node written under its true content address**, so it passes the integrity check and isolates the depth guard. Subtests cover `walk`, `nodeRefs`, `collectAll`, `diffNodes` and `lookup`.

## Verification

- `env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./...` — all packages pass
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./internal/hamt/... ./internal/engine/...` — 0 issues