### PR TITLE
chore(engine): remove dead metaCache field from RestoreManager

### DIFF
--- a/internal/engine/restore.go
+++ b/internal/engine/restore.go
@@ -85,10 +85,9 @@ type RestoreWriter interface {
 
 // RestoreManager recreates a snapshot's file tree using a RestoreWriter output format.
 type RestoreManager struct {
-	store     store.ObjectStore
-	tree      *hamt.Tree
-	reporter  ui.Reporter
-	metaCache map[string]core.FileMeta
+	store    store.ObjectStore
+	tree     *hamt.Tree
+	reporter ui.Reporter
 }
 
 func NewRestoreManager(s store.ObjectStore, reporter ui.Reporter) *RestoreManager {
@@ -192,8 +191,6 @@ func (rm *RestoreManager) prepareRestore(ctx context.Context, snapshotRef string
 	for _, opt := range opts {
 		opt(&cfg)
 	}
-
-	rm.metaCache = make(map[string]core.FileMeta)
 
 	snap, resolvedRef, err := rm.resolveSnapshot(ctx, snapshotRef)
 	if err != nil {
@@ -671,9 +668,6 @@ func (rm *RestoreManager) collectMetadata(ctx context.Context, root string) (map
 }
 
 func (rm *RestoreManager) loadMeta(ctx context.Context, ref string) (*core.FileMeta, error) {
-	if fm, ok := rm.metaCache[ref]; ok {
-		return &fm, nil
-	}
 	data, err := rm.store.Get(ctx, ref)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- `loadMeta` (`internal/engine/restore.go`) checked `rm.metaCache` before every store `Get`, but nothing anywhere in the codebase ever wrote to it — it was allocated empty in `prepareRestore` and never populated, so the cache-hit branch was permanently dead code and every filemeta lookup already hit the store
- Confirmed there's no legitimate repeat-lookup scenario this would have memoized against: `loadMeta` is called exactly once per ref from `collectMetadata`'s single pass over the tree walk, and restore path building (`buildRestorePath`) reads the already-collected `byID` map rather than re-fetching from the store — so wiring the cache up wouldn't actually save any work
- Removed the field and both dead references (in `prepareRestore` and `loadMeta`) rather than wiring it up

Note: `perf/restore-parallel-fetch` (#335, still open) also touches `collectMetadata`/`loadMeta` in the same area to parallelize filemeta fetching — expect a small rebase/conflict resolution between the two when merging, but they don't conflict semantically (that PR doesn't write to `metaCache` either).

## Verification
- `env GOCACHE=/tmp/cloudstic-gocache go build ./...`
- `env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./...`
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./...`