### PR TITLE
feat(tui): bubbles/textinput profile forms in internal/tui/forms (RFC 0012)

### DIFF
--- a/cmd/cloudstic/cmd_tui_bubbletea.go
+++ b/cmd/cloudstic/cmd_tui_bubbletea.go
@@ -38,7 +38,8 @@ func runBubbleTeaTUI(r *runner, ctx context.Context, profilesFile string) int {
 	skeleton := tui.BuildDashboard(cfg, nil)
 	model := tui.NewModel(skeleton).
 		WithConfig(cfg, bubbleStoreProber{r: r}).
-		WithRunner(bubbleActionRunner{r: r, profilesFile: profilesFile})
+		WithRunner(bubbleActionRunner{r: r, profilesFile: profilesFile}).
+		WithForms(newBubbleFormsBackend(r, profilesFile, cfg))
 
 	stdin := r.stdin
 	if stdin == nil {

--- a/cmd/cloudstic/cmd_tui_bubbletea_forms.go
+++ b/cmd/cloudstic/cmd_tui_bubbletea_forms.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"fmt"
+
+	cloudstic "github.com/cloudstic/cli"
+	"github.com/cloudstic/cli/internal/tui"
+)
+
+// bubbleFormsBackend adapts the cmd-side profile/source helpers to the Bubble
+// Tea model's forms boundary (tui.FormsBackend). It caches the profiles config
+// and refreshes it on Reload so option lists and existence checks stay current
+// across form opens.
+type bubbleFormsBackend struct {
+	r            *runner
+	profilesFile string
+	cfg          *cloudstic.ProfilesConfig
+}
+
+func newBubbleFormsBackend(r *runner, profilesFile string, cfg *cloudstic.ProfilesConfig) *bubbleFormsBackend {
+	return &bubbleFormsBackend{r: r, profilesFile: profilesFile, cfg: cfg}
+}
+
+var _ tui.FormsBackend = (*bubbleFormsBackend)(nil)
+
+func (b *bubbleFormsBackend) StoreOptions() []string {
+	if b.cfg == nil {
+		return nil
+	}
+	return sortedKeys(b.cfg.Stores)
+}
+
+func (b *bubbleFormsBackend) ProviderForSourceType(sourceType string) string {
+	return tuiProfileSource{Type: sourceType}.Provider()
+}
+
+func (b *bubbleFormsBackend) AuthOptions(provider string) []string {
+	if b.cfg == nil {
+		return nil
+	}
+	return profileAuthOptions(b.cfg, provider)
+}
+
+func (b *bubbleFormsBackend) SourceParts(sourceURI string) (string, string) {
+	source := newTUIProfileSource(sourceURI)
+	return source.Type, source.Value
+}
+
+func (b *bubbleFormsBackend) SourceDetailLabel(sourceType string) string {
+	return tuiProfileSource{Type: sourceType}.DetailLabel()
+}
+
+func (b *bubbleFormsBackend) SourceDetailRequired(sourceType string) bool {
+	return tuiProfileSource{Type: sourceType}.DetailRequired()
+}
+
+func (b *bubbleFormsBackend) SourceExample(sourceType string) string {
+	return tuiProfileSource{Type: sourceType}.ExampleText()
+}
+
+func (b *bubbleFormsBackend) ComposeSource(sourceType, value string) (string, error) {
+	source := tuiProfileSource{Type: sourceType, Value: value}.Compose()
+	if source == "" {
+		return "", nil
+	}
+	if _, err := parseSourceURI(source); err != nil {
+		return "", fmt.Errorf("invalid source: %v", err)
+	}
+	return source, nil
+}
+
+func (b *bubbleFormsBackend) ValidateNewName(name string) error {
+	return validateRefName("profile", name)
+}
+
+func (b *bubbleFormsBackend) ProfileExists(name string) bool {
+	if b.cfg == nil {
+		return false
+	}
+	_, ok := b.cfg.Profiles[name]
+	return ok
+}
+
+func (b *bubbleFormsBackend) SaveProfile(name, sourceURI, storeRef, authRef string, editing bool) error {
+	profile := cloudstic.BackupProfile{}
+	if editing && b.cfg != nil {
+		if existing, ok := b.cfg.Profiles[name]; ok {
+			profile = existing
+		}
+	}
+	profile.Source = sourceURI
+	profile.Store = storeRef
+	profile.AuthRef = authRef
+	return tuiServiceFactory(nil, b.profilesFile, nil).SaveProfile(b.profilesFile, name, profile)
+}
+
+func (b *bubbleFormsBackend) DeleteProfile(name string) error {
+	return tuiServiceFactory(nil, b.profilesFile, nil).DeleteProfile(b.profilesFile, name)
+}
+
+func (b *bubbleFormsBackend) Reload() (*cloudstic.ProfilesConfig, error) {
+	cfg, err := tuiLoadConfig(b.profilesFile)
+	if err != nil {
+		return nil, err
+	}
+	b.cfg = cfg
+	return cfg, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/kms v1.54.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.105.2
 	github.com/aws/smithy-go v1.27.3
+	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/godbus/dbus/v5 v5.2.2
@@ -40,6 +41,7 @@ require (
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/Backblaze/blazer v0.7.2 h1:UWNHMLB+Nf+UmbO2qkVvgriODLEMz4kIyr2Hm+DVXQ
 github.com/Backblaze/blazer v0.7.2/go.mod h1:T4y3EYa9IQ5J0PKc/C/J8/CEnSd3qa/lgNw938wZg10=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aws/aws-sdk-go-v2 v1.42.1 h1:9eOTgu1z/dVtYpNZ3/8/XbbaX0x/BqE3HUzAzs6K0ek=
 github.com/aws/aws-sdk-go-v2 v1.42.1/go.mod h1:5pKeft2eJj+gElQ38Jqg4ibCqh+/AK33/0X3hip7IjM=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14 h1:3IZY0XAJquT3aHzbkHfPzy4ACPcEjVG0x87KOwtpqGY=
@@ -58,6 +60,8 @@ github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK3
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/charmbracelet/bubbles v1.0.0 h1:12J8/ak/uCZEMQ6KU7pcfwceyjLlWsDLAxB5fXonfvc=
+github.com/charmbracelet/bubbles v1.0.0/go.mod h1:9d/Zd5GdnauMI5ivUIVisuEm3ave1XwXtD1ckyV6r3E=
 github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlvF9nRvCICw=
 github.com/charmbracelet/bubbletea v1.3.10/go.mod h1:ORQfo0fk8U+po9VaNvnV95UPWA1BitP1E0N6xJPlHr4=
 github.com/charmbracelet/colorprofile v0.4.1 h1:a1lO03qTrSIRaK8c3JRxJDZOvhvIeSco3ej+ngLk1kk=

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -8,6 +8,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/cloudstic/cli/internal/engine"
+	"github.com/cloudstic/cli/internal/tui/forms"
 )
 
 // Model is the root Bubble Tea model for the interactive dashboard. This is
@@ -38,6 +39,12 @@ type Model struct {
 	running  bool
 	cancel   context.CancelFunc
 	activity ActivityPanel
+
+	// Profile management state (issue #340). forms is the domain backend;
+	// form and confirm are the active overlay, at most one at a time.
+	forms   FormsBackend
+	form    *forms.Form
+	confirm *confirmState
 
 	// reload, when non-nil, is run when the user presses "r". It returns a
 	// DashboardLoadedMsg or DashboardLoadError. The read-only launcher can
@@ -117,8 +124,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case actionUpdateMsg:
 		return m.handleActionUpdate(msg)
+	case configReloadedMsg:
+		return m.handleConfigReloaded(msg)
 	case tea.KeyMsg:
+		if m.form != nil {
+			return m.updateForm(msg)
+		}
+		if m.confirm != nil {
+			return m.updateConfirm(msg)
+		}
 		return m.handleKey(msg)
+	default:
+		// Route other messages (e.g. textinput cursor blink) to an open form.
+		if m.form != nil {
+			return m.updateForm(msg)
+		}
 	}
 	return m, nil
 }
@@ -201,6 +221,12 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "b", "c":
 		return m.startAction(msg.String())
+	case "n":
+		return m.openCreateProfile()
+	case "e":
+		return m.openEditProfile()
+	case "d":
+		return m.openDeleteProfile()
 	case "r":
 		return m, m.reload
 	}
