### PR TITLE
fix(engine): abort operations when the repo lock is lost

### DIFF
--- a/internal/engine/backup.go
+++ b/internal/engine/backup.go
@@ -157,11 +157,12 @@ type RunResult struct {
 // files, build a new HAMT root, and persist a snapshot.
 func (bm *BackupManager) Run(ctx context.Context) (*RunResult, error) {
 	if !bm.cfg.dryRun {
-		lock, err := AcquireSharedLock(ctx, bm.store, "backup")
+		lock, lockedCtx, err := AcquireSharedLock(ctx, bm.store, "backup")
 		if err != nil {
 			return nil, err
 		}
 		defer lock.Release()
+		ctx = lockedCtx
 	}
 
 	defer func() {

--- a/internal/engine/prune.go
+++ b/internal/engine/prune.go
@@ -59,11 +59,12 @@ func (pm *PruneManager) Run(ctx context.Context, opts ...PruneOption) (*PruneRes
 	}
 
 	if !cfg.dryRun {
-		lock, err := AcquireRepoLock(ctx, pm.store, "prune")
+		lock, lockedCtx, err := AcquireRepoLock(ctx, pm.store, "prune")
 		if err != nil {
 			return nil, err
 		}
 		defer lock.Release()
+		ctx = lockedCtx
 	}
 
 	pm.metaCache = make(map[string]core.FileMeta)

--- a/internal/engine/repolock.go
+++ b/internal/engine/repolock.go
@@ -42,6 +42,12 @@ func (ref *RepoLock) ownsLock(current *RepoLock) bool {
 // operation completes. A background goroutine refreshes the lock every
 // refreshRate so that the TTL stays short (fast recovery on crash) while
 // supporting arbitrarily long operations.
+//
+// cancel cancels the operation context returned alongside the handle. It is
+// called by Release on normal completion, and by the refresh goroutine the
+// moment it can no longer prove ownership of the lock — so an operation that
+// has lost its lock (TTL expired after a sleep, or another machine took over)
+// is aborted rather than left writing into a repository someone else now owns.
 type LockHandle struct {
 	store  store.ObjectStore
 	key    string
@@ -70,13 +76,17 @@ func (h *LockHandle) Release() {
 // AcquireRepoLock creates an exclusive lock for operation. If another
 // non-expired lock exists (exclusive or shared), the call returns an error.
 //
+// The returned context is derived from ctx and is cancelled if the lock is
+// ever lost while held, so the caller must run the operation under it rather
+// than under the original ctx.
+//
 // To mitigate TOCTOU races on stores without conditional writes, the lock is
 // written and then immediately re-read to verify this process still owns it.
-func AcquireRepoLock(ctx context.Context, s store.ObjectStore, operation string) (*LockHandle, error) {
+func AcquireRepoLock(ctx context.Context, s store.ObjectStore, operation string) (*LockHandle, context.Context, error) {
 	if existing, err := readLockByKey(ctx, s, exclusiveLockKey); err == nil {
 		expires, parseErr := time.Parse(time.RFC3339Nano, existing.ExpiresAt)
 		if parseErr != nil || time.Now().Before(expires) {
-			return nil, fmt.Errorf(
+			return nil, nil, fmt.Errorf(
 				"repository is locked by %s (operation: %s, acquired: %s, expires: %s)",
 				existing.Holder, existing.Operation, existing.AcquiredAt, existing.ExpiresAt,
 			)
@@ -85,7 +95,7 @@ func AcquireRepoLock(ctx context.Context, s store.ObjectStore, operation string)
 
 	// Check if any shared locks are active.
 	if err := checkSharedLocks(ctx, s); err != nil {
-		return nil, fmt.Errorf("cannot acquire exclusive lock: %w", err)
+		return nil, nil, fmt.Errorf("cannot acquire exclusive lock: %w", err)
 	}
 
 	holder := lockHolder()
@@ -97,38 +107,55 @@ func AcquireRepoLock(ctx context.Context, s store.ObjectStore, operation string)
 		ExpiresAt:  now.Add(lockTTL).Format(time.RFC3339Nano),
 	}
 	if err := writeLockByKey(ctx, s, exclusiveLockKey, lock); err != nil {
-		return nil, fmt.Errorf("acquire repo lock: %w", err)
+		return nil, nil, fmt.Errorf("acquire repo lock: %w", err)
 	}
 
 	// Re-read to verify ownership (TOCTOU mitigation).
 	current, err := readLockByKey(ctx, s, exclusiveLockKey)
 	if err != nil {
-		return nil, fmt.Errorf("verify repo lock: %w", err)
+		return nil, nil, fmt.Errorf("verify repo lock: %w", err)
 	}
 	if !lock.ownsLock(current) {
-		return nil, fmt.Errorf(
+		return nil, nil, fmt.Errorf(
 			"repository is locked by %s (operation: %s) — lost lock race",
 			current.Holder, current.Operation,
 		)
 	}
 
-	refreshCtx, cancel := context.WithCancel(ctx)
+	// Re-check shared locks after writing ours, mirroring the exclusive re-read
+	// AcquireSharedLock performs. Without this, a shared lock written between
+	// our initial checkSharedLocks and our write would go unseen and both the
+	// exclusive operation and the shared one would proceed concurrently.
+	if err := checkSharedLocks(ctx, s); err != nil {
+		// Roll back only if we still own the exclusive lock, so a concurrent
+		// exclusive acquirer that overwrote our key is not deleted from under it.
+		if owner, readErr := readLockByKey(ctx, s, exclusiveLockKey); readErr == nil && lock.ownsLock(owner) {
+			_ = s.Delete(ctx, exclusiveLockKey)
+		}
+		return nil, nil, fmt.Errorf("cannot acquire exclusive lock: %w", err)
+	}
+
+	opCtx, cancel := context.WithCancel(ctx)
 	h := &LockHandle{store: s, key: exclusiveLockKey, lock: lock, cancel: cancel}
 	h.wg.Add(1)
-	go h.refreshLoop(refreshCtx)
+	go h.refreshLoop(opCtx)
 
-	return h, nil
+	return h, opCtx, nil
 }
 
 // AcquireSharedLock creates a shared lock for an operation (like backup or restore).
 // If an exclusive lock exists, the call returns an error.
 // Multiple shared locks can exist simultaneously.
-func AcquireSharedLock(ctx context.Context, s store.ObjectStore, operation string) (*LockHandle, error) {
+//
+// The returned context is derived from ctx and is cancelled if the lock is
+// ever lost while held, so the caller must run the operation under it rather
+// than under the original ctx.
+func AcquireSharedLock(ctx context.Context, s store.ObjectStore, operation string) (*LockHandle, context.Context, error) {
 	// 1. Check if an exclusive lock exists
 	if existing, err := readLockByKey(ctx, s, exclusiveLockKey); err == nil {
 		expires, parseErr := time.Parse(time.RFC3339Nano, existing.ExpiresAt)
 		if parseErr != nil || time.Now().Before(expires) {
-			return nil, fmt.Errorf(
+			return nil, nil, fmt.Errorf(
 				"repository is exclusively locked by %s (operation: %s)",
 				existing.Holder, existing.Operation,
 			)
@@ -140,7 +167,7 @@ func AcquireSharedLock(ctx context.Context, s store.ObjectStore, operation strin
 	now := time.Now()
 	sharedLockKey, err := newSharedLockKey()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	lock := RepoLock{
@@ -151,7 +178,7 @@ func AcquireSharedLock(ctx context.Context, s store.ObjectStore, operation strin
 		IsShared:   true,
 	}
 	if err := writeLockByKey(ctx, s, sharedLockKey, lock); err != nil {
-		return nil, fmt.Errorf("acquire shared lock: %w", err)
+		return nil, nil, fmt.Errorf("acquire shared lock: %w", err)
 	}
 
 	// 3. Re-read exclusive lock to catch race with prune creating an exclusive lock at the same time
@@ -161,19 +188,19 @@ func AcquireSharedLock(ctx context.Context, s store.ObjectStore, operation strin
 			// Found an exclusive lock that was created during our shared lock creation
 			// Rollback our shared lock
 			_ = s.Delete(ctx, sharedLockKey)
-			return nil, fmt.Errorf(
+			return nil, nil, fmt.Errorf(
 				"repository was exclusively locked by %s while acquiring shared lock",
 				existing.Holder,
 			)
 		}
 	}
 
-	refreshCtx, cancel := context.WithCancel(ctx)
+	opCtx, cancel := context.WithCancel(ctx)
 	h := &LockHandle{store: s, key: sharedLockKey, lock: lock, cancel: cancel}
 	h.wg.Add(1)
-	go h.refreshLoop(refreshCtx)
+	go h.refreshLoop(opCtx)
 
-	return h, nil
+	return h, opCtx, nil
 }
 
 func newSharedLockKey() (string, error) {
@@ -201,17 +228,24 @@ func (h *LockHandle) refreshLoop(ctx context.Context) {
 			if err != nil {
 				consecutiveFailures++
 				if consecutiveFailures >= maxRefreshFailures {
+					// Cannot confirm we still hold the lock; the TTL will lapse
+					// and another process may take over. Abort the operation.
+					h.cancel()
 					return
 				}
 				continue
 			}
 			if !h.lock.ownsLock(current) {
+				// Another holder owns the lock now. Abort the operation before
+				// it writes into a repository we no longer control.
+				h.cancel()
 				return
 			}
 			h.lock.ExpiresAt = time.Now().Add(lockTTL).Format(time.RFC3339Nano)
 			if err := writeLockByKey(ctx, h.store, h.key, h.lock); err != nil {
 				consecutiveFailures++
 				if consecutiveFailures >= maxRefreshFailures {
+					h.cancel()
 					return
 				}
 				continue

--- a/internal/engine/repolock_test.go
+++ b/internal/engine/repolock_test.go
@@ -15,7 +15,7 @@ func TestAcquireRepoLock_Success(t *testing.T) {
 	ctx := context.Background()
 	s := NewMockStore()
 
-	lock, err := AcquireRepoLock(ctx, s, "prune")
+	lock, _, err := AcquireRepoLock(ctx, s, "prune")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -41,13 +41,13 @@ func TestAcquireRepoLock_Conflict(t *testing.T) {
 	ctx := context.Background()
 	s := NewMockStore()
 
-	lock1, err := AcquireRepoLock(ctx, s, "prune")
+	lock1, _, err := AcquireRepoLock(ctx, s, "prune")
 	if err != nil {
 		t.Fatalf("first acquire: %v", err)
 	}
 	defer lock1.Release()
 
-	_, err = AcquireRepoLock(ctx, s, "prune")
+	_, _, err = AcquireRepoLock(ctx, s, "prune")
 	if err == nil {
 		t.Fatal("second acquire should fail while first lock is held")
 	}
@@ -69,7 +69,7 @@ func TestAcquireRepoLock_ExpiredLockIsOverridden(t *testing.T) {
 	data, _ := json.Marshal(expired)
 	_ = s.Put(ctx, exclusiveLockKey, data)
 
-	lock, err := AcquireRepoLock(ctx, s, "prune")
+	lock, _, err := AcquireRepoLock(ctx, s, "prune")
 	if err != nil {
 		t.Fatalf("should override expired lock: %v", err)
 	}
@@ -89,7 +89,7 @@ func TestAcquireRepoLock_MalformedExpiresAtTreatedAsLocked(t *testing.T) {
 	data, _ := json.Marshal(bad)
 	_ = s.Put(ctx, exclusiveLockKey, data)
 
-	_, err := AcquireRepoLock(ctx, s, "backup")
+	_, _, err := AcquireRepoLock(ctx, s, "backup")
 	if err == nil {
 		t.Fatal("malformed ExpiresAt should be treated as locked")
 	}
@@ -102,7 +102,7 @@ func TestRelease_DeletesOwnLock(t *testing.T) {
 	ctx := context.Background()
 	s := NewMockStore()
 
-	lock, err := AcquireRepoLock(ctx, s, "prune")
+	lock, _, err := AcquireRepoLock(ctx, s, "prune")
 	if err != nil {
 		t.Fatalf("acquire: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestRelease_DoesNotDeleteOtherLock(t *testing.T) {
 	ctx := context.Background()
 	s := NewMockStore()
 
-	lock, err := AcquireRepoLock(ctx, s, "prune")
+	lock, _, err := AcquireRepoLock(ctx, s, "prune")
 	if err != nil {
 		t.Fatalf("acquire: %v", err)
 	}
@@ -155,7 +155,7 @@ func TestCheckRepoLock_ActiveLock(t *testing.T) {
 	ctx := context.Background()
 	s := NewMockStore()
 
-	lock, err := AcquireRepoLock(ctx, s, "prune")
+	lock, _, err := AcquireRepoLock(ctx, s, "prune")
 	if err != nil {
 		t.Fatalf("acquire: %v", err)
 	}
@@ -228,7 +228,7 @@ func TestLockRefresh(t *testing.T) {
 	ctx := context.Background()
 	s := NewMockStore()
 
-	lock, err := AcquireRepoLock(ctx, s, "prune")
+	lock, _, err := AcquireRepoLock(ctx, s, "prune")
 	if err != nil {
 		t.Fatalf("acquire: %v", err)
 	}
@@ -266,7 +266,7 @@ func TestRefresh_StopsWhenOwnershipLost(t *testing.T) {
 	ctx := context.Background()
 	s := NewMockStore()
 
-	lock, err := AcquireRepoLock(ctx, s, "prune")
+	lock, _, err := AcquireRepoLock(ctx, s, "prune")
 	if err != nil {
 		t.Fatalf("acquire: %v", err)
 	}
@@ -307,6 +307,46 @@ func TestRefresh_StopsWhenOwnershipLost(t *testing.T) {
 	lock.wg.Wait()
 }
 
+func TestRefresh_CancelsOperationWhenOwnershipLost(t *testing.T) {
+	origTTL, origRate := lockTTL, refreshRate
+	lockTTL = 2 * time.Second
+	refreshRate = 200 * time.Millisecond
+	defer func() { lockTTL, refreshRate = origTTL, origRate }()
+
+	ctx := context.Background()
+	s := NewMockStore()
+
+	lock, opCtx, err := AcquireRepoLock(ctx, s, "prune")
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	defer lock.Release()
+
+	if opCtx.Err() != nil {
+		t.Fatalf("operation context should be live right after acquire: %v", opCtx.Err())
+	}
+
+	// Let one refresh cycle complete, then hand the lock to another holder.
+	time.Sleep(refreshRate + 100*time.Millisecond)
+
+	other := RepoLock{
+		Operation:  "backup",
+		Holder:     "other-host (pid 99)",
+		AcquiredAt: time.Now().Format(time.RFC3339Nano),
+		ExpiresAt:  time.Now().Add(lockTTL).Format(time.RFC3339Nano),
+	}
+	otherData, _ := json.Marshal(other)
+	_ = s.Put(ctx, exclusiveLockKey, otherData)
+
+	// The refresh goroutine must notice the lost lock and cancel the operation
+	// context so the in-flight operation aborts.
+	select {
+	case <-opCtx.Done():
+	case <-time.After(3 * time.Second):
+		t.Fatal("operation context was not cancelled after losing the lock")
+	}
+}
+
 func TestPruneDryRun_NoLock(t *testing.T) {
 	ctx := context.Background()
 	s := NewMockStore()
@@ -345,7 +385,7 @@ func TestAcquireSharedLock_Success(t *testing.T) {
 	ctx := context.Background()
 	s := NewMockStore()
 
-	lock, err := AcquireSharedLock(ctx, s, "backup")
+	lock, _, err := AcquireSharedLock(ctx, s, "backup")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -377,7 +417,7 @@ func TestAcquireSharedLock_UsesFilesystemSafeKey(t *testing.T) {
 	ctx := context.Background()
 	s := NewMockStore()
 
-	lock, err := AcquireSharedLock(ctx, s, "backup")
+	lock, _, err := AcquireSharedLock(ctx, s, "backup")
 	if err != nil {
 		t.Fatalf("acquire shared lock: %v", err)
 	}
@@ -400,7 +440,7 @@ func TestAcquireSharedLock_ConcurrentSharedLocks(t *testing.T) {
 	ctx := context.Background()
 	s := NewMockStore()
 
-	lock1, err := AcquireSharedLock(ctx, s, "backup1")
+	lock1, _, err := AcquireSharedLock(ctx, s, "backup1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -409,7 +449,7 @@ func TestAcquireSharedLock_ConcurrentSharedLocks(t *testing.T) {
 	// Wait briefly to ensure AcquiredAt timestamp differs
 	time.Sleep(1 * time.Millisecond)
 
-	lock2, err := AcquireSharedLock(ctx, s, "backup2")
+	lock2, _, err := AcquireSharedLock(ctx, s, "backup2")
 	if err != nil {
 		t.Fatalf("second shared lock should succeed: %v", err)
 	}
@@ -425,13 +465,13 @@ func TestAcquireSharedLock_ConflictWithExclusive(t *testing.T) {
 	ctx := context.Background()
 	s := NewMockStore()
 
-	lockExcl, err := AcquireRepoLock(ctx, s, "prune")
+	lockExcl, _, err := AcquireRepoLock(ctx, s, "prune")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	defer lockExcl.Release()
 
-	_, err = AcquireSharedLock(ctx, s, "backup")
+	_, _, err = AcquireSharedLock(ctx, s, "backup")
 	if err == nil {
 		t.Fatal("shared lock should fail if exclusive lock exists")
 	}
@@ -444,13 +484,13 @@ func TestAcquireExclusiveLock_ConflictWithShared(t *testing.T) {
 	ctx := context.Background()
 	s := NewMockStore()
 
-	lockShared, err := AcquireSharedLock(ctx, s, "backup")
+	lockShared, _, err := AcquireSharedLock(ctx, s, "backup")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	defer lockShared.Release()
 
-	_, err = AcquireRepoLock(ctx, s, "prune")
+	_, _, err = AcquireRepoLock(ctx, s, "prune")
 	if err == nil {
 		t.Fatal("exclusive lock should fail if shared lock exists")
 	}

--- a/internal/engine/restore.go
+++ b/internal/engine/restore.go
@@ -102,11 +102,12 @@ func NewRestoreManager(s store.ObjectStore, reporter ui.Reporter) *RestoreManage
 // Run restores the snapshot's file tree to the provided writer format.
 // snapshotRef can be "", "latest", a bare hash, or "snapshot/<hash>".
 func (rm *RestoreManager) Run(ctx context.Context, writer RestoreWriter, snapshotRef string, opts ...RestoreOption) (*RestoreResult, error) {
-	lock, err := AcquireSharedLock(ctx, rm.store, "restore")
+	lock, lockedCtx, err := AcquireSharedLock(ctx, rm.store, "restore")
 	if err != nil {
 		return nil, err
 	}
 	defer lock.Release()
+	ctx = lockedCtx
 
 	plan, err := rm.prepareRestore(ctx, snapshotRef, opts...)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Make `refreshLoop` cancel the in-flight operation when it can no longer prove it owns the lock, instead of returning silently. Previously a backup/restore/prune kept writing after losing its lock — e.g. a laptop sleeping past the 1-minute TTL, or a second machine starting a prune once the TTL lapsed — into a repository another process could now own.
- `AcquireRepoLock`/`AcquireSharedLock` now return an operation `context.Context` derived from the caller's `ctx`; the refresh goroutine cancels it on lost ownership *and* on `maxRefreshFailures`. Callers (`backup`, `restore`, `prune`) run the operation under the returned context so cancellation actually aborts the work.
- `AcquireRepoLock` re-checks shared locks after writing its exclusive lock, mirroring the shared path's post-write exclusive re-read — closing the other direction of the acquire race, where a shared lock written between the initial check and the exclusive write would go unseen. The rollback delete is ownership-guarded so a concurrent exclusive acquirer is never deleted from under it.
- Added `TestRefresh_CancelsOperationWhenOwnershipLost`; updated existing acquire call sites for the new signature.

Note: two related weaknesses mentioned in the original report were already fixed on `main` and left unchanged — the shared lock key already uses `crypto/rand` (`newSharedLockKey`, verified by `TestAcquireSharedLock_UsesFilesystemSafeKey`), and `LockHandle` already stores its key directly rather than reconstructing it from `AcquiredAt`.

## Verification

- `env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./internal/engine` passes
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./internal/engine/...` passes (0 issues)
- `env GOCACHE=/tmp/cloudstic-gocache go build ./...` and `go vet ./internal/engine` clean