### PR TITLE
perf(engine): pool chunk buffers in the FastCDC pipeline

### DIFF
--- a/internal/engine/chunker.go
+++ b/internal/engine/chunker.go
@@ -27,6 +27,21 @@ const (
 	cdcMaxSize = 8 * 1024 * 1024 // 8 MiB
 )
 
+// chunkBufPool pools the up-to-8MiB copies ProcessStream makes of each
+// chunk before handing it to a storage worker. Without pooling, the 32-slot
+// job channel plus per-worker in-flight chunks can pin on the order of
+// hundreds of MB per file being chunked concurrently, all freshly allocated
+// and GC'd per chunk. Every store.Put in the chain below (compression,
+// encryption, packing, the backend) consumes its data argument synchronously
+// before returning — none retain the slice past the call — so it is safe to
+// return a buffer to the pool the moment storeChunk completes.
+var chunkBufPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, cdcMaxSize)
+		return &b
+	},
+}
+
 // Chunker splits a byte stream into content-defined chunks, deduplicates
 // them, and persists the resulting Content object.
 type Chunker struct {
@@ -58,8 +73,9 @@ func (c *Chunker) ProcessStream(ctx context.Context, r io.Reader, onProgress fun
 	hasher := sha256.New()
 
 	type chunkJob struct {
-		index int
-		data  []byte
+		index  int
+		data   []byte
+		bufPtr *[]byte // underlying pooled buffer backing data; returned to chunkBufPool once storeChunk completes
 	}
 	type chunkResult struct {
 		index int
@@ -80,6 +96,7 @@ func (c *Chunker) ProcessStream(ctx context.Context, r io.Reader, onProgress fun
 		g.Go(func() error {
 			for job := range jobs {
 				ref, err := c.storeChunk(gCtx, job.data)
+				chunkBufPool.Put(job.bufPtr)
 				if err != nil {
 					return err
 				}
@@ -114,14 +131,18 @@ func (c *Chunker) ProcessStream(ctx context.Context, r io.Reader, onProgress fun
 				onProgress(n)
 			}
 
-			// Copy data so it is safe to process asynchronously
-			dataCopy := make([]byte, len(chunk.Data))
+			// Copy data so it is safe to process asynchronously, from a pooled
+			// buffer so repeated up-to-8MiB allocations don't pile up as GC
+			// churn while many chunks are in flight.
+			bufPtr := chunkBufPool.Get().(*[]byte)
+			dataCopy := (*bufPtr)[:len(chunk.Data)]
 			copy(dataCopy, chunk.Data)
 
 			select {
-			case jobs <- chunkJob{index: totalChunks, data: dataCopy}:
+			case jobs <- chunkJob{index: totalChunks, data: dataCopy, bufPtr: bufPtr}:
 				totalChunks++
 			case <-gCtx.Done():
+				chunkBufPool.Put(bufPtr)
 				return gCtx.Err()
 			}
 		}

--- a/internal/engine/mock_test.go
+++ b/internal/engine/mock_test.go
@@ -29,8 +29,14 @@ func NewMockStore() *MockStore {
 }
 
 func (s *MockStore) Put(_ context.Context, key string, data []byte) error {
+	// Every real ObjectStore backend consumes data synchronously and never
+	// retains the slice past the call — callers are free to reuse or pool
+	// their buffer the instant Put returns. Aliasing data here instead of
+	// copying it would make MockStore the one implementation that breaks
+	// that contract, silently corrupting previously "stored" entries the
+	// moment a caller's buffer gets reused.
 	s.mu.Lock()
-	s.Data[key] = data
+	s.Data[key] = append([]byte(nil), data...)
 	s.mu.Unlock()
 	return nil
 }

--- a/pkg/store/interface.go
+++ b/pkg/store/interface.go
@@ -8,6 +8,11 @@ import (
 // ObjectStore is the interface for content-addressable object storage.
 // Keys are slash-separated paths like "chunk/<hash>" or "snapshot/<hash>".
 type ObjectStore interface {
+	// Put must not retain data beyond the call: read or copy it synchronously
+	// before returning. Callers (chunking in particular) pool and reuse their
+	// write buffers the instant Put returns, so an implementation that keeps
+	// the slice — instead of the bytes — would see it mutated out from under
+	// a previously "stored" value.
 	Put(ctx context.Context, key string, data []byte) error
 	Get(ctx context.Context, key string) ([]byte, error)
 	Exists(ctx context.Context, key string) (bool, error)


### PR DESCRIPTION
## Summary
- Pool the up-to-8MiB per-chunk copies `ProcessStream` makes in `internal/engine/chunker.go`, returning each buffer to a `sync.Pool` right after `storeChunk` completes instead of letting it become garbage. The 32-slot job channel plus per-worker in-flight chunks previously meant a concurrently-chunked file could pin on the order of hundreds of MB, all freshly allocated and GC'd per chunk.
- This is safe because every real store in the chain (`CompressedStore`, `EncryptedStore`, `MeteredStore`, `PackStore`, and every backend — `LocalStore`, `S3Store`, `B2Store`, `SFTPStore`) consumes `Put`'s `data` argument synchronously and never retains the slice past the call.
- Document that contract explicitly on `store.ObjectStore.Put` (`pkg/store/interface.go`) so it doesn't quietly erode in a future implementation.
- Fix a real bug this surfaced in `MockStore.Put` (`internal/engine/mock_test.go`, test-only): it aliased the `data` slice instead of copying it — harmless while every caller freshly allocated per chunk, but as soon as buffers get reused it let a later chunk's write silently corrupt a previously "stored" mock entry through the shared backing array. `pkg/store`'s own `memStore` test double already copies defensively; `MockStore` was the one holdout, now fixed to match.

## Verification
- Caught the `MockStore` bug empirically: `TestRestoreManager_MultiChunkFile_RoundTrips` failed with "chunk order or data corrupted" under `-race` with pooling enabled and the old aliasing `MockStore.Put`; confirmed clean on `main` without the pooling change, isolating the cause. Fixed `MockStore.Put` to copy, then reran the full `internal/engine` suite under `-race` five times with no failures.
- `go build ./...`
- `go vet ./...`
- `env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./internal/engine/...` (x5)
- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./...`
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./internal/engine/... ./pkg/store/...`