@@ -208,6 +234,12 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) View() string {
+	if m.form != nil {
+		return strings.Join([]string{m.renderHeader(), m.form.View(), m.renderFooter()}, "\n")
+	}
+	if m.confirm != nil {
+		return strings.Join([]string{m.renderHeader(), m.renderConfirm(), m.renderFooter()}, "\n")
+	}
 	header := m.renderHeader()
 	body := lipgloss.JoinHorizontal(lipgloss.Top, m.renderProfileList(), m.renderDetail())
 	sections := []string{header, body}
@@ -216,6 +248,18 @@ func (m Model) View() string {
 	}
 	sections = append(sections, m.renderFooter())
 	return strings.Join(sections, "\n")
+}
+
+func (m Model) renderConfirm() string {
+	c := m.confirm
+	lines := []string{
+		m.theme.title.Render(c.title),
+		"",
+		c.message,
+		"",
+		m.theme.subtle.Render("Enter/y delete · Esc/n cancel"),
+	}
+	return m.theme.box.Render(strings.Join(lines, "\n"))
 }
 
 func (m Model) renderActivity() string {
@@ -359,15 +403,31 @@ func (m Model) renderHistory(profile ProfileCard) []string {
 
 func (m Model) renderFooter() string {
 	var hints string
-	if m.running {
+	switch {
+	case m.form != nil, m.confirm != nil:
+		// The overlay renders its own key hints.
+		return ""
+	case m.running:
 		hints = "x cancel · running…"
-	} else {
-		hints = m.actionHints() + "↑/↓ select · s/h view · r refresh · q quit"
+	default:
+		hints = m.actionHints() + m.formHints() + "↑/↓ select · s/h view · r refresh · q quit"
 	}
 	if m.loadErr != "" {
 		return m.theme.stateError.Render("error: "+m.loadErr) + "\n" + m.theme.footer.Render(hints)
 	}
 	return m.theme.footer.Render(hints)
+}
+
+// formHints advertises the profile-management keys when the forms backend is
+// wired in.
+func (m Model) formHints() string {
+	if m.forms == nil {
+		return ""
+	}
+	if _, ok := m.currentProfile(); ok {
+		return "n new · e edit · d delete · "
+	}
+	return "n new · "
 }
 
 // actionHints lists the enabled action keys for the selected profile so the

--- a/internal/tui/forms/form.go
+++ b/internal/tui/forms/form.go
@@ -1,0 +1,453 @@
+// Package forms provides Bubble Tea form components for the interactive TUI.
+//
+// It replaces the hand-rolled modal state machines and the ASCII-only byte
+// reader in package main (RFC 0012 Phase 2, issue #340). Text fields are
+// backed by bubbles/textinput, so Unicode input, cursor movement, and paste
+// work by construction rather than being re-implemented byte by byte.
+package forms
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// FieldKind distinguishes a free-text field from a fixed-option selector.
+type FieldKind int
+
+const (
+	// FieldText is a free-text field backed by bubbles/textinput.
+	FieldText FieldKind = iota
+	// FieldSelect cycles through a fixed set of options.
+	FieldSelect
+)
+
+// Field is one editable row in a form.
+type Field struct {
+	Key      string
+	Label    string
+	Kind     FieldKind
+	Options  []string
+	Required bool
+	Disabled bool
+	// Help is an optional dimmed hint rendered under the field when focused.
+	Help string
+
+	input  textinput.Model
+	selIdx int
+}
+
+func newTextField(key, label, value string, required bool) Field {
+	ti := textinput.New()
+	ti.SetValue(value)
+	ti.Prompt = ""
+	return Field{Key: key, Label: label, Kind: FieldText, Required: required, input: ti}
+}
+
+func newSelectField(key, label string, options []string, value string, required bool) Field {
+	f := Field{Key: key, Label: label, Kind: FieldSelect, Options: options, Required: required}
+	f.selIdx = indexOf(options, value)
+	return f
+}
+
+// Value returns the field's current value.
+func (f Field) Value() string {
+	if f.Kind == FieldSelect {
+		if f.selIdx < 0 || f.selIdx >= len(f.Options) {
+			return ""
+		}
+		return f.Options[f.selIdx]
+	}
+	return f.input.Value()
+}
+
+func (f *Field) setValue(v string) {
+	if f.Kind == FieldSelect {
+		f.selIdx = indexOf(f.Options, v)
+		return
+	}
+	f.input.SetValue(v)
+}
+
+func (f *Field) cycle(delta int) {
+	if f.Kind != FieldSelect || len(f.Options) == 0 {
+		return
+	}
+	f.selIdx = wrap(f.selIdx+delta, len(f.Options))
+}
+
+func indexOf(options []string, value string) int {
+	for i, o := range options {
+		if o == value {
+			return i
+		}
+	}
+	return 0
+}
+
+func wrap(i, n int) int {
+	if n == 0 {
+		return 0
+	}
+	i %= n
+	if i < 0 {
+		i += n
+	}
+	return i
+}
+
+// FieldError attaches an error message to a specific field so the form can
+// highlight it. Submit hooks return it to report per-field validation errors.
+type FieldError struct {
+	Field   string
+	Message string
+}
+
+func (e *FieldError) Error() string { return e.Message }
+
+// NewFieldError builds a FieldError for the given field key.
+func NewFieldError(field, message string) error {
+	return &FieldError{Field: field, Message: message}
+}
+
+// Form is a vertical, keyboard-driven form. The owning model delegates input
+// to Update while a form is open and reads Done/Canceled/Result afterward.
+type Form struct {
+	Title    string
+	Subtitle string
+
+	fields []Field
+	focus  int
+
+	errField string
+	errMsg   string
+
+	done     bool
+	canceled bool
+	result   string
+
+	// OnChange is called after any field value changes, so the form can
+	// recompute derived fields (labels, options, enabled/disabled). It may be
+	// nil for static forms.
+	OnChange func(f *Form, changedKey string)
+	// Submit validates and persists the form. It returns the result value on
+	// success, or a *FieldError / plain error on failure. It is required.
+	Submit func(f *Form) (string, error)
+
+	theme formTheme
+}
+
+// New builds a form with the given fields and focuses the first editable one.
+func New(title, subtitle string, fields []Field) *Form {
+	f := &Form{Title: title, Subtitle: subtitle, fields: fields, theme: newFormTheme()}
+	f.focusFirst()
+	return f
+}
+
+// Init returns the command that starts the focused text field's cursor blink.
+func (f *Form) Init() tea.Cmd { return textinput.Blink }
+
+// Fields exposes the form's fields for derivation hooks.
+func (f *Form) Fields() []Field { return f.fields }
+
+// Value returns the current value of the named field.
+func (f *Form) Value(key string) string {
+	if field := f.field(key); field != nil {
+		return field.Value()
+	}
+	return ""
+}
+
+// TrimmedValue returns the named field's value with surrounding space removed.
+func (f *Form) TrimmedValue(key string) string {
+	return strings.TrimSpace(f.Value(key))
+}
+
+// SetValue sets the named field's value.
+func (f *Form) SetValue(key, value string) {
+	if field := f.field(key); field != nil {
+		field.setValue(value)
+	}
+}
+
+// SetOptions replaces a select field's options, keeping the current value when
+// still present.
+func (f *Form) SetOptions(key string, options []string) {
+	field := f.field(key)
+	if field == nil || field.Kind != FieldSelect {
+		return
+	}
+	current := field.Value()
+	field.Options = options
+	field.selIdx = indexOf(options, current)
+}
+
+// SetLabel updates a field's label (used by derived source/store labels).
+func (f *Form) SetLabel(key, label string) {
+	if field := f.field(key); field != nil {
+		field.Label = label
+	}
+}
+
+// SetRequired toggles a field's required flag.
+func (f *Form) SetRequired(key string, required bool) {
+	if field := f.field(key); field != nil {
+		field.Required = required
+	}
+}
+
+// SetDisabled toggles a field's disabled flag; a disabled field is skipped by
+// focus movement and rendered dimmed.
+func (f *Form) SetDisabled(key string, disabled bool) {
+	if field := f.field(key); field != nil {
+		field.Disabled = disabled
+	}
+}
+
+// SetHelp sets the dimmed hint shown under the field when focused.
+func (f *Form) SetHelp(key, help string) {
+	if field := f.field(key); field != nil {
+		field.Help = help
+	}
+}
+
+// FocusedKey returns the key of the currently focused field.
+func (f *Form) FocusedKey() string {
+	if f.focus < 0 || f.focus >= len(f.fields) {
+		return ""
+	}
+	return f.fields[f.focus].Key
+}
+
+// Done reports whether the form was submitted successfully.
+func (f *Form) Done() bool { return f.done }
+
+// Canceled reports whether the form was canceled (Esc).
+func (f *Form) Canceled() bool { return f.canceled }
+
+// Result returns the value produced by a successful Submit.
+func (f *Form) Result() string { return f.result }
+
+func (f *Form) field(key string) *Field {
+	for i := range f.fields {
+		if f.fields[i].Key == key {
+			return &f.fields[i]
+		}
+	}
+	return nil
+}
+
+func (f *Form) focusFirst() {
+	for i := range f.fields {
+		if !f.fields[i].Disabled {
+			f.setFocus(i)
+			return
+		}
+	}
+}
+
+func (f *Form) setFocus(idx int) {
+	for i := range f.fields {
+		if f.fields[i].Kind == FieldText {
+			f.fields[i].input.Blur()
+		}
+	}
+	f.focus = idx
+	if idx >= 0 && idx < len(f.fields) && f.fields[idx].Kind == FieldText {
+		f.fields[idx].input.Focus()
+	}
+}
+
+func (f *Form) moveFocus(delta int) {
+	if len(f.fields) == 0 {
+		return
+	}
+	idx := f.focus
+	for range f.fields {
+		idx = wrap(idx+delta, len(f.fields))
+		if !f.fields[idx].Disabled {
+			f.setFocus(idx)
+			return
+		}
+	}
+}
+
+func (f *Form) clearError() {
+	f.errField = ""
+	f.errMsg = ""
+}
+
+// Update processes one message while the form is open.
+func (f *Form) Update(msg tea.Msg) (*Form, tea.Cmd) {
+	key, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return f, f.updateFocusedInput(msg)
+	}
+
+	switch key.Type {
+	case tea.KeyEsc:
+		f.canceled = true
+		f.done = true
+		return f, nil
+	case tea.KeyEnter:
+		return f, f.submit()
+	case tea.KeyTab, tea.KeyDown:
+		f.moveFocus(1)
+		return f, nil
+	case tea.KeyShiftTab, tea.KeyUp:
+		f.moveFocus(-1)
+		return f, nil
+	case tea.KeyLeft:
+		if f.focusedIsSelect() {
+			f.cycleFocused(-1)
+			return f, nil
+		}
+	case tea.KeyRight:
+		if f.focusedIsSelect() {
+			f.cycleFocused(1)
+			return f, nil
+		}
+	}
+	// Text editing (including Unicode runes and paste) goes to textinput.
+	return f, f.updateFocusedInput(msg)
+}
+
+func (f *Form) submit() tea.Cmd {
+	if f.Submit == nil {
+		return nil
+	}
+	result, err := f.Submit(f)
+	if err != nil {
+		var fieldErr *FieldError
+		if fe, ok := err.(*FieldError); ok {
+			fieldErr = fe
+		}
+		if fieldErr != nil {
+			f.errField = fieldErr.Field
+			f.errMsg = fieldErr.Message
+			if field := f.field(fieldErr.Field); field != nil {
+				f.setFocusToKey(fieldErr.Field)
+			}
+		} else {
+			f.errField = ""
+			f.errMsg = err.Error()
+		}
+		return nil
+	}
+	f.done = true
+	f.result = result
+	return nil
+}
+
+func (f *Form) setFocusToKey(key string) {
+	for i := range f.fields {
+		if f.fields[i].Key == key && !f.fields[i].Disabled {
+			f.setFocus(i)
+			return
+		}
+	}
+}
+
+func (f *Form) focusedIsSelect() bool {
+	return f.focus >= 0 && f.focus < len(f.fields) && f.fields[f.focus].Kind == FieldSelect
+}
+
+func (f *Form) cycleFocused(delta int) {
+	field := &f.fields[f.focus]
+	field.cycle(delta)
+	f.clearError()
+	if f.OnChange != nil {
+		f.OnChange(f, field.Key)
+	}
+}
+
+func (f *Form) updateFocusedInput(msg tea.Msg) tea.Cmd {
+	if f.focus < 0 || f.focus >= len(f.fields) {
+		return nil
+	}
+	field := &f.fields[f.focus]
+	if field.Kind != FieldText || field.Disabled {
+		return nil
+	}
+	before := field.input.Value()
+	var cmd tea.Cmd
+	field.input, cmd = field.input.Update(msg)
+	if field.input.Value() != before {
+		f.clearError()
+		if f.OnChange != nil {
+			f.OnChange(f, field.Key)
+		}
+	}
+	return cmd
+}
+
+// View renders the form as a bordered box.
+func (f *Form) View() string {
+	lines := []string{f.theme.title.Render(f.Title)}
+	if f.Subtitle != "" {
+		lines = append(lines, f.theme.subtle.Render(f.Subtitle), "")
+	}
+	for i := range f.fields {
+		field := f.fields[i]
+		if field.Disabled && !field.Required {
+			continue
+		}
+		lines = append(lines, f.renderField(i))
+		if i == f.focus && field.Help != "" {
+			lines = append(lines, f.theme.subtle.Render("  "+field.Help))
+		}
+		if i == f.focus && f.errField == field.Key && f.errMsg != "" {
+			lines = append(lines, f.theme.errStyle.Render("  "+f.errMsg))
+		}
+	}
+	if f.errMsg != "" && f.errField == "" {
+		lines = append(lines, "", f.theme.errStyle.Render(f.errMsg))
+	}
+	lines = append(lines, "", f.theme.subtle.Render("Tab/↑↓ move · ←/→ change · Enter save · Esc cancel"))
+	return f.theme.box.Render(strings.Join(lines, "\n"))
+}
+
+func (f *Form) renderField(i int) string {
+	field := f.fields[i]
+	focused := i == f.focus
+	label := f.theme.label.Render(padLabel(field.Label))
+	var value string
+	switch field.Kind {
+	case FieldSelect:
+		value = renderSelect(field, focused, f.theme)
+	default:
+		if focused {
+			value = field.input.View()
+		} else if field.input.Value() == "" {
+			value = f.theme.subtle.Render("—")
+		} else {
+			value = field.input.Value()
+		}
+	}
+	marker := "  "
+	if focused {
+		marker = f.theme.marker.Render("> ")
+	}
+	return marker + label + " " + value
+}
+
+func renderSelect(field Field, focused bool, t formTheme) string {
+	value := field.Value()
+	if value == "" {
+		value = "—"
+	}
+	if !focused {
+		return value
+	}
+	return t.selectStyle.Render("‹ " + value + " ›")
+}
+
+func padLabel(label string) string {
+	const width = 16
+	if lipgloss.Width(label) >= width {
+		return label
+	}
+	return label + strings.Repeat(" ", width-lipgloss.Width(label))
+}

--- a/internal/tui/forms/form_test.go
+++ b/internal/tui/forms/form_test.go
@@ -1,0 +1,142 @@
+package forms
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func typeInto(f *Form, s string) *Form {
+	for _, r := range s {
+		f, _ = f.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	return f
+}
+
+func textForm(t *testing.T) *Form {
+	t.Helper()
+	fields := []Field{
+		newTextField("name", "Name", "", true),
+		newSelectField("kind", "Kind", []string{"a", "b", "c"}, "a", true),
+	}
+	f := New("Test", "", fields)
+	return f
+}
+
+func TestForm_UnicodeTextInput(t *testing.T) {
+	f := textForm(t)
+	// Accented and non-Latin runes must be accepted, unlike the old
+	// ASCII-only byte reader.
+	f = typeInto(f, "café-Ω-日本")
+	if got := f.Value("name"); got != "café-Ω-日本" {
+		t.Fatalf("name=%q want café-Ω-日本", got)
+	}
+}
+
+func TestForm_Backspace(t *testing.T) {
+	f := textForm(t)
+	f = typeInto(f, "abé")
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	if got := f.Value("name"); got != "ab" {
+		t.Fatalf("name=%q want ab", got)
+	}
+}
+
+func TestForm_SelectCyclesWithArrows(t *testing.T) {
+	f := textForm(t)
+	// Move focus to the select field.
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if f.FocusedKey() != "kind" {
+		t.Fatalf("focus=%q want kind", f.FocusedKey())
+	}
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyRight})
+	if got := f.Value("kind"); got != "b" {
+		t.Fatalf("kind=%q want b after right", got)
+	}
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	if got := f.Value("kind"); got != "c" {
+		t.Fatalf("kind=%q want c after wrap-around left", got)
+	}
+}
+
+func TestForm_LeftRightEditsTextCursorNotSelect(t *testing.T) {
+	f := textForm(t)
+	f = typeInto(f, "abc")
+	// Left arrow on a text field moves the cursor; it must not be swallowed as
+	// a select change. Typing then inserts before the last char.
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	f = typeInto(f, "X")
+	if got := f.Value("name"); got != "abXc" {
+		t.Fatalf("name=%q want abXc", got)
+	}
+}
+
+func TestForm_TabSkipsDisabledFields(t *testing.T) {
+	fields := []Field{
+		newTextField("a", "A", "", false),
+		newTextField("b", "B", "", false),
+		newTextField("c", "C", "", false),
+	}
+	f := New("t", "", fields)
+	f.SetDisabled("b", true)
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if f.FocusedKey() != "c" {
+		t.Fatalf("focus=%q want c (b disabled, skipped)", f.FocusedKey())
+	}
+}
+
+func TestForm_SubmitSuccess(t *testing.T) {
+	f := textForm(t)
+	f.Submit = func(f *Form) (string, error) {
+		return f.Value("name"), nil
+	}
+	f = typeInto(f, "hello")
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if !f.Done() || f.Canceled() {
+		t.Fatalf("expected done+not-canceled, got done=%v canceled=%v", f.Done(), f.Canceled())
+	}
+	if f.Result() != "hello" {
+		t.Fatalf("result=%q want hello", f.Result())
+	}
+}
+
+func TestForm_SubmitFieldErrorFocusesField(t *testing.T) {
+	f := textForm(t)
+	f.Submit = func(f *Form) (string, error) {
+		return "", NewFieldError("kind", "kind is wrong")
+	}
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if f.Done() {
+		t.Fatalf("form should not be done after a field error")
+	}
+	if f.FocusedKey() != "kind" {
+		t.Fatalf("focus=%q want kind (error field)", f.FocusedKey())
+	}
+	if !strings.Contains(f.View(), "kind is wrong") {
+		t.Fatalf("view missing error message\n%s", f.View())
+	}
+}
+
+func TestForm_Cancel(t *testing.T) {
+	f := textForm(t)
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if !f.Done() || !f.Canceled() {
+		t.Fatalf("esc should cancel: done=%v canceled=%v", f.Done(), f.Canceled())
+	}
+}
+
+func TestForm_OnChangeFires(t *testing.T) {
+	f := textForm(t)
+	var changed []string
+	f.OnChange = func(_ *Form, key string) { changed = append(changed, key) }
+	f = typeInto(f, "x")
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if _, cmd := f.Update(tea.KeyMsg{Type: tea.KeyRight}); cmd != nil {
+		t.Fatalf("select change should not emit a command")
+	}
+	if len(changed) < 2 || changed[0] != "name" {
+		t.Fatalf("OnChange keys=%v want name then kind", changed)
+	}
+}

--- a/internal/tui/forms/profile.go
+++ b/internal/tui/forms/profile.go
@@ -1,0 +1,181 @@
+package forms
+
+import "fmt"
+
+// ProfileBackend is the domain boundary for the profile form. The cmd package
+// implements it by reusing the existing source-URI, options, validation, and
+// save helpers, so this package stays free of URI-parsing and persistence
+// concerns.
+type ProfileBackend interface {
+	// StoreOptions returns the selectable store names.
+	StoreOptions() []string
+	// ProviderForSourceType returns the auth provider a source type requires,
+	// or "" when the source needs no auth.
+	ProviderForSourceType(sourceType string) string
+	// AuthOptions returns the auth refs available for a provider.
+	AuthOptions(provider string) []string
+	// SourceParts splits an existing source URI into its (type, value) pair.
+	SourceParts(sourceURI string) (sourceType, value string)
+	// SourceDetailLabel returns the label for the source detail field.
+	SourceDetailLabel(sourceType string) string
+	// SourceDetailRequired reports whether the source detail is mandatory.
+	SourceDetailRequired(sourceType string) bool
+	// SourceExample returns an example hint for the source detail field.
+	SourceExample(sourceType string) string
+	// ComposeSource builds and validates a source URI from type and value.
+	ComposeSource(sourceType, value string) (string, error)
+	// ValidateNewName validates a candidate new profile name.
+	ValidateNewName(name string) error
+	// ProfileExists reports whether a profile name is already taken.
+	ProfileExists(name string) bool
+	// SaveProfile persists the profile.
+	SaveProfile(name, sourceURI, storeRef, authRef string, editing bool) error
+}
+
+// SourceTypes are the source schemes offered by the profile form, in order.
+var SourceTypes = []string{
+	"local",
+	"sftp",
+	"gdrive",
+	"gdrive-changes",
+	"onedrive",
+	"onedrive-changes",
+}
+
+// NewProfileForm builds the create/edit profile form. For editing, name and
+// the current source/store/auth are pre-filled and the name field is locked.
+func NewProfileForm(backend ProfileBackend, existingName, existingSource, existingStore, existingAuth string, editing bool) *Form {
+	sourceType, sourceValue := "local", ""
+	if existingSource != "" {
+		sourceType, sourceValue = backend.SourceParts(existingSource)
+	}
+	stores := backend.StoreOptions()
+
+	fields := []Field{
+		newTextField("name", "Name", existingName, true),
+		newSelectField("source_type", "Source Type", append([]string{}, SourceTypes...), sourceType, true),
+		newTextField("source_value", backend.SourceDetailLabel(sourceType), sourceValue, backend.SourceDetailRequired(sourceType)),
+		newSelectField("store", "Store", stores, firstNonEmpty(existingStore, firstOr(stores, "")), true),
+		newSelectField("auth", "Auth", nil, existingAuth, false),
+	}
+	if editing {
+		fields[0].Disabled = true
+	}
+
+	title := "Create Profile"
+	if editing {
+		title = "Edit Profile"
+	}
+
+	f := New(title, "", fields)
+	pf := &profileFormState{backend: backend, editing: editing, originalName: existingName}
+	f.OnChange = pf.onChange
+	f.Submit = pf.submit
+	pf.refreshDerived(f)
+	f.focusFirst()
+	return f
+}
+
+type profileFormState struct {
+	backend      ProfileBackend
+	editing      bool
+	originalName string
+}
+
+func (p *profileFormState) onChange(f *Form, changedKey string) {
+	switch changedKey {
+	case "source_type", "source_value":
+		p.refreshDerived(f)
+	}
+}
+
+func (p *profileFormState) refreshDerived(f *Form) {
+	sourceType := f.Value("source_type")
+	f.SetLabel("source_value", p.backend.SourceDetailLabel(sourceType))
+	f.SetRequired("source_value", p.backend.SourceDetailRequired(sourceType))
+	if f.FocusedKey() == "source_value" {
+		f.SetHelp("source_value", p.backend.SourceExample(sourceType))
+	} else {
+		f.SetHelp("source_value", "")
+	}
+
+	provider := p.backend.ProviderForSourceType(sourceType)
+	if provider == "" {
+		f.SetDisabled("auth", true)
+		f.SetRequired("auth", false)
+		f.SetLabel("auth", "Auth")
+		f.SetOptions("auth", nil)
+		f.SetValue("auth", "")
+		return
+	}
+	options := p.backend.AuthOptions(provider)
+	f.SetDisabled("auth", false)
+	f.SetRequired("auth", true)
+	f.SetLabel("auth", fmt.Sprintf("Auth (%s)", provider))
+	f.SetOptions("auth", options)
+	if len(options) > 0 && indexOf(options, f.Value("auth")) == 0 && f.Value("auth") != options[0] {
+		f.SetValue("auth", options[0])
+	}
+}
+
+func (p *profileFormState) submit(f *Form) (string, error) {
+	name := f.TrimmedValue("name")
+	if p.editing {
+		name = p.originalName
+	} else {
+		if name == "" {
+			return "", NewFieldError("name", "profile name is required")
+		}
+		if err := p.backend.ValidateNewName(name); err != nil {
+			return "", NewFieldError("name", err.Error())
+		}
+		if p.backend.ProfileExists(name) {
+			return "", NewFieldError("name", fmt.Sprintf("profile %q already exists", name))
+		}
+	}
+
+	sourceType := f.Value("source_type")
+	source, err := p.backend.ComposeSource(sourceType, f.TrimmedValue("source_value"))
+	if err != nil {
+		return "", NewFieldError("source_value", err.Error())
+	}
+	if source == "" {
+		return "", NewFieldError("source_value", "source details are required")
+	}
+
+	storeRef := f.TrimmedValue("store")
+	if storeRef == "" {
+		return "", NewFieldError("store", "store reference is required")
+	}
+
+	authRef := f.TrimmedValue("auth")
+	provider := p.backend.ProviderForSourceType(sourceType)
+	if provider != "" {
+		if authRef == "" {
+			return "", NewFieldError("auth", fmt.Sprintf("auth reference is required for %s sources", provider))
+		}
+	} else {
+		authRef = ""
+	}
+
+	if err := p.backend.SaveProfile(name, source, storeRef, authRef, p.editing); err != nil {
+		return "", err
+	}
+	return name, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func firstOr(options []string, fallback string) string {
+	if len(options) == 0 {
+		return fallback
+	}
+	return options[0]
+}

--- a/internal/tui/forms/profile_test.go
+++ b/internal/tui/forms/profile_test.go
@@ -1,0 +1,180 @@
+package forms
+
+import (
+	"errors"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type stubProfileBackend struct {
+	stores    []string
+	auth      map[string][]string
+	provider  map[string]string
+	existing  map[string]bool
+	saved     *savedProfile
+	saveErr   error
+	nameError error
+}
+
+type savedProfile struct {
+	name, source, store, auth string
+	editing                   bool
+}
+
+func newStubBackend() *stubProfileBackend {
+	return &stubProfileBackend{
+		stores:   []string{"local-store", "remote"},
+		auth:     map[string][]string{"google": {"gauth"}},
+		provider: map[string]string{"gdrive": "google", "gdrive-changes": "google"},
+		existing: map[string]bool{},
+	}
+}
+
+func (b *stubProfileBackend) StoreOptions() []string { return b.stores }
+func (b *stubProfileBackend) ProviderForSourceType(t string) string {
+	return b.provider[t]
+}
+func (b *stubProfileBackend) AuthOptions(provider string) []string { return b.auth[provider] }
+func (b *stubProfileBackend) SourceParts(uri string) (string, string) {
+	// Minimal splitter for tests: "type:value".
+	for i := 0; i < len(uri); i++ {
+		if uri[i] == ':' {
+			return uri[:i], uri[i+1:]
+		}
+	}
+	return uri, ""
+}
+func (b *stubProfileBackend) SourceDetailLabel(t string) string {
+	if t == "sftp" {
+		return "Target"
+	}
+	return "Path"
+}
+func (b *stubProfileBackend) SourceDetailRequired(t string) bool {
+	return t != "gdrive"
+}
+func (b *stubProfileBackend) SourceExample(string) string { return "example" }
+func (b *stubProfileBackend) ComposeSource(t, v string) (string, error) {
+	if t == "gdrive" && v == "" {
+		return "gdrive", nil
+	}
+	if v == "" {
+		return "", nil
+	}
+	return t + ":" + v, nil
+}
+func (b *stubProfileBackend) ValidateNewName(string) error { return b.nameError }
+func (b *stubProfileBackend) ProfileExists(name string) bool {
+	return b.existing[name]
+}
+func (b *stubProfileBackend) SaveProfile(name, source, store, auth string, editing bool) error {
+	if b.saveErr != nil {
+		return b.saveErr
+	}
+	b.saved = &savedProfile{name: name, source: source, store: store, auth: auth, editing: editing}
+	return nil
+}
+
+func TestProfileForm_CreateSaves(t *testing.T) {
+	b := newStubBackend()
+	f := NewProfileForm(b, "", "", "", "", false)
+	f = typeInto(f, "alpha")               // name
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyTab}) // -> source_type
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyTab}) // -> source_value
+	f = typeInto(f, "/data")
+
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if !f.Done() || f.Canceled() {
+		t.Fatalf("expected save; done=%v canceled=%v", f.Done(), f.Canceled())
+	}
+	if b.saved == nil {
+		t.Fatalf("SaveProfile not called")
+	}
+	if b.saved.name != "alpha" || b.saved.source != "local:/data" || b.saved.store != "local-store" {
+		t.Fatalf("saved=%+v", *b.saved)
+	}
+	if b.saved.auth != "" {
+		t.Fatalf("local source should have no auth, got %q", b.saved.auth)
+	}
+}
+
+func TestProfileForm_DuplicateNameRejected(t *testing.T) {
+	b := newStubBackend()
+	b.existing["dupe"] = true
+	f := NewProfileForm(b, "", "", "", "", false)
+	f = typeInto(f, "dupe")
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyTab})
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyTab})
+	f = typeInto(f, "/data")
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if f.Done() {
+		t.Fatalf("duplicate name should block submit")
+	}
+	if b.saved != nil {
+		t.Fatalf("SaveProfile must not be called for a duplicate")
+	}
+	if f.FocusedKey() != "name" {
+		t.Fatalf("focus=%q want name", f.FocusedKey())
+	}
+}
+
+func TestProfileForm_EditLocksNameAndPrefills(t *testing.T) {
+	b := newStubBackend()
+	f := NewProfileForm(b, "beta", "sftp:user@host/data", "remote", "", true)
+	// Name field is disabled; first focus should be source_type.
+	if f.FocusedKey() == "name" {
+		t.Fatalf("edit form must not focus the locked name field")
+	}
+	if got := f.Value("source_type"); got != "sftp" {
+		t.Fatalf("source_type=%q want sftp", got)
+	}
+	if got := f.Value("store"); got != "remote" {
+		t.Fatalf("store=%q want remote", got)
+	}
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if !f.Done() {
+		t.Fatalf("edit submit should succeed")
+	}
+	if b.saved == nil || !b.saved.editing || b.saved.name != "beta" {
+		t.Fatalf("saved=%+v want editing beta", b.saved)
+	}
+}
+
+func TestProfileForm_GdriveRequiresAuth(t *testing.T) {
+	b := newStubBackend()
+	f := NewProfileForm(b, "", "", "", "", false)
+	f = typeInto(f, "g")
+	// Move to source_type and switch to gdrive.
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyTab})
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyRight}) // local -> sftp
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyRight}) // sftp -> gdrive
+	if got := f.Value("source_type"); got != "gdrive" {
+		t.Fatalf("source_type=%q want gdrive", got)
+	}
+	// gdrive resolves auth to the single available option.
+	if got := f.Value("auth"); got != "gauth" {
+		t.Fatalf("auth=%q want gauth auto-selected", got)
+	}
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if !f.Done() || b.saved == nil {
+		t.Fatalf("gdrive with auth should save; done=%v saved=%v", f.Done(), b.saved)
+	}
+	if b.saved.auth != "gauth" {
+		t.Fatalf("saved auth=%q want gauth", b.saved.auth)
+	}
+}
+
+func TestProfileForm_SaveErrorSurfaces(t *testing.T) {
+	b := newStubBackend()
+	b.saveErr = errors.New("disk full")
+	f := NewProfileForm(b, "", "", "", "", false)
+	f = typeInto(f, "alpha")
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyTab})
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyTab})
+	f = typeInto(f, "/data")
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if f.Done() {
+		t.Fatalf("submit should not complete when SaveProfile errors")
+	}
+}

