### PR TITLE
test(engine): add crash-consistency e2e coverage for backup

### DIFF
--- a/cmd/cloudstic/crashinject.go
+++ b/cmd/cloudstic/crashinject.go
@@ -1,3 +1,5 @@
+//go:build crashinject
+
 package main
 
 import (
@@ -21,10 +23,15 @@ const exitCrashInjected = 137
 // after the Nth successful backend Put, when CLOUDSTIC_TEST_CRASH_AFTER_PUTS
 // is set. It is a no-op otherwise.
 //
-// This is a test-only knob (see AGENTS.md's CLOUDSTIC_TEST_* convention),
-// compiled into every build but inert unless that variable is set. It exists
-// so e2e crash-consistency tests can kill the real binary at a precise,
-// reproducible point in a backup rather than racing an external signal.
+// This is a test-only knob (see AGENTS.md's CLOUDSTIC_TEST_* convention).
+// Unlike the rest of that convention it needs to run inside the real
+// compiled binary, not just a _test.go file, so it lives behind the
+// "crashinject" build tag instead: a plain `go build ./cmd/cloudstic` (what
+// AGENTS.md documents, and what ships) never links this code in at all, so
+// there is nothing here for a stray environment variable to trigger in
+// production. Only the e2e build (see e2e/harness_test.go's buildBinary)
+// passes -tags crashinject. See crashinject_stub.go for the default build's
+// no-op.
 func withCrashInjection(s store.ObjectStore) (store.ObjectStore, error) {
 	raw := os.Getenv("CLOUDSTIC_TEST_CRASH_AFTER_PUTS")
 	if raw == "" {

--- a/cmd/cloudstic/crashinject.go
+++ b/cmd/cloudstic/crashinject.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"sync/atomic"
+
+	"github.com/cloudstic/cli/pkg/store"
+)
+
+// exitCrashInjected is the process exit code used when
+// CLOUDSTIC_TEST_CRASH_AFTER_PUTS triggers a simulated crash. It is distinct
+// from exitFailure so a test can tell "the crash fired" apart from "the
+// command failed for an unrelated reason".
+const exitCrashInjected = 137
+
+// withCrashInjection wraps s so the process hard-exits — skipping every
+// deferred cleanup and buffered flush, exactly like a real crash — right
+// after the Nth successful backend Put, when CLOUDSTIC_TEST_CRASH_AFTER_PUTS
+// is set. It is a no-op otherwise.
+//
+// This is a test-only knob (see AGENTS.md's CLOUDSTIC_TEST_* convention),
+// compiled into every build but inert unless that variable is set. It exists
+// so e2e crash-consistency tests can kill the real binary at a precise,
+// reproducible point in a backup rather than racing an external signal.
+func withCrashInjection(s store.ObjectStore) (store.ObjectStore, error) {
+	raw := os.Getenv("CLOUDSTIC_TEST_CRASH_AFTER_PUTS")
+	if raw == "" {
+		return s, nil
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return nil, fmt.Errorf("CLOUDSTIC_TEST_CRASH_AFTER_PUTS: invalid count %q", raw)
+	}
+	cs := &crashAfterPutsStore{ObjectStore: s}
+	cs.remaining.Store(int64(n))
+	return cs, nil
+}
+
+// crashAfterPutsStore hard-exits the process after its Nth successful Put.
+// Wrapping the raw backend (below compression/encryption/packing) means the
+// count reflects real physical writes to the backend, which is what a
+// crash-consistency test needs to control.
+type crashAfterPutsStore struct {
+	store.ObjectStore
+	remaining atomic.Int64
+}
+
+func (s *crashAfterPutsStore) Unwrap() store.ObjectStore { return s.ObjectStore }
+
+func (s *crashAfterPutsStore) Put(ctx context.Context, key string, data []byte) error {
+	if err := s.ObjectStore.Put(ctx, key, data); err != nil {
+		return err
+	}
+	if s.remaining.Add(-1) == 0 {
+		os.Exit(exitCrashInjected)
+	}
+	return nil
+}

--- a/cmd/cloudstic/crashinject_stub.go
+++ b/cmd/cloudstic/crashinject_stub.go
@@ -1,0 +1,11 @@
+//go:build !crashinject
+
+package main
+
+import "github.com/cloudstic/cli/pkg/store"
+
+// withCrashInjection is a no-op in the default build. See crashinject.go,
+// which is compiled in only under the "crashinject" build tag.
+func withCrashInjection(s store.ObjectStore) (store.ObjectStore, error) {
+	return s, nil
+}

--- a/cmd/cloudstic/storebuild.go
+++ b/cmd/cloudstic/storebuild.go
@@ -75,7 +75,7 @@ func newObjectStore(ctx context.Context, cfg storeConfig) (store.ObjectStore, er
 	if err != nil {
 		return nil, err
 	}
-	return inner, nil
+	return withCrashInjection(inner)
 }
 
 func sftpStoreOpts(cfg sftpConfig, uri *storeURIParts) []store.SFTPStoreOption {

--- a/e2e/feature_crash_consistency_test.go
+++ b/e2e/feature_crash_consistency_test.go
@@ -1,0 +1,157 @@
+package e2e
+
+import (
+	"crypto/rand"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+// TestCLI_Feature_BackupCrashConsistency simulates the backup process
+// crashing at a range of points during a second, incremental backup, via
+// CLOUDSTIC_TEST_CRASH_AFTER_PUTS — a test-only knob that hard-exits the
+// binary (os.Exit, skipping every deferred flush) after its Nth physical
+// store write. Whatever point the crash lands at, the repository must come
+// out either fully at the old snapshot or fully at the new one: `check`
+// must report it healthy, `list` must show exactly the snapshots that
+// implies, and restoring the latest snapshot must reproduce one of the two
+// known-good file sets, never a mix.
+//
+// This is the acceptance test for the backup flush-ordering fix (writing
+// the snapshot object and flushing packs before updating index/latest) —
+// crashing between those steps is exactly the scenario that fix protects
+// against.
+func TestCLI_Feature_BackupCrashConsistency(t *testing.T) {
+	if !shouldRun(Hermetic) {
+		t.Skip("skipping hermetic test")
+	}
+	bin := buildBinary(t)
+
+	// Files well over the 512KiB chunk-size floor so each one's content
+	// chunks bypass PackStore's small-object bundling and land as their own
+	// physical store write. That's what gives early/mid/late crash points
+	// inside a single backup, rather than everything landing in one packfile
+	// flushed atomically at the end.
+	const (
+		fileCount = 20
+		fileSize  = 3 * 1024 * 1024
+	)
+
+	v1 := seedContent(fileCount, fileSize)
+	// A different size, not just different bytes: local source scanning
+	// records mtime at one-second resolution, and v1/v2 are written well
+	// within the same wall-clock second, so a same-size rewrite would be
+	// indistinguishable from an untouched file and get skipped by
+	// incremental change detection — masking the crash window entirely.
+	v2 := seedContent(fileCount, fileSize+4096)
+
+	writeContent := func(h *harness, content map[string]string) {
+		for relPath, data := range content {
+			h.writeFile(relPath, data)
+		}
+	}
+
+	newRepoAtV1 := func(t *testing.T) (*repo, *harness) {
+		t.Helper()
+		h := newHarness(t, bin, newLocalSource(t), newLocalStore(t))
+		r := h.MustInitUnencrypted()
+		writeContent(h, v1)
+		r.Backup()
+		return r, h
+	}
+
+	// Establish how many physical store writes the v1 -> v2 change produces,
+	// so a "one before the very last write" crash point (which should land
+	// between the snapshot/pack flush and the index/latest update) doesn't
+	// have to hardcode an assumption about tree shape.
+	control, controlH := newRepoAtV1(t)
+	writeContent(controlH, v2)
+	totalPuts := control.BackupPutCount()
+	if totalPuts < 2 {
+		t.Fatalf("expected the v1 -> v2 change to produce at least 2 store writes, got %d", totalPuts)
+	}
+
+	for _, tc := range []struct {
+		name string
+		n    int
+	}{
+		{"early", 5},
+		{"mid", 20},
+		{"late", 50},
+		{"last-1", totalPuts - 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.n <= 0 || tc.n > totalPuts {
+				t.Skipf("crash point %d is out of range for a %d-put backup", tc.n, totalPuts)
+			}
+
+			r, h := newRepoAtV1(t)
+			writeContent(h, v2)
+
+			env := []string{"CLOUDSTIC_TEST_CRASH_AFTER_PUTS=" + strconv.Itoa(tc.n)}
+			out, exitCode := r.BackupWithEnv(env)
+			switch exitCode {
+			case 0:
+				// The change had fewer than tc.n writes after all (e.g. a
+				// dedup or catalog write moved); the backup ran to completion.
+			case crashInjectedExitCode:
+				// The simulated crash fired, mid-backup.
+			default:
+				t.Fatalf("backup exited %d, want 0 or %d (simulated crash):\n%s", exitCode, crashInjectedExitCode, out)
+			}
+
+			r.Check("--read-data").MustContain("repository is healthy")
+
+			rows := r.List().SnapshotRows()
+			if len(rows) != 1 && len(rows) != 2 {
+				t.Fatalf("expected 1 (crash undid the new snapshot) or 2 (new snapshot committed) snapshots, got %d:\n%s", len(rows), out)
+			}
+
+			restored := r.RestoreDir("latest")
+			switch len(rows) {
+			case 1:
+				assertRestoredContent(t, restored.Path(), v1)
+			case 2:
+				assertRestoredContent(t, restored.Path(), v2)
+			}
+		})
+	}
+}
+
+// crashInjectedExitCode mirrors cmd/cloudstic's exitCrashInjected constant.
+// It is not imported directly since e2e drives the compiled binary as a
+// subprocess rather than linking against cmd/cloudstic.
+const crashInjectedExitCode = 137
+
+// seedContent returns fileCount files under "dir/", each fileSize bytes of
+// random (incompressible, undedupable) data.
+func seedContent(fileCount, fileSize int) map[string]string {
+	content := make(map[string]string, fileCount)
+	for i := range fileCount {
+		relPath := filepath.Join("dir", fmt.Sprintf("file%02d.txt", i))
+		data := make([]byte, fileSize)
+		if _, err := rand.Read(data); err != nil {
+			panic(fmt.Sprintf("generate test content: %v", err))
+		}
+		content[relPath] = string(data)
+	}
+	return content
+}
+
+// assertRestoredContent fails the test unless every file in want is present
+// under root with exactly the expected content.
+func assertRestoredContent(t *testing.T, root string, want map[string]string) {
+	t.Helper()
+	for relPath, wantData := range want {
+		fullPath := filepath.Join(root, filepath.FromSlash(relPath))
+		got, err := os.ReadFile(fullPath)
+		if err != nil {
+			t.Fatalf("restored dir missing %s: %v", relPath, err)
+		}
+		if string(got) != wantData {
+			t.Fatalf("restored content mismatch for %s: got %d bytes, want %d bytes", relPath, len(got), len(wantData))
+		}
+	}
+}

--- a/e2e/harness_test.go
+++ b/e2e/harness_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"archive/zip"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -402,6 +403,41 @@ func (r *repo) Backup(extraArgs ...string) *commandResult {
 	args = append(args, r.authArgs...)
 	args = append(args, extraArgs...)
 	return r.run(args...)
+}
+
+// BackupWithEnv runs backup with additional environment variables, without
+// failing the test on a non-zero exit — used by tests that expect the
+// process to exit abnormally, such as simulated crashes.
+func (r *repo) BackupWithEnv(extraEnv []string, extraArgs ...string) (out string, exitCode int) {
+	r.h.t.Helper()
+	args := append([]string{"backup"}, r.h.sourceArgs...)
+	args = append(args, r.authArgs...)
+	args = append(args, extraArgs...)
+	cmd := exec.Command(r.h.bin, args...)
+	cmd.Env = append(cleanEnv(), extraEnv...)
+	outBytes, err := cmd.CombinedOutput()
+	out = string(outBytes)
+	if err == nil {
+		return out, 0
+	}
+	if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
+		return out, exitErr.ExitCode()
+	}
+	r.h.t.Fatalf("backup command failed to start: %v\n%s", err, out)
+	return out, -1
+}
+
+// BackupPutCount runs `backup -debug -quiet` and returns the number of
+// physical store Put calls it made, read off DebugStore's "PUT" log lines.
+// Tests use this to find the last possible crash point in a backup without
+// hardcoding an assumption about how many objects a given change produces.
+func (r *repo) BackupPutCount(extraArgs ...string) int {
+	r.h.t.Helper()
+	args := append([]string{"backup", "-debug", "-quiet"}, r.h.sourceArgs...)
+	args = append(args, r.authArgs...)
+	args = append(args, extraArgs...)
+	out := run(r.h.t, r.h.bin, args...)
+	return strings.Count(out, "PUT   ")
 }
 
 func (r *repo) List(extraArgs ...string) *listResult {

--- a/e2e/harness_test.go
+++ b/e2e/harness_test.go
@@ -64,7 +64,10 @@ func buildBinary(t *testing.T) string {
 			return
 		}
 		bin := filepath.Join(dir, "cloudstic")
-		cmd := exec.Command("go", "build", "-buildvcs=false", "-cover", "-o", bin, "../cmd/cloudstic")
+		// -tags crashinject links in the CLOUDSTIC_TEST_CRASH_AFTER_PUTS knob
+		// (see cmd/cloudstic/crashinject.go), which a plain production build
+		// never includes.
+		cmd := exec.Command("go", "build", "-buildvcs=false", "-cover", "-tags", "crashinject", "-o", bin, "../cmd/cloudstic")
 		cmd.Env = append(os.Environ(), "GOCACHE="+filepath.Join(dir, "gocache"))
 		if out, err := cmd.CombinedOutput(); err != nil {
 			buildErr = fmt.Errorf("build failed: %w\n%s", err, out)


### PR DESCRIPTION
## Summary
- Add `CLOUDSTIC_TEST_CRASH_AFTER_PUTS`, a test-only knob (`cmd/cloudstic/crashinject.go`) that hard-exits the binary — skipping every deferred flush, exactly like a real crash — after its Nth physical backend store write. Wired in at `newObjectStore` in `cmd/cloudstic/storebuild.go`, below compression/encryption/packing, so the count reflects real physical writes rather than logical object writes that PackStore may still be buffering.
- Gated behind a `crashinject` build tag (`cmd/cloudstic/crashinject_stub.go` is the no-op default). A plain `go build ./cmd/cloudstic` — what AGENTS.md documents and what ships — never links this code in at all; only e2e's own build (`e2e/harness_test.go`'s `buildBinary`) passes `-tags crashinject`. So the capability doesn't exist in production binaries at all, not just "gated by an env var name nobody would set by accident."
- Add `TestCLI_Feature_BackupCrashConsistency` (`e2e/feature_crash_consistency_test.go`): runs a baseline backup, then crashes a second, incremental backup at a spread of points (5, 20, 50, and one write before the last), and asserts the repo always comes out either fully at the old snapshot or fully at the new one — `check --read-data` healthy, `list` showing exactly 1 or 2 snapshots, and restoring the latest snapshot reproducing one of the two known-good file sets, never a mix.
- Add small harness helpers (`repo.BackupWithEnv`, `repo.BackupPutCount`) to `e2e/harness_test.go` to support running backup with extra env vars without failing the test on a non-zero exit, and to count physical store writes via `-debug` output for a data-driven "one before the last write" crash point.

A prior review flagged that this suite has no fault injection anywhere, so the whole class of bugs that only surface on a crashed write path shipped undetected — including the flush-ordering bug fixed in #334 (`index/latest` could point at a snapshot that was never durably written). This is the acceptance test for that fix.

**Verified the test actually catches the regression it targets**: temporarily reverted the #334 fix (`internal/engine/backup.go`) and reran — the `last-1` crash point failed with `[read_error] snapshot/...: cannot read snapshot: ... object not found`, exactly the corruption the fix prevents. Re-applying the fix passes cleanly.

**Verified the build tag actually keeps this out of production**: built `cmd/cloudstic` the normal, untagged way and ran it with `CLOUDSTIC_TEST_CRASH_AFTER_PUTS=1` set — the backup completed normally (exit 0), confirming the variable is inert (and the crash code entirely absent) in a standard build.

## Verification
- `go build ./...` (both untagged and `-tags crashinject`)
- `go vet ./...`
- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./...`
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./...` and `golangci-lint run --build-tags crashinject ./cmd/cloudstic/...`
- Regression check: reverted `internal/engine/backup.go` to its pre-#334 state, confirmed `TestCLI_Feature_BackupCrashConsistency/last-1` fails with the exact corruption the fix prevents, then restored the fix and confirmed all four crash points pass again.