### PR TITLE
fix(engine): flush packs before updating index/latest

### DIFF
--- a/internal/engine/backup.go
+++ b/internal/engine/backup.go
@@ -275,9 +275,25 @@ func (bm *BackupManager) Run(ctx context.Context) (*RunResult, error) {
 		return r, nil
 	}
 
-	snapRef, snapHash, snap, err := bm.saveSnapshot(ctx, newRoot, seq+1, newToken)
+	newSeq := seq + 1
+	snapRef, snapHash, snap, err := bm.writeSnapshotObject(ctx, newRoot, newSeq, newToken)
 	if err != nil {
 		return nil, err
+	}
+
+	// Both the HAMT nodes committed above and the snapshot object just
+	// written are content-addressed, so PackStore may still be holding them
+	// only in its in-memory buffer. index/latest is a mutable key and is
+	// never packed, so writing it lands on the backend immediately — if that
+	// happened before this flush, a crash in between would leave index/latest
+	// pointing at a snapshot whose bytes (or tree) were never actually
+	// uploaded. Flushing first, then pointing index/latest at the result,
+	// keeps that pointer always valid.
+	if err := bm.store.Flush(ctx); err != nil {
+		return nil, fmt.Errorf("flush store before updating index/latest: %w", err)
+	}
+	if err := updateLatest(bm.store, snapRef, newSeq); err != nil {
+		return nil, fmt.Errorf("update index/latest: %w", err)
 	}
 
 	// Update snapshot catalog (best-effort).
@@ -364,7 +380,13 @@ func (bm *BackupManager) findPreviousSnapshot(info core.SourceInfo) (*core.Snaps
 	return nil, nil
 }
 
