### PR TITLE
feat(tui): async cancellable actions and concurrent store probes (RFC 0012)

### DIFF
--- a/cmd/cloudstic/cmd_tui.go
+++ b/cmd/cloudstic/cmd_tui.go
@@ -26,12 +26,15 @@ func runTUI(r *runner, ctx context.Context, args *tuiArgs) int {
 		return r.fail("cloudstic tui requires an interactive terminal")
 	}
 
+	if args.bubbletea {
+		// The Bubble Tea renderer builds its own skeleton and probes stores
+		// concurrently, so it skips the serial pre-probe below.
+		return runBubbleTeaTUI(r, ctx, args.profilesFile)
+	}
+
 	dashboard, err := tuiBuildDashboard(ctx, args.profilesFile)
 	if err != nil {
 		return r.fail("Failed to build TUI dashboard: %v", err)
-	}
-	if args.bubbletea {
-		return runBubbleTeaTUI(r, ctx, dashboard)
 	}
 	return newTUISession(r, args.profilesFile, dashboard).run(ctx)
 }

--- a/cmd/cloudstic/cmd_tui_bubbletea.go
+++ b/cmd/cloudstic/cmd_tui_bubbletea.go
@@ -2,9 +2,14 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"sync"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	cloudstic "github.com/cloudstic/cli"
+	"github.com/cloudstic/cli/internal/app"
 	"github.com/cloudstic/cli/internal/tui"
 )
 
@@ -15,15 +20,30 @@ var tuiRunBubbleTea = func(ctx context.Context, model tea.Model, opts ...tea.Pro
 	return err
 }
 
-// runBubbleTeaTUI launches the experimental Bubble Tea renderer with an
-// already-built dashboard. It is the parallel, read-only renderer added in
-// RFC 0012 Phase 2 (issue #338); the legacy renderer remains the default.
-func runBubbleTeaTUI(r *runner, ctx context.Context, dashboard tui.Dashboard) int {
+// tuiLoadConfig loads the profiles config for the Bubble Tea renderer. It is a
+// package var so tests can supply a fixed config.
+var tuiLoadConfig = func(profilesFile string) (*cloudstic.ProfilesConfig, error) {
+	return app.NewTUIService(nil).LoadDashboardConfig(profilesFile)
+}
+
+// runBubbleTeaTUI launches the experimental Bubble Tea renderer. It builds a
+// probe-less dashboard skeleton and lets the model probe stores concurrently
+// (issue #339) rather than probing serially before the first frame.
+func runBubbleTeaTUI(r *runner, ctx context.Context, profilesFile string) int {
+	cfg, err := tuiLoadConfig(profilesFile)
+	if err != nil {
+		return r.fail("Failed to load profiles: %v", err)
+	}
+
+	skeleton := tui.BuildDashboard(cfg, nil)
+	model := tui.NewModel(skeleton).
+		WithConfig(cfg, bubbleStoreProber{r: r}).
+		WithRunner(bubbleActionRunner{r: r, profilesFile: profilesFile})
+
 	stdin := r.stdin
 	if stdin == nil {
 		stdin = os.Stdin
 	}
-	model := tui.NewModel(dashboard)
 	opts := []tea.ProgramOption{
 		tea.WithInput(stdin),
 		tea.WithOutput(r.out),
@@ -33,4 +53,93 @@ func runBubbleTeaTUI(r *runner, ctx context.Context, dashboard tui.Dashboard) in
 		return r.fail("TUI exited with error: %v", err)
 	}
 	return 0
+}
+
+// bubbleStoreProber probes a single store's health by listing its snapshots,
+// the same signal the serial dashboard builder used, but now bounded by the
+// per-store timeout the model applies.
+type bubbleStoreProber struct {
+	r *runner
+}
+
+func (p bubbleStoreProber) Probe(ctx context.Context, name string, store cloudstic.ProfileStore) tui.StoreProbe {
+	snapshots, err := (tuiCLIBackend{r: p.r}).LoadStoreSnapshots(ctx, name, store)
+	if err != nil {
+		return tui.StoreProbe{Status: "error", Error: err.Error()}
+	}
+	return tui.StoreProbe{Status: "ok", Snapshots: snapshots}
+}
+
+// bubbleActionRunner adapts the shared TUIService action methods to the model's
+// streaming ActionRunner contract. It reuses tuiActionState so progress and log
+// lines match the legacy renderer's activity panel.
+type bubbleActionRunner struct {
+	r            *runner
+	profilesFile string
+}
+
+func (a bubbleActionRunner) Start(ctx context.Context, profile tui.ProfileCard, kind tui.ActionKind) <-chan tui.ActionUpdate {
+	ch := make(chan tui.ActionUpdate, 32)
+	log := newTUIActionState(10)
+	seedActionLabel(log, profile, kind)
+
+	go func() {
+		defer close(ch)
+
+		restore := captureTUIRunnerOutput(a.r, log)
+		defer restore()
+
+		// Stream periodic progress snapshots until the action returns.
+		stop := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Go(func() {
+			ticker := time.NewTicker(100 * time.Millisecond)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-stop:
+					return
+				case <-ticker.C:
+					ch <- tui.ActionUpdate{Panel: log.Snapshot()}
+				}
+			}
+		})
+
+		service := tuiServiceFactory(a.r, a.profilesFile, log)
+		var err error
+		if kind == tui.ActionKindCheck {
+			err = service.RunProfileCheck(ctx, a.profilesFile, profile, log.Reporter())
+		} else {
+			err = service.RunProfileAction(ctx, a.profilesFile, profile, log.Reporter())
+		}
+
+		close(stop)
+		wg.Wait()
+
+		if err != nil {
+			log.Fail(err.Error())
+			log.Printf("Action failed: %v", err)
+		} else {
+			log.Succeed("completed successfully")
+			log.Printf("Action completed successfully")
+		}
+		ch <- tui.ActionUpdate{Panel: log.Snapshot(), Done: true, Err: err}
+	}()
+
+	return ch
+}
+
+func seedActionLabel(log *tuiActionState, profile tui.ProfileCard, kind tui.ActionKind) {
+	target := fmt.Sprintf("profile %s", profile.Name)
+	switch kind {
+	case tui.ActionKindCheck:
+		log.Start("Run repository check", target)
+		log.Printf("Running repository check for profile %s", profile.Name)
+	case tui.ActionKindInit:
+		log.Start("Initialize store", target)
+		log.Printf("Initializing store for profile %s", profile.Name)
+	default:
+		log.Start("Run backup", target)
+		log.Printf("Running backup for profile %s", profile.Name)
+	}
 }