--- a/internal/tui/forms/theme.go
+++ b/internal/tui/forms/theme.go
@@ -1,0 +1,29 @@
+package forms
+
+import "github.com/charmbracelet/lipgloss"
+
+// formTheme holds the lipgloss styles for form rendering. It mirrors the small
+// theme used by the dashboard model; the shared adaptive/NO_COLOR theme lands
+// with the legacy-engine deletion (issue #341).
+type formTheme struct {
+	title       lipgloss.Style
+	subtle      lipgloss.Style
+	label       lipgloss.Style
+	marker      lipgloss.Style
+	selectStyle lipgloss.Style
+	errStyle    lipgloss.Style
+	box         lipgloss.Style
+}
+
+func newFormTheme() formTheme {
+	subtle := lipgloss.AdaptiveColor{Light: "245", Dark: "241"}
+	return formTheme{
+		title:       lipgloss.NewStyle().Bold(true),
+		subtle:      lipgloss.NewStyle().Foreground(subtle),
+		label:       lipgloss.NewStyle().Foreground(subtle),
+		marker:      lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("6")),
+		selectStyle: lipgloss.NewStyle().Foreground(lipgloss.Color("6")),
+		errStyle:    lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("1")),
+		box:         lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(subtle).Padding(0, 1),
+	}
+}

