### PR TITLE
test(store): cover the full decorator chain and PackStore.Exists

### DIFF
--- a/pkg/store/fullchain_test.go
+++ b/pkg/store/fullchain_test.go
@@ -1,0 +1,89 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"testing"
+
+	"github.com/cloudstic/cli/pkg/crypto"
+)
+
+// buildFullChain assembles the exact decorator chain Client.NewClient builds
+// for an encrypted, packfile-enabled repository:
+// Compressed(Encrypted(Metered(Pack(Local)))). pack is returned alongside so
+// callers can Flush it, since PackStore only lands packed objects on the
+// backend at flush time.
+func buildFullChain(t *testing.T) (chain ObjectStore, pack *PackStore) {
+	t.Helper()
+	base, err := NewLocalStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	masterKey := testIndexKey(t, 7)
+	indexKey, err := crypto.DeriveKey(masterKey, crypto.HKDFInfoPackIndexV1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pack, err = NewPackStore(base, WithPackIndexKey(indexKey))
+	if err != nil {
+		t.Fatal(err)
+	}
+	encrypted := NewEncryptedStore(NewMeteredStore(pack), masterKey)
+	compressed := NewCompressedStore(encrypted, WithFramedWrites(true))
+	return compressed, pack
+}
+
+// TestFullStoreChain_RoundTripsAdversarialPayloads exercises the actual chain
+// Client.NewClient assembles rather than each decorator in isolation. Every
+// layer here has its own tests, but nothing previously round-tripped a
+// payload through all of them together — and a bug in how two layers
+// interact (compression framing vs. encryption vs. pack bundling) would not
+// show up in either layer's tests alone. Framed writes are the mode any
+// current repository uses, so this is the regression guard for the
+// compression-sniffing corruption fix (see compressed.go's frame doc
+// comment): a valid gzip/zstd stream that zstd cannot shrink further, stored
+// verbatim, must come back byte-for-byte rather than being sniffed and
+// wrongly inflated on read.
+func TestFullStoreChain_RoundTripsAdversarialPayloads(t *testing.T) {
+	ctx := context.Background()
+
+	incompressible := make([]byte, 8192)
+	if _, err := rand.Read(incompressible); err != nil {
+		t.Fatal(err)
+	}
+
+	payloads := map[string][]byte{
+		"already-gzip":       gzipBytes(t, []byte("a payload that happens to look like gzip once compressed")),
+		"already-zstd":       zstdBytes(t, []byte("a payload that happens to look like zstd once compressed")),
+		"frame-magic-prefix": append([]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a}, incompressible...),
+		"empty":              {},
+		"incompressible":     incompressible,
+	}
+
+	for name, payload := range payloads {
+		t.Run(name, func(t *testing.T) {
+			chain, pack := buildFullChain(t)
+			key := "content/" + name
+
+			if err := chain.Put(ctx, key, payload); err != nil {
+				t.Fatalf("Put: %v", err)
+			}
+			if err := pack.Flush(ctx); err != nil {
+				t.Fatalf("Flush: %v", err)
+			}
+
+			got, err := chain.Get(ctx, key)
+			if err != nil {
+				t.Fatalf("Get: %v", err)
+			}
+			if !bytes.Equal(got, payload) {
+				t.Errorf("round trip through the full chain mismatched: got %d bytes, want %d bytes", len(got), len(payload))
+			}
+
+			if ok, err := chain.Exists(ctx, key); err != nil || !ok {
+				t.Errorf("Exists = %v, %v, want true, nil", ok, err)
+			}
+		})
+	}
+}

--- a/pkg/store/pack_test.go
+++ b/pkg/store/pack_test.go
@@ -204,3 +204,53 @@ func TestPackStore_RepackNoFragment(t *testing.T) {
 		t.Fatalf("Expected packfile to remain, got %d", len(packs))
 	}
 }
