### PR TITLE
fix(keychain): join per-resolver errors instead of one generic message

### DIFF
--- a/pkg/keychain/keychain.go
+++ b/pkg/keychain/keychain.go
@@ -4,12 +4,24 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 
 	"github.com/cloudstic/cli/pkg/crypto"
 	"github.com/cloudstic/cli/pkg/store"
 )
+
+// noMatchingSlotErr builds the error a Credential.Resolve returns when its
+// slots exist but none could be unwrapped. It joins each slot's specific
+// failure (wrong password, corrupt slot, unreachable KMS, ...) instead of one
+// generic message that looks identical regardless of cause.
+func noMatchingSlotErr(kind string, errs []error) error {
+	if len(errs) == 0 {
+		return fmt.Errorf("no %s key slot found", kind)
+	}
+	return fmt.Errorf("no compatible %s key slot found: %w", kind, errors.Join(errs...))
+}
 
 // DeriveEncryptionKey derives the AES-256 encryption key from a master key.
 func DeriveEncryptionKey(masterKey []byte) ([]byte, error) {
@@ -93,13 +105,21 @@ func (c Chain) Resolve(ctx context.Context, slots []KeySlot) ([]byte, error) {
 		return nil, fmt.Errorf("repository is encrypted: no resolvers configured in the keychain")
 	}
 
+	var errs []error
 	for _, resolver := range c {
 		mk, err := resolver.Resolve(ctx, slots)
 		if err == nil && len(mk) > 0 {
 			return mk, nil
 		}
+		if err != nil {
+			errs = append(errs, err)
+		}
 	}
-	return nil, fmt.Errorf("repository is encrypted: no provided credential matches the stored key slots (types: %s)", SlotTypes(slots))
+	if len(errs) == 0 {
+		return nil, fmt.Errorf("repository is encrypted: no provided credential matches the stored key slots (types: %s)", SlotTypes(slots))
+	}
+	return nil, fmt.Errorf("repository is encrypted: no provided credential matches the stored key slots (types: %s): %w",
+		SlotTypes(slots), errors.Join(errs...))
 }
 
 // WrapAll attempts to wrap the master key using all configured credentials in the chain.