--- a/internal/tui/forms_bridge.go
+++ b/internal/tui/forms_bridge.go
@@ -1,0 +1,150 @@
+package tui
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/cloudstic/cli/internal/engine"
+	"github.com/cloudstic/cli/internal/tui/forms"
+)
+
+// FormsBackend is the domain boundary the model uses for profile management.
+// It extends the profile form's own backend with the delete and config-reload
+// operations the model orchestrates around a form. The cmd package implements
+// it by reusing the existing source/options/validation/save helpers.
+type FormsBackend interface {
+	forms.ProfileBackend
+	// DeleteProfile removes a profile from the profiles file.
+	DeleteProfile(name string) error
+	// Reload re-reads the profiles config after a mutation.
+	Reload() (*engine.ProfilesConfig, error)
+}
+
+// WithForms enables the profile create/edit/delete flows (issue #340). Without
+// it the model stays read-only plus actions.
+func (m Model) WithForms(backend FormsBackend) Model {
+	m.forms = backend
+	return m
+}
+
+// confirmState is a minimal yes/no confirmation overlay (used for delete).
+type confirmState struct {
+	title   string
+	message string
+	target  string
+}
+
+// configReloadedMsg carries a reloaded profiles config back into the model
+// after a form save or delete, with the profile name to reselect.
+type configReloadedMsg struct {
+	cfg        *engine.ProfilesConfig
+	err        error
+	selectName string
+}
+
+func (m Model) reloadConfigCmd(selectName string) tea.Cmd {
+	backend := m.forms
+	if backend == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		cfg, err := backend.Reload()
+		return configReloadedMsg{cfg: cfg, err: err, selectName: selectName}
+	}
+}
+
+func (m Model) handleConfigReloaded(msg configReloadedMsg) (tea.Model, tea.Cmd) {
+	if msg.err != nil {
+		m.loadErr = msg.err.Error()
+		return m, nil
+	}
+	m.cfg = msg.cfg
+	// Keep existing probe results so unchanged stores don't flicker back to
+	// "checking…"; probeAllCmd refreshes them (and any new store) below.
+	m.dashboard = BuildDashboard(m.cfg, m.probes)
+	if msg.selectName != "" {
+		m.dashboard.SelectedProfile = msg.selectName
+	} else {
+		m.dashboard.SelectedProfile = m.selectedName()
+	}
+	m.selected = indexOfSelected(m.dashboard)
+	return m, m.probeAllCmd()
+}
+
+// openCreateProfile opens the create-profile form.
+func (m Model) openCreateProfile() (Model, tea.Cmd) {
+	if m.forms == nil {
+		return m, nil
+	}
+	m.form = forms.NewProfileForm(m.forms, "", "", "", "", false)
+	return m, m.form.Init()
+}
+
+// openEditProfile opens the edit form for the selected profile.
+func (m Model) openEditProfile() (Model, tea.Cmd) {
+	if m.forms == nil {
+		return m, nil
+	}
+	profile, ok := m.currentProfile()
+	if !ok {
+		return m, nil
+	}
+	m.form = forms.NewProfileForm(m.forms, profile.Name, profile.Source, profile.StoreRef, profile.AuthRef, true)
+	return m, m.form.Init()
+}
+
+// openDeleteProfile opens a delete confirmation for the selected profile.
+func (m Model) openDeleteProfile() (Model, tea.Cmd) {
+	if m.forms == nil {
+		return m, nil
+	}
+	profile, ok := m.currentProfile()
+	if !ok {
+		return m, nil
+	}
+	m.confirm = &confirmState{
+		title:   "Delete Profile",
+		message: "Delete profile \"" + profile.Name + "\"? This edits profiles.yaml only.",
+		target:  profile.Name,
+	}
+	return m, nil
+}
+
+func (m Model) updateForm(msg tea.Msg) (tea.Model, tea.Cmd) {
+	form, cmd := m.form.Update(msg)
+	m.form = form
+	if !form.Done() {
+		return m, cmd
+	}
+
+	canceled := form.Canceled()
+	result := form.Result()
+	m.form = nil
+	if canceled {
+		m.activity = managementActivity(ActivityStatusIdle, "Profile form", "canceled")
+		return m, nil
+	}
+	m.activity = managementActivity(ActivityStatusSuccess, "Save profile", "saved \""+result+"\"")
+	return m, m.reloadConfigCmd(result)
+}
+
+func (m Model) updateConfirm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "n", "q":
+		m.confirm = nil
+		m.activity = managementActivity(ActivityStatusIdle, "Delete profile", "canceled")
+		return m, nil
+	case "enter", "y":
+		target := m.confirm.target
+		m.confirm = nil
+		if err := m.forms.DeleteProfile(target); err != nil {
+			m.loadErr = err.Error()
+			return m, nil
+		}
+		m.activity = managementActivity(ActivityStatusSuccess, "Delete profile", "deleted \""+target+"\"")
+		return m, m.reloadConfigCmd("")
+	}
+	return m, nil
+}
+
+func managementActivity(status ActivityStatus, action, summary string) ActivityPanel {
+	return ActivityPanel{Status: status, Action: action, Summary: summary}
+}