+
+// TestPackStore_Exists covers all three paths Exists can take: a key still
+// sitting in the unflushed buffer, a key already recorded in the flushed
+// catalog, and a key PackStore never packed at all (falling back to inner).
+func TestPackStore_Exists(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	localStore, err := NewLocalStore(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create local store: %v", err)
+	}
+	packStore, err := NewPackStore(localStore)
+	if err != nil {
+		t.Fatalf("Failed to init pack store: %v", err)
+	}
+
+	buffered := "filemeta/buffered"
+	if err := packStore.Put(ctx, buffered, []byte("not flushed yet")); err != nil {
+		t.Fatalf("Put buffered: %v", err)
+	}
+	if ok, err := packStore.Exists(ctx, buffered); err != nil || !ok {
+		t.Errorf("Exists(buffered) = %v, %v, want true, nil", ok, err)
+	}
+
+	flushed := "filemeta/flushed"
+	if err := packStore.Put(ctx, flushed, []byte("this one gets flushed")); err != nil {
+		t.Fatalf("Put flushed: %v", err)
+	}
+	if err := packStore.Flush(ctx); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if ok, err := packStore.Exists(ctx, flushed); err != nil || !ok {
+		t.Errorf("Exists(flushed) = %v, %v, want true, nil", ok, err)
+	}
+
+	// index/latest is never packed (mutable, unpacked keys bypass PackStore's
+	// buffer entirely), so this path only succeeds by falling back to inner.
+	unpacked := "index/latest"
+	if err := localStore.Put(ctx, unpacked, []byte("direct to inner")); err != nil {
+		t.Fatalf("Put unpacked directly on inner: %v", err)
+	}
+	if ok, err := packStore.Exists(ctx, unpacked); err != nil || !ok {
+		t.Errorf("Exists(unpacked) = %v, %v, want true, nil (fallback to inner)", ok, err)
+	}
+
+	if ok, err := packStore.Exists(ctx, "filemeta/never-written"); err != nil || ok {
+		t.Errorf("Exists(never-written) = %v, %v, want false, nil", ok, err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `TestFullStoreChain_RoundTripsAdversarialPayloads` (`pkg/store/fullchain_test.go`): round-trips already-gzip, already-zstd, frame-magic-prefixed, empty, and incompressible payloads through the actual chain `Client.NewClient` assembles — `Compressed(Encrypted(Metered(Pack(Local))))` — rather than each decorator's own isolated tests. That's exactly where the compression-sniffing corruption bug (fixed in #329) lived: it only manifests from how framing, encryption, and pack bundling interact, not from any single layer alone.
- Add `TestPackStore_Exists` (`pkg/store/pack_test.go`), covering all three paths `Exists` takes: a key still in the unflushed buffer, a key already in the flushed catalog, and a key PackStore never packed (fallback to inner). Was 0% covered.

A prior review flagged `pkg/store` as the riskiest, least-covered package (42.8% at the time; some gaps have since closed from other work, but these two were still real): nothing tested the composed chain as a whole, and `PackStore.Exists`/`PackStore.List` sat at 0%. `PackStore.List` has since gained coverage elsewhere; `Exists` and the composed-chain gap were still open.

**Verified the new chain test is a real regression guard**, not just plausible-looking coverage: temporarily set the chain to unframed writes (`WithFramedWrites(false)`) and reran — `already-gzip`/`already-zstd` failed with mangled round trips (56 bytes back instead of 74/69), reproducing the exact #329 corruption. Restored to framed (what any current repository uses) and all five payload cases pass.

B2Store's 0% coverage (also flagged in the same review) is out of scope here — faking it means emulating Backblaze's REST handshake (auth, bucket lookup, upload URL, upload/download/list/hide) behind `blazer`'s `APIBase` hook, not just adding a couple of routes, so it's being tracked as separate follow-up work rather than folded into this PR.

## Verification
- `go build ./...`
- `go vet ./...`
- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./...`
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./pkg/store/...`
- Regression check: disabled framing in the chain builder, confirmed `TestFullStoreChain_RoundTripsAdversarialPayloads/already-gzip` and `/already-zstd` fail with corrupted round trips, then restored framing and confirmed all cases pass.