### PR TITLE
fix(store): scope SFTPStore.List to the prefix subdirectory

### DIFF
--- a/pkg/store/sftp.go
+++ b/pkg/store/sftp.go
@@ -242,8 +242,21 @@ func (s *SFTPStore) Flush(ctx context.Context) error {
 }
 
 func (s *SFTPStore) List(_ context.Context, prefix string) ([]string, error) {
+	startPath := s.basePath
+	if prefix != "" {
+		candidate := path.Join(s.basePath, prefix)
+		if info, err := s.client.Stat(candidate); err == nil && info.IsDir() {
+			startPath = candidate
+		} else {
+			dir := path.Dir(candidate)
+			if _, err := s.client.Stat(dir); err == nil {
+				startPath = dir
+			}
+		}
+	}
+
 	var keys []string
-	walker := s.client.Walk(s.basePath)
+	walker := s.client.Walk(startPath)
 	for walker.Step() {
 		if err := walker.Err(); err != nil {
 			return nil, err


### PR DESCRIPTION
## Summary
- `SFTPStore.List` always walked from `s.basePath` regardless of the requested prefix, unlike `LocalStore.List`, which scopes its walk to the prefix subdirectory
- `checkSharedLocks` (`internal/engine/repolock.go`) lists `index/lock.shared/` on every lock acquisition, so every backup/restore against an SFTP store walked the entire repository over the wire just to check for shared locks
- Resolve the prefix to a subdirectory (or its parent directory, for a partial-filename prefix) via `Stat`, and start the walk there — same approach `LocalStore.List` already uses

## Verification
- `go build ./...`
- `env GOCACHE=/tmp/cloudstic-gocache go test -v -run TestSFTPStore ./pkg/store/...` (hermetic, Docker-backed SFTP container test) — passes, including `List` coverage and the `RangeGetter` conformance subtests