--- a/internal/tui/forms_bridge_test.go
+++ b/internal/tui/forms_bridge_test.go
@@ -1,0 +1,175 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/cloudstic/cli/internal/engine"
+)
+
+// stubFormsBackend implements FormsBackend for model-level tests.
+type stubFormsBackend struct {
+	stores     []string
+	cfg        *engine.ProfilesConfig
+	saved      bool
+	deleted    string
+	reloadHits int
+}
+
+func (b *stubFormsBackend) StoreOptions() []string                 { return b.stores }
+func (b *stubFormsBackend) ProviderForSourceType(string) string    { return "" }
+func (b *stubFormsBackend) AuthOptions(string) []string            { return nil }
+func (b *stubFormsBackend) SourceParts(uri string) (string, string) {
+	for i := 0; i < len(uri); i++ {
+		if uri[i] == ':' {
+			return uri[:i], uri[i+1:]
+		}
+	}
+	return uri, ""
+}
+func (b *stubFormsBackend) SourceDetailLabel(string) string   { return "Path" }
+func (b *stubFormsBackend) SourceDetailRequired(string) bool  { return true }
+func (b *stubFormsBackend) SourceExample(string) string       { return "" }
+func (b *stubFormsBackend) ComposeSource(t, v string) (string, error) {
+	if v == "" {
+		return "", nil
+	}
+	return t + ":" + v, nil
+}
+func (b *stubFormsBackend) ValidateNewName(string) error { return nil }
+func (b *stubFormsBackend) ProfileExists(string) bool    { return false }
+func (b *stubFormsBackend) SaveProfile(string, string, string, string, bool) error {
+	b.saved = true
+	return nil
+}
+func (b *stubFormsBackend) DeleteProfile(name string) error {
+	b.deleted = name
+	return nil
+}
+func (b *stubFormsBackend) Reload() (*engine.ProfilesConfig, error) {
+	b.reloadHits++
+	return b.cfg, nil
+}
+
+func formsTestDashboard() Dashboard {
+	return Dashboard{
+		SelectedProfile: "alpha",
+		Profiles: []ProfileCard{
+			{Name: "alpha", Source: "local:/tmp/a", StoreRef: "s1"},
+		},
+	}
+}
+
+func keyPress(s string) tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+}
+
+func TestModel_OpenCreateProfileForm(t *testing.T) {
+	backend := &stubFormsBackend{stores: []string{"s1"}, cfg: &engine.ProfilesConfig{}}
+	m := NewModel(formsTestDashboard()).WithForms(backend)
+
+	next, _ := m.Update(keyPress("n"))
+	m = next.(Model)
+	if m.form == nil {
+		t.Fatalf("pressing n should open the create form")
+	}
+	if !strings.Contains(m.View(), "Create Profile") {
+		t.Fatalf("view should show the create form\n%s", m.View())
+	}
+}
+
+func TestModel_CreateProfileSavesAndReloads(t *testing.T) {
+	backend := &stubFormsBackend{stores: []string{"s1"}, cfg: &engine.ProfilesConfig{}}
+	m := NewModel(formsTestDashboard()).WithForms(backend).WithConfig(&engine.ProfilesConfig{}, nil)
+
+	next, _ := m.Update(keyPress("n"))
+	m = next.(Model)
+
+	// name -> tab -> tab -> type path -> enter
+	for _, r := range "beta" {
+		next, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = next.(Model)
+	}
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = next.(Model)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = next.(Model)
+	for _, r := range "/data" {
+		next, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = next.(Model)
+	}
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+
+	if !backend.saved {
+		t.Fatalf("SaveProfile was not called")
+	}
+	if m.form != nil {
+		t.Fatalf("form should close after a successful save")
+	}
+	if cmd == nil {
+		t.Fatalf("save should trigger a config reload command")
+	}
+	// The reload command should hit the backend and produce a configReloadedMsg.
+	msg := cmd()
+	if _, ok := msg.(configReloadedMsg); !ok {
+		t.Fatalf("reload cmd produced %T want configReloadedMsg", msg)
+	}
+	if backend.reloadHits != 1 {
+		t.Fatalf("reload hits=%d want 1", backend.reloadHits)
+	}
+}
+
+func TestModel_DeleteProfileConfirmFlow(t *testing.T) {
+	backend := &stubFormsBackend{stores: []string{"s1"}, cfg: &engine.ProfilesConfig{}}
+	m := NewModel(formsTestDashboard()).WithForms(backend).WithConfig(&engine.ProfilesConfig{}, nil)
+
+	next, _ := m.Update(keyPress("d"))
+	m = next.(Model)
+	if m.confirm == nil {
+		t.Fatalf("pressing d should open the delete confirm")
+	}
+	if !strings.Contains(m.View(), "Delete profile") {
+		t.Fatalf("confirm view should mention deletion\n%s", m.View())
+	}
+
+	// Confirm with Enter.
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if backend.deleted != "alpha" {
+		t.Fatalf("deleted=%q want alpha", backend.deleted)
+	}
+	if m.confirm != nil {
+		t.Fatalf("confirm should close after deletion")
+	}
+	if cmd == nil {
+		t.Fatalf("deletion should trigger a config reload")
+	}
+}
+
+func TestModel_DeleteProfileCancel(t *testing.T) {
+	backend := &stubFormsBackend{stores: []string{"s1"}, cfg: &engine.ProfilesConfig{}}
+	m := NewModel(formsTestDashboard()).WithForms(backend)
+
+	next, _ := m.Update(keyPress("d"))
+	m = next.(Model)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = next.(Model)
+	if m.confirm != nil {
+		t.Fatalf("esc should cancel the confirm")
+	}
+	if backend.deleted != "" {
+		t.Fatalf("no deletion should occur on cancel, got %q", backend.deleted)
+	}
+}
+
+func TestModel_FormKeysNoOpWithoutBackend(t *testing.T) {
+	m := NewModel(formsTestDashboard())
+	next, cmd := m.Update(keyPress("n"))
+	m = next.(Model)
+	if m.form != nil || cmd != nil {
+		t.Fatalf("form keys must be a no-op without a forms backend")
+	}
+}
+


