### PR TITLE
fix(store): frame the compressed encoding instead of sniffing magic bytes

### DIFF
--- a/client.go
+++ b/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sync/atomic"
 
 	"github.com/cloudstic/cli/internal/core"
 	"github.com/cloudstic/cli/internal/engine"
@@ -56,16 +57,14 @@ func InitRepo(ctx context.Context, rawStore store.ObjectStore, opts ...InitOptio
 // of data they can still read correctly, which is the same harm the version
 // gate exists to prevent.
 //
-// It is called after a successful mutation (backup, prune, forget), so a
-// repository written by this build tells other machines sharing it to upgrade.
-// It is deliberately not called on read.
-//
-// Because the stamp lands *after* the mutation, and its failure is not fatal, a
-// write cannot rely on it having happened. A change whose output an older build
-// would misread must therefore gate itself on the format already recorded
-// rather than on the stamp this call will attempt — see
-// core.FramedCompressionFormat for the case that motivates this.
-// See docs/compatibility.md.
+// A mutation calls it — never a read — so a repository written by this build
+// tells other machines sharing it to upgrade. When it stamps relative to the
+// write depends on the mutation: prune and forget stamp afterwards (best-effort,
+// via Client.stampWriteFormat), because what they write is decoded correctly at
+// either format; backup stamps beforehand (fatal, via Client.raiseRepoFormat),
+// because it writes content whose encoding an older build would misread and
+// which cannot be rewritten once stored. See core.FramedCompressionFormat and
+// docs/compatibility.md.
 func UpgradeRepoFormat(ctx context.Context, rawStore store.ObjectStore, to int) error {
 	if to > core.MaxSupportedRepoFormat {
 		return fmt.Errorf(
@@ -306,9 +305,11 @@ type Client struct {
 	// as the format version can be written without passing through encryption
 	// or packing, which is where init writes them too.
 	base store.ObjectStore
-	// compressed is the outermost wrapper, held by concrete type so a mutation
-	// can turn framed writes on once it has raised the repository format.
-	compressed     *store.CompressedStore
+	// repoFormat is the in-process view of the on-disk format version, and the
+	// single source of truth for format-dependent write policy. The compression
+	// layer's frame gate reads it, and raiseRepoFormat is its only writer, so
+	// framing cannot disagree with the format a mutation has stamped.
+	repoFormat     atomic.Int64
 	storedMeter    *store.MeteredStore
 	encryptionKey  []byte
 	hmacKey        []byte
@@ -386,15 +387,24 @@ func NewClient(ctx context.Context, base store.ObjectStore, opts ...ClientOption
 		inner = store.NewEncryptedStore(storedMeter, c.encryptionKey)
 	}
 
-	// Frame compressed objects only once the repository records a format whose
-	// readers understand the frame. A repository below that version is raised by
-	// prepareFramedWrites before a mutation writes anything, so this is the
-	// starting state rather than the final one. See core.FramedCompressionFormat.
-	framed := cfg != nil && cfg.Version >= core.FramedCompressionFormat
-	c.compressed = store.NewCompressedStore(inner, store.WithFramedWrites(framed))
-	c.store = c.compressed
+	// Seed the in-process format from disk, then let the compression layer read
+	// it through the gate. Framing is thus derived from the format, not a
+	// separate switch: a mutation raises the format (raiseRepoFormat) and every
+	// subsequent write frames, with nothing to keep in sync. A repository below
+	// core.FramedCompressionFormat starts unframed and is raised before its
+	// first framed write.
+	if cfg != nil {
+		c.repoFormat.Store(int64(cfg.Version))
+	}
+	c.store = store.NewCompressedStore(inner, store.WithFrameGate(c.framingEnabled))
 	c.storedMeter = storedMeter
 	return c, nil
+}
+
+// framingEnabled reports whether writes should be framed at the repository's
+// current recorded format. It is the gate the compression layer consults.
+func (c *Client) framingEnabled() bool {
+	return c.repoFormat.Load() >= core.FramedCompressionFormat
 }
 
 // resolveKeyFromConfig uses the Keychain to resolve the master key and derive
@@ -451,66 +461,57 @@ var (
 	WithWorkstationStoreRef = engine.WithWorkstationStoreRef
 )
 
-// stampWriteFormat raises the repository's recorded format after a successful
-// mutation, so a repository written by this build tells every other machine
-// sharing it to upgrade.
+// raiseRepoFormat stamps the on-disk format and updates the in-process view in
+// lockstep, so format-dependent write policy — framing — follows immediately.
+// It is the only writer of c.repoFormat.
 //
-// It is deliberately tied to writes rather than to opening a repository. A read
-// that silently changed the repository — locking out a machine that was only
-// listing snapshots — would be a surprising side effect of an innocuous
-// command. "A newer build has written here" is a real signal; "a newer build
-// looked at it" is not.
-//
-// Failure is not fatal to the operation that just succeeded: the data is
-// already written, and the next mutation stamps again.
-//
-// It remains the right shape for prune and forget, which is why they still use
-// it. What they write through the compression layer is JSON — snapshot and
-// index manifests — which always compresses, so an unframed one is decoded
-// correctly by the legacy read path and nothing is lost by stamping afterwards.
-// Backup is the exception, and uses prepareFramedWrites instead: it stores user
-// file content, which may be incompressible and may carry a magic header, and
-// that is the combination the frame exists for.
-func (c *Client) stampWriteFormat(ctx context.Context) {
+// Raising is a write, so it obeys the "writes stamp, reads do not" rule: a read
+// that silently changed the repository would be a surprising side effect of an
+// innocuous command, and would lock out a machine that was only listing
+// snapshots. A newer build having *written* here is a real signal; a newer
+// build having *looked* is not.
+func (c *Client) raiseRepoFormat(ctx context.Context) error {
 	if c.base == nil {
-		return
+		return nil
 	}
 	if err := UpgradeRepoFormat(ctx, c.base, core.RepoFormatVersion); err != nil {
+		return err
+	}
+	c.repoFormat.Store(int64(core.RepoFormatVersion))
+	return nil
+}
+
+// stampWriteFormat raises the format after a successful mutation, best-effort:
+// the data is already written and the next mutation stamps again, so a failure
+// is logged rather than surfaced.
+//
+// This is right for prune and forget. What they write through the compression
+// layer is JSON — snapshot and index manifests — which always compresses, so an
+// unframed one is decoded correctly by the legacy read path and nothing is lost
+// by stamping afterwards. Backup is the exception: it stamps *before* writing
+// (see its comment), because it stores user file content, the one thing an
+// unframed write corrupts permanently.
+func (c *Client) stampWriteFormat(ctx context.Context) {
+	if err := c.raiseRepoFormat(ctx); err != nil {
 		log.Debugf("could not stamp repository format: %v", err)
 	}
 }
 
-// prepareFramedWrites raises the repository format and turns on framed writes,
-// before the caller writes anything.
-//
-// Framing has to be established up front rather than stamped afterwards. An
-// object this build writes unframed is unframed permanently: content-addressed
-// objects are never rewritten, so a later framed backup skips them on the
-// Exists check and the mistake is not repaired by anything. Stamping after the
-// write would mean every repository below the framing format loses its
-// already-compressed files on the *first* backup after upgrading — precisely
-// the corruption the frame exists to prevent, applied once to every existing
-// user.
-//
-// Unlike stampWriteFormat, a failure here is fatal to the operation. The whole
-// point is that nothing is written until the format is raised; continuing on
-// error would write the unframed objects this exists to avoid.
-func (c *Client) prepareFramedWrites(ctx context.Context) error {
-	if c.base == nil || c.compressed == nil || c.compressed.FramedWrites() {
-		return nil
-	}
-	if err := UpgradeRepoFormat(ctx, c.base, core.RepoFormatVersion); err != nil {
-		return fmt.Errorf("raise repository format before writing: %w", err)
-	}
-	c.compressed.SetFramedWrites(true)
-	return nil
-}
-
 func (c *Client) Backup(ctx context.Context, src source.Source, opts ...BackupOption) (*BackupResult, error) {
-	// Backup is the path that stores user file content, so it is the one where
-	// an unframed write does lasting damage. Raise the format first.
-	if err := c.prepareFramedWrites(ctx); err != nil {
-		return nil, err
+	// Raise the format before writing anything, and fail if it cannot be raised.
+	//
+	// Backup stores user file content, which may be incompressible and may begin
+	// with a magic header — the combination the frame exists for. An object this
+	// build writes unframed is unframed permanently: content-addressed objects
+	// are never rewritten, so a later framed backup skips it on the Exists check
+	// and nothing repairs it. Stamping afterwards, as prune and forget do, would
+	// mean every repository below the framing format lost its already-compressed
+	// files on the first backup after upgrading. Raising first makes framing
+	// (which follows the format) already on by the time the first object is
+	// written; continuing on a raise error would write exactly those unframed
+	// objects, so the error is fatal.
+	if err := c.raiseRepoFormat(ctx); err != nil {
+		return nil, fmt.Errorf("raise repository format before writing: %w", err)
 	}
 
 	rawMeter := store.NewMeteredStore(c.store)

--- a/client.go
+++ b/client.go
@@ -56,9 +56,15 @@ func InitRepo(ctx context.Context, rawStore store.ObjectStore, opts ...InitOptio
 // of data they can still read correctly, which is the same harm the version
 // gate exists to prevent.
 //
-// It is called after a successful mutation (backup, prune, forget) and from the
-// pack index seal path, so a repository written by this build tells other
-// machines sharing it to upgrade. It is deliberately not called on read.
+// It is called after a successful mutation (backup, prune, forget), so a
+// repository written by this build tells other machines sharing it to upgrade.
+// It is deliberately not called on read.
+//
+// Because the stamp lands *after* the mutation, and its failure is not fatal, a
+// write cannot rely on it having happened. A change whose output an older build
+// would misread must therefore gate itself on the format already recorded
+// rather than on the stamp this call will attempt — see
+// core.FramedCompressionFormat for the case that motivates this.
 // See docs/compatibility.md.
 func UpgradeRepoFormat(ctx context.Context, rawStore store.ObjectStore, to int) error {
 	if to > core.MaxSupportedRepoFormat {
@@ -299,7 +305,10 @@ type Client struct {
 	// base is the raw, undecorated store. Kept so repository-level markers such
 	// as the format version can be written without passing through encryption
 	// or packing, which is where init writes them too.
-	base           store.ObjectStore
+	base store.ObjectStore
+	// compressed is the outermost wrapper, held by concrete type so a mutation
+	// can turn framed writes on once it has raised the repository format.
+	compressed     *store.CompressedStore
 	storedMeter    *store.MeteredStore
 	encryptionKey  []byte
 	hmacKey        []byte
@@ -377,7 +386,13 @@ func NewClient(ctx context.Context, base store.ObjectStore, opts ...ClientOption
 		inner = store.NewEncryptedStore(storedMeter, c.encryptionKey)
 	}
 
-	c.store = store.NewCompressedStore(inner)
+	// Frame compressed objects only once the repository records a format whose
+	// readers understand the frame. A repository below that version is raised by
+	// prepareFramedWrites before a mutation writes anything, so this is the
+	// starting state rather than the final one. See core.FramedCompressionFormat.
+	framed := cfg != nil && cfg.Version >= core.FramedCompressionFormat
+	c.compressed = store.NewCompressedStore(inner, store.WithFramedWrites(framed))
+	c.store = c.compressed
 	c.storedMeter = storedMeter
 	return c, nil
 }
@@ -448,6 +463,14 @@ var (
 //
 // Failure is not fatal to the operation that just succeeded: the data is
 // already written, and the next mutation stamps again.
+//
+// It remains the right shape for prune and forget, which is why they still use
+// it. What they write through the compression layer is JSON — snapshot and
+// index manifests — which always compresses, so an unframed one is decoded
+// correctly by the legacy read path and nothing is lost by stamping afterwards.
+// Backup is the exception, and uses prepareFramedWrites instead: it stores user
+// file content, which may be incompressible and may carry a magic header, and
+// that is the combination the frame exists for.
 func (c *Client) stampWriteFormat(ctx context.Context) {
 	if c.base == nil {
 		return
@@ -457,7 +480,39 @@ func (c *Client) stampWriteFormat(ctx context.Context) {
 	}
 }
 
+// prepareFramedWrites raises the repository format and turns on framed writes,
+// before the caller writes anything.
+//
+// Framing has to be established up front rather than stamped afterwards. An
+// object this build writes unframed is unframed permanently: content-addressed
+// objects are never rewritten, so a later framed backup skips them on the
+// Exists check and the mistake is not repaired by anything. Stamping after the
+// write would mean every repository below the framing format loses its
+// already-compressed files on the *first* backup after upgrading — precisely
+// the corruption the frame exists to prevent, applied once to every existing
+// user.
+//
+// Unlike stampWriteFormat, a failure here is fatal to the operation. The whole
+// point is that nothing is written until the format is raised; continuing on
+// error would write the unframed objects this exists to avoid.
+func (c *Client) prepareFramedWrites(ctx context.Context) error {
+	if c.base == nil || c.compressed == nil || c.compressed.FramedWrites() {
+		return nil
+	}
+	if err := UpgradeRepoFormat(ctx, c.base, core.RepoFormatVersion); err != nil {
+		return fmt.Errorf("raise repository format before writing: %w", err)
+	}
+	c.compressed.SetFramedWrites(true)
+	return nil
+}
+
 func (c *Client) Backup(ctx context.Context, src source.Source, opts ...BackupOption) (*BackupResult, error) {
+	// Backup is the path that stores user file content, so it is the one where
+	// an unframed write does lasting damage. Raise the format first.
+	if err := c.prepareFramedWrites(ctx); err != nil {
+		return nil, err
+	}
+
 	rawMeter := store.NewMeteredStore(c.store)
 	c.storedMeter.Reset()
 
@@ -469,7 +524,6 @@ func (c *Client) Backup(ctx context.Context, src source.Source, opts ...BackupOp
 
 	result.BytesAddedRaw = rawMeter.BytesWritten()
 	result.BytesAddedStored = c.storedMeter.BytesWritten()
-	c.stampWriteFormat(ctx)
 	return result, nil
 }
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -148,6 +148,9 @@ What actually happens when a newer build writes to an older repository:
   as they were
 - `index/latest` stops being packed, but an already-packed one keeps being read
   from where it is
+- objects are written inside a compression frame once the repository records
+  format 2; objects stored before the frame existed keep none, and are read by
+  detecting a gzip or zstd stream as before
 
 So a long-lived repository is a mixture of eras indefinitely, and that is the
 intended steady state rather than a transitional one. Because backward
@@ -173,6 +176,41 @@ The correct rule is narrower:
 
 > Stamp the repository when a build **writes** to it — not when it is opened,
 > and not when migration finishes.
+
+### Before the write, when the write depends on it
+
+"When a build writes to it" leaves the timing open, and the timing matters.
+
+The default is to stamp *after* a successful mutation: the data is already
+written, a failed stamp is not fatal, and the next mutation stamps again. That
+is right for a change whose output older builds can still read — `prune` and
+`forget` write JSON manifests, which are unremarkable to any reader.
+
+It is wrong when the write itself is gated on the format. The compression frame
+is the case that forced this distinction:
+
+- an object written unframed is unframed **permanently** — content-addressed
+  objects are never rewritten, so a later framed backup finds the object already
+  present and skips it
+- writers must not frame while the repository still records an older format, or
+  a build predating the frame will read a framed object as opaque bytes
+
+Stamp afterwards and the two combine badly. Every repository ever released is
+below the framing format, so the first backup after upgrading would write
+unframed objects — permanently — and only then raise the format. For an
+already-compressed file that is unrecoverable data loss, inflicted once on every
+existing user.
+
+So the rule for this class of change is:
+
+> When a write is only correct at a given format, raise the format **before** the
+> first object is written, and treat the failure as fatal to the operation.
+
+`Client.prepareFramedWrites` implements that for `backup`. It stays within the
+"writes stamp, reads do not" rule — `backup` is a mutation — and it costs one
+thing: a mutation that fails early leaves the repository stamped, locking out
+older builds from a repository that gained nothing. That is recoverable by
+upgrading the other machine. The alternative is not recoverable at all.
 
 `UpgradeRepoFormat` (`client.go`) does this. It raises the recorded version,
 never lowers it, and refuses to stamp a version the running build could not
@@ -264,12 +302,35 @@ deletes the packfiles. See "What the gate cannot do" above.
 
 ### v1.15.0 against a repository written by a later build
 
-Refused cleanly:
+Refused cleanly, on `list`, `check`, and `restore` alike:
 
 ```text
 repository format version 2 is newer than this build supports (up to 1):
 upgrade cloudstic to work with this repository
 ```
+
+### v1.15.0 against a compression frame
+
+It never meets one. This was verified rather than assumed, because the frame is
+the one structure an older build would misread instead of refusing: v1.15.0
+recognises neither the magic nor the algorithm byte, so it would return the
+framed bytes verbatim — header included — and write them to a restored file.
+
+Two runs establish that it cannot reach that state:
+
+- A repository this build created is stamped format 2, and v1.15.0 refuses it at
+  the gate before reading any object.
+- A repository v1.15.0 created (format 1), backed up into by this build, is
+  raised to format 2 *before* the first object is written, so no framed object
+  is ever added to a repository still recording format 1. Both machines see a
+  consistent repository: either format 1 with no frames, or format 2, which
+  v1.15.0 declines.
+
+Confirmed on the second path by inspecting the store after the backup: the
+chunk, packfile, snapshot catalog, and `index/latest` are all framed, and the
+repository records version 2. The one unframed object is the pack index shard
+under `index/packmap/`, which `PackStore` writes *below* the compression layer
+and which therefore never carries a frame by construction.
 
 ## Fixtures
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -72,7 +72,7 @@ flowchart TD
 
 The pipeline from outermost (application layer) to innermost (network layer) is:
 
-1. **Compressed Store**: Compresses outgoing objects using `zstd` and decompresses incoming objects.
+1. **Compressed Store**: Compresses outgoing objects using `zstd` and decompresses incoming objects. The encoding is recorded in a frame header (see [Compression Frame](#compression-frame)) rather than recovered by inspecting the stored bytes.
 2. **Encrypted Store** *(optional)*: Encrypts the compressed data using AES-256-GCM, and decrypts/authenticates the ciphertext on read.
 3. **Metered Store**: Tracks bytes written to and read from the underlying layer to precisely report progress reflecting the actual physical bytes stored/retrieved.
 4. **Pack Store** *(optional)*: Intercepts small objects (like `filemeta/`, `node/`, and small manifests). Buffers them in memory and groups them into 8MB pack files (`packs/<hash>`) to drastically reduce bucket API requests and billing. Large objects bypass the buffer and pass through directly.
@@ -81,6 +81,40 @@ The pipeline from outermost (application layer) to innermost (network layer) is:
 **Data Flow Example (Read):**
 
 `App ← [decompress] ← [decrypt] ← [measure] ← [extract from pack or get] ← [Base Store]`
+
+#### Compression Frame
+
+zstd does not shrink every input. When it cannot, the Compressed Store keeps the
+object verbatim — so "compressed" is a per-object property, and the reader has to
+know which it holds.
+
+Repositories at format `2` or above record that in a header:
+
+```text
+┌──────────────────────────────────────────────┐
+│ magic 0x43 0x53 0x00 0x01           4 bytes  │
+│ algorithm (0x00 raw, 0x01 zstd)     1 byte   │
+│ uncompressed length (big-endian)    8 bytes  │
+│ payload                             …        │
+└──────────────────────────────────────────────┘
+```
+
+The length field makes the frame self-checking: a payload that does not decode to
+exactly that many bytes is an error, never data.
+
+Objects without the header are read by detecting a gzip or zstd stream and
+otherwise returning the bytes unchanged. That path is permanent — every
+repository keeps unframed objects from before the frame existed — but it is only
+a fallback, and it is the reason the frame exists. Sniffing cannot distinguish
+"this store compressed the object" from "the user's file begins with those
+bytes", so backing up an already-compressed `.gz` or `.zst` file yielded its
+*decompressed* contents on restore.
+
+Writers frame only once the repository records format `2`, because the format
+stamp is applied after a mutation completes: a build predating the frame reads
+one as opaque bytes rather than refusing it, so a repository still recording
+format `1` must not be handed framed objects. See
+[compatibility.md](compatibility.md).
 
 ### Commands
 
@@ -110,7 +144,9 @@ All objects are stored under a flat key namespace of the form `<type>/<hash>`.
 * Raw file data, zstd-compressed.
 * Object key: `chunk/<hmac_sha256>` (HMAC-SHA256 keyed by the dedup key when
   encryption is enabled, plain SHA-256 otherwise)
-* **Format:** Raw binary (zstd stream). Not JSON-wrapped.
+* **Format:** Raw binary, not JSON-wrapped. Written inside a
+  [compression frame](#compression-frame) at format `2` and above, which records
+  whether the payload is a zstd stream or the chunk verbatim.
 * Produced by **FastCDC** content-defined chunking:
 
 | Parameter | Value    |

--- a/e2e/feature_compressed_roundtrip_test.go
+++ b/e2e/feature_compressed_roundtrip_test.go
@@ -1,0 +1,148 @@
+package e2e
+
+import (
+	"bytes"
+	"compress/gzip"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// Already-compressed files are the payloads the storage layer used to get
+// wrong. zstd cannot shrink them, so the compression layer stores them
+// verbatim; a reader that recovered the encoding by sniffing magic bytes then
+// inflated the user's own gzip or zstd stream and returned its contents instead
+// of the file. Small files came back silently wrong, larger ones failed with
+// truncation errors.
+//
+// These fixtures are built rather than committed so the test states what makes
+// them dangerous: they begin with a magic header the old read path recognised.
+func gzipFixture(t *testing.T, payload []byte) string {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := zw.Write(payload); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.String()
+}
+
+func zstdFixture(t *testing.T, payload []byte) string {
+	t.Helper()
+	enc, err := zstd.NewWriter(nil)
+	if err != nil {
+		t.Fatalf("zstd writer: %v", err)
+	}
+	defer func() { _ = enc.Close() }()
+	return string(enc.EncodeAll(payload, nil))
+}
+
+// mustHaveExactBytes compares restored content byte-for-byte without dumping
+// megabytes of binary into the failure message.
+func mustHaveExactBytes(t *testing.T, dir, relPath, want string) {
+	t.Helper()
+	got, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(relPath)))
+	if err != nil {
+		t.Fatalf("restore dir missing %s: %v", relPath, err)
+	}
+	if string(got) == want {
+		return
+	}
+	t.Errorf("%s did not survive the round trip: restored %d bytes, backed up %d",
+		relPath, len(got), len(want))
+	if len(got) != len(want) {
+		return
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("%s: first difference at byte %d: got 0x%02x, want 0x%02x",
+				relPath, i, got[i], want[i])
+			return
+		}
+	}
+}
+
+// incompressibleBytes returns n deterministic pseudo-random bytes. The payload
+// has to be genuinely incompressible for these fixtures to mean anything: if
+// the archive compresses, the storage layer takes the zstd branch and never
+// reaches the stored-raw path where the corruption lived.
+func incompressibleBytes(n int) []byte {
+	rng := rand.New(rand.NewSource(0x5EED))
+	b := make([]byte, n)
+	_, _ = rng.Read(b)
+	return b
+}
+
+// compressedFixtures returns the payloads a repository must round-trip
+// unchanged.
+//
+// The sizes are chosen against two thresholds in the backup pipeline, and the
+// test is worthless without them. Files at or below inlineThreshold (512 KiB)
+// are embedded in the content manifest as JSON, so their bytes never reach the
+// compression layer on their own and cannot exercise this bug at all. Above it,
+// content is chunked with a 512 KiB minimum and a 1 MiB average, so a ~768 KiB
+// archive lands in a single chunk — the case that used to be returned inflated
+// and silently wrong — while a ~5 MiB archive spans several, where the first
+// chunk carries the magic header and used to fail on truncation instead.
+func compressedFixtures(t *testing.T) map[string]string {
+	t.Helper()
+
+	singleChunk := incompressibleBytes(768 * 1024)
+	multiChunk := incompressibleBytes(5 * 1024 * 1024)
+
+	return map[string]string{
+		"single-chunk.gz":  gzipFixture(t, singleChunk),
+		"single-chunk.zst": zstdFixture(t, singleChunk),
+		"multi-chunk.gz":   gzipFixture(t, multiChunk),
+		"multi-chunk.zst":  zstdFixture(t, multiChunk),
+		// The stored-raw branch without a recognised magic header, and an
+		// ordinary compressible file for contrast.
+		"incompressible.bin": string(incompressibleBytes(768 * 1024)),
+		"plain.txt":          "an ordinary file, for contrast",
+	}
+}
+
+func TestCLI_Feature_CompressedFilesRoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		encrypted bool
+	}{
+		{"unencrypted", false},
+		{"encrypted", true},
+	} {
+		runFeatureMatrix(t, featureSpec{
+			name: "compressed_roundtrip_" + tc.name,
+			// The encoding decision belongs to the store layer, so it is
+			// identical for every source. The portable source is additionally
+			// a 10 MB RAM disk, too small for fixtures that must clear the
+			// 512 KiB inline threshold several times over.
+			sourceFilter: localOnlySource,
+			test: func(t *testing.T, h *harness, _ matrixEntry) {
+				fixtures := compressedFixtures(t)
+				for name, content := range fixtures {
+					h.WithFile(name, content)
+				}
+
+				var r *repo
+				if tc.encrypted {
+					r = h.MustInitEncrypted()
+				} else {
+					r = h.MustInitUnencrypted()
+				}
+
+				r.Backup()
+				out := r.RestoreDir("roundtrip")
+
+				for name, content := range fixtures {
+					mustHaveExactBytes(t, out.Path(), name, content)
+				}
+			},
+		})
+	}
+}

--- a/e2e/feature_legacy_repo_test.go
+++ b/e2e/feature_legacy_repo_test.go
@@ -186,8 +186,60 @@ func TestCLI_Feature_ReadsLegacyRepositories(t *testing.T) {
 					assertFixtureFiles(t, outDir, m.Files)
 				}
 			})
+
+			// A repository below the framing format must be raised before the
+			// first object is written, not after. An object written unframed is
+			// unframed permanently — content-addressed objects are never
+			// rewritten, so a later framed backup skips them on the Exists
+			// check — and an already-compressed file stored that way is
+			// unrestorable forever.
+			//
+			// This needs its own copy of the fixture: it has to be the *first*
+			// backup onto the repository, while it still records the old
+			// format. Sharing storeDir with the subtest above would run it
+			// against a repository that backup had already stamped, which is
+			// exactly the case that was never broken.
+			//
+			// Every released repository is below the framing format, so the
+			// window this covers is every user's first backup after upgrading.
+			t.Run("already-compressed file survives the format upgrade", func(t *testing.T) {
+				freshStore := materialiseFixture(t, dir)
+				freshAuth := []string{"-store", "local:" + freshStore, "-password", m.Password}
+
+				archive := gzipFixture(t, incompressibleBytes(768*1024))
+				gzDir := t.TempDir()
+				if err := os.WriteFile(filepath.Join(gzDir, "archive.gz"), []byte(archive), 0o644); err != nil {
+					t.Fatal(err)
+				}
+
+				backupArgs := append([]string{"backup"}, freshAuth...)
+				backupArgs = append(backupArgs, "-source", "local:"+gzDir)
+				snapshot := snapshotIDFrom(t, run(t, bin, backupArgs...))
+
+				// Restore by id. The fixture holds snapshots from another
+				// source, and "latest" resolves per source identity, so it
+				// would not name the one just written.
+				outDir := filepath.Join(t.TempDir(), "compressed")
+				restoreArgs := append([]string{"restore"}, freshAuth...)
+				restoreArgs = append(restoreArgs, "-format", "dir", "-output", outDir, snapshot)
+				run(t, bin, restoreArgs...)
+				mustHaveExactBytes(t, outDir, "archive.gz", archive)
+			})
 		})
 	}
+}
+
+// snapshotIDFrom extracts the id a backup reported writing.
+func snapshotIDFrom(t *testing.T, backupOutput string) string {
+	t.Helper()
+	for _, line := range strings.Split(backupOutput, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 3 && fields[0] == "Snapshot" && fields[2] == "saved" {
+			return fields[1]
+		}
+	}
+	t.Fatalf("no snapshot id in backup output:\n%s", backupOutput)
+	return ""
 }
 
 func assertFixtureFiles(t *testing.T, dir string, want map[string]string) {

--- a/internal/core/models.go
+++ b/internal/core/models.go
@@ -158,6 +158,19 @@ const (
 	//
 	// Both changes ship in the same release, so one version covers them.
 	MaxSupportedRepoFormat = 2
+
+	// FramedCompressionFormat is the lowest recorded format at which the
+	// compression layer may write framed objects (see pkg/store/compressed.go).
+	//
+	// It gates writes rather than reads: a framed object is always readable,
+	// but a build predating the frame reads one as opaque bytes and returns
+	// them, which is a misread rather than a clean refusal. The version gate
+	// cannot prevent that on its own, because the stamp is applied after a
+	// mutation completes — so a repository still recording format 1 would
+	// otherwise be handed framed objects that an older build sails straight
+	// into. Framing only once the repository already records this version
+	// closes that window without stamping repositories speculatively.
+	FramedCompressionFormat = 2
 )
 
 type RepoConfig struct {

--- a/pkg/store/compressed.go
+++ b/pkg/store/compressed.go
@@ -4,8 +4,13 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
 	"io"
+	"math"
 	"sync"
+	"sync/atomic"
 
 	"github.com/klauspost/compress/zstd"
 )
@@ -32,25 +37,114 @@ func initZstd() {
 	})
 }
 
+// Framed object encoding.
+//
+// The encoding of a stored object is recorded in a header at write time rather
+// than reconstructed on read by inspecting the bytes. Sniffing cannot tell "this
+// store compressed the object" from "the user's own file begins with those
+// bytes", and a backup tool that guesses wrong returns something other than what
+// was backed up.
+//
+//	magic(4) || algorithm(1) || uncompressed length(8, big-endian) || payload
+//
+// The length field makes the frame self-checking: a payload that does not decode
+// to exactly that many bytes is rejected rather than returned.
+//
+// Frames are detected on read regardless of whether this store writes them, so
+// that a frame is never handed to the sniffing path. The cost is that an
+// unframed legacy object whose first four bytes coincide with the magic is
+// refused. That is deliberate, and the two outcomes are not equally likely: to
+// be silently mis-decoded such an object would have to match the magic, carry a
+// valid algorithm byte, and record a length its payload decodes to exactly,
+// which is beyond negligible; to be refused it need only match the magic. An
+// error is the acceptable half of that trade, and it is the half that keeps a
+// mis-decode from reaching a restored file.
+const (
+	frameAlgoRaw  byte = 0x00 // payload is the object verbatim
+	frameAlgoZstd byte = 0x01 // payload is zstd-compressed
+
+	frameHeaderSize = 4 + 1 + 8
+)
+
+// frameMagic identifies a framed object. "CS" and a NUL, which no text payload
+// carries in its first bytes.
+var frameMagic = [4]byte{'C', 'S', 0x00, 0x01}
+
+// ErrInvalidFrame reports a framed object whose header or payload is not
+// self-consistent. It is never downgraded to "return the bytes as they are":
+// that is the sniffing behaviour this frame exists to remove.
+var ErrInvalidFrame = errors.New("store: invalid compression frame")
+
 // CompressedStore wraps an ObjectStore and transparently zstd-compresses on
-// write and decompresses (zstd or gzip) on read. Uncompressed data is returned as-is.
+// write and decompresses on read.
+//
+// Writes are framed only when framing is enabled — see WithFramedWrites, and
+// core.FramedCompressionFormat for why that is tied to the repository format.
+// Reads accept both framed and unframed objects regardless: unframed objects
+// exist in every repository indefinitely, because upgrades are opportunistic and
+// permanently partial (docs/compatibility.md).
 type CompressedStore struct {
 	inner ObjectStore
+	frame atomic.Bool
 }
+
+// CompressedOption configures a CompressedStore.
+type CompressedOption func(*CompressedStore)
+
+// WithFramedWrites enables the framed object encoding on write.
+//
+// It is off by default so that a store built without an established repository
+// format — tests, and any caller that has not read the config — cannot write
+// objects an older build would misread.
+func WithFramedWrites(enabled bool) CompressedOption {
+	return func(s *CompressedStore) { s.frame.Store(enabled) }
+}
+
+// FramedWrites reports whether this store frames what it writes.
+func (s *CompressedStore) FramedWrites() bool { return s.frame.Load() }
+
+// SetFramedWrites turns framing on once the repository is known to record a
+// format whose readers understand the frame.
+//
+// It exists because that becomes true *during* a client's life: a mutation
+// raises the format of an older repository before writing to it, and everything
+// written from then on must be framed. Callers must enable framing before the
+// first write of that mutation, not partway through — an unframed object written
+// by this build is a permanent one, since content-addressed objects are never
+// rewritten once stored.
+func (s *CompressedStore) SetFramedWrites(enabled bool) { s.frame.Store(enabled) }
 
 func (s *CompressedStore) Unwrap() ObjectStore { return s.inner }
 
-func NewCompressedStore(inner ObjectStore) *CompressedStore {
+func NewCompressedStore(inner ObjectStore, opts ...CompressedOption) *CompressedStore {
 	initZstd()
-	return &CompressedStore{inner: inner}
+	s := &CompressedStore{inner: inner}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
 }
 
 func (s *CompressedStore) Put(ctx context.Context, key string, data []byte) error {
 	out := zstdEncoder.EncodeAll(data, make([]byte, 0, len(data)))
+	algo := frameAlgoZstd
 	if len(out) >= len(data) {
-		out = data
+		out, algo = data, frameAlgoRaw
+	}
+	if s.frame.Load() {
+		out = encodeFrame(algo, len(data), out)
 	}
 	return s.inner.Put(ctx, key, out)
+}
+
+// encodeFrame prefixes payload with the frame header describing how it was
+// encoded and how many bytes it must decode to.
+func encodeFrame(algo byte, rawLen int, payload []byte) []byte {
+	out := make([]byte, frameHeaderSize, frameHeaderSize+len(payload))
+	copy(out, frameMagic[:])
+	out[4] = algo
+	binary.BigEndian.PutUint64(out[5:], uint64(rawLen))
+	return append(out, payload...)
 }
 
 func (s *CompressedStore) Get(ctx context.Context, key string) ([]byte, error) {
@@ -58,7 +152,7 @@ func (s *CompressedStore) Get(ctx context.Context, key string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return maybeDecompress(data)
+	return decodeObject(data)
 }
 
 func (s *CompressedStore) Exists(ctx context.Context, key string) (bool, error) {
@@ -88,6 +182,54 @@ func (s *CompressedStore) Flush(ctx context.Context) error {
 	return nil
 }
 
+// decodeObject reverses Put. A framed object is decoded from its header and
+// validated against the recorded length; anything else falls back to sniffing,
+// which is how objects written before framing — and objects in repositories
+// still below core.FramedCompressionFormat — are read.
+func decodeObject(data []byte) ([]byte, error) {
+	if !isFramed(data) {
+		return maybeDecompress(data)
+	}
+
+	algo := data[4]
+	rawLen := binary.BigEndian.Uint64(data[5:frameHeaderSize])
+	if rawLen > math.MaxInt {
+		return nil, fmt.Errorf("%w: length %d exceeds addressable size", ErrInvalidFrame, rawLen)
+	}
+	payload := data[frameHeaderSize:]
+
+	var out []byte
+	switch algo {
+	case frameAlgoRaw:
+		out = payload
+	case frameAlgoZstd:
+		initZstd()
+		dec, err := zstdDecoder.DecodeAll(payload, nil)
+		if err != nil {
+			return nil, fmt.Errorf("%w: zstd payload: %w", ErrInvalidFrame, err)
+		}
+		out = dec
+	default:
+		return nil, fmt.Errorf("%w: unknown algorithm 0x%02x", ErrInvalidFrame, algo)
+	}
+
+	if uint64(len(out)) != rawLen {
+		return nil, fmt.Errorf("%w: decoded %d bytes, frame records %d", ErrInvalidFrame, len(out), rawLen)
+	}
+	return out, nil
+}
+
+// isFramed reports whether data carries a frame header. A legacy object whose
+// first bytes coincide with the magic is the residual case the length check in
+// decodeObject exists to catch.
+func isFramed(data []byte) bool {
+	return len(data) >= frameHeaderSize && bytes.HasPrefix(data, frameMagic[:])
+}
+
+// maybeDecompress is the legacy read path for unframed objects: it guesses the
+// encoding from magic bytes. It cannot be removed — a repository is a permanent
+// mixture of eras (docs/compatibility.md) — but it must not be reached for
+// anything this build wrote framed.
 func maybeDecompress(data []byte) ([]byte, error) {
 	if len(data) < 2 {
 		return data, nil

--- a/pkg/store/compressed.go
+++ b/pkg/store/compressed.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"math"
 	"sync"
-	"sync/atomic"
 
 	"github.com/klauspost/compress/zstd"
 )
@@ -78,47 +77,50 @@ var ErrInvalidFrame = errors.New("store: invalid compression frame")
 // CompressedStore wraps an ObjectStore and transparently zstd-compresses on
 // write and decompresses on read.
 //
-// Writes are framed only when framing is enabled — see WithFramedWrites, and
-// core.FramedCompressionFormat for why that is tied to the repository format.
-// Reads accept both framed and unframed objects regardless: unframed objects
-// exist in every repository indefinitely, because upgrades are opportunistic and
-// permanently partial (docs/compatibility.md).
+// Whether a write is framed is not a mode this store is told to enter; it is
+// derived, per write, from a gate the caller supplies (WithFrameGate). Framing
+// belongs on only once the repository records a format whose readers understand
+// the frame, and that format is raised during a mutation — so the gate lets the
+// owner of the format flip one value and have every write follow, with no
+// second copy of the decision to keep in sync. See core.FramedCompressionFormat.
+//
+// Reads accept both framed and unframed objects regardless of the gate: unframed
+// objects exist in every repository indefinitely, because upgrades are
+// opportunistic and permanently partial (docs/compatibility.md).
 type CompressedStore struct {
 	inner ObjectStore
-	frame atomic.Bool
+	// frame reports whether the next write should be framed. Never nil — the
+	// constructor installs a default. The field itself is set once at
+	// construction; any dynamism lives in what the gate reads.
+	frame func() bool
 }
 
 // CompressedOption configures a CompressedStore.
 type CompressedOption func(*CompressedStore)
 
-// WithFramedWrites enables the framed object encoding on write.
+// WithFrameGate frames writes whenever gate reports true, evaluated per write.
 //
-// It is off by default so that a store built without an established repository
-// format — tests, and any caller that has not read the config — cannot write
-// objects an older build would misread.
-func WithFramedWrites(enabled bool) CompressedOption {
-	return func(s *CompressedStore) { s.frame.Store(enabled) }
+// This is how framing tracks the repository format without a second source of
+// truth: the caller owns one format value and points the gate at it, so raising
+// the format turns framing on for every subsequent write at once. Enabling
+// framing partway through a mutation is still the caller's responsibility to
+// avoid — an object written unframed by this build is unframed permanently,
+// since content-addressed objects are never rewritten once stored.
+func WithFrameGate(gate func() bool) CompressedOption {
+	return func(s *CompressedStore) { s.frame = gate }
 }
 
-// FramedWrites reports whether this store frames what it writes.
-func (s *CompressedStore) FramedWrites() bool { return s.frame.Load() }
-
-// SetFramedWrites turns framing on once the repository is known to record a
-// format whose readers understand the frame.
-//
-// It exists because that becomes true *during* a client's life: a mutation
-// raises the format of an older repository before writing to it, and everything
-// written from then on must be framed. Callers must enable framing before the
-// first write of that mutation, not partway through — an unframed object written
-// by this build is a permanent one, since content-addressed objects are never
-// rewritten once stored.
-func (s *CompressedStore) SetFramedWrites(enabled bool) { s.frame.Store(enabled) }
+// WithFramedWrites is the static form of WithFrameGate, for callers whose
+// framing decision does not change over the store's life (chiefly tests).
+func WithFramedWrites(enabled bool) CompressedOption {
+	return WithFrameGate(func() bool { return enabled })
+}
 
 func (s *CompressedStore) Unwrap() ObjectStore { return s.inner }
 
 func NewCompressedStore(inner ObjectStore, opts ...CompressedOption) *CompressedStore {
 	initZstd()
-	s := &CompressedStore{inner: inner}
+	s := &CompressedStore{inner: inner, frame: func() bool { return false }}
 	for _, opt := range opts {
 		opt(s)
 	}
@@ -131,7 +133,7 @@ func (s *CompressedStore) Put(ctx context.Context, key string, data []byte) erro
 	if len(out) >= len(data) {
 		out, algo = data, frameAlgoRaw
 	}
-	if s.frame.Load() {
+	if s.frame() {
 		out = encodeFrame(algo, len(data), out)
 	}
 	return s.inner.Put(ctx, key, out)

--- a/pkg/store/compressed_frame_test.go
+++ b/pkg/store/compressed_frame_test.go
@@ -1,0 +1,264 @@
+package store
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/binary"
+	"errors"
+	"testing"
+)
+
+// gzipBytes returns a valid gzip stream, i.e. bytes that begin with the gzip
+// magic header without being anything this store produced.
+func gzipBytes(t *testing.T, payload []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := zw.Write(payload); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// zstdBytes returns a valid zstd stream, for the same reason as gzipBytes.
+func zstdBytes(t *testing.T, payload []byte) []byte {
+	t.Helper()
+	initZstd()
+	return zstdEncoder.EncodeAll(payload, nil)
+}
+
+// TestCompressedStore_FramedRoundTripsAlreadyCompressedData is the regression
+// test for the corruption this frame exists to prevent: a user's own .gz or
+// .zst file that zstd cannot shrink is stored verbatim, and an unframed read
+// then inflates it and hands back something other than the file.
+func TestCompressedStore_FramedRoundTripsAlreadyCompressedData(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		data []byte
+	}{
+		// Small enough to land in a single chunk: the branch that silently
+		// returned the inflated content.
+		{"single-chunk gzip", gzipBytes(t, bytes.Repeat([]byte("A"), 7500))},
+		{"single-chunk zstd", zstdBytes(t, bytes.Repeat([]byte("A"), 7500))},
+		// Large enough that the truncated read failed loudly instead.
+		{"multi-chunk gzip", gzipBytes(t, bytes.Repeat([]byte("hello world "), 400_000))},
+		{"multi-chunk zstd", zstdBytes(t, bytes.Repeat([]byte("hello world "), 400_000))},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NewCompressedStore(newMemStore(), WithFramedWrites(true))
+			if err := s.Put(ctx, "chunk/x", tc.data); err != nil {
+				t.Fatalf("Put: %v", err)
+			}
+			got, err := s.Get(ctx, "chunk/x")
+			if err != nil {
+				t.Fatalf("Get: %v", err)
+			}
+			if !bytes.Equal(got, tc.data) {
+				t.Fatalf("round trip corrupted data: put %d bytes, got back %d", len(tc.data), len(got))
+			}
+		})
+	}
+}
+
+func TestCompressedStore_FramedRoundTripsBothBranches(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		data []byte
+	}{
+		{"empty", []byte{}},
+		{"tiny incompressible", []byte("tiny")},
+		{"highly compressible", bytes.Repeat([]byte("A"), 10*1024)},
+		{"leading NUL bytes", append([]byte{0, 0, 0, 0}, []byte("payload")...)},
+		// Begins with the frame magic without being a frame.
+		{"payload wearing the magic", append(frameMagic[:], []byte("not a frame at all")...)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NewCompressedStore(newMemStore(), WithFramedWrites(true))
+			if err := s.Put(ctx, "chunk/x", tc.data); err != nil {
+				t.Fatalf("Put: %v", err)
+			}
+			got, err := s.Get(ctx, "chunk/x")
+			if err != nil {
+				t.Fatalf("Get: %v", err)
+			}
+			if !bytes.Equal(got, tc.data) {
+				t.Fatalf("round trip mismatch: want %q, got %q", tc.data, got)
+			}
+		})
+	}
+}
+
+// TestCompressedStore_FramedWritesUseBothAlgorithms pins the stored-raw branch:
+// incompressible input must be framed as raw, compressible input as zstd.
+func TestCompressedStore_FramedWritesUseBothAlgorithms(t *testing.T) {
+	ctx := context.Background()
+	mem := newMemStore()
+	s := NewCompressedStore(mem, WithFramedWrites(true))
+
+	raw := gzipBytes(t, []byte("incompressible enough that zstd gives up"))
+	compressible := bytes.Repeat([]byte("A"), 10*1024)
+
+	if err := s.Put(ctx, "chunk/raw", raw); err != nil {
+		t.Fatalf("Put raw: %v", err)
+	}
+	if err := s.Put(ctx, "chunk/zstd", compressible); err != nil {
+		t.Fatalf("Put compressible: %v", err)
+	}
+
+	if got := mem.data["chunk/raw"][4]; got != frameAlgoRaw {
+		t.Errorf("incompressible object: algorithm = 0x%02x, want raw (0x%02x)", got, frameAlgoRaw)
+	}
+	if got := mem.data["chunk/zstd"][4]; got != frameAlgoZstd {
+		t.Errorf("compressible object: algorithm = 0x%02x, want zstd (0x%02x)", got, frameAlgoZstd)
+	}
+	if len(mem.data["chunk/zstd"]) >= len(compressible) {
+		t.Errorf("compressible object was not compressed: stored %d bytes for %d", len(mem.data["chunk/zstd"]), len(compressible))
+	}
+}
+
+// TestCompressedStore_RejectsInconsistentFrame covers the frame's whole point:
+// a frame that does not decode to the length it records is an error, never data.
+func TestCompressedStore_RejectsInconsistentFrame(t *testing.T) {
+	ctx := context.Background()
+
+	frameWith := func(mutate func([]byte) []byte) []byte {
+		f := encodeFrame(frameAlgoRaw, 5, []byte("hello"))
+		return mutate(f)
+	}
+
+	cases := []struct {
+		name  string
+		frame []byte
+	}{
+		{"length larger than payload", frameWith(func(f []byte) []byte {
+			binary.BigEndian.PutUint64(f[5:], 99)
+			return f
+		})},
+		{"length smaller than payload", frameWith(func(f []byte) []byte {
+			binary.BigEndian.PutUint64(f[5:], 2)
+			return f
+		})},
+		{"truncated payload", frameWith(func(f []byte) []byte {
+			return f[:len(f)-2]
+		})},
+		{"unknown algorithm", frameWith(func(f []byte) []byte {
+			f[4] = 0x7f
+			return f
+		})},
+		{"zstd algorithm over non-zstd payload", frameWith(func(f []byte) []byte {
+			f[4] = frameAlgoZstd
+			return f
+		})},
+		{"bit-flipped zstd payload", func() []byte {
+			payload := zstdBytes(t, bytes.Repeat([]byte("A"), 1024))
+			payload[len(payload)/2] ^= 0xff
+			return encodeFrame(frameAlgoZstd, 1024, payload)
+		}()},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mem := newMemStore()
+			mem.data["chunk/x"] = tc.frame
+			s := NewCompressedStore(mem, WithFramedWrites(true))
+
+			got, err := s.Get(ctx, "chunk/x")
+			if err == nil {
+				t.Fatalf("Get returned %d bytes, want an error", len(got))
+			}
+			if !errors.Is(err, ErrInvalidFrame) {
+				t.Errorf("error = %v, want ErrInvalidFrame", err)
+			}
+		})
+	}
+}
+
+// TestCompressedStore_ReadsUnframedObjects covers the fallback that
+// docs/compatibility.md makes permanent: objects written before framing, and
+// objects written into a repository still below the gating format, stay
+// readable by a store that frames its own writes.
+func TestCompressedStore_ReadsUnframedObjects(t *testing.T) {
+	ctx := context.Background()
+	mem := newMemStore()
+
+	legacy := NewCompressedStore(mem)
+	framing := NewCompressedStore(mem, WithFramedWrites(true))
+
+	cases := []struct {
+		name string
+		data []byte
+	}{
+		{"compressible", bytes.Repeat([]byte("A"), 10*1024)},
+		{"incompressible", []byte("tiny")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := legacy.Put(ctx, "chunk/"+tc.name, tc.data); err != nil {
+				t.Fatalf("legacy Put: %v", err)
+			}
+			if isFramed(mem.data["chunk/"+tc.name]) {
+				t.Fatal("legacy store wrote a frame")
+			}
+			got, err := framing.Get(ctx, "chunk/"+tc.name)
+			if err != nil {
+				t.Fatalf("framing Get of legacy object: %v", err)
+			}
+			if !bytes.Equal(got, tc.data) {
+				t.Errorf("legacy object misread: want %q, got %q", tc.data, got)
+			}
+		})
+	}
+}
+
+// TestCompressedStore_LegacyObjectWearingTheMagicIsRefused documents the
+// residual collision. An unframed object whose first bytes happen to match the
+// magic is refused rather than mis-decoded. Refusing is the acceptable half of
+// that trade: a mis-decode would reach a restored file, an error cannot.
+func TestCompressedStore_LegacyObjectWearingTheMagicIsRefused(t *testing.T) {
+	ctx := context.Background()
+	mem := newMemStore()
+
+	// Written by a build predating the frame, stored raw because zstd could not
+	// shrink it, and beginning with the bytes the frame now claims.
+	mem.data["chunk/x"] = append(frameMagic[:], zstdBytes(t, []byte("payload"))...)
+
+	if _, err := NewCompressedStore(mem).Get(ctx, "chunk/x"); !errors.Is(err, ErrInvalidFrame) {
+		t.Fatalf("error = %v, want ErrInvalidFrame", err)
+	}
+}
+
+// TestCompressedStore_UnframedByDefault pins the write gate. A store built
+// without an established repository format must not emit frames, because a
+// build predating the frame returns one verbatim instead of refusing it.
+func TestCompressedStore_UnframedByDefault(t *testing.T) {
+	ctx := context.Background()
+	mem := newMemStore()
+	s := NewCompressedStore(mem)
+
+	if err := s.Put(ctx, "chunk/x", bytes.Repeat([]byte("A"), 1024)); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if isFramed(mem.data["chunk/x"]) {
+		t.Error("default store wrote a framed object")
+	}
+
+	if err := NewCompressedStore(mem, WithFramedWrites(false)).Put(ctx, "chunk/y", []byte("tiny")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if isFramed(mem.data["chunk/y"]) {
+		t.Error("WithFramedWrites(false) wrote a framed object")
+	}
+}


### PR DESCRIPTION
## Summary

- Frame the compressed object encoding instead of recovering it from magic bytes on read. `CompressedStore.Put` stored data verbatim whenever zstd could not shrink it and discarded that fact; `maybeDecompress` then guessed. Nothing distinguished "this store compressed the object" from "the user's file begins with those bytes", so an already-compressed `.gz` or `.zst` came back *inflated* — silent data loss.
- The frame is `magic(4) || algorithm(1) || uncompressed length(8, BE) || payload`. The length makes it self-checking: a payload that does not decode to exactly that many bytes is an error, never data.
- Detect frames on read regardless of whether this build writes them, so a frame never reaches the sniffing path. Unframed objects keep the legacy path, which cannot be removed — `docs/compatibility.md` makes upgrades permanently partial.
- **Raise the repository format before the first object of a backup is written**, rather than after the mutation succeeds. This is the non-obvious part; see below.
- No version bump. Format 2 is unreleased (`9bfb4ef`, no tag contains it; `v1.15.0` is format 1), so framing folds into it before it ships rather than spending a second transition on users who never saw the first.

Closes #319

## Why the stamp moved

The issue originally proposed gating framing on the recorded format and letting the post-mutation stamp enable it from the next run. Building it that way showed why that fails.

An object written unframed is unframed **permanently**: content-addressed objects are never rewritten, so a later framed backup finds the object already present and skips it on the `Exists` check. Nothing repairs it. Since every released repository is below the framing format, that design corrupts already-compressed files on **every existing user's first backup after upgrading**. Measured against the `v1.15.0` fixture:

```text
restore: Files: 0, Dirs: 0, Errors: 1
check -read-data: [corrupt] chunk/5a5306e9…: hash mismatch
```

`Client.prepareFramedWrites` therefore raises the format at the start of `backup`, before any object is stored, and fails the operation if it cannot. `prune` and `forget` keep the post-mutation stamp: what they write through the compression layer is JSON, which always compresses, so an unframed one is decoded correctly by the legacy path.

The cost is that a mutation failing early leaves the repository stamped, locking older builds out of a repository that gained nothing — recoverable by upgrading the other machine. The alternative is not recoverable at all.

`docs/compatibility.md` gains this as a normative rule. `UpgradeRepoFormat`'s doc comment is also corrected: it claimed a pack-index-seal call site that does not exist.

## What an old binary does, verified by running it

Built `v1.15.0` from the tag and ran it, as `docs/compatibility.md` requires.

**A repository this build created (format 2)** — refused at the gate on `list`, `check`, and `restore` alike:

```text
repository format version 2 is newer than this build supports (up to 1):
upgrade cloudstic to work with this repository
```

**A repository `v1.15.0` created (format 1), backed up into by this build** — raised to format 2 *before* the first object is written, so no framed object is ever added to a repository still recording format 1. After the backup, `config` records version 2 and the store holds:

```text
framed:   chunk/5a5306e9…
framed:   index/latest
framed:   index/snapshots
framed:   packs/602e529a…
unframed: index/packmap/49de8a8a…
```

The one unframed object is the pack index shard, which `PackStore` writes *below* the compression layer and which therefore never carries a frame by construction. This build restores the `.gz` byte-for-byte.

So both machines always see a consistent repository: either format 1 with no frames, or format 2, which `v1.15.0` declines.

## Notes on the tests

Two of these were wrong before they were right, and both failure modes are worth knowing about:

- The e2e round trip initially passed with *and* without the fix. The fixtures were smaller than the 512 KiB `inlineThreshold`, so their bytes were embedded in the content manifest as JSON and never reached the compression layer. Sizes are now chosen against that threshold and the CDC chunk sizes (768 KiB single-chunk, 5 MiB multi-chunk, incompressible payloads), with the reasoning in the test comment.
- The legacy-fixture regression test initially passed without the fix because the preceding subtest had already stamped the repository to format 2. It now materialises its own pristine copy so it is the *first* backup onto a format-1 repository.

Both now fail without the fix and pass with it — the legacy one on both committed baselines.

## Verification

- `env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./...`
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./...`
- `npx markdownlint-cli2 docs/compatibility.md docs/spec.md`
- Old-binary behaviour verified by building `v1.15.0` from the tag and running it, per the section above.