@@ -194,15 +214,18 @@ func (c platformKeyCred) Resolve(ctx context.Context, slots []KeySlot) ([]byte, 
 	if len(c.key) == 0 {
 		return nil, fmt.Errorf("empty platform key")
 	}
+	var errs []error
 	for _, slot := range slots {
 		if slot.SlotType != "platform" {
 			continue
 		}
-		if mk, err := unwrapMasterKey(slot, c.key); err == nil {
+		mk, err := unwrapMasterKey(slot, c.key)
+		if err == nil {
 			return mk, nil
 		}
+		errs = append(errs, fmt.Errorf("slot %q: %w", slot.Label, err))
 	}
-	return nil, fmt.Errorf("no compatible platform key slot found")
+	return nil, noMatchingSlotErr("platform", errs)
 }
 
 func (c platformKeyCred) Wrap(ctx context.Context, masterKey []byte) (KeySlot, error) {
@@ -225,12 +248,18 @@ func (c passwordCred) Resolve(ctx context.Context, slots []KeySlot) ([]byte, err
 	if c.password == "" {
 		return nil, fmt.Errorf("empty password")
 	}
+	var errs []error
 	for _, slot := range slots {
-		if slot.SlotType != "password" || slot.KDFParams == nil {
+		if slot.SlotType != "password" {
+			continue
+		}
+		if slot.KDFParams == nil {
+			errs = append(errs, fmt.Errorf("slot %q: missing KDF params", slot.Label))
 			continue
 		}
 		salt, err := base64.StdEncoding.DecodeString(slot.KDFParams.Salt)
 		if err != nil {
+			errs = append(errs, fmt.Errorf("slot %q: decode salt: %w", slot.Label, err))
 			continue
 		}
 		wrappingKey := crypto.DeriveKeyFromPassword(c.password, salt, crypto.Argon2Params{
@@ -238,11 +267,13 @@ func (c passwordCred) Resolve(ctx context.Context, slots []KeySlot) ([]byte, err
 			Memory:  slot.KDFParams.Memory,
 			Threads: slot.KDFParams.Threads,
 		})
-		if mk, err := unwrapMasterKey(slot, wrappingKey); err == nil {
+		mk, err := unwrapMasterKey(slot, wrappingKey)
+		if err == nil {
 			return mk, nil
 		}
+		errs = append(errs, fmt.Errorf("slot %q: %w", slot.Label, err))
 	}
-	return nil, fmt.Errorf("no compatible password key slot found")
+	return nil, noMatchingSlotErr("password", errs)
 }
 
 func (c passwordCred) Wrap(ctx context.Context, masterKey []byte) (KeySlot, error) {
@@ -266,15 +297,18 @@ func (c recoveryCred) Resolve(ctx context.Context, slots []KeySlot) ([]byte, err
 	if err != nil {
 		return nil, fmt.Errorf("invalid recovery key mnemonic: %w", err)
 	}
+	var errs []error
 	for _, slot := range slots {
 		if slot.SlotType != "recovery" {
 			continue
 		}
-		if mk, err := unwrapMasterKey(slot, recoveryKey); err == nil {
+		mk, err := unwrapMasterKey(slot, recoveryKey)
+		if err == nil {
 			return mk, nil
 		}
+		errs = append(errs, fmt.Errorf("slot %q: %w", slot.Label, err))
 	}
-	return nil, fmt.Errorf("no compatible recovery key slot found")
+	return nil, noMatchingSlotErr("recovery", errs)
 }
 
 func (c recoveryCred) Wrap(ctx context.Context, masterKey []byte) (KeySlot, error) {
@@ -294,19 +328,23 @@ func (c kmsClientCred) Resolve(ctx context.Context, slots []KeySlot) ([]byte, er
 	if c.client == nil {
 		return nil, fmt.Errorf("nil KMS client")
 	}
+	var errs []error
 	for _, slot := range slots {
 		if slot.SlotType != "kms-platform" {
 			continue
 		}
 		wrapped, err := base64.StdEncoding.DecodeString(slot.WrappedKey)
 		if err != nil {
+			errs = append(errs, fmt.Errorf("slot %q: decode wrapped key: %w", slot.Label, err))
 			continue
 		}
-		if mk, err := c.client.Decrypt(ctx, wrapped); err == nil {
+		mk, err := c.client.Decrypt(ctx, wrapped)
+		if err == nil {
 			return mk, nil
 		}
+		errs = append(errs, fmt.Errorf("slot %q: %w", slot.Label, err))
 	}
-	return nil, fmt.Errorf("no compatible kms-platform key slot found")
+	return nil, noMatchingSlotErr("kms-platform", errs)
 }
 
 func (c kmsClientCred) Wrap(ctx context.Context, masterKey []byte) (KeySlot, error) {
@@ -341,19 +379,23 @@ func (c kmsARNCred) Resolve(ctx context.Context, slots []KeySlot) ([]byte, error
 	if err != nil {
 		return nil, fmt.Errorf("init kms client: %w", err)
 	}
+	var errs []error
 	for _, slot := range slots {
 		if slot.SlotType != "kms-platform" {
 			continue
 		}
 		wrapped, err := base64.StdEncoding.DecodeString(slot.WrappedKey)
 		if err != nil {
+			errs = append(errs, fmt.Errorf("slot %q: decode wrapped key: %w", slot.Label, err))
 			continue
 		}
-		if mk, err := client.Decrypt(ctx, wrapped); err == nil {
+		mk, err := client.Decrypt(ctx, wrapped)
+		if err == nil {
 			return mk, nil
 		}
+		errs = append(errs, fmt.Errorf("slot %q: %w", slot.Label, err))
 	}
-	return nil, fmt.Errorf("no compatible kms-platform key slot found")
+	return nil, noMatchingSlotErr("kms-platform", errs)
 }
 
 func (c kmsARNCred) Wrap(ctx context.Context, masterKey []byte) (KeySlot, error) {

--- a/pkg/keychain/keychain_test.go
+++ b/pkg/keychain/keychain_test.go
@@ -138,6 +138,54 @@ func TestResolve_EmptyConfig(t *testing.T) {
 	}
 }
 
+// A wrong password must produce an error naming the specific failure
+// (the underlying decrypt error), not just a generic "no slot matches"
+// message indistinguishable from a corrupt slot or an unreachable KMS.
+func TestPasswordCred_WrongPassword_ReportsUnderlyingFailure(t *testing.T) {
+	ctx := context.Background()
+	masterKey, _ := crypto.GenerateKey()
+	slot, _ := CreatePasswordSlot(masterKey, "correct-password")
+
+	_, err := WithPassword("wrong-password").Resolve(ctx, []KeySlot{slot})
+	if err == nil {
+		t.Fatal("expected error for wrong password")
+	}
+	if !strings.Contains(err.Error(), "no compatible password key slot found") {
+		t.Errorf("error = %v, want it to mention the password slot kind", err)
+	}
+	if !strings.Contains(err.Error(), slot.Label) {
+		t.Errorf("error = %v, want it to name the slot label %q", err, slot.Label)
+	}
+}
+
+// Chain.Resolve must accumulate each resolver's specific error rather than
+// collapsing them into one generic message, so a wrong password and an
+// incompatible platform key are distinguishable in the final error.
+func TestChainResolve_JoinsEachResolverError(t *testing.T) {
+	ctx := context.Background()
+	masterKey, _ := crypto.GenerateKey()
+	pwSlot, _ := CreatePasswordSlot(masterKey, "correct-password")
+	platformKey := []byte("0123456789abcdef0123456789abcdef")
+	platformSlot, _ := CreatePlatformSlot(masterKey, platformKey)
+	slots := []KeySlot{pwSlot, platformSlot}
+
+	wrongPlatformKey := []byte("badbadbadbadbadbadbadbadbadbadba")
+	c := Chain{WithPassword("wrong-password"), WithPlatformKey(wrongPlatformKey)}
+	_, err := c.Resolve(ctx, slots)
+	if err == nil {
+		t.Fatal("expected error when no credential matches")
+	}
+	if !strings.Contains(err.Error(), "no provided credential matches") {
+		t.Errorf("error = %v, want it to mention the top-level failure", err)
+	}
+	if !strings.Contains(err.Error(), "no compatible password key slot found") {
+		t.Errorf("error = %v, want it to include the password resolver's failure", err)
+	}
+	if !strings.Contains(err.Error(), "no compatible platform key slot found") {
+		t.Errorf("error = %v, want it to include the platform resolver's failure", err)
+	}
+}
+
 func TestWithPrompt(t *testing.T) {
 	ctx := context.Background()
 	masterKey, _ := crypto.GenerateKey()


### PR DESCRIPTION
## Summary
- `Chain.Resolve` tried each configured credential and, on total failure, reported only `"no provided credential matches the stored key slots"` — a wrong password, a corrupt key slot, and an unreachable KMS endpoint were all indistinguishable
- Each individual `Credential.Resolve` implementation (`platformKeyCred`, `passwordCred`, `recoveryCred`, `kmsClientCred`, `kmsARNCred`) had the same pattern one level down: looping over multiple slots of its type and discarding every per-slot failure (decrypt error, corrupt/missing KDF params, undecodable wrapped key) behind one generic `"no compatible X key slot found"`
- Added a shared `noMatchingSlotErr` helper and use `errors.Join` throughout to accumulate each resolver's/slot's specific error into the final message, labelled by slot so multiple slots of the same type are distinguishable too
- Kept the existing top-level substrings (`"no provided credential matches"`, `"no key slots found"`, `"no resolvers configured..."`) unchanged, since `e2e/feature_encryption_test.go` and unit tests match on them

## Example
Before: `no provided credential matches the stored key slots (types: password, platform)`

After:
```
repository is encrypted: no provided credential matches the stored key slots (types: password, platform): no compatible password key slot found: slot "default": crypto: decryption failed (wrong key or tampered data)
no compatible platform key slot found: slot "default": crypto: decryption failed (wrong key or tampered data)
```

## Verification
- `env GOCACHE=/tmp/cloudstic-gocache go build ./...`
- `env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./pkg/keychain/... ./e2e/...`
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./...`