### PR DESCRIPTION
## Summary
- Add `internal/tui/forms`: a generic **bubbles/textinput-backed `Form` widget** — focus movement (Tab/↑↓, skips disabled fields), select cycling (←/→), per-field validation errors, and rendering — plus a data-driven **profile form**. Because text fields use `bubbles/textinput`, Unicode input, cursor movement, and paste work by construction, fixing the ASCII-only (`0x20`–`0x7e`) byte reader that silently dropped accented and non-Latin input (a Medium finding in the RFC 0012 revision).
- A **`ProfileBackend` boundary** keeps URI parsing, option lists, validation, and persistence in the cmd package; the forms package stays presentation-only (no cmd import).
- **Model integration**: `n`/`e`/`d` open create/edit/delete overlays, a small confirm for delete, and a config reload after any mutation that refreshes the dashboard and re-probes stores (keeping unchanged stores from flickering back to "checking…").
- **cmd adapter** implements the backend by reusing `tuiProfileSource`, the existing option/validation helpers, and `TUIService` save/delete.
- New direct dep `github.com/charmbracelet/bubbles`; `go mod tidy` pulled in `atotto/clipboard` (indirect, textinput paste).
- Still gated behind `cloudstic tui -bubbletea`; the legacy renderer and its forms are untouched.