-func (bm *BackupManager) saveSnapshot(ctx context.Context, root string, seq int, changeToken string) (ref, hash string, snap core.Snapshot, err error) {
+// writeSnapshotObject builds and writes the snapshot object for the given
+// root and sequence number, but deliberately does not update index/latest —
+// that pointer is a mutable, unpacked key that lands durably the instant it
+// is written, so the caller must flush the store first to make sure the
+// snapshot object (and the HAMT nodes it names) are durable before anything
+// points at them.
+func (bm *BackupManager) writeSnapshotObject(ctx context.Context, root string, seq int, changeToken string) (ref, hash string, snap core.Snapshot, err error) {
 	meta := make(map[string]string, len(bm.cfg.meta)+1)
 	for k, v := range bm.cfg.meta {
 		meta[k] = v
@@ -390,10 +412,6 @@ func (bm *BackupManager) saveSnapshot(ctx context.Context, root string, seq int,
 
 	ref = "snapshot/" + hash
 	if err := bm.store.Put(ctx, ref, snapData); err != nil {
-		return "", "", snap, err
-	}
-
-	if err := updateLatest(bm.store, ref, seq); err != nil {
 		return "", "", snap, err
 	}
 

--- a/internal/engine/backup_test.go
+++ b/internal/engine/backup_test.go
@@ -531,3 +531,52 @@ func TestBackupManager_Run_PropagatesLatestIndexError(t *testing.T) {
 		t.Errorf("Run error = %v, want it to wrap %v", err, backendErr)
 	}
 }
+
+// TestBackupManager_Run_FlushesPacksBeforeUpdatingIndexLatest is a
+// crash-consistency check: the snapshot object and the HAMT nodes it names
+// are content-addressed, so PackStore may hold them only in its in-memory
+// buffer until Flush uploads a packfile. index/latest is a mutable,
+// unpacked key, so writing it lands on the real backend immediately. If
+// index/latest were written before that flush, a crash in between would
+// leave it pointing at a snapshot whose data was never actually uploaded.
+// This asserts the true backend receives a packfile before it ever
+// receives index/latest.
+func TestBackupManager_Run_FlushesPacksBeforeUpdatingIndexLatest(t *testing.T) {
+	ctx := context.Background()
+	rec := &recordingStore{ObjectStore: NewMockStore()}
+	packed, err := store.NewPackStore(rec)
+	if err != nil {
+		t.Fatalf("NewPackStore: %v", err)
+	}
+
+	src := NewMockSource()
+	src.AddFile("file1.txt", "id1", []byte("hello world"))
+
+	mgr := NewBackupManager(src, packed, ui.NewNoOpReporter(), nil)
+	if _, err := mgr.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	keys := rec.recordedPutKeys()
+
+	packIdx, latestIdx := -1, -1
+	for i, k := range keys {
+		if packIdx == -1 && strings.HasPrefix(k, "packs/") {
+			packIdx = i
+		}
+		if latestIdx == -1 && k == "index/latest" {
+			latestIdx = i
+		}
+	}
+
+	if latestIdx == -1 {
+		t.Fatal("index/latest was never durably written to the backend")
+	}
+	if packIdx == -1 {
+		t.Fatal("no packfile was ever durably written to the backend")
+	}
+	if packIdx > latestIdx {
+		t.Errorf("packfile landed on the backend at position %d, after index/latest at position %d (order: %v)",
+			packIdx, latestIdx, keys)
+	}
+}

--- a/internal/engine/mock_test.go
+++ b/internal/engine/mock_test.go
@@ -120,6 +120,34 @@ func (s *errorOnGetStore) Get(ctx context.Context, key string) ([]byte, error) {
 	return s.ObjectStore.Get(ctx, key)
 }
 
+// recordingStore wraps a store.ObjectStore and records, in order, every key
+// that actually lands a Put on it. Placed underneath PackStore in a test, it
+// stands in for "the true backend": PackStore's own Puts of a packfile or of
+// an unpacked mutable key (like index/latest) only reach it once genuinely
+// durable, so the recorded order is exactly what a crash-consistency test
+// needs to check.
+type recordingStore struct {
+	store.ObjectStore
+	mu      sync.Mutex
+	putKeys []string
+}
+
+func (s *recordingStore) Put(ctx context.Context, key string, data []byte) error {
+	if err := s.ObjectStore.Put(ctx, key, data); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.putKeys = append(s.putKeys, key)
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *recordingStore) recordedPutKeys() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.putKeys...)
+}
+
 // MockSource implements source.Source
 type MockSource struct {
 	Files map[string]MockFile


### PR DESCRIPTION
## Summary
- The snapshot object and the HAMT nodes it names are content-addressed, so `PackStore` may hold them only in its in-memory buffer until `Flush` uploads a packfile. `index/latest` is a mutable, unpacked key (`TestPackStore_DoesNotPackMutableIndexKeys`), so writing it lands on the backend immediately
- `BackupManager.Run` wrote the snapshot object and `index/latest` synchronously, while the only `store.Flush()` call was `defer`red at the top of `Run` — meaning it ran *after* `index/latest` was already durably written. A crash or network loss between the two could leave `index/latest` pointing at a snapshot whose tree (or the snapshot object itself) was never actually uploaded; reading that snapshot would then fail
- Split `saveSnapshot` into `writeSnapshotObject` (writes the snapshot object only) and an explicit `bm.store.Flush(ctx)` call in `Run`, positioned after the snapshot object is written but before `updateLatest` — so `index/latest` never points at data that isn't durable yet. The pre-existing deferred `Flush` at the top of `Run` is unchanged and still acts as a general safety net for other paths (dry run skip, `ignoreEmptySnapshot` early return, errors)

## Verification
- Added `TestBackupManager_Run_FlushesPacksBeforeUpdatingIndexLatest`, which wraps a `PackStore` around a recording store and asserts a packfile is durably written to the backend before `index/latest` ever is. Confirmed this test fails against the old ordering (reverted the fix locally and reran) and passes with the fix.
- `env GOCACHE=/tmp/cloudstic-gocache go build ./...`
- `env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./...`
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./...`