### PR TITLE
test(store): add a shared FaultStore for fault-injection tests

### DIFF
--- a/internal/engine/mock_test.go
+++ b/internal/engine/mock_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cloudstic/cli/internal/hamt"
 	"github.com/cloudstic/cli/pkg/source"
 	"github.com/cloudstic/cli/pkg/store"
+	"github.com/cloudstic/cli/pkg/store/storetest"
 )
 
 // MockStore implements store.ObjectStore. It is safe for concurrent use.
@@ -94,30 +95,13 @@ func (s *MockStore) Flush(_ context.Context) error {
 	return nil
 }
 
-// errorOnGetStore wraps a store.ObjectStore and forces Get to return a fixed
-// error for a chosen set of keys, simulating a real backend failure (network,
-// permission, ...) as distinct from the key simply not existing. Tests use
-// this to verify that such an error is propagated rather than silently
-// treated as "not found".
-type errorOnGetStore struct {
-	store.ObjectStore
-	errKeys map[string]bool
-	err     error
-}
-
-func newErrorOnGetStore(inner store.ObjectStore, err error, keys ...string) *errorOnGetStore {
-	m := make(map[string]bool, len(keys))
-	for _, k := range keys {
-		m[k] = true
-	}
-	return &errorOnGetStore{ObjectStore: inner, errKeys: m, err: err}
-}
-
-func (s *errorOnGetStore) Get(ctx context.Context, key string) ([]byte, error) {
-	if s.errKeys[key] {
-		return nil, s.err
-	}
-	return s.ObjectStore.Get(ctx, key)
+// newErrorOnGetStore wraps a store.ObjectStore and forces Get to return a
+// fixed error for a chosen set of keys, simulating a real backend failure
+// (network, permission, ...) as distinct from the key simply not existing.
+// Tests use this to verify that such an error is propagated rather than
+// silently treated as "not found".
+func newErrorOnGetStore(inner store.ObjectStore, err error, keys ...string) *storetest.FaultStore {
+	return &storetest.FaultStore{ObjectStore: inner, FailGet: storetest.FailKeys(err, keys...)}
 }
 
 // concurrencyTrackingStore wraps a store.ObjectStore and records the peak

--- a/pkg/store/quota_test.go
+++ b/pkg/store/quota_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"testing"
+
+	"github.com/cloudstic/cli/pkg/store/storetest"
 )
 
 func TestQuotaStore_UnderBudget(t *testing.T) {
@@ -85,7 +87,7 @@ func TestQuotaStore_PutErrorDoesNotCount(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	defer cancel(nil)
 
-	failing := &failingStore{err: fmt.Errorf("disk full")}
+	failing := &storetest.FaultStore{ObjectStore: newMemStore(), FailPut: storetest.AlwaysFail(fmt.Errorf("disk full"))}
 	qs := NewQuotaStore(failing, 10, cancel)
 
 	if err := qs.Put(ctx, "chunk/aaa", make([]byte, 50)); err == nil {
@@ -95,10 +97,3 @@ func TestQuotaStore_PutErrorDoesNotCount(t *testing.T) {
 		t.Fatal("failed Put should not count toward quota")
 	}
 }
-
-type failingStore struct {
-	memStore
-	err error
-}
-
-func (f *failingStore) Put(_ context.Context, _ string, _ []byte) error { return f.err }

--- a/pkg/store/storetest/faultstore.go
+++ b/pkg/store/storetest/faultstore.go
@@ -1,0 +1,116 @@
+// Package storetest provides test doubles for store.ObjectStore.
+package storetest
+
+import (
+	"context"
+	"sync"
+)
+
+// ObjectStore mirrors the method set of store.ObjectStore. It is declared
+// independently, rather than imported, so this package can also be used from
+// pkg/store's own internal (package store) tests without an import cycle —
+// any store.ObjectStore implementation satisfies this interface structurally.
+type ObjectStore interface {
+	Put(ctx context.Context, key string, data []byte) error
+	Get(ctx context.Context, key string) ([]byte, error)
+	Exists(ctx context.Context, key string) (bool, error)
+	Delete(ctx context.Context, key string) error
+	List(ctx context.Context, prefix string) ([]string, error)
+	Size(ctx context.Context, key string) (int64, error)
+	TotalSize(ctx context.Context) (int64, error)
+	Flush(ctx context.Context) error
+}
+
+// FaultHook decides whether a FaultStore call should fail. key is the object
+// key (List passes its prefix instead), and callNum is the 1-indexed count of
+// calls to that method so far, including the current one. A nil return lets
+// the call proceed to the wrapped store.
+type FaultHook func(key string, callNum int) error
+
+// FaultStore wraps an ObjectStore and lets tests inject failures into Get,
+// Put, or List independently of what the backend itself would do —
+// simulating a network blip, a permission error, or a partial outage. Each
+// hook is optional; a nil hook means that method always passes through.
+//
+// FaultStore is safe for concurrent use.
+type FaultStore struct {
+	ObjectStore
+
+	FailGet  FaultHook
+	FailPut  FaultHook
+	FailList FaultHook
+
+	mu    sync.Mutex
+	calls map[string]int
+}
+
+func (f *FaultStore) nextCall(method string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.calls == nil {
+		f.calls = make(map[string]int)
+	}
+	f.calls[method]++
+	return f.calls[method]
+}
+
+func (f *FaultStore) Get(ctx context.Context, key string) ([]byte, error) {
+	if f.FailGet != nil {
+		if err := f.FailGet(key, f.nextCall("Get")); err != nil {
+			return nil, err
+		}
+	}
+	return f.ObjectStore.Get(ctx, key)
+}
+
+func (f *FaultStore) Put(ctx context.Context, key string, data []byte) error {
+	if f.FailPut != nil {
+		if err := f.FailPut(key, f.nextCall("Put")); err != nil {
+			return err
+		}
+	}
+	return f.ObjectStore.Put(ctx, key, data)
+}
+
+func (f *FaultStore) List(ctx context.Context, prefix string) ([]string, error) {
+	if f.FailList != nil {
+		if err := f.FailList(prefix, f.nextCall("List")); err != nil {
+			return nil, err
+		}
+	}
+	return f.ObjectStore.List(ctx, prefix)
+}
+
+// FailKeys returns a FaultHook that fails every call whose key is in keys,
+// regardless of call count. For List, "key" is the queried prefix.
+func FailKeys(err error, keys ...string) FaultHook {
+	set := make(map[string]bool, len(keys))
+	for _, k := range keys {
+		set[k] = true
+	}
+	return func(key string, _ int) error {
+		if set[key] {
+			return err
+		}
+		return nil
+	}
+}
+
+// FailNth returns a FaultHook that fails only on the nth call (1-indexed) to
+// that method, regardless of key. Use it to fail one call in the middle of a
+// multi-step operation and assert the rest of the operation reacts correctly.
+func FailNth(n int, err error) FaultHook {
+	return func(_ string, callNum int) error {
+		if callNum == n {
+			return err
+		}
+		return nil
+	}
+}
+
+// AlwaysFail returns a FaultHook that fails every call to that method.
+func AlwaysFail(err error) FaultHook {
+	return func(_ string, _ int) error {
+		return err
+	}
+}


### PR DESCRIPTION
## Summary
- Add `pkg/store/storetest.FaultStore`, an `ObjectStore` decorator that injects failures into `Get`/`Put`/`List` via per-key or per-call-count hooks (`FailKeys`, `FailNth`, `AlwaysFail`)
- Replace the two ad-hoc single-purpose fakes that existed for this — `errorOnGetStore` (`internal/engine/mock_test.go`) and `failingStore` (`pkg/store/quota_test.go`) — with `FaultStore`, so there's one canonical fault double instead of three call sites reinventing it

A code review flagged that this suite has no shared fault-injection mock, which is why several past bugs (swallowed pack-catalog load errors, `resolveLatest`/`findPreviousSnapshot` eating failures, prune sweeping on a partial reachable set, silent lock-refresh failure) all shipped on error paths that failure-free mocks structurally couldn't exercise. Those four bugs are already fixed and merged (#293, #294, #330, #332); this PR adds the reusable test double the review recommended so the next one is easier to catch.

`storetest` declares its own `ObjectStore` interface (structurally identical to `store.ObjectStore`) rather than importing `pkg/store`, since `pkg/store`'s own internal (`package store`) tests need to use it too, and importing `store` from `storetest` while `store`'s tests import `storetest` would be a cycle.

## Verification
- `go build ./...`
- `go vet ./...`
- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./pkg/store/... ./internal/engine/...`
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./pkg/store/... ./internal/engine/...`