### PR TITLE
feat(tui): restyle the Bubble Tea dashboard with titled lipgloss panels (RFC 0012)

### DIFF
--- a/internal/tui/action_test.go
+++ b/internal/tui/action_test.go
@@ -64,7 +64,7 @@ func TestModel_StartAction_RunsAndCompletes(t *testing.T) {
 	if m.activity.Status != ActivityStatusSuccess {
 		t.Fatalf("activity status=%q want success", m.activity.Status)
 	}
-	if !strings.Contains(m.View(), "done") {
+	if !strings.Contains(m.View(), "success") {
 		t.Fatalf("view missing completion state\n%s", m.View())
 	}
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -234,145 +235,273 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) View() string {
+	width := m.viewWidth()
 	if m.form != nil {
-		return strings.Join([]string{m.renderHeader(), m.form.View(), m.renderFooter()}, "\n")
+		return strings.Join([]string{m.renderTitle(), m.form.View(), m.renderFooter()}, "\n")
 	}
 	if m.confirm != nil {
-		return strings.Join([]string{m.renderHeader(), m.renderConfirm(), m.renderFooter()}, "\n")
+		return strings.Join([]string{m.renderTitle(), m.renderConfirm(), m.renderFooter()}, "\n")
 	}
-	header := m.renderHeader()
-	body := lipgloss.JoinHorizontal(lipgloss.Top, m.renderProfileList(), m.renderDetail())
-	sections := []string{header, body}
-	if activity := m.renderActivity(); activity != "" {
-		sections = append(sections, activity)
+	sections := []string{
+		m.renderTitle(),
+		m.renderOverview(width),
+		m.renderPanes(width),
+		m.renderActivitySection(width),
+		m.renderFooter(),
 	}
-	sections = append(sections, m.renderFooter())
 	return strings.Join(sections, "\n")
+}
+
+func (m Model) viewWidth() int {
+	if m.width > 0 {
+		return m.width
+	}
+	return 92
+}
+
+// fullContentWidth is the panel content width for a full-width panel at the
+// given terminal width (border + padding cost 4 columns).
+func (m Model) fullContentWidth(width int) int {
+	if w := width - 4; w >= 24 {
+		return w
+	}
+	return 24
+}
+
+// panel renders a titled, bordered box at a fixed content width.
+func (m Model) panel(title, body string, contentWidth int) string {
+	style := m.theme.panel
+	if contentWidth > 0 {
+		style = style.Width(contentWidth)
+	}
+	return style.Render(m.theme.panelTitle.Render(title) + "\n\n" + body)
+}
+
+// panelH is panel with a fixed content height, used to equalize the two
+// side-by-side panes so their borders align.
+func (m Model) panelH(title, body string, contentWidth, contentHeight int) string {
+	return m.theme.panel.Width(contentWidth).Height(contentHeight).
+		Render(m.theme.panelTitle.Render(title) + "\n\n" + body)
+}
+
+func (m Model) renderTitle() string {
+	return m.theme.title.Render("Cloudstic") + "  " +
+		m.theme.subtitle.Render("Operator dashboard for profiles, stores, and auth.")
 }
 
 func (m Model) renderConfirm() string {
 	c := m.confirm
-	lines := []string{
-		m.theme.title.Render(c.title),
-		"",
-		c.message,
-		"",
-		m.theme.subtle.Render("Enter/y delete · Esc/n cancel"),
-	}
-	return m.theme.box.Render(strings.Join(lines, "\n"))
+	body := c.message + "\n\n" + m.theme.subtle.Render("Enter/y delete · Esc/n cancel")
+	return m.panel(c.title, body, 0)
 }
 
-func (m Model) renderActivity() string {
-	a := m.activity
-	if a.Status == ActivityStatusIdle && a.Action == "" {
-		return ""
-	}
-	label := a.Action
-	if label == "" {
-		label = string(a.ActionKind)
-	}
-	var head string
-	switch a.Status {
-	case ActivityStatusRunning:
-		head = m.theme.stateWarning.Render("● running") + "  " + label
-	case ActivityStatusSuccess:
-		head = m.theme.stateReady.Render("✓ done") + "  " + label
-	case ActivityStatusError:
-		head = m.theme.stateError.Render("✗ failed") + "  " + label
-	default:
-		head = label
-	}
-	lines := []string{head}
-	if a.Phase != "" {
-		lines = append(lines, m.theme.subtle.Render(a.Phase))
-	}
-	if bar := progressBarLine(a, 30); bar != "" {
-		lines = append(lines, bar)
-	}
-	if a.Summary != "" {
-		lines = append(lines, m.theme.subtle.Render(a.Summary))
-	}
-	return m.theme.box.Render(strings.Join(lines, "\n"))
+func (m Model) renderOverview(width int) string {
+	stats := strings.Join([]string{
+		m.theme.accent.Render("Profiles") + " " + strconv.Itoa(m.dashboard.ProfileCount),
+		m.theme.accent.Render("Stores") + " " + strconv.Itoa(m.dashboard.StoreCount),
+		m.theme.accent.Render("Auth") + " " + strconv.Itoa(m.dashboard.AuthCount),
+	}, "    ")
+	return m.panel("Overview", stats, m.fullContentWidth(width))
 }
 
-func (m Model) renderHeader() string {
-	title := m.theme.title.Render("cloudstic")
-	counts := m.theme.subtle.Render(fmt.Sprintf(
-		"%d profiles · %d stores · %d auth",
-		m.dashboard.ProfileCount, m.dashboard.StoreCount, m.dashboard.AuthCount,
-	))
-	return title + "  " + counts
+// renderPanes lays out the Profiles and Selection panels side by side, or
+// stacked vertically on narrow terminals (responsive, per RFC 0012 Style).
+func (m Model) renderPanes(width int) string {
+	profiles := m.renderProfileListBody()
+	selection := m.renderSelectionBody()
+	if width < 80 {
+		fw := m.fullContentWidth(width)
+		return m.panel("Profiles", profiles, fw) + "\n" + m.panel("Selection", selection, fw)
+	}
+	leftW, rightW := m.paneWidths(width)
+	h := max(
+		lipgloss.Height(m.theme.panelTitle.Render("Profiles")+"\n\n"+profiles),
+		lipgloss.Height(m.theme.panelTitle.Render("Selection")+"\n\n"+selection),
+	)
+	left := m.panelH("Profiles", profiles, leftW, h)
+	right := m.panelH("Selection", selection, rightW, h)
+	return lipgloss.JoinHorizontal(lipgloss.Top, left, "  ", right)
 }
 
-func (m Model) renderProfileList() string {
+func (m Model) paneWidths(width int) (int, int) {
+	inner := max(width-10, 40) // two panels (+4 each) plus a 2-col gap
+	left := max(inner/3, 18)
+	right := inner - left
+	if right < 32 {
+		right = 32
+		left = max(inner-right, 16)
+	}
+	return left, right
+}
+
+func (m Model) renderProfileListBody() string {
 	if len(m.dashboard.Profiles) == 0 {
-		return m.theme.box.Render(m.theme.subtle.Render("No profiles configured"))
+		return m.theme.subtle.Render("No profiles configured.")
 	}
+	nameWidth, badgeWidth := profileListWidths(m.dashboard.Profiles)
 	lines := make([]string, 0, len(m.dashboard.Profiles))
 	for i, profile := range m.dashboard.Profiles {
-		marker := "  "
-		name := profile.Name
-		if i == m.selected {
-			marker = m.theme.selected.Render("> ")
-			name = m.theme.selected.Render(name)
-		}
-		state := m.theme.stateStyle(profile.Status).Render(plainProfileStateLabel(profile))
-		lines = append(lines, fmt.Sprintf("%s%s [%s]", marker, name, state))
+		lines = append(lines, m.profileRow(profile, i == m.selected, nameWidth, badgeWidth))
 	}
-	return m.theme.box.Render(strings.Join(lines, "\n"))
+	return strings.Join(lines, "\n")
 }
 
-func (m Model) renderDetail() string {
+func (m Model) profileRow(profile ProfileCard, selected bool, nameWidth, badgeWidth int) string {
+	marker := "  "
+	name := padRight(profile.Name, nameWidth)
+	if selected {
+		marker = m.theme.marker.Render("› ")
+		name = m.theme.selected.Render(name)
+	}
+	return marker + name + "  " + m.renderBadge(profile, badgeWidth)
+}
+
+func (m Model) renderBadge(profile ProfileCard, width int) string {
+	inner := padRight(plainProfileStateLabel(profile), width-2)
+	return "[" + m.theme.stateStyle(profile.Status).Render(inner) + "]"
+}
+
+func (m Model) renderSelectionBody() string {
 	profile, ok := m.currentProfile()
 	if !ok {
-		return m.theme.box.Render(m.theme.subtle.Render("Select a profile"))
+		return m.theme.subtle.Render("No profile selected.")
 	}
-	tabs := m.renderTabs()
-	var body []string
-	switch m.view {
-	case ProfileViewHistory:
-		body = m.renderHistory(profile)
-	default:
-		body = m.renderSummary(profile)
+	lines := []string{
+		m.theme.selected.Render(profile.Name),
+		m.renderTabs(),
+		"",
 	}
-	content := append([]string{tabs, ""}, body...)
-	return m.theme.box.Render(strings.Join(content, "\n"))
+	if m.view == ProfileViewHistory {
+		lines = append(lines, m.renderHistory(profile)...)
+	} else {
+		lines = append(lines, m.renderSummary(profile)...)
+	}
+	lines = append(lines, m.renderActionButtons(profile)...)
+	return strings.Join(lines, "\n")
 }
 
 func (m Model) renderTabs() string {
-	summary := "[s] Summary"
-	history := "[h] History"
-	switch m.view {
-	case ProfileViewHistory:
-		history = m.theme.tabActive.Render(history)
-		summary = m.theme.tabInactive.Render(summary)
-	default:
-		summary = m.theme.tabActive.Render(summary)
-		history = m.theme.tabInactive.Render(history)
+	summary, history := "Summary (s)", "History (h)"
+	if m.view == ProfileViewHistory {
+		return m.theme.tabIdle.Render(summary) + "   " + m.theme.tabActive.Render(history)
 	}
-	return summary + "  " + history
+	return m.theme.tabActive.Render(summary) + "   " + m.theme.tabIdle.Render(history)
 }
 
 func (m Model) renderSummary(profile ProfileCard) []string {
 	rows := [][2]string{
+		{"State", plainProfileStateLabel(profile)},
 		{"Source", profile.Source},
-		{"Store", profile.StoreRef},
+		{"Store", dashIfEmpty(profile.StoreRef)},
 	}
 	if profile.AuthRef != "" {
 		rows = append(rows, [2]string{"Auth", profile.AuthRef})
 	}
 	rows = append(rows, [2]string{"Health", m.styledHealth(profile)})
 	if last := lastBackupLabel(profile); last != "" {
-		rows = append(rows, [2]string{"Last backup", last})
+		rows = append(rows, [2]string{"Backup", last})
 	}
 	if profile.LastRef != "" {
-		rows = append(rows, [2]string{"Last ref", trimSnapshotRef(profile.LastRef)})
+		rows = append(rows, [2]string{"Ref", trimSnapshotRef(profile.LastRef)})
+	}
+	if check := profileCheckSummary(m.activity, profile); check != "" {
+		rows = append(rows, [2]string{"Check", check})
+	}
+	if note := profileStatusSummary(profile); note != "" {
+		rows = append(rows, [2]string{"Status", note})
 	}
 	lines := make([]string, 0, len(rows))
 	for _, row := range rows {
-		lines = append(lines, m.theme.label.Render(fmt.Sprintf("%-12s", row[0]))+" "+row[1])
+		lines = append(lines, m.detailRow(row[0], row[1]))
 	}
 	return lines
+}
+
+func (m Model) detailRow(label, value string) string {
+	return m.theme.label.Render(padRight(label, 8)) + "  " + value
+}
+
+func (m Model) renderActionButtons(profile ProfileCard) []string {
+	buttons := selectedProfileActionButtons(profile)
+	if len(buttons) == 0 {
+		return nil
+	}
+	lines := []string{""}
+	for _, b := range buttons {
+		label := b.Label
+		if !b.Enabled {
+			label = m.theme.subtle.Render(label)
+		}
+		lines = append(lines, "  "+m.theme.key.Render("["+b.Key+"]")+" "+label)
+		if !b.Enabled && b.Reason != "" {
+			lines = append(lines, m.theme.subtle.Render("      "+b.Reason))
+		}
+	}
+	return lines
+}
+
+func (m Model) renderActivitySection(width int) string {
+	return m.panel("Activity", m.activityBody(), m.fullContentWidth(width))
+}
+
+func (m Model) activityBody() string {
+	a := m.activity
+	if a.Status == ActivityStatusIdle && a.Action == "" && len(a.Lines) == 0 {
+		return m.theme.subtle.Render("No recent activity.")
+	}
+	var lines []string
+	if status := m.activityStatusLabel(a.Status); status != "" {
+		lines = append(lines, m.detailRow("Status", status))
+	}
+	if a.Action != "" {
+		lines = append(lines, m.detailRow("Action", a.Action))
+	}
+	if a.Phase != "" {
+		lines = append(lines, m.detailRow("Phase", a.Phase))
+	}
+	if bar := progressBarLine(a, 28); bar != "" {
+		lines = append(lines, m.detailRow("Progress", bar))
+	}
+	if a.Summary != "" {
+		lines = append(lines, m.detailRow("Result", a.Summary))
+	}
+	if a.UpdatedAt != "" {
+		lines = append(lines, m.detailRow("Updated", a.UpdatedAt))
+	}
+	if len(a.Lines) > 0 {
+		if len(lines) > 0 {
+			lines = append(lines, "")
+		}
+		lines = append(lines, a.Lines...)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (m Model) activityStatusLabel(status ActivityStatus) string {
+	switch status {
+	case ActivityStatusRunning:
+		return m.theme.stateWarning.Render("running")
+	case ActivityStatusSuccess:
+		return m.theme.stateReady.Render("success")
+	case ActivityStatusError:
+		return m.theme.stateError.Render("error")
+	default:
+		return ""
+	}
+}
+
+func padRight(s string, width int) string {
+	if w := lipgloss.Width(s); w < width {
+		return s + strings.Repeat(" ", width-w)
+	}
+	return s
+}
+
+func dashIfEmpty(s string) string {
+	if s == "" {
+		return "—"
+	}
+	return s
 }
 
 func (m Model) styledHealth(profile ProfileCard) string {
@@ -402,62 +531,57 @@ func (m Model) renderHistory(profile ProfileCard) []string {
 }
 
 func (m Model) renderFooter() string {
-	var hints string
-	switch {
-	case m.form != nil, m.confirm != nil:
+	if m.form != nil || m.confirm != nil {
 		// The overlay renders its own key hints.
 		return ""
-	case m.running:
-		hints = "x cancel · running…"
-	default:
-		hints = m.actionHints() + m.formHints() + "↑/↓ select · s/h view · r refresh · q quit"
 	}
+	if m.running {
+		return m.hint("x", "cancel") + m.theme.subtle.Render("   ·   ") + m.theme.stateWarning.Render("running…")
+	}
+	line := strings.Join(m.footerHints(), m.theme.subtle.Render("  ·  "))
 	if m.loadErr != "" {
-		return m.theme.stateError.Render("error: "+m.loadErr) + "\n" + m.theme.footer.Render(hints)
+		return m.theme.stateError.Render("error: "+m.loadErr) + "\n" + line
 	}
-	return m.theme.footer.Render(hints)
+	return line
 }
 
-// formHints advertises the profile-management keys when the forms backend is
-// wired in.
-func (m Model) formHints() string {
-	if m.forms == nil {
-		return ""
-	}
-	if _, ok := m.currentProfile(); ok {
-		return "n new · e edit · d delete · "
-	}
-	return "n new · "
-}
-
-// actionHints lists the enabled action keys for the selected profile so the
-// footer advertises only actions that will actually run.
-func (m Model) actionHints() string {
-	if m.runner == nil {
-		return ""
-	}
-	profile, ok := m.currentProfile()
-	if !ok {
-		return ""
-	}
+// footerHints builds the context-aware key-hint bar: only actions and
+// management keys that will actually do something for the current selection.
+func (m Model) footerHints() []string {
 	var parts []string
-	for _, action := range profile.Actions {
-		if !action.Enabled {
-			continue
-		}
-		switch action.Kind {
-		case ActionKindInit:
-			parts = append(parts, "b init")
-		case ActionKindBackup:
-			parts = append(parts, "b backup")
-		case ActionKindCheck:
-			parts = append(parts, "c check")
+	profile, hasProfile := m.currentProfile()
+	if m.runner != nil && hasProfile {
+		for _, action := range profile.Actions {
+			if !action.Enabled {
+				continue
+			}
+			switch action.Kind {
+			case ActionKindInit:
+				parts = append(parts, m.hint("b", "init"))
+			case ActionKindBackup:
+				parts = append(parts, m.hint("b", "backup"))
+			case ActionKindCheck:
+				parts = append(parts, m.hint("c", "check"))
+			}
 		}
 	}
-	if len(parts) == 0 {
-		return ""
+	if m.forms != nil {
+		parts = append(parts, m.hint("n", "new"))
+		if hasProfile {
+			parts = append(parts, m.hint("e", "edit"), m.hint("d", "delete"))
+		}
 	}
-	return strings.Join(parts, " · ") + " · "
+	parts = append(parts,
+		m.hint("↑↓", "select"),
+		m.hint("s/h", "view"),
+		m.hint("r", "refresh"),
+		m.hint("q", "quit"),
+	)
+	return parts
+}
+
+func (m Model) hint(key, label string) string {
+	return m.theme.footerKey.Render(key) + m.theme.footer.Render(" "+label)
 }
 
 func (m Model) currentProfile() (ProfileCard, bool) {

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -47,7 +47,7 @@ func TestNewModel_SelectsDashboardProfile(t *testing.T) {
 func TestModel_View_RendersProfilesAndCounts(t *testing.T) {
 	m := NewModel(testDashboard())
 	view := m.View()
-	for _, want := range []string{"alpha", "zeta", "2 profiles", "1 stores", "local:/tmp/alpha"} {
+	for _, want := range []string{"alpha", "zeta", "Profiles 2", "Stores 1", "local:/tmp/alpha"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("view missing %q\n%s", want, view)
 		}

--- a/internal/tui/render_test.go
+++ b/internal/tui/render_test.go
@@ -1,0 +1,103 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func richDashboard() Dashboard {
+	return Dashboard{
+		ProfileCount: 2, StoreCount: 1, AuthCount: 1,
+		SelectedProfile: "docs",
+		SelectedView:    ProfileViewSummary,
+		Profiles: []ProfileCard{
+			{Name: "docs", Source: "local:/data", StoreRef: "b2", Enabled: true,
+				Status: ProfileStatusReady, StoreHealth: StoreHealthReady,
+				Reachability: StoreReachabilityReachable, Repository: RepositoryStateInitialized,
+				BackupState: BackupFreshnessRecent, LastBackup: "2026-07-24 08:12",
+				LastRef: "snapshot/abc123",
+				Actions: deriveProfileActions(ProfileStatusReady, StoreHealthReady)},
+			{Name: "photos", Source: "gdrive://Photos", StoreRef: "s3", AuthRef: "g", Enabled: true,
+				Status: ProfileStatusWarning, StoreHealth: StoreHealthUnavailable,
+				Reachability: StoreReachabilityUnavailable},
+		},
+	}
+}
+
+func TestView_ShowsTitledPanels(t *testing.T) {
+	m := NewModel(richDashboard())
+	m.width = 100
+	view := m.View()
+	for _, title := range []string{"Overview", "Profiles", "Selection", "Activity"} {
+		if !strings.Contains(view, title) {
+			t.Fatalf("view missing panel title %q\n%s", title, view)
+		}
+	}
+}
+
+func TestView_ShowsSummaryRowsAndActionButtons(t *testing.T) {
+	m := NewModel(richDashboard())
+	m.width = 100
+	view := m.View()
+	for _, want := range []string{
+		"State", "Source", "Store", "Health", "Backup", "Ref",
+		"[b] Run backup", "[c] Run check", "[e] Edit profile", "[d] Delete profile",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("summary/actions missing %q\n%s", want, view)
+		}
+	}
+}
+
+func TestView_WarningProfileShowsHealthNote(t *testing.T) {
+	d := richDashboard()
+	d.SelectedProfile = "photos"
+	m := NewModel(d)
+	m.width = 100
+	view := m.View()
+	if !strings.Contains(view, "store unavailable") {
+		t.Fatalf("warning profile should surface health note\n%s", view)
+	}
+}
+
+func TestView_NarrowWidthStacksPanels(t *testing.T) {
+	m := NewModel(richDashboard())
+	m.width = 68
+	view := m.View()
+	// Both panel titles present, but stacked (each on its own set of rows):
+	// no line should contain both "Profiles" and "Selection".
+	if !strings.Contains(view, "Profiles") || !strings.Contains(view, "Selection") {
+		t.Fatalf("narrow view missing a panel\n%s", view)
+	}
+	for line := range strings.SplitSeq(view, "\n") {
+		if strings.Contains(line, "Profiles") && strings.Contains(line, "Selection") {
+			t.Fatalf("panels should be stacked, not side by side, at width 68\n%s", view)
+		}
+	}
+}
+
+func TestView_ActivityPanelAlwaysPresent(t *testing.T) {
+	m := NewModel(richDashboard())
+	m.width = 100
+	if !strings.Contains(m.View(), "No recent activity.") {
+		t.Fatalf("idle activity panel should show a placeholder\n%s", m.View())
+	}
+	m.activity = ActivityPanel{Status: ActivityStatusRunning, Action: "Run backup", Phase: "scanning"}
+	view := m.View()
+	for _, want := range []string{"Status", "running", "Action", "Run backup", "Phase", "scanning"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("running activity missing %q\n%s", want, view)
+		}
+	}
+}
+
+func TestView_FooterShowsContextualHints(t *testing.T) {
+	m := NewModel(richDashboard()).WithForms(&stubFormsBackend{}).WithRunner(&stubRunner{})
+	m.width = 100
+	view := m.View()
+	for _, want := range []string{"backup", "check", "new", "edit", "delete", "quit"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("footer missing hint %q\n%s", want, view)
+		}
+	}
+}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -2,20 +2,26 @@ package tui
 
 import "github.com/charmbracelet/lipgloss"
 
-// theme holds the lipgloss styles for the Bubble Tea renderer. It is
-// intentionally small for the read-only foundation (issue #338); the full
-// adaptive light/dark, NO_COLOR-aware theme lands with the legacy engine
-// deletion (issue #341).
+// theme holds the lipgloss styles for the Bubble Tea renderer: titled panels,
+// aligned columns, and semantic status colors with the correct hierarchy
+// (unlike the legacy renderer, where warning showed cyan and error was
+// uncolored — see issue #341). Colors are adaptive for light/dark terminals.
 type theme struct {
-	title       lipgloss.Style
-	subtle      lipgloss.Style
-	label       lipgloss.Style
-	value       lipgloss.Style
-	selected    lipgloss.Style
-	box         lipgloss.Style
-	tabActive   lipgloss.Style
-	tabInactive lipgloss.Style
-	footer      lipgloss.Style
+	title      lipgloss.Style
+	subtitle   lipgloss.Style
+	subtle     lipgloss.Style
+	label      lipgloss.Style
+	value      lipgloss.Style
+	accent     lipgloss.Style
+	selected   lipgloss.Style
+	marker     lipgloss.Style
+	key        lipgloss.Style
+	panel      lipgloss.Style
+	panelTitle lipgloss.Style
+	tabActive  lipgloss.Style
+	tabIdle    lipgloss.Style
+	footer     lipgloss.Style
+	footerKey  lipgloss.Style
 
 	stateReady    lipgloss.Style
 	stateWarning  lipgloss.Style
@@ -24,24 +30,33 @@ type theme struct {
 }
 
 func newTheme() theme {
-	subtle := lipgloss.AdaptiveColor{Light: "245", Dark: "241"}
-	return theme{
-		title:       lipgloss.NewStyle().Bold(true),
-		subtle:      lipgloss.NewStyle().Foreground(subtle),
-		label:       lipgloss.NewStyle().Foreground(subtle),
-		value:       lipgloss.NewStyle(),
-		selected:    lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("6")),
-		box:         lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(subtle).Padding(0, 1),
-		tabActive:   lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("6")),
-		tabInactive: lipgloss.NewStyle().Foreground(subtle),
-		footer:      lipgloss.NewStyle().Foreground(subtle),
+	subtle := lipgloss.AdaptiveColor{Light: "246", Dark: "244"}
+	faint := lipgloss.AdaptiveColor{Light: "250", Dark: "240"}
+	accent := lipgloss.AdaptiveColor{Light: "31", Dark: "45"}   // teal/cyan
+	ready := lipgloss.AdaptiveColor{Light: "28", Dark: "42"}    // green
+	warn := lipgloss.AdaptiveColor{Light: "130", Dark: "214"}   // amber
+	danger := lipgloss.AdaptiveColor{Light: "160", Dark: "203"} // red
 
-		// Semantic status colors, with the correct hierarchy (unlike the
-		// legacy renderer, where warning showed cyan and error was
-		// uncolored — see issue #341).
-		stateReady:    lipgloss.NewStyle().Foreground(lipgloss.Color("2")),
-		stateWarning:  lipgloss.NewStyle().Foreground(lipgloss.Color("3")),
-		stateError:    lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("1")),
+	return theme{
+		title:      lipgloss.NewStyle().Bold(true).Foreground(accent),
+		subtitle:   lipgloss.NewStyle().Foreground(subtle),
+		subtle:     lipgloss.NewStyle().Foreground(subtle),
+		label:      lipgloss.NewStyle().Foreground(subtle),
+		value:      lipgloss.NewStyle(),
+		accent:     lipgloss.NewStyle().Foreground(accent),
+		selected:   lipgloss.NewStyle().Bold(true).Foreground(accent),
+		marker:     lipgloss.NewStyle().Bold(true).Foreground(accent),
+		key:        lipgloss.NewStyle().Bold(true).Foreground(accent),
+		panel:      lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(faint).Padding(0, 1),
+		panelTitle: lipgloss.NewStyle().Bold(true),
+		tabActive:  lipgloss.NewStyle().Bold(true).Foreground(accent).Underline(true),
+		tabIdle:    lipgloss.NewStyle().Foreground(subtle),
+		footer:     lipgloss.NewStyle().Foreground(subtle),
+		footerKey:  lipgloss.NewStyle().Bold(true).Foreground(accent),
+
+		stateReady:    lipgloss.NewStyle().Foreground(ready),
+		stateWarning:  lipgloss.NewStyle().Foreground(warn),
+		stateError:    lipgloss.NewStyle().Bold(true).Foreground(danger),
 		stateDisabled: lipgloss.NewStyle().Foreground(subtle),
 	}
 }


### PR DESCRIPTION
## Summary
Bring the Bubble Tea renderer up to — and past — the legacy dashboard's look and information density, which the read-only foundation (#338) had pared back to a bare list.

- **Titled, bordered panels** (Overview / Profiles / Selection / Activity) via lipgloss, with an app subtitle and full-width top/bottom panels.
- **Equal-height side-by-side** Profiles/Selection panes that **stack vertically below 80 columns** (responsive, per RFC 0012 Style).
- **Aligned** name + status-badge columns; **semantic adaptive light/dark colors** with the correct hierarchy (ready green / warning amber / error red).
- **Restored missing info**: the `State` row, health note, check summary, and the **action-button list** (`[b]`/`[c]`/`[e]`/`[d]`); the Activity panel is **always shown** with structured Status/Action/Phase/Progress/Result rows plus log lines.
- A **context-aware key-hint footer** with styled keys, advertising only the actions and management keys valid for the current selection.

Reuses the existing view-model info helpers (`profileHealthSummary`, `profileStatusSummary`, `selectedProfileActionButtons`, `progressBarLine`) so both renderers stay in agreement. This pulls forward the RFC 0012 "Style" items that #341 would otherwise carry.

Builds on the merged forms work (#351); this diff is purely the presentational restyle. Still gated behind `cloudstic tui -bubbletea`.

Part of #132 (RFC 0012, Phase 2)

## Verification
- `env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./internal/tui` passes (adds render tests: titled panels, summary rows + action buttons, warning health note, narrow-width stacking, always-on activity, contextual footer)
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./internal/tui/...` — 0 issues
- `go build ./...` passes

## Before / after (width 92)

Before — a bare list with ragged badges and no panels:

```
cloudstic  3 profiles · 2 stores · 1 auth
╭───────────────────────╮╭────────────────────────────────────────╮
│ > documents [enabled] ││ [s] Summary  [h] History               │
│   photos [warning]    ││ Source       local:/Users/me/Documents │
│   archive [disabled]  ││ Store        b2-main                   │
╰───────────────────────╯│ ...                                    │
```

After — titled panels, aligned columns, State/Health/Backup/Ref rows, action buttons, always-on Activity, and a colored contextual footer:

```
Cloudstic  Operator dashboard for profiles, stores, and auth.
╭── Overview ─────────────────────────────────────────────────────╮
│ Profiles 3    Stores 2    Auth 1                                 │
╰─────────────────────────────────────────────────────────────────╯
╭── Profiles ──────────────╮  ╭── Selection ───────────────────────╮
│ › documents  [enabled ]  │  │ documents                          │
│   photos     [warning ]  │  │ State     enabled                  │
│   archive    [disabled]  │  │ Health    ready                    │
│                          │  │ ...   [b] Run backup  [c] Run check │
╰──────────────────────────╯  ╰────────────────────────────────────╯
b backup · c check · n new · e edit · d delete · ↑↓ select · s/h view · r refresh · q quit
```

(Panel titles render inside the top border in the terminal; shown here abbreviated.)

## Reviewer notes
- Testing follows the earlier Phase 2 PRs: the tea program isn't smoke-tested headlessly; the `View()` output (panel titles, rows, buttons, responsive stacking, footer) is asserted directly.
- The lipgloss colors are `AdaptiveColor` (light/dark). Full `NO_COLOR` handling and the shared theme extraction remain part of #341, which also deletes the legacy renderer these styles now visually supersede.