This is the **first slice of #340** (profile forms). Store + secret-ref forms and the nested store-from-profile flow (#232) are tracked as **#350** and follow in the next stacked PR — hence "Part of", not "Closes".

Part of #132, #340 (RFC 0012, Phase 2 step 3)

## Verification
- `env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./internal/tui ./internal/tui/forms` passes (incl. a Unicode-input test: `café-Ω-日本`)
- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./cmd/cloudstic ./internal/app` passes
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./cmd/cloudstic/... ./internal/tui/...` — 0 issues
- `go build ./...` passes

## Reviewer notes
- Scope call: #340 bundles profile + store + secret-ref forms (~1,800 lines of interdependent legacy state machines). Porting all three at once would be a sprawling, hard-to-review change, and this repo prefers small stacked PRs — so I split off the store/secret work as #350. The generic `Form` widget and the backend-boundary pattern here are built to be reused by both.
- The `store` field in the profile form is a plain selector over existing stores for now (no nested "+ Create store" yet — that arrives with the store form in #350). This is additive: the `-bubbletea` renderer previously had no forms at all, so nothing regresses; the legacy renderer keeps the full nested flow.
- Testing mirrors the earlier Phase 2 PRs — the tea program isn't smoke-tested headlessly; the `Form` behavior, profile derivation/validation, and the model's open/save/delete/reload flows are covered by direct unit tests (race-clean).
