### PR TITLE
fix(store): distinguish not-found from real Get failures

### DIFF
--- a/internal/engine/backup.go
+++ b/internal/engine/backup.go
@@ -177,13 +177,15 @@ func (bm *BackupManager) Run(ctx context.Context) (*RunResult, error) {
 	var g errgroup.Group
 
 	g.Go(func() error {
-		seq = bm.loadLatestSeq()
-		return nil
+		var err error
+		seq, err = bm.loadLatestSeq()
+		return err
 	})
 
 	g.Go(func() error {
-		prevSnap = bm.findPreviousSnapshot(bm.sourceInfo)
-		return nil
+		var err error
+		prevSnap, err = bm.findPreviousSnapshot(bm.sourceInfo)
+		return err
 	})
 
 	if err := g.Wait(); err != nil {
@@ -304,19 +306,23 @@ func (bm *BackupManager) buildResult() *RunResult {
 
 // loadLatestSeq returns the global sequence number from the most recent
 // snapshot. On a fresh repository it returns 0.
-func (bm *BackupManager) loadLatestSeq() int {
-	_, seq := resolveLatest(bm.store)
-	return seq
+func (bm *BackupManager) loadLatestSeq() (int, error) {
+	_, seq, err := resolveLatest(bm.store)
+	return seq, err
 }
 
 // findPreviousSnapshot lists all snapshots and returns the most recent one
 // whose Source matches the given info. Matching prefers the new identity
 // fields and falls back to legacy fields for backward compatibility.
-// Returns nil when no matching snapshot exists.
-func (bm *BackupManager) findPreviousSnapshot(info core.SourceInfo) *core.Snapshot {
+// Returns nil when no matching snapshot exists in an otherwise readable
+// catalog; returns an error when the catalog could not be read, since that is
+// not the same thing as "no previous snapshot" — treating it as such would
+// silently downgrade an incremental backup to a full rescan and reset the
+// sequence number.
+func (bm *BackupManager) findPreviousSnapshot(info core.SourceInfo) (*core.Snapshot, error) {
 	entries, err := LoadSnapshotCatalog(bm.store)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
 	// Pass 1: identity + path_id (preferred).
@@ -327,7 +333,7 @@ func (bm *BackupManager) findPreviousSnapshot(info core.SourceInfo) *core.Snapsh
 				e.Snap.Source.Identity == info.Identity &&
 				e.Snap.Source.PathID == info.PathID {
 				snap := e.Snap
-				return &snap
+				return &snap, nil
 			}
 		}
 	}
@@ -340,7 +346,7 @@ func (bm *BackupManager) findPreviousSnapshot(info core.SourceInfo) *core.Snapsh
 				e.Snap.Source.Identity == info.Identity &&
 				e.Snap.Source.Path == info.Path {
 				snap := e.Snap
-				return &snap
+				return &snap, nil
 			}
 		}
 	}
@@ -352,10 +358,10 @@ func (bm *BackupManager) findPreviousSnapshot(info core.SourceInfo) *core.Snapsh
 			e.Snap.Source.Account == info.Account &&
 			e.Snap.Source.Path == info.Path {
 			snap := e.Snap
-			return &snap
+			return &snap, nil
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 func (bm *BackupManager) saveSnapshot(ctx context.Context, root string, seq int, changeToken string) (ref, hash string, snap core.Snapshot, err error) {

--- a/internal/engine/backup_test.go
+++ b/internal/engine/backup_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -352,7 +353,10 @@ func TestFindPreviousSnapshot_Identity(t *testing.T) {
 		Identity: "A1B2C3D4-1234-5678-ABCD-EF0123456789",
 		PathID:   ".",
 	}
-	prev := bm.findPreviousSnapshot(info)
+	prev, err := bm.findPreviousSnapshot(info)
+	if err != nil {
+		t.Fatalf("findPreviousSnapshot: %v", err)
+	}
 	if prev == nil {
 		t.Fatal("expected to find previous snapshot via identity match")
 	} else if prev.Root != "node/linux" {
@@ -391,7 +395,10 @@ func TestFindPreviousSnapshot_LegacyFallback(t *testing.T) {
 		Account: "myhost",
 		Path:    "/data",
 	}
-	prev := bm.findPreviousSnapshot(info)
+	prev, err := bm.findPreviousSnapshot(info)
+	if err != nil {
+		t.Fatalf("findPreviousSnapshot: %v", err)
+	}
 	if prev == nil {
 		t.Fatal("expected to find previous snapshot via legacy match")
 	} else if prev.Root != "node/legacy" {
@@ -449,7 +456,10 @@ func TestFindPreviousSnapshot_IdentityPreferredOverLegacy(t *testing.T) {
 		Identity: "UUID-1234",
 		PathID:   ".",
 	}
-	prev := bm.findPreviousSnapshot(info)
+	prev, err := bm.findPreviousSnapshot(info)
+	if err != nil {
+		t.Fatalf("findPreviousSnapshot: %v", err)
+	}
 	if prev == nil {
 		t.Fatal("expected to find previous snapshot")
 	} else if prev.Root != "node/new" {
@@ -491,8 +501,33 @@ func TestFindPreviousSnapshot_IdentityDifferentSubdirs(t *testing.T) {
 		Identity: "UUID-SAME-DRIVE",
 		PathID:   "Documents",
 	}
-	prev := bm.findPreviousSnapshot(info)
+	prev, err := bm.findPreviousSnapshot(info)
+	if err != nil {
+		t.Fatalf("findPreviousSnapshot: %v", err)
+	}
 	if prev != nil {
 		t.Errorf("expected nil (different subdir on same drive), got root=%s", prev.Root)
+	}
+}
+
+// TestBackupManager_Run_PropagatesLatestIndexError verifies that a real
+// backend failure reading index/latest aborts the backup instead of being
+// silently treated as a fresh repository — which would reset the sequence
+// number and force an unnecessary full rescan.
+func TestBackupManager_Run_PropagatesLatestIndexError(t *testing.T) {
+	ctx := context.Background()
+	backendErr := errors.New("simulated network error")
+	dest := newErrorOnGetStore(NewMockStore(), backendErr, "index/latest")
+
+	src := NewMockSource()
+	src.AddFile("file1.txt", "id1", []byte("hello"))
+
+	mgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil)
+	_, err := mgr.Run(ctx)
+	if err == nil {
+		t.Fatal("expected Run to fail when index/latest cannot be read")
+	}
+	if !errors.Is(err, backendErr) {
+		t.Errorf("Run error = %v, want it to wrap %v", err, backendErr)
 	}
 }

--- a/internal/engine/forget.go
+++ b/internal/engine/forget.go
@@ -185,7 +185,10 @@ func (fm *ForgetManager) Run(ctx context.Context, snapshotID string, opts ...For
 
 func (fm *ForgetManager) resolveSnapshot(id string) (string, error) {
 	if id == "latest" {
-		ref, _ := resolveLatest(fm.store)
+		ref, _, err := resolveLatest(fm.store)
+		if err != nil {
+			return "", err
+		}
 		if ref == "" {
 			return "", fmt.Errorf("no latest snapshot found")
 		}
@@ -205,7 +208,10 @@ func (fm *ForgetManager) resolveSnapshot(id string) (string, error) {
 // If the deleted ref was the latest, pick the remaining snapshot with the
 // highest Seq. If no snapshots remain, delete index/latest.
 func (fm *ForgetManager) fixupLatest(deletedRef string) error {
-	curRef, _ := resolveLatest(fm.store)
+	curRef, _, err := resolveLatest(fm.store)
+	if err != nil {
+		return err
+	}
 	if curRef != deletedRef {
 		return nil
 	}

--- a/internal/engine/forget_test.go
+++ b/internal/engine/forget_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/cloudstic/cli/internal/core"
@@ -62,6 +63,46 @@ func TestForgetManager_Run(t *testing.T) {
 	}
 	if idx.Seq != 1 {
 		t.Errorf("Latest seq should be 1, got %d", idx.Seq)
+	}
+}
+
+// A real backend failure while resolving "latest" must propagate rather than
+// be reported as "no latest snapshot found", which would be misleading.
+func TestForgetManager_ResolveSnapshot_PropagatesLatestError(t *testing.T) {
+	backendErr := errors.New("simulated network error")
+	s := newErrorOnGetStore(NewMockStore(), backendErr, "index/latest")
+	fm := NewForgetManager(s, ui.NewNoOpReporter())
+
+	_, err := fm.resolveSnapshot("latest")
+	if err == nil {
+		t.Fatal("expected resolveSnapshot(latest) to propagate a real backend error")
+	}
+	if !errors.Is(err, backendErr) {
+		t.Errorf("resolveSnapshot error = %v, want it to wrap %v", err, backendErr)
+	}
+}
+
+// A real backend failure while re-reading index/latest during fixupLatest
+// must abort rather than be silently treated as "not the deleted ref" —
+// otherwise index/latest could keep pointing at a snapshot that was just
+// deleted.
+func TestForgetManager_FixupLatest_PropagatesError(t *testing.T) {
+	backendErr := errors.New("simulated network error")
+	inner := NewMockStore()
+	ctx := context.Background()
+	snap := core.Snapshot{Seq: 1, Root: "node/1"}
+	ref := saveSnapshot(ctx, inner, &snap)
+	_ = inner.Put(ctx, "index/latest", createIndex(ref, 1))
+
+	s := newErrorOnGetStore(inner, backendErr, "index/latest")
+	fm := NewForgetManager(s, ui.NewNoOpReporter())
+
+	err := fm.fixupLatest(ref)
+	if err == nil {
+		t.Fatal("expected fixupLatest to propagate a real backend error")
+	}
+	if !errors.Is(err, backendErr) {
+		t.Errorf("fixupLatest error = %v, want it to wrap %v", err, backendErr)
 	}
 }
 

--- a/internal/engine/init.go
+++ b/internal/engine/init.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -72,9 +73,13 @@ func (m *InitManager) Run(ctx context.Context, opts ...InitOption) (*InitResult,
 	initLog.Debugf("InitRepo: encrypted=%v, noEncryption=%v, adoptSlots=%v, hasChain=%v, recovery=%v",
 		!cfg.noEncryption && len(cfg.chain) > 0, cfg.noEncryption, cfg.adoptSlots, len(cfg.chain) > 0, cfg.recovery)
 
-	// Check if already initialized.
+	// Check if already initialized. A read failure that is not "no config yet"
+	// must abort rather than fall through as if this were a fresh repository —
+	// otherwise a transient store error could make init overwrite an existing
+	// repository's key slots and config.
 	cfgData, err := m.store.Get(ctx, configKey)
-	if err == nil && cfgData != nil {
+	switch {
+	case err == nil && cfgData != nil:
 		if !cfg.adoptSlots {
 			return nil, fmt.Errorf("repository is already initialized")
 		}
@@ -94,6 +99,13 @@ func (m *InitManager) Run(ctx context.Context, opts ...InitOption) (*InitResult,
 				)
 			}
 		}
+	case err == nil, errors.Is(err, store.ErrNotFound):
+		// Not yet initialized. (Some ObjectStore test doubles return (nil,
+		// nil) rather than ErrNotFound for a missing key; a real backend
+		// never does, but treating a nil error as "not found" here is
+		// harmless either way.)
+	default:
+		return nil, fmt.Errorf("check for existing repository: %w", err)
 	}
 
 	hasCreds := len(cfg.chain) > 0
@@ -187,13 +199,19 @@ func (m *InitManager) writeRepoConfig(ctx context.Context, encrypted bool) error
 	// The recorded format is a floor and must never move down. Adopting an
 	// existing repository rewrites this marker, and stamping a lower version
 	// than the repository has already reached would advertise it as readable by
-	// builds that would misread it.
+	// builds that would misread it. A transient read failure here must not be
+	// mistaken for "no existing config" — that would silently move the floor
+	// down instead of leaving it alone.
 	version := core.RepoFormatVersion
-	if data, err := m.store.Get(ctx, configKey); err == nil && data != nil {
+	existingData, err := m.store.Get(ctx, configKey)
+	switch {
+	case err == nil:
 		var existing core.RepoConfig
-		if err := json.Unmarshal(data, &existing); err == nil && existing.Version > version {
+		if err := json.Unmarshal(existingData, &existing); err == nil && existing.Version > version {
 			version = existing.Version
 		}
+	case !errors.Is(err, store.ErrNotFound):
+		return fmt.Errorf("read existing repository config: %w", err)
 	}
 
 	cfg := core.RepoConfig{

--- a/internal/engine/init_test.go
+++ b/internal/engine/init_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/cloudstic/cli/internal/core"
@@ -142,6 +143,41 @@ func TestInitManager_AlreadyInitialized(t *testing.T) {
 	_, err := mgr.Run(context.Background(), WithInitNoEncryption())
 	if err == nil {
 		t.Fatal("expected error for already-initialized repo")
+	}
+}
+
+// A real backend failure while checking for an existing "config" marker must
+// abort Run rather than be treated as "not yet initialized" — otherwise a
+// transient store error could make init overwrite an existing repository's
+// key slots and config.
+func TestInitManager_Run_PropagatesConfigCheckError(t *testing.T) {
+	backendErr := errors.New("simulated network error")
+	s := newErrorOnGetStore(NewMockStore(), backendErr, configKey)
+	mgr := NewInitManager(s)
+
+	_, err := mgr.Run(context.Background(), WithInitNoEncryption())
+	if err == nil {
+		t.Fatal("expected Run to fail when the existing config cannot be read")
+	}
+	if !errors.Is(err, backendErr) {
+		t.Errorf("Run error = %v, want it to wrap %v", err, backendErr)
+	}
+}
+
+// writeRepoConfig must not silently move the recorded format version down
+// when it cannot read the existing config to compare against — that floor is
+// permanent (see docs/compatibility.md).
+func TestInitManager_WriteRepoConfig_PropagatesReadError(t *testing.T) {
+	backendErr := errors.New("simulated network error")
+	s := newErrorOnGetStore(NewMockStore(), backendErr, configKey)
+	mgr := NewInitManager(s)
+
+	err := mgr.writeRepoConfig(context.Background(), false)
+	if err == nil {
+		t.Fatal("expected writeRepoConfig to fail when the existing config cannot be read")
+	}
+	if !errors.Is(err, backendErr) {
+		t.Errorf("writeRepoConfig error = %v, want it to wrap %v", err, backendErr)
 	}
 }
 

--- a/internal/engine/mock_test.go
+++ b/internal/engine/mock_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cloudstic/cli/internal/core"
 	"github.com/cloudstic/cli/internal/hamt"
 	"github.com/cloudstic/cli/pkg/source"
+	"github.com/cloudstic/cli/pkg/store"
 )
 
 // MockStore implements store.ObjectStore. It is safe for concurrent use.
@@ -38,7 +39,7 @@ func (s *MockStore) Get(_ context.Context, key string) ([]byte, error) {
 	data, ok := s.Data[key]
 	s.mu.RUnlock()
 	if !ok {
-		return nil, fmt.Errorf("key not found: %s", key)
+		return nil, fmt.Errorf("%s: %w", key, store.ErrNotFound)
 	}
 	return data, nil
 }
@@ -74,7 +75,7 @@ func (s *MockStore) Size(_ context.Context, key string) (int64, error) {
 	data, ok := s.Data[key]
 	s.mu.RUnlock()
 	if !ok {
-		return 0, fmt.Errorf("key not found: %s", key)
+		return 0, fmt.Errorf("%s: %w", key, store.ErrNotFound)
 	}
 	return int64(len(data)), nil
 }
@@ -91,6 +92,32 @@ func (s *MockStore) TotalSize(_ context.Context) (int64, error) {
 
 func (s *MockStore) Flush(_ context.Context) error {
 	return nil
+}
+
+// errorOnGetStore wraps a store.ObjectStore and forces Get to return a fixed
+// error for a chosen set of keys, simulating a real backend failure (network,
+// permission, ...) as distinct from the key simply not existing. Tests use
+// this to verify that such an error is propagated rather than silently
+// treated as "not found".
+type errorOnGetStore struct {
+	store.ObjectStore
+	errKeys map[string]bool
+	err     error
+}
+
+func newErrorOnGetStore(inner store.ObjectStore, err error, keys ...string) *errorOnGetStore {
+	m := make(map[string]bool, len(keys))
+	for _, k := range keys {
+		m[k] = true
+	}
+	return &errorOnGetStore{ObjectStore: inner, errKeys: m, err: err}
+}
+
+func (s *errorOnGetStore) Get(ctx context.Context, key string) ([]byte, error) {
+	if s.errKeys[key] {
+		return nil, s.err
+	}
+	return s.ObjectStore.Get(ctx, key)
 }
 
 // MockSource implements source.Source

--- a/internal/engine/snapshots.go
+++ b/internal/engine/snapshots.go
@@ -3,6 +3,8 @@ package engine
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -73,7 +75,10 @@ func LoadSnapshotCatalog(s store.ObjectStore) ([]SnapshotEntry, error) {
 
 	// 5. Fetch missing snapshot objects concurrently.
 	if len(missing) > 0 {
-		fetched := fetchSnapshots(s, missing)
+		fetched, err := fetchSnapshots(s, missing)
+		if err != nil {
+			return nil, fmt.Errorf("load snapshot catalog: %w", err)
+		}
 		for ref, snap := range fetched {
 			catalogMap[ref] = snapshotToSummary(ref, snap)
 		}
@@ -134,13 +139,33 @@ func SaveSnapshotCatalog(s store.ObjectStore, catalog []core.SnapshotSummary) er
 	return s.Put(context.Background(), snapshotCatalogKey, data)
 }
 
+// loadCatalogForUpdate reads the current catalog for AppendSnapshotCatalog and
+// RemoveFromSnapshotCatalog. ok is false when the read failed for a real
+// reason (not simply "no catalog yet"): callers must not treat that as an
+// empty catalog, since persisting one would clobber every existing entry with
+// a base that just happens to be wrong rather than absent. The self-heal in
+// LoadSnapshotCatalog recovers a merely stale catalog on the next read; it
+// cannot recover one that was overwritten with fabricated emptiness.
+func loadCatalogForUpdate(s store.ObjectStore) (catalog []core.SnapshotSummary, ok bool) {
+	data, err := s.Get(context.Background(), snapshotCatalogKey)
+	switch {
+	case err == nil:
+		_ = json.Unmarshal(data, &catalog)
+		return catalog, true
+	case errors.Is(err, store.ErrNotFound):
+		return nil, true
+	default:
+		return nil, false
+	}
+}
+
 // AppendSnapshotCatalog loads the current catalog, appends a new summary, and
 // persists it. This is best-effort; errors are logged but not propagated.
 func AppendSnapshotCatalog(s store.ObjectStore, summary core.SnapshotSummary) {
-	ctx := context.Background()
-	var catalog []core.SnapshotSummary
-	if data, err := s.Get(ctx, snapshotCatalogKey); err == nil {
-		_ = json.Unmarshal(data, &catalog)
+	catalog, ok := loadCatalogForUpdate(s)
+	if !ok {
+		snapLog.Debugf("failed to append snapshot catalog: could not read existing catalog")
+		return
 	}
 	catalog = append(catalog, summary)
 	if err := SaveSnapshotCatalog(s, catalog); err != nil {
@@ -151,10 +176,10 @@ func AppendSnapshotCatalog(s store.ObjectStore, summary core.SnapshotSummary) {
 // RemoveFromSnapshotCatalog loads the current catalog, removes entries whose
 // refs match, and persists the result. This is best-effort.
 func RemoveFromSnapshotCatalog(s store.ObjectStore, refs ...string) {
-	ctx := context.Background()
-	var catalog []core.SnapshotSummary
-	if data, err := s.Get(ctx, snapshotCatalogKey); err == nil {
-		_ = json.Unmarshal(data, &catalog)
+	catalog, ok := loadCatalogForUpdate(s)
+	if !ok {
+		snapLog.Debugf("failed to update snapshot catalog after removal: could not read existing catalog")
+		return
 	}
 	if len(catalog) == 0 {
 		return
@@ -193,10 +218,17 @@ func snapshotToSummary(ref string, snap core.Snapshot) core.SnapshotSummary {
 // ---------------------------------------------------------------------------
 
 // fetchSnapshots concurrently fetches and unmarshals the given snapshot keys.
-func fetchSnapshots(s store.ObjectStore, keys []string) map[string]core.Snapshot {
+// A key that no longer exists (e.g. removed by a concurrent prune) is simply
+// omitted from the result — that is a legitimate "gone". Any other failure,
+// including a snapshot that fails to decode, aborts the whole fetch instead:
+// the caller cannot tell "gone" from "unreadable", and silently dropping an
+// unreadable-but-still-live snapshot would persist a catalog that is missing
+// an entry that is actually still there.
+func fetchSnapshots(s store.ObjectStore, keys []string) (map[string]core.Snapshot, error) {
 	ctx := context.Background()
 	result := make(map[string]core.Snapshot, len(keys))
 	var mu sync.Mutex
+	var firstErr error
 	var wg sync.WaitGroup
 
 	for _, key := range keys {
@@ -205,10 +237,23 @@ func fetchSnapshots(s store.ObjectStore, keys []string) map[string]core.Snapshot
 			defer wg.Done()
 			data, err := s.Get(ctx, k)
 			if err != nil {
+				if errors.Is(err, store.ErrNotFound) {
+					return
+				}
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = fmt.Errorf("fetch %s: %w", k, err)
+				}
+				mu.Unlock()
 				return
 			}
 			var snap core.Snapshot
 			if err := json.Unmarshal(data, &snap); err != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = fmt.Errorf("decode %s: %w", k, err)
+				}
+				mu.Unlock()
 				return
 			}
 			mu.Lock()
@@ -218,7 +263,10 @@ func fetchSnapshots(s store.ObjectStore, keys []string) map[string]core.Snapshot
 	}
 
 	wg.Wait()
-	return result
+	if firstErr != nil {
+		return nil, firstErr
+	}
+	return result, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -226,17 +274,24 @@ func fetchSnapshots(s store.ObjectStore, keys []string) map[string]core.Snapshot
 // ---------------------------------------------------------------------------
 
 // resolveLatest reads index/latest and returns the snapshot ref it points to.
-// Returns empty string on error (fresh repo).
-func resolveLatest(s store.ObjectStore) (ref string, seq int) {
+// Returns ("", 0, nil) on a fresh repository (no index/latest yet). Any other
+// read or decode failure is returned as an error rather than treated as a
+// fresh repo — a transient store error is not the same as "no snapshots
+// exist", and confusing the two would silently reset the sequence number and
+// downgrade the next backup from incremental to a full rescan.
+func resolveLatest(s store.ObjectStore) (ref string, seq int, err error) {
 	data, err := s.Get(context.Background(), "index/latest")
 	if err != nil {
-		return "", 0
+		if errors.Is(err, store.ErrNotFound) {
+			return "", 0, nil
+		}
+		return "", 0, fmt.Errorf("read index/latest: %w", err)
 	}
 	var idx core.Index
 	if err := json.Unmarshal(data, &idx); err != nil {
-		return "", 0
+		return "", 0, fmt.Errorf("decode index/latest: %w", err)
 	}
-	return idx.LatestSnapshot, idx.Seq
+	return idx.LatestSnapshot, idx.Seq, nil
 }
 
 // updateLatest sets index/latest to point to the given snapshot, or deletes it

--- a/internal/engine/snapshots_test.go
+++ b/internal/engine/snapshots_test.go
@@ -3,10 +3,12 @@ package engine
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/cloudstic/cli/internal/core"
+	"github.com/cloudstic/cli/pkg/store"
 )
 
 // helper: store a snapshot object and return its ref.
@@ -269,5 +271,135 @@ func TestLoadSnapshotCatalog_EmptyRepo(t *testing.T) {
 	}
 	if len(entries) != 0 {
 		t.Errorf("expected 0 entries, got %d", len(entries))
+	}
+}
+
+// A real backend failure while reading index/latest must not be confused
+// with "no snapshots exist yet" — that would silently reset the sequence
+// number and downgrade the next backup from incremental to a full rescan.
+func TestResolveLatest_FreshRepoNoError(t *testing.T) {
+	s := NewMockStore()
+
+	ref, seq, err := resolveLatest(s)
+	if err != nil {
+		t.Fatalf("resolveLatest on fresh repo: %v", err)
+	}
+	if ref != "" || seq != 0 {
+		t.Errorf("resolveLatest on fresh repo = (%q, %d), want (\"\", 0)", ref, seq)
+	}
+}
+
+func TestResolveLatest_PropagatesRealError(t *testing.T) {
+	backendErr := errors.New("simulated network error")
+	s := newErrorOnGetStore(NewMockStore(), backendErr, "index/latest")
+
+	_, _, err := resolveLatest(s)
+	if err == nil {
+		t.Fatal("expected resolveLatest to propagate a real backend error")
+	}
+	if !errors.Is(err, backendErr) {
+		t.Errorf("resolveLatest error = %v, want it to wrap %v", err, backendErr)
+	}
+}
+
+// fetchSnapshots must distinguish a snapshot removed concurrently (a
+// legitimate omission) from any other failure, which must abort the fetch
+// rather than silently produce a catalog missing a snapshot that is still
+// there.
+func TestFetchSnapshots_SkipsConcurrentlyDeletedKey(t *testing.T) {
+	s := NewMockStore()
+	now := time.Now()
+	snap := &core.Snapshot{Seq: 1, Created: now.Format(time.RFC3339), Root: "node/a"}
+	ref := putSnapshot(t, s, snap)
+
+	result, err := fetchSnapshots(s, []string{ref, "snapshot/does-not-exist"})
+	if err != nil {
+		t.Fatalf("fetchSnapshots: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 fetched snapshot, got %d", len(result))
+	}
+	if _, ok := result[ref]; !ok {
+		t.Errorf("expected %s in result", ref)
+	}
+}
+
+func TestFetchSnapshots_PropagatesRealError(t *testing.T) {
+	backendErr := errors.New("simulated network error")
+	inner := NewMockStore()
+	ref := putSnapshot(t, inner, &core.Snapshot{Seq: 1, Root: "node/a"})
+	s := newErrorOnGetStore(inner, backendErr, ref)
+
+	_, err := fetchSnapshots(s, []string{ref})
+	if err == nil {
+		t.Fatal("expected fetchSnapshots to propagate a real backend error")
+	}
+	if !errors.Is(err, backendErr) {
+		t.Errorf("fetchSnapshots error = %v, want it to wrap %v", err, backendErr)
+	}
+}
+
+// LoadSnapshotCatalog must not persist a catalog that silently omits a
+// snapshot it failed to fetch for a real (non-not-found) reason.
+func TestLoadSnapshotCatalog_PropagatesFetchError(t *testing.T) {
+	backendErr := errors.New("simulated network error")
+	inner := NewMockStore()
+	snap := &core.Snapshot{Seq: 1, Root: "node/a"}
+	ref := putSnapshot(t, inner, snap)
+	// No catalog yet, so LoadSnapshotCatalog must fetch ref individually.
+	s := newErrorOnGetStore(inner, backendErr, ref)
+
+	_, err := LoadSnapshotCatalog(s)
+	if err == nil {
+		t.Fatal("expected LoadSnapshotCatalog to propagate a real fetch error")
+	}
+	if !errors.Is(err, backendErr) {
+		t.Errorf("LoadSnapshotCatalog error = %v, want it to wrap %v", err, backendErr)
+	}
+}
+
+// A real read failure on index/snapshots must not cause AppendSnapshotCatalog
+// to silently overwrite the existing catalog with one containing only the
+// new entry.
+func TestAppendSnapshotCatalog_DoesNotClobberOnReadError(t *testing.T) {
+	backendErr := errors.New("simulated network error")
+	inner := NewMockStore()
+	putCatalog(t, inner, []core.SnapshotSummary{
+		{Ref: "snapshot/existing", Seq: 1, Created: time.Now().Format(time.RFC3339)},
+	})
+	s := newErrorOnGetStore(inner, backendErr, snapshotCatalogKey)
+
+	AppendSnapshotCatalog(s, core.SnapshotSummary{Ref: "snapshot/new", Seq: 2})
+
+	catalog := readCatalog(t, inner)
+	if len(catalog) != 1 || catalog[0].Ref != "snapshot/existing" {
+		t.Errorf("catalog was clobbered on read error: %+v", catalog)
+	}
+}
+
+func TestRemoveFromSnapshotCatalog_DoesNotClobberOnReadError(t *testing.T) {
+	backendErr := errors.New("simulated network error")
+	inner := NewMockStore()
+	putCatalog(t, inner, []core.SnapshotSummary{
+		{Ref: "snapshot/existing", Seq: 1, Created: time.Now().Format(time.RFC3339)},
+	})
+	s := newErrorOnGetStore(inner, backendErr, snapshotCatalogKey)
+
+	RemoveFromSnapshotCatalog(s, "snapshot/existing")
+
+	catalog := readCatalog(t, inner)
+	if len(catalog) != 1 || catalog[0].Ref != "snapshot/existing" {
+		t.Errorf("catalog was clobbered on read error: %+v", catalog)
+	}
+}
+
+// MockStore.Get must wrap store.ErrNotFound for a missing key, matching real
+// backend behavior — resolveLatest and friends rely on errors.Is to tell a
+// genuinely missing object apart from a real failure.
+func TestMockStore_GetNotFound(t *testing.T) {
+	s := NewMockStore()
+	_, err := s.Get(context.Background(), "does/not/exist")
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("MockStore.Get(missing) error = %v, want errors.Is(err, store.ErrNotFound)", err)
 	}
 }

--- a/pkg/store/b2.go
+++ b/pkg/store/b2.go
@@ -121,7 +121,14 @@ func (s *B2Store) Get(ctx context.Context, key string) ([]byte, error) {
 	r := obj.NewReader(ctx)
 	defer func() { _ = r.Close() }()
 
-	return io.ReadAll(r)
+	data, err := io.ReadAll(r)
+	if err != nil {
+		if b2.IsNotExist(err) {
+			return nil, fmt.Errorf("%s: %w", key, ErrNotFound)
+		}
+		return nil, err
+	}
+	return data, nil
 }
 
 // GetRange implements RangeGetter using a B2 ranged download, so a caller

--- a/pkg/store/errors.go
+++ b/pkg/store/errors.go
@@ -1,0 +1,12 @@
+package store
+
+import "errors"
+
+// ErrNotFound is the sentinel error returned by Get when the requested key
+// does not exist. Each backend translates its own not-found signal — a
+// missing file, an S3 NoSuchKey/404, an SFTP no-such-file, a B2 404 — into
+// this sentinel, wrapped with the key, so callers can use
+// errors.Is(err, ErrNotFound) instead of treating every Get failure (network
+// error, permission error, corrupt response, ...) as "the object isn't
+// there".
+var ErrNotFound = errors.New("object not found")

--- a/pkg/store/keycache_test.go
+++ b/pkg/store/keycache_test.go
@@ -77,12 +77,6 @@ func (s *countingStore) TotalSize(_ context.Context) (int64, error) { return 0, 
 
 func (s *countingStore) Flush(_ context.Context) error { return nil }
 
-var ErrNotFound = &notFoundError{}
-
-type notFoundError struct{}
-
-func (e *notFoundError) Error() string { return "not found" }
-
 func TestKeyCacheStore_ExistsAfterPreload(t *testing.T) {
 	ctx := context.Background()
 	inner := newCountingStore()

--- a/pkg/store/local.go
+++ b/pkg/store/local.go
@@ -71,7 +71,14 @@ func (s *LocalStore) Put(_ context.Context, key string, data []byte) error {
 }
 
 func (s *LocalStore) Get(_ context.Context, key string) ([]byte, error) {
-	return os.ReadFile(s.getPath(key))
+	data, err := os.ReadFile(s.getPath(key))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("%s: %w", key, ErrNotFound)
+		}
+		return nil, err
+	}
+	return data, nil
 }
 
 // GetRange implements RangeGetter, letting callers read a packfile footer

--- a/pkg/store/local_test.go
+++ b/pkg/store/local_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -110,5 +111,18 @@ func TestLocalStore(t *testing.T) {
 	}
 	if len(keys) != 2 {
 		t.Errorf("Expected 2 keys under 'nested', got %d", len(keys))
+	}
+}
+
+func TestLocalStore_GetNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	s, err := NewLocalStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewLocalStore failed: %v", err)
+	}
+
+	_, err = s.Get(context.Background(), "missing/key")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get(missing) error = %v, want errors.Is(err, ErrNotFound)", err)
 	}
 }

--- a/pkg/store/s3.go
+++ b/pkg/store/s3.go
@@ -173,11 +173,32 @@ func (s *S3Store) Get(ctx context.Context, key string) ([]byte, error) {
 		Key:    aws.String(fullKey),
 	})
 	if err != nil {
+		if isS3NotFound(err) {
+			return nil, fmt.Errorf("%s: %w", key, ErrNotFound)
+		}
 		return nil, err
 	}
 	defer func() { _ = out.Body.Close() }()
 
 	return io.ReadAll(out.Body)
+}
+
+// isS3NotFound reports whether err indicates the requested key or object does
+// not exist. GetObject on a missing key typically returns *types.NoSuchKey;
+// HeadObject (used by Exists) tends to surface a generic *types.NotFound or an
+// APIError coded "NotFound" instead — S3-compatible services (MinIO, R2, ...)
+// are not consistent here, so the substring fallback catches the rest.
+func isS3NotFound(err error) bool {
+	if apiErr, ok := errors.AsType[smithy.APIError](err); ok && apiErr.ErrorCode() == "NotFound" {
+		return true
+	}
+	if _, ok := errors.AsType[*types.NotFound](err); ok {
+		return true
+	}
+	if _, ok := errors.AsType[*types.NoSuchKey](err); ok {
+		return true
+	}
+	return strings.Contains(err.Error(), "NotFound") || strings.Contains(err.Error(), "404")
 }
 
 // GetRange implements RangeGetter using an HTTP range request, so a caller
@@ -219,16 +240,7 @@ func (s *S3Store) Exists(ctx context.Context, key string) (bool, error) {
 	})
 
 	if err != nil {
-		var apiErr smithy.APIError
-		if errors.As(err, &apiErr) && apiErr.ErrorCode() == "NotFound" {
-			return false, nil
-		}
-		// S3 HeadObject can also return generic 404s
-		var notFound *types.NotFound
-		if errors.As(err, &notFound) {
-			return false, nil
-		}
-		if strings.Contains(err.Error(), "NotFound") || strings.Contains(err.Error(), "404") {
+		if isS3NotFound(err) {
 			return false, nil
 		}
 		return false, err

--- a/pkg/store/s3_test.go
+++ b/pkg/store/s3_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"os/exec"
 	"strings"
 	"testing"
@@ -118,6 +119,11 @@ func TestS3Store(t *testing.T) {
 	}
 	if exists {
 		t.Fatalf("Expected nonexistent key to report false")
+	}
+
+	// Get (not found)
+	if _, err := store.Get(ctx, "nonexistent"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get(nonexistent) error = %v, want errors.Is(err, ErrNotFound)", err)
 	}
 
 	// Size

--- a/pkg/store/sftp.go
+++ b/pkg/store/sftp.go
@@ -165,6 +165,9 @@ func (s *SFTPStore) Put(_ context.Context, key string, data []byte) error {
 func (s *SFTPStore) Get(_ context.Context, key string) ([]byte, error) {
 	f, err := s.client.Open(s.key(key))
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("%s: %w", key, ErrNotFound)
+		}
 		return nil, err
 	}
 	defer func() { _ = f.Close() }()

--- a/pkg/store/sftp_test.go
+++ b/pkg/store/sftp_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -161,6 +162,11 @@ func TestSFTPStore(t *testing.T) {
 	}
 	if exists {
 		t.Fatalf("Expected nonexistent key to report false")
+	}
+
+	// Get (not found)
+	if _, err := st.Get(ctx, "nonexistent/key"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get(nonexistent) error = %v, want errors.Is(err, ErrNotFound)", err)
 	}
 
 	// Size


### PR DESCRIPTION
## Summary
- Add a real `store.ErrNotFound` sentinel in `pkg/store` (previously only a test-only fixture in `keycache_test.go`)
- Have every backend (`LocalStore`, `S3Store`, `B2Store`, `SFTPStore`) translate its own not-found signal (`os.IsNotExist`, S3 `NoSuchKey`/404, `b2.IsNotExist`) into that sentinel on `Get`, wrapped so it survives the full decorator chain (Compressed/Encrypted/Debug/KeyCache/Pack/Metered/Quota) via `errors.Is`
- Fix the 9 call sites in `internal/engine` that previously treated *any* `Get` error as "object doesn't exist," which silently downgraded real backend failures into behavior appropriate only for a genuinely missing key:
  - `resolveLatest` / `loadLatestSeq` / `findPreviousSnapshot` (`backup.go`, `snapshots.go`) — a transient error no longer resets the sequence number or silently downgrades an incremental backup to a full rescan
  - `fetchSnapshots` / `LoadSnapshotCatalog` (`snapshots.go`) — a snapshot that fails to fetch for a real reason now aborts the catalog rebuild instead of silently persisting a catalog missing a still-live snapshot; a snapshot removed concurrently is still correctly treated as gone
  - `AppendSnapshotCatalog` / `RemoveFromSnapshotCatalog` (`snapshots.go`) — stay best-effort, but a real read error now aborts the update instead of clobbering the existing catalog with a fabricated empty base
  - `InitManager.Run`'s already-initialized check and `writeRepoConfig` (`init.go`) — a transient error no longer risks double-initializing over an existing repository or silently lowering the recorded format-version floor
  - `resolveSnapshot("latest")` / `fixupLatest` (`forget.go`) — a real error is no longer reported as "no latest snapshot found," nor silently left pointing `index/latest` at a just-deleted snapshot

## Verification
- `env GOCACHE=/tmp/cloudstic-gocache go build ./...`
- `env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./...`
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./...`