--- a/cmd/cloudstic/cmd_tui_bubbletea_test.go
+++ b/cmd/cloudstic/cmd_tui_bubbletea_test.go
@@ -7,30 +7,38 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/cloudstic/cli/internal/tui"
+	cloudstic "github.com/cloudstic/cli"
 )
 
 func TestRunBubbleTeaTUI_Success(t *testing.T) {
-	restore := swapBubbleTeaRunner(func(context.Context, tea.Model, ...tea.ProgramOption) error {
+	restoreRun := swapBubbleTeaRunner(func(context.Context, tea.Model, ...tea.ProgramOption) error {
 		return nil
 	})
-	defer restore()
+	defer restoreRun()
+	restoreCfg := swapTUILoadConfig(func(string) (*cloudstic.ProfilesConfig, error) {
+		return &cloudstic.ProfilesConfig{Version: 1}, nil
+	})
+	defer restoreCfg()
 
 	r := &runner{out: &strings.Builder{}, errOut: &strings.Builder{}}
-	if code := runBubbleTeaTUI(r, context.Background(), tui.Dashboard{}); code != 0 {
+	if code := runBubbleTeaTUI(r, context.Background(), "profiles.yaml"); code != 0 {
 		t.Fatalf("exit code=%d want 0", code)
 	}
 }
 
-func TestRunBubbleTeaTUI_Error(t *testing.T) {
-	restore := swapBubbleTeaRunner(func(context.Context, tea.Model, ...tea.ProgramOption) error {
+func TestRunBubbleTeaTUI_ProgramError(t *testing.T) {
+	restoreRun := swapBubbleTeaRunner(func(context.Context, tea.Model, ...tea.ProgramOption) error {
 		return errors.New("boom")
 	})
-	defer restore()
+	defer restoreRun()
+	restoreCfg := swapTUILoadConfig(func(string) (*cloudstic.ProfilesConfig, error) {
+		return &cloudstic.ProfilesConfig{Version: 1}, nil
+	})
+	defer restoreCfg()
 
 	errOut := &strings.Builder{}
 	r := &runner{out: &strings.Builder{}, errOut: errOut}
-	if code := runBubbleTeaTUI(r, context.Background(), tui.Dashboard{}); code == 0 {
+	if code := runBubbleTeaTUI(r, context.Background(), "profiles.yaml"); code == 0 {
 		t.Fatalf("exit code=0 want non-zero on error")
 	}
 	if !strings.Contains(errOut.String(), "boom") {
@@ -38,8 +46,30 @@ func TestRunBubbleTeaTUI_Error(t *testing.T) {
 	}
 }
 
+func TestRunBubbleTeaTUI_ConfigError(t *testing.T) {
+	restoreCfg := swapTUILoadConfig(func(string) (*cloudstic.ProfilesConfig, error) {
+		return nil, errors.New("bad config")
+	})
+	defer restoreCfg()
+
+	errOut := &strings.Builder{}
+	r := &runner{out: &strings.Builder{}, errOut: errOut}
+	if code := runBubbleTeaTUI(r, context.Background(), "profiles.yaml"); code == 0 {
+		t.Fatalf("exit code=0 want non-zero on config error")
+	}
+	if !strings.Contains(errOut.String(), "bad config") {
+		t.Fatalf("errOut missing config error: %q", errOut.String())
+	}
+}
+
 func swapBubbleTeaRunner(fn func(context.Context, tea.Model, ...tea.ProgramOption) error) func() {
 	prev := tuiRunBubbleTea
 	tuiRunBubbleTea = fn
 	return func() { tuiRunBubbleTea = prev }
+}
+
+func swapTUILoadConfig(fn func(string) (*cloudstic.ProfilesConfig, error)) func() {
+	prev := tuiLoadConfig
+	tuiLoadConfig = fn
+	return func() { tuiLoadConfig = prev }
 }

--- a/internal/app/tui_service.go
+++ b/internal/app/tui_service.go
@@ -140,6 +140,13 @@ func (s *TUIService) SaveStore(profilesFile, name string, store cloudstic.Profil
 	return nil
 }
 
+// LoadDashboardConfig loads and normalizes the profiles config for the TUI.
+// The Bubble Tea renderer builds a probe-less dashboard skeleton from it and
+// then probes stores concurrently, rather than probing serially up front.
+func (s *TUIService) LoadDashboardConfig(profilesFile string) (*cloudstic.ProfilesConfig, error) {
+	return s.loadConfig(profilesFile)
+}
+
 func (s *TUIService) loadConfig(profilesFile string) (*cloudstic.ProfilesConfig, error) {
 	load := s.loadProfiles
 	if load == nil {

--- a/internal/tui/action.go
+++ b/internal/tui/action.go
@@ -1,0 +1,93 @@
+package tui
+
+import (
+	"context"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// ActionUpdate is a single progress update from a running profile action.
+// Non-final updates carry the live ActivityPanel; the final update sets Done
+// (and Err when the action failed) and is the last value sent before the
+// channel closes.
+type ActionUpdate struct {
+	Panel ActivityPanel
+	Done  bool
+	Err   error
+}
+
+// ActionRunner executes a profile action asynchronously. Start launches the
+// action against ctx and returns a channel that streams progress updates and
+// closes once the final (Done) update has been sent. Implementations must
+// respect ctx cancellation so the model's cancel key can stop a running
+// action.
+type ActionRunner interface {
+	Start(ctx context.Context, profile ProfileCard, kind ActionKind) <-chan ActionUpdate
+}
+
+// actionUpdateMsg carries one ActionUpdate plus the channel it came from so
+// the model can re-subscribe for the next update without holding the channel
+// in its own state.
+type actionUpdateMsg struct {
+	update ActionUpdate
+	ch     <-chan ActionUpdate
+}
+
+// waitForAction blocks on the next update from ch and delivers it as a
+// message. A closed channel is reported as a terminal Done update so the model
+// always leaves the running state even if a runner forgets the final send.
+func waitForAction(ch <-chan ActionUpdate) tea.Cmd {
+	return func() tea.Msg {
+		update, ok := <-ch
+		if !ok {
+			return actionUpdateMsg{update: ActionUpdate{Done: true}, ch: nil}
+		}
+		return actionUpdateMsg{update: update, ch: ch}
+	}
+}
+
+// startAction begins the action bound to the given key for the selected
+// profile, if one is enabled and no action is already running. It returns the
+// command that listens for the first progress update.
+func (m Model) startAction(key string) (Model, tea.Cmd) {
+	if m.running || m.runner == nil {
+		return m, nil
+	}
+	profile, ok := m.currentProfile()
+	if !ok {
+		return m, nil
+	}
+	action, ok := enabledActionForKey(profile, key)
+	if !ok {
+		return m, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := m.runner.Start(ctx, profile, action.Kind)
+	m.running = true
+	m.cancel = cancel
+	m.activity = ActivityPanel{
+		Status:     ActivityStatusRunning,
+		ActionKind: action.Kind,
+		Target:     profile.Name,
+	}
+	return m, waitForAction(ch)
+}
+
+func enabledActionForKey(profile ProfileCard, key string) (ProfileAction, bool) {
+	for _, action := range profile.Actions {
+		if action.Key == key && action.Enabled {
+			return action, true
+		}
+	}
+	return ProfileAction{}, false
+}
+
+// cancelAction requests cancellation of the running action, if any. The action
+// finishes on its own and delivers a terminal update; the model stays in the
+// running state until that arrives.
+func (m *Model) cancelAction() {
+	if m.cancel != nil {
+		m.cancel()
+	}
+}

--- a/internal/tui/action_test.go
+++ b/internal/tui/action_test.go
@@ -1,0 +1,122 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// stubRunner is a scripted ActionRunner: it emits the given updates in order,
+// records the kind it was asked to run, and cancels via ctx.
+type stubRunner struct {
+	updates  []ActionUpdate
+	started  ActionKind
+	canceled bool
+}
+
+func (s *stubRunner) Start(ctx context.Context, _ ProfileCard, kind ActionKind) <-chan ActionUpdate {
+	s.started = kind
+	ch := make(chan ActionUpdate, len(s.updates)+1)
+	go func() {
+		defer close(ch)
+		for _, u := range s.updates {
+			ch <- u
+		}
+		// If nothing terminal was scripted, watch for cancellation.
+		if len(s.updates) == 0 {
+			<-ctx.Done()
+			s.canceled = true
+			ch <- ActionUpdate{Panel: ActivityPanel{Status: ActivityStatusError, Summary: "canceled"}, Done: true, Err: ctx.Err()}
+		}
+	}()
+	return ch
+}
+
+func TestModel_StartAction_RunsAndCompletes(t *testing.T) {
+	runner := &stubRunner{updates: []ActionUpdate{
+		{Panel: ActivityPanel{Status: ActivityStatusRunning, Action: "Run backup", Phase: "scanning"}},
+		{Panel: ActivityPanel{Status: ActivityStatusSuccess, Summary: "completed"}, Done: true},
+	}}
+	m := NewModel(testDashboard()).WithRunner(runner)
+
+	// Press "b": on the ready "alpha" profile this maps to a backup action.
+	next, cmd := m.Update(keyRunes("b"))
+	m = next.(Model)
+	if !m.running {
+		t.Fatalf("model should be running after starting action")
+	}
+	if runner.started != ActionKindBackup {
+		t.Fatalf("started kind=%q want backup", runner.started)
+	}
+
+	// Pump the streamed updates through the model.
+	for i := 0; i < 5 && cmd != nil; i++ {
+		msg := cmd()
+		var next tea.Model
+		next, cmd = m.Update(msg)
+		m = next.(Model)
+	}
+	if m.running {
+		t.Fatalf("model still running after terminal update")
+	}
+	if m.activity.Status != ActivityStatusSuccess {
+		t.Fatalf("activity status=%q want success", m.activity.Status)
+	}
+	if !strings.Contains(m.View(), "done") {
+		t.Fatalf("view missing completion state\n%s", m.View())
+	}
+}
+
+func TestModel_StartAction_IgnoredWhenAlreadyRunning(t *testing.T) {
+	runner := &stubRunner{} // blocks until canceled
+	m := NewModel(testDashboard()).WithRunner(runner)
+
+	next, _ := m.Update(keyRunes("b"))
+	m = next.(Model)
+	if !m.running {
+		t.Fatalf("expected running")
+	}
+	// A second action key while running must be a no-op (no new command).
+	next, cmd := m.Update(keyRunes("c"))
+	m = next.(Model)
+	if cmd != nil {
+		t.Fatalf("second action while running should not start a command")
+	}
+}
+
+func TestModel_CancelKey_CancelsRunningAction(t *testing.T) {
+	runner := &stubRunner{} // waits for ctx cancellation
+	m := NewModel(testDashboard()).WithRunner(runner)
+
+	next, cmd := m.Update(keyRunes("b"))
+	m = next.(Model)
+	if !m.running {
+		t.Fatalf("expected running")
+	}
+
+	// Press "x" to cancel.
+	next, _ = m.Update(keyRunes("x"))
+	m = next.(Model)
+
+	// The wait command should now observe the terminal (canceled) update.
+	msg := cmd()
+	next, _ = m.Update(msg)
+	m = next.(Model)
+	if m.running {
+		t.Fatalf("model should stop running after cancellation")
+	}
+	if !runner.canceled {
+		t.Fatalf("runner ctx was not canceled")
+	}
+}
+
+func TestModel_StartAction_NoRunnerIsNoOp(t *testing.T) {
+	m := NewModel(testDashboard())
+	next, cmd := m.Update(keyRunes("b"))
+	m = next.(Model)
+	if m.running || cmd != nil {
+		t.Fatalf("action without a runner must be a no-op")
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1,11 +1,13 @@
 package tui
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/cloudstic/cli/internal/engine"
 )
 
 // Model is the root Bubble Tea model for the interactive dashboard. This is
@@ -22,6 +24,21 @@ type Model struct {
 	theme     theme
 	loadErr   string
 
+	// Concurrent-probe state (issue #339). When cfg and prober are set, the
+	// model probes every store concurrently on Init and rebuilds the
+	// dashboard from probes as they arrive, so the first paint shows
+	// "checking…" instead of blocking.
+	cfg    *engine.ProfilesConfig
+	prober StoreProber
+	probes map[string]StoreProbe
+
+	// Async action state (issue #339). runner executes profile actions off
+	// the event loop; cancel stops the running one.
+	runner   ActionRunner
+	running  bool
+	cancel   context.CancelFunc
+	activity ActivityPanel
+
 	// reload, when non-nil, is run when the user presses "r". It returns a
 	// DashboardLoadedMsg or DashboardLoadError. The read-only launcher can
 	// leave it nil for a static snapshot.
@@ -34,8 +51,25 @@ func NewModel(d Dashboard) Model {
 		dashboard: d,
 		view:      ProfileViewSummary,
 		theme:     newTheme(),
+		probes:    map[string]StoreProbe{},
 	}
 	m.selected = indexOfSelected(d)
+	return m
+}
+
+// WithConfig attaches the profiles config and a store prober, enabling
+// concurrent probing on Init. The seeded dashboard should be a probe-less
+// skeleton (BuildDashboard(cfg, nil)) so the first frame renders immediately.
+func (m Model) WithConfig(cfg *engine.ProfilesConfig, prober StoreProber) Model {
+	m.cfg = cfg
+	m.prober = prober
+	return m
+}
+
+// WithRunner attaches the async action runner used by the backup/check/init
+// keys.
+func (m Model) WithRunner(runner ActionRunner) Model {
+	m.runner = runner
 	return m
 }
 
@@ -54,7 +88,11 @@ func indexOfSelected(d Dashboard) int {
 	return 0
 }
 
-func (m Model) Init() tea.Cmd { return nil }
+// Init kicks off concurrent store probing when the model is configured with a
+// prober; otherwise it renders the seeded dashboard as-is.
+func (m Model) Init() tea.Cmd {
+	return m.probeAllCmd()
+}
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
@@ -74,10 +112,50 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.loadErr = msg.Err.Error()
 		}
 		return m, nil
+	case probeResultMsg:
+		m.applyProbe(msg.name, msg.probe)
+		return m, nil
+	case actionUpdateMsg:
+		return m.handleActionUpdate(msg)
 	case tea.KeyMsg:
 		return m.handleKey(msg)
 	}
 	return m, nil
+}
+
+// applyProbe records a store probe result and rebuilds the derived dashboard
+// from the accumulated probes, preserving the current selection.
+func (m *Model) applyProbe(name string, probe StoreProbe) {
+	if m.probes == nil {
+		m.probes = map[string]StoreProbe{}
+	}
+	m.probes[name] = probe
+	if m.cfg == nil {
+		return
+	}
+	selected := m.selectedName()
+	m.dashboard = BuildDashboard(m.cfg, m.probes)
+	m.dashboard.SelectedProfile = selected
+	m.selected = indexOfSelected(m.dashboard)
+}
+
+func (m Model) selectedName() string {
+	if p, ok := m.currentProfile(); ok {
+		return p.Name
+	}
+	return m.dashboard.SelectedProfile
+}
+
+func (m Model) handleActionUpdate(msg actionUpdateMsg) (tea.Model, tea.Cmd) {
+	m.activity = msg.update.Panel
+	if !msg.update.Done {
+		return m, waitForAction(msg.ch)
+	}
+	m.running = false
+	m.cancel = nil
+	// Refresh the store backing the profile we just acted on so state
+	// changes (e.g. a freshly initialized repository) show up.
+	return m, m.probeSelectedStoreCmd()
 }
 
 func clampSelection(n int) int {
@@ -90,7 +168,14 @@ func clampSelection(n int) int {
 func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "q", "ctrl+c", "esc":
+		// Cancel a running action before leaving so we don't orphan it.
+		m.cancelAction()
 		return m, tea.Quit
+	case "x":
+		if m.running {
+			m.cancelAction()
+		}
+		return m, nil
 	case "up", "k":
 		if m.selected > 0 {
 			m.selected--
@@ -114,6 +199,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.view = ProfileViewSummary
 		}
 		return m, nil
+	case "b", "c":
+		return m.startAction(msg.String())
 	case "r":
 		return m, m.reload
 	}
@@ -123,8 +210,45 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m Model) View() string {
 	header := m.renderHeader()
 	body := lipgloss.JoinHorizontal(lipgloss.Top, m.renderProfileList(), m.renderDetail())
-	footer := m.renderFooter()
-	return strings.Join([]string{header, body, footer}, "\n")
+	sections := []string{header, body}
+	if activity := m.renderActivity(); activity != "" {
+		sections = append(sections, activity)
+	}
+	sections = append(sections, m.renderFooter())
+	return strings.Join(sections, "\n")
+}
+
+func (m Model) renderActivity() string {
+	a := m.activity
+	if a.Status == ActivityStatusIdle && a.Action == "" {
+		return ""
+	}
+	label := a.Action
+	if label == "" {
+		label = string(a.ActionKind)
+	}
+	var head string
+	switch a.Status {
+	case ActivityStatusRunning:
+		head = m.theme.stateWarning.Render("● running") + "  " + label
+	case ActivityStatusSuccess:
+		head = m.theme.stateReady.Render("✓ done") + "  " + label
+	case ActivityStatusError:
+		head = m.theme.stateError.Render("✗ failed") + "  " + label
+	default:
+		head = label
+	}
+	lines := []string{head}
+	if a.Phase != "" {
+		lines = append(lines, m.theme.subtle.Render(a.Phase))
+	}
+	if bar := progressBarLine(a, 30); bar != "" {
+		lines = append(lines, bar)
+	}
+	if a.Summary != "" {
+		lines = append(lines, m.theme.subtle.Render(a.Summary))
+	}
+	return m.theme.box.Render(strings.Join(lines, "\n"))
 }
 
 func (m Model) renderHeader() string {
@@ -234,11 +358,46 @@ func (m Model) renderHistory(profile ProfileCard) []string {
 }
 
 func (m Model) renderFooter() string {
-	hints := "↑/↓ select · s/h view · r refresh · q quit"
+	var hints string
+	if m.running {
+		hints = "x cancel · running…"
+	} else {
+		hints = m.actionHints() + "↑/↓ select · s/h view · r refresh · q quit"
+	}
 	if m.loadErr != "" {
 		return m.theme.stateError.Render("error: "+m.loadErr) + "\n" + m.theme.footer.Render(hints)
 	}
 	return m.theme.footer.Render(hints)
+}
+
+// actionHints lists the enabled action keys for the selected profile so the
+// footer advertises only actions that will actually run.
+func (m Model) actionHints() string {
+	if m.runner == nil {
+		return ""
+	}
+	profile, ok := m.currentProfile()
+	if !ok {
+		return ""
+	}
+	var parts []string
+	for _, action := range profile.Actions {
+		if !action.Enabled {
+			continue
+		}
+		switch action.Kind {
+		case ActionKindInit:
+			parts = append(parts, "b init")
+		case ActionKindBackup:
+			parts = append(parts, "b backup")
+		case ActionKindCheck:
+			parts = append(parts, "c check")
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, " · ") + " · "
 }
 
 func (m Model) currentProfile() (ProfileCard, bool) {

--- a/internal/tui/probe.go
+++ b/internal/tui/probe.go
@@ -1,0 +1,68 @@
+package tui
+
+import (
+	"context"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/cloudstic/cli/internal/engine"
+)
+
+// StoreProbeTimeout bounds a single store health probe so one unreachable
+// backend cannot stall the dashboard. Probes run concurrently, so the whole
+// first paint is bounded by this regardless of how many stores are configured.
+const StoreProbeTimeout = 15 * time.Second
+
+// StoreProber checks the health of a single store. Implementations must honor
+// ctx (including its deadline) and must not block past it.
+type StoreProber interface {
+	Probe(ctx context.Context, name string, store engine.ProfileStore) StoreProbe
+}
+
+// probeResultMsg reports the outcome of one store probe back into the model.
+type probeResultMsg struct {
+	name  string
+	probe StoreProbe
+}
+
+// probeStoreCmd probes a single store under a per-store timeout and reports the
+// result. Batching several of these yields concurrent, bounded probing.
+func probeStoreCmd(prober StoreProber, name string, store engine.ProfileStore) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), StoreProbeTimeout)
+		defer cancel()
+		return probeResultMsg{name: name, probe: prober.Probe(ctx, name, store)}
+	}
+}
+
+// probeAllCmd returns a command that probes every configured store
+// concurrently. Each store resolves independently, so the model can render
+// "checking…" badges immediately and update them as results arrive.
+func (m Model) probeAllCmd() tea.Cmd {
+	if m.cfg == nil || m.prober == nil || len(m.cfg.Stores) == 0 {
+		return nil
+	}
+	cmds := make([]tea.Cmd, 0, len(m.cfg.Stores))
+	for name, store := range m.cfg.Stores {
+		cmds = append(cmds, probeStoreCmd(m.prober, name, store))
+	}
+	return tea.Batch(cmds...)
+}
+
+// probeSelectedStoreCmd re-probes the store backing the selected profile. It is
+// used to refresh the dashboard after an action (e.g. init) changes store
+// state.
+func (m Model) probeSelectedStoreCmd() tea.Cmd {
+	if m.cfg == nil || m.prober == nil {
+		return nil
+	}
+	profile, ok := m.currentProfile()
+	if !ok {
+		return nil
+	}
+	store, ok := m.cfg.Stores[profile.StoreRef]
+	if !ok {
+		return nil
+	}
+	return probeStoreCmd(m.prober, profile.StoreRef, store)
+}

--- a/internal/tui/probe_test.go
+++ b/internal/tui/probe_test.go
@@ -1,0 +1,108 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/cloudstic/cli/internal/engine"
+)
+
+type stubProber struct {
+	results map[string]StoreProbe
+}
+
+func (p stubProber) Probe(_ context.Context, name string, _ engine.ProfileStore) StoreProbe {
+	if probe, ok := p.results[name]; ok {
+		return probe
+	}
+	return StoreProbe{Status: "error", Error: "no result"}
+}
+
+func probeConfig() *engine.ProfilesConfig {
+	enabled := true
+	return &engine.ProfilesConfig{
+		Stores: map[string]engine.ProfileStore{
+			"remote": {URI: "s3:bucket/prod"},
+		},
+		Profiles: map[string]engine.BackupProfile{
+			"alpha": {Source: "local:/tmp/alpha", Store: "remote", Enabled: &enabled},
+		},
+	}
+}
+
+func TestModel_InitProbesConfiguredStores(t *testing.T) {
+	cfg := probeConfig()
+	prober := stubProber{results: map[string]StoreProbe{"remote": {Status: "ok"}}}
+	skeleton := BuildDashboard(cfg, nil)
+	m := NewModel(skeleton).WithConfig(cfg, prober)
+
+	// First frame: store health is pending → "checking store".
+	if !strings.Contains(m.View(), "checking store") {
+		t.Fatalf("first frame missing pending badge\n%s", m.View())
+	}
+
+	cmd := m.Init()
+	if cmd == nil {
+		t.Fatalf("Init returned no probe command")
+	}
+	msg := cmd()
+	next, _ := m.Update(msg)
+	m = next.(Model)
+
+	if got := m.dashboard.Profiles[0].StoreHealth; got != StoreHealthReady {
+		t.Fatalf("store health=%q want ready after probe", got)
+	}
+}
+
+func TestModel_InitWithoutConfigIsNoOp(t *testing.T) {
+	m := NewModel(testDashboard())
+	if cmd := m.Init(); cmd != nil {
+		t.Fatalf("Init without a prober should return nil")
+	}
+}
+
+func TestModel_ProbeResultPreservesSelection(t *testing.T) {
+	cfg := probeConfig()
+	prober := stubProber{results: map[string]StoreProbe{"remote": {Status: "ok"}}}
+	m := NewModel(BuildDashboard(cfg, nil)).WithConfig(cfg, prober)
+	m.dashboard.SelectedProfile = "alpha"
+	m.selected = 0
+
+	next, _ := m.Update(probeResultMsg{name: "remote", probe: StoreProbe{Status: "error", Error: "unreachable"}})
+	m = next.(Model)
+
+	if name := m.selectedName(); name != "alpha" {
+		t.Fatalf("selection=%q want alpha preserved across probe", name)
+	}
+	if got := m.dashboard.Profiles[0].Status; got != ProfileStatusWarning {
+		t.Fatalf("status=%q want warning after failed probe", got)
+	}
+}
+
+func TestProbeStoreCmd_UsesTimeout(t *testing.T) {
+	var gotDeadline bool
+	prober := deadlineProber{seen: &gotDeadline}
+	cmd := probeStoreCmd(prober, "remote", engine.ProfileStore{})
+	msg := cmd()
+	if _, ok := msg.(probeResultMsg); !ok {
+		t.Fatalf("probeStoreCmd returned %T want probeResultMsg", msg)
+	}
+	if !gotDeadline {
+		t.Fatalf("probe ctx had no deadline; per-store timeout not applied")
+	}
+}
+
+type deadlineProber struct {
+	seen *bool
+}
+
+func (p deadlineProber) Probe(ctx context.Context, _ string, _ engine.ProfileStore) StoreProbe {
+	if _, ok := ctx.Deadline(); ok {
+		*p.seen = true
+	}
+	return StoreProbe{Status: "ok"}
+}
+
+var _ tea.Msg = probeResultMsg{}


### PR DESCRIPTION
## Summary
- Add `internal/tui/action.go`: an `ActionRunner` interface plus a channel-based streaming pattern (`waitForAction`) so backup/check/init run **off the event loop**. Progress streams into the activity panel, and an **`x` cancel key** wired to a `context.CancelFunc` stops a running action. Pressing an action key while one is running, or with no runner, is a no-op.
- Add `internal/tui/probe.go`: a `StoreProber` run as **concurrent, per-store timeout-bounded** `tea.Cmd`s. The model builds a probe-less skeleton first (stores render "checking…"), then rebuilds the derived dashboard as each probe resolves — so the first frame is immediate even when a store is unreachable. Selection is preserved across rebuilds; the acted-on store is re-probed after an action completes.
- Wire cmd adapters (`cmd_tui_bubbletea.go`) that reuse the existing `tuiActionState`/`tuiReporter` and `app.TUIService`, so activity output matches the legacy renderer; add `TUIService.LoadDashboardConfig` for the skeleton build. Runner output is captured into the activity log (not the tea output) during an action.
- Still gated behind `cloudstic tui -bubbletea`; the legacy renderer is untouched and remains the default.

This directly resolves the two High-severity findings in the RFC 0012 revision (UI freezes during every operation; startup blocks on serial, timeout-free probes).

Builds on the merged foundation (#344); this diff is scoped to the async/probe work.

Part of #132 (RFC 0012 tracking epic)
Closes #339

## Verification
- `env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./internal/tui ./internal/app` passes
- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./cmd/cloudstic ./internal/app ./internal/tui` passes
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./cmd/cloudstic/... ./internal/app/... ./internal/tui/...` — 0 issues

## Reviewer notes
- Ordering guarantee: the progress ticker goroutine is stopped and joined (`close(stop)` + `wg.Wait()`) **before** the terminal `Done` update is sent, so the model reads all progress in FIFO order with `Done` last; the channel is buffered (32) to keep the action goroutine from stalling on a slow consumer.
- The action goroutine swaps `runner.out`/`errOut` into the activity log via the existing `captureTUIRunnerOutput`; only one action runs at a time (guarded by `m.running`), and the tea program holds its own output writer captured at start, so there's no write contention on the real terminal.
- As with #344, the Bubble Tea program isn't smoke-tested headlessly; the model's `Update`/`View`, action streaming, cancel, and probe flows are covered by direct unit tests (race-clean).
