### PR TITLE
feat(tui): store form and nested store-from-profile flow (RFC 0012)

### DIFF
--- a/cmd/cloudstic/cmd_tui_bubbletea_store.go
+++ b/cmd/cloudstic/cmd_tui_bubbletea_store.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"fmt"
+
+	cloudstic "github.com/cloudstic/cli"
+	"github.com/cloudstic/cli/internal/secretref"
+	"github.com/cloudstic/cli/internal/tui/forms"
+)
+
+// Store form backend (tui/forms.StoreBackend), implemented by reusing the
+// existing store-URI and secret-ref helpers so the forms package stays free of
+// parsing and persistence concerns.
+
+func (b *bubbleFormsBackend) StoreDetailLabel(storeType string) string {
+	return tuiStoreConfig{Type: storeType}.DetailLabel()
+}
+
+func (b *bubbleFormsBackend) StoreExample(storeType string) string {
+	return tuiStoreConfig{Type: storeType}.ExampleText()
+}
+
+func (b *bubbleFormsBackend) ComposeStore(storeType, value string) (string, error) {
+	uri := tuiStoreConfig{Type: storeType, Value: value}.Compose()
+	if uri == "" {
+		return "", nil
+	}
+	if _, err := parseStoreURI(uri); err != nil {
+		return "", fmt.Errorf("invalid store: %v", err)
+	}
+	return uri, nil
+}
+
+func (b *bubbleFormsBackend) ValidateStoreName(name string) error {
+	return validateRefName("store", name)
+}
+
+func (b *bubbleFormsBackend) StoreExists(name string) bool {
+	if b.cfg == nil {
+		return false
+	}
+	_, ok := b.cfg.Stores[name]
+	return ok
+}
+
+func (b *bubbleFormsBackend) ValidateSecretRef(ref string) error {
+	if _, err := secretref.Parse(ref); err != nil {
+		return fmt.Errorf("invalid secret reference: %v", err)
+	}
+	return nil
+}
+
+// InitialStoreValues seeds an edit-store form from an existing store.
+func (b *bubbleFormsBackend) InitialStoreValues(name string) map[string]string {
+	if b.cfg == nil {
+		return nil
+	}
+	store, ok := b.cfg.Stores[name]
+	if !ok {
+		return nil
+	}
+	cfg := newTUIStoreConfig(store.URI)
+	return map[string]string{
+		forms.FieldStoreType:      cfg.Type,
+		forms.FieldStoreValue:     cfg.Value,
+		forms.FieldS3Region:       store.S3Region,
+		forms.FieldS3Profile:      store.S3Profile,
+		forms.FieldS3Endpoint:     store.S3Endpoint,
+		forms.FieldS3AccessKey:    store.S3AccessKeySecret,
+		forms.FieldS3SecretKey:    store.S3SecretKeySecret,
+		forms.FieldSFTPPassword:   store.StoreSFTPPasswordSecret,
+		forms.FieldSFTPKey:        store.StoreSFTPKeySecret,
+		forms.FieldEncryptionMode: string(newTUIStoreEncryptionMode(store)),
+		forms.FieldPasswordSecret: store.PasswordSecret,
+		forms.FieldPlatformSecret: store.EncryptionKeySecret,
+		forms.FieldKMSKeyARN:      store.KMSKeyARN,
+		forms.FieldKMSRegion:      store.KMSRegion,
+		forms.FieldKMSEndpoint:    store.KMSEndpoint,
+	}
+}
+
+// SaveStore assembles a ProfileStore from the form's collected values and
+// persists it. Connection and encryption fields irrelevant to the selected
+// type/mode are cleared, mirroring the legacy store form.
+func (b *bubbleFormsBackend) SaveStore(name string, values map[string]string, editing bool) error {
+	store := cloudstic.ProfileStore{}
+	if editing && b.cfg != nil {
+		if existing, ok := b.cfg.Stores[name]; ok {
+			store = existing
+		}
+	}
+	store.URI = values[forms.FieldStoreURI]
+	applyStoreConnectionValues(&store, values)
+	applyStoreEncryptionValues(&store, values)
+
+	if err := tuiServiceFactory(nil, b.profilesFile, nil).SaveStore(b.profilesFile, name, store); err != nil {
+		return err
+	}
+	// Refresh the cache so the profile form's store selector immediately sees
+	// the new/edited store.
+	if cfg, err := tuiLoadConfig(b.profilesFile); err == nil {
+		b.cfg = cfg
+	}
+	return nil
+}
+
+func applyStoreConnectionValues(store *cloudstic.ProfileStore, values map[string]string) {
+	// Start clean; only the selected type's fields are populated.
+	store.S3Region = ""
+	store.S3Profile = ""
+	store.S3Endpoint = ""
+	store.S3AccessKeySecret = ""
+	store.S3SecretKeySecret = ""
+	store.StoreSFTPPasswordSecret = ""
+	store.StoreSFTPKeySecret = ""
+
+	switch values[forms.FieldStoreType] {
+	case "s3", "b2":
+		store.S3Region = values[forms.FieldS3Region]
+		store.S3Profile = values[forms.FieldS3Profile]
+		store.S3Endpoint = values[forms.FieldS3Endpoint]
+		store.S3AccessKeySecret = values[forms.FieldS3AccessKey]
+		store.S3SecretKeySecret = values[forms.FieldS3SecretKey]
+	case "sftp":
+		store.StoreSFTPPasswordSecret = values[forms.FieldSFTPPassword]
+		store.StoreSFTPKeySecret = values[forms.FieldSFTPKey]
+	}
+}
+
+func applyStoreEncryptionValues(store *cloudstic.ProfileStore, values map[string]string) {
+	store.PasswordSecret = ""
+	store.EncryptionKeySecret = ""
+	store.KMSKeyARN = ""
+	store.KMSRegion = ""
+	store.KMSEndpoint = ""
+
+	switch values[forms.FieldEncryptionMode] {
+	case forms.EncPassword:
+		store.PasswordSecret = values[forms.FieldPasswordSecret]
+	case forms.EncPlatform:
+		store.EncryptionKeySecret = values[forms.FieldPlatformSecret]
+	case forms.EncKMS:
+		store.KMSKeyARN = values[forms.FieldKMSKeyARN]
+		store.KMSRegion = firstNonEmpty(values[forms.FieldKMSRegion], "us-east-1")
+		store.KMSEndpoint = values[forms.FieldKMSEndpoint]
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -9,7 +9,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/cloudstic/cli/internal/engine"
-	"github.com/cloudstic/cli/internal/tui/forms"
 )
 
 // Model is the root Bubble Tea model for the interactive dashboard. This is
@@ -41,11 +40,12 @@ type Model struct {
 	cancel   context.CancelFunc
 	activity ActivityPanel
 
-	// Profile management state (issue #340). forms is the domain backend;
-	// form and confirm are the active overlay, at most one at a time.
-	forms   FormsBackend
-	form    *forms.Form
-	confirm *confirmState
+	// Profile/store management state (issues #340, #350). forms is the domain
+	// backend; formStack is the (possibly nested) form overlay — a profile form
+	// can push a store form (#232) — and confirm is the delete overlay.
+	forms     FormsBackend
+	formStack []formFrame
+	confirm   *confirmState
 
 	// reload, when non-nil, is run when the user presses "r". It returns a
 	// DashboardLoadedMsg or DashboardLoadError. The read-only launcher can
@@ -128,8 +128,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case configReloadedMsg:
 		return m.handleConfigReloaded(msg)
 	case tea.KeyMsg:
-		if m.form != nil {
-			return m.updateForm(msg)
+		if m.activeForm() != nil {
+			return m.updateForms(msg)
 		}
 		if m.confirm != nil {
 			return m.updateConfirm(msg)
@@ -137,8 +137,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleKey(msg)
 	default:
 		// Route other messages (e.g. textinput cursor blink) to an open form.
-		if m.form != nil {
-			return m.updateForm(msg)
+		if m.activeForm() != nil {
+			return m.updateForms(msg)
 		}
 	}
 	return m, nil
@@ -236,8 +236,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m Model) View() string {
 	width := m.viewWidth()
-	if m.form != nil {
-		return strings.Join([]string{m.renderTitle(), m.form.View(), m.renderFooter()}, "\n")
+	if form := m.activeForm(); form != nil {
+		return strings.Join([]string{m.renderTitle(), form.View(), m.renderFooter()}, "\n")
 	}
 	if m.confirm != nil {
 		return strings.Join([]string{m.renderTitle(), m.renderConfirm(), m.renderFooter()}, "\n")
@@ -531,7 +531,7 @@ func (m Model) renderHistory(profile ProfileCard) []string {
 }
 
 func (m Model) renderFooter() string {
-	if m.form != nil || m.confirm != nil {
+	if m.activeForm() != nil || m.confirm != nil {
 		// The overlay renders its own key hints.
 		return ""
 	}

--- a/internal/tui/forms/form.go
+++ b/internal/tui/forms/form.go
@@ -135,6 +135,12 @@ type Form struct {
 	// Submit validates and persists the form. It returns the result value on
 	// success, or a *FieldError / plain error on failure. It is required.
 	Submit func(f *Form) (string, error)
+	// Interrupt, if set, is consulted for every key before normal handling. It
+	// may return a navigation Intent to yield to the host (e.g. open a nested
+	// form) without editing or completing the form.
+	Interrupt func(f *Form, key tea.KeyMsg) (Intent, bool)
+
+	pendingIntent Intent
 
 	theme formTheme
 }
@@ -279,11 +285,39 @@ func (f *Form) clearError() {
 	f.errMsg = ""
 }
 
+// Intent is a navigation request a form yields to its host instead of
+// completing — for example, opening a nested form. Name identifies the action;
+// Value carries a parameter (e.g. the store to edit, or the secret field key).
+type Intent struct {
+	Name  string
+	Value string
+}
+
+// TakeIntent returns and clears any pending intent set by the Interrupt hook.
+// The host calls it after Update to decide whether to open a nested form.
+func (f *Form) TakeIntent() (Intent, bool) {
+	if f.pendingIntent.Name == "" {
+		return Intent{}, false
+	}
+	intent := f.pendingIntent
+	f.pendingIntent = Intent{}
+	return intent, true
+}
+
 // Update processes one message while the form is open.
 func (f *Form) Update(msg tea.Msg) (*Form, tea.Cmd) {
 	key, ok := msg.(tea.KeyMsg)
 	if !ok {
 		return f, f.updateFocusedInput(msg)
+	}
+
+	// The Interrupt hook may intercept a key to yield a navigation intent
+	// (e.g. "open the store form") without completing or editing the form.
+	if f.Interrupt != nil {
+		if intent, ok := f.Interrupt(f, key); ok {
+			f.pendingIntent = intent
+			return f, nil
+		}
 	}
 
 	switch key.Type {

--- a/internal/tui/forms/profile.go
+++ b/internal/tui/forms/profile.go
@@ -1,6 +1,21 @@
 package forms
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// CreateStoreOption is the sentinel store-field option that opens the nested
+// store-create form (#232).
+const CreateStoreOption = "+ Create store"
+
+// Intent names yielded by the profile form's store field.
+const (
+	IntentCreateStore = "create_store"
+	IntentEditStore   = "edit_store"
+)
 
 // ProfileBackend is the domain boundary for the profile form. The cmd package
 // implements it by reusing the existing source-URI, options, validation, and
@@ -49,7 +64,7 @@ func NewProfileForm(backend ProfileBackend, existingName, existingSource, existi
 	if existingSource != "" {
 		sourceType, sourceValue = backend.SourceParts(existingSource)
 	}
-	stores := backend.StoreOptions()
+	stores := storeFieldOptions(backend.StoreOptions())
 
 	fields := []Field{
 		newTextField("name", "Name", existingName, true),
@@ -71,9 +86,32 @@ func NewProfileForm(backend ProfileBackend, existingName, existingSource, existi
 	pf := &profileFormState{backend: backend, editing: editing, originalName: existingName}
 	f.OnChange = pf.onChange
 	f.Submit = pf.submit
+	f.Interrupt = pf.interrupt
 	pf.refreshDerived(f)
 	f.focusFirst()
 	return f
+}
+
+// storeFieldOptions appends the create-store sentinel to the available stores.
+func storeFieldOptions(stores []string) []string {
+	return append(append([]string{}, stores...), CreateStoreOption)
+}
+
+// interrupt lets the store field open the nested store form: Enter on the
+// "+ Create store" option, or "e" on a real store to edit it (#232).
+func (p *profileFormState) interrupt(f *Form, key tea.KeyMsg) (Intent, bool) {
+	if f.FocusedKey() != "store" {
+		return Intent{}, false
+	}
+	value := f.Value("store")
+	switch {
+	case key.Type == tea.KeyEnter && value == CreateStoreOption:
+		return Intent{Name: IntentCreateStore}, true
+	case key.Type == tea.KeyRunes && strings.EqualFold(string(key.Runes), "e") &&
+		value != "" && value != CreateStoreOption:
+		return Intent{Name: IntentEditStore, Value: value}, true
+	}
+	return Intent{}, false
 }
 
 type profileFormState struct {
@@ -86,6 +124,20 @@ func (p *profileFormState) onChange(f *Form, changedKey string) {
 	switch changedKey {
 	case "source_type", "source_value":
 		p.refreshDerived(f)
+	case "store":
+		f.SetHelp("store", storeFieldHelp(f.Value("store")))
+	}
+}
+
+// storeFieldHelp returns the contextual hint for the store selector.
+func storeFieldHelp(value string) string {
+	switch {
+	case value == CreateStoreOption:
+		return "Press Enter to create a store."
+	case value != "":
+		return "Press e to edit the selected store."
+	default:
+		return ""
 	}
 }
 
@@ -98,6 +150,8 @@ func (p *profileFormState) refreshDerived(f *Form) {
 	} else {
 		f.SetHelp("source_value", "")
 	}
+
+	f.SetHelp("store", storeFieldHelp(f.Value("store")))
 
 	provider := p.backend.ProviderForSourceType(sourceType)
 	if provider == "" {
@@ -146,6 +200,9 @@ func (p *profileFormState) submit(f *Form) (string, error) {
 	storeRef := f.TrimmedValue("store")
 	if storeRef == "" {
 		return "", NewFieldError("store", "store reference is required")
+	}
+	if storeRef == CreateStoreOption {
+		return "", NewFieldError("store", "create a store before saving the profile")
 	}
 
 	authRef := f.TrimmedValue("auth")

--- a/internal/tui/forms/profile_test.go
+++ b/internal/tui/forms/profile_test.go
@@ -165,6 +165,40 @@ func TestProfileForm_GdriveRequiresAuth(t *testing.T) {
 	}
 }
 
+func TestProfileForm_StoreFieldOffersCreateOption(t *testing.T) {
+	b := newStubBackend()
+	f := NewProfileForm(b, "", "", "", "", false)
+	f = focusKey(f, "store")
+	// The create sentinel is the last option; a single left-cycle wraps to it.
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	if f.Value("store") != CreateStoreOption {
+		t.Fatalf("store selector should reach %q, got %q", CreateStoreOption, f.Value("store"))
+	}
+	// Enter on the create sentinel yields a create-store intent, not a submit.
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	intent, ok := f.TakeIntent()
+	if !ok || intent.Name != IntentCreateStore {
+		t.Fatalf("expected create_store intent, got %+v ok=%v", intent, ok)
+	}
+	if f.Done() {
+		t.Fatalf("form must not complete when yielding a create intent")
+	}
+}
+
+func TestProfileForm_EditStoreIntent(t *testing.T) {
+	b := newStubBackend()
+	f := NewProfileForm(b, "", "", "local-store", "", false)
+	f = focusKey(f, "store")
+	if f.Value("store") != "local-store" {
+		t.Fatalf("store=%q want local-store", f.Value("store"))
+	}
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("e")})
+	intent, ok := f.TakeIntent()
+	if !ok || intent.Name != IntentEditStore || intent.Value != "local-store" {
+		t.Fatalf("expected edit_store intent for local-store, got %+v ok=%v", intent, ok)
+	}
+}
+
 func TestProfileForm_SaveErrorSurfaces(t *testing.T) {
 	b := newStubBackend()
 	b.saveErr = errors.New("disk full")

--- a/internal/tui/forms/store.go
+++ b/internal/tui/forms/store.go
@@ -1,0 +1,244 @@
+package forms
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Store form field keys. They are shared with the cmd-side StoreBackend adapter
+// (which assembles a ProfileStore from the collected values), so both sides
+// must agree on them.
+const (
+	FieldStoreName      = "name"
+	FieldStoreType      = "store_type"
+	FieldStoreValue     = "store_value"
+	FieldS3Region       = "s3_region"
+	FieldS3Profile      = "s3_profile"
+	FieldS3Endpoint     = "s3_endpoint"
+	FieldS3AccessKey    = "s3_access_key_secret"
+	FieldS3SecretKey    = "s3_secret_key_secret"
+	FieldSFTPPassword   = "sftp_password_secret"
+	FieldSFTPKey        = "sftp_key_secret"
+	FieldEncryptionMode = "encryption_mode"
+	FieldPasswordSecret = "password_secret"
+	FieldPlatformSecret = "encryption_key_secret"
+	FieldKMSKeyARN      = "kms_key_arn"
+	FieldKMSRegion      = "kms_region"
+	FieldKMSEndpoint    = "kms_endpoint"
+	// FieldStoreURI is not an input; the form writes the composed URI here for
+	// the backend to consume.
+	FieldStoreURI = "uri"
+)
+
+// Encryption modes offered by the store form.
+const (
+	EncNone     = "none"
+	EncPassword = "password"
+	EncPlatform = "platform"
+	EncKMS      = "kms"
+)
+
+// StoreTypes lists the store schemes offered by the form, in order.
+var StoreTypes = []string{"local", "s3", "b2", "sftp"}
+
+// EncryptionModes lists the encryption modes offered by the form, in order.
+var EncryptionModes = []string{EncNone, EncPassword, EncPlatform, EncKMS}
+
+var (
+	storeS3Fields   = []string{FieldS3Region, FieldS3Profile, FieldS3Endpoint, FieldS3AccessKey, FieldS3SecretKey}
+	storeSFTPFields = []string{FieldSFTPPassword, FieldSFTPKey}
+	storeEncFields  = []string{FieldPasswordSecret, FieldPlatformSecret, FieldKMSKeyARN, FieldKMSRegion, FieldKMSEndpoint}
+	storeSecretRefFields = []string{
+		FieldS3AccessKey, FieldS3SecretKey, FieldSFTPPassword, FieldSFTPKey,
+		FieldPasswordSecret, FieldPlatformSecret,
+	}
+	// allStoreFieldKeys is the set of keys sent to SaveStore.
+	allStoreFieldKeys = []string{
+		FieldStoreType, FieldStoreValue,
+		FieldS3Region, FieldS3Profile, FieldS3Endpoint, FieldS3AccessKey, FieldS3SecretKey,
+		FieldSFTPPassword, FieldSFTPKey,
+		FieldEncryptionMode, FieldPasswordSecret, FieldPlatformSecret,
+		FieldKMSKeyARN, FieldKMSRegion, FieldKMSEndpoint,
+	}
+)
+
+// StoreBackend is the domain boundary for the store form. The cmd package
+// implements it by reusing the store-URI and secret-ref helpers, keeping this
+// package free of parsing and persistence concerns.
+type StoreBackend interface {
+	// StoreDetailLabel returns the label for the primary value field.
+	StoreDetailLabel(storeType string) string
+	// StoreExample returns an example hint for the primary value field.
+	StoreExample(storeType string) string
+	// ComposeStore builds and validates a store URI from type and value.
+	ComposeStore(storeType, value string) (string, error)
+	// ValidateStoreName validates a candidate new store name.
+	ValidateStoreName(name string) error
+	// StoreExists reports whether a store name is already taken.
+	StoreExists(name string) bool
+	// ValidateSecretRef validates a non-empty secret reference's format.
+	ValidateSecretRef(ref string) error
+	// SaveStore persists the store from the collected field values.
+	SaveStore(name string, values map[string]string, editing bool) error
+}
+
+// NewStoreForm builds the create/edit store form. initial seeds field values
+// (built by the backend from an existing ProfileStore for edits); for creates
+// it may be nil.
+func NewStoreForm(backend StoreBackend, existingName string, initial map[string]string, editing bool) *Form {
+	get := func(key, def string) string {
+		if v := initial[key]; v != "" {
+			return v
+		}
+		return def
+	}
+	storeType := get(FieldStoreType, "local")
+
+	fields := []Field{
+		newTextField(FieldStoreName, "Name", existingName, true),
+		newSelectField(FieldStoreType, "Store Type", append([]string{}, StoreTypes...), storeType, true),
+		newTextField(FieldStoreValue, backend.StoreDetailLabel(storeType), initial[FieldStoreValue], true),
+		newTextField(FieldS3Region, "S3 Region", initial[FieldS3Region], false),
+		newTextField(FieldS3Profile, "S3 Profile", initial[FieldS3Profile], false),
+		newTextField(FieldS3Endpoint, "S3 Endpoint", initial[FieldS3Endpoint], false),
+		newTextField(FieldS3AccessKey, "Access Key Ref", initial[FieldS3AccessKey], false),
+		newTextField(FieldS3SecretKey, "Secret Key Ref", initial[FieldS3SecretKey], false),
+		newTextField(FieldSFTPPassword, "Password Ref", initial[FieldSFTPPassword], false),
+		newTextField(FieldSFTPKey, "Key Ref", initial[FieldSFTPKey], false),
+		newSelectField(FieldEncryptionMode, "Encryption", append([]string{}, EncryptionModes...), get(FieldEncryptionMode, EncNone), true),
+		newTextField(FieldPasswordSecret, "Password Ref", initial[FieldPasswordSecret], false),
+		newTextField(FieldPlatformSecret, "Platform Key Ref", initial[FieldPlatformSecret], false),
+		newTextField(FieldKMSKeyARN, "KMS Key ARN", initial[FieldKMSKeyARN], false),
+		newTextField(FieldKMSRegion, "KMS Region", get(FieldKMSRegion, "us-east-1"), false),
+		newTextField(FieldKMSEndpoint, "KMS Endpoint", initial[FieldKMSEndpoint], false),
+	}
+	if editing {
+		fields[0].Disabled = true
+	}
+
+	title := "Create Store"
+	if editing {
+		title = "Edit Store"
+	}
+	f := New(title, "", fields)
+	sf := &storeFormState{backend: backend, editing: editing, originalName: existingName}
+	f.OnChange = sf.onChange
+	f.Submit = sf.submit
+	sf.refresh(f)
+	f.focusFirst()
+	return f
+}
+
+type storeFormState struct {
+	backend      StoreBackend
+	editing      bool
+	originalName string
+}
+
+func (s *storeFormState) onChange(f *Form, changedKey string) {
+	switch changedKey {
+	case FieldStoreType, FieldEncryptionMode, FieldStoreValue:
+		s.refresh(f)
+	}
+}
+
+// refresh applies type- and mode-driven visibility: connection fields show only
+// for their store type, and encryption sub-fields only for their mode. Hidden
+// fields are Disabled and not Required, so the generic form skips them.
+func (s *storeFormState) refresh(f *Form) {
+	storeType := f.Value(FieldStoreType)
+	f.SetLabel(FieldStoreValue, s.backend.StoreDetailLabel(storeType))
+	f.SetHelp(FieldStoreValue, s.backend.StoreExample(storeType))
+
+	enableS3 := storeType == "s3" || storeType == "b2"
+	for _, key := range storeS3Fields {
+		f.SetDisabled(key, !enableS3)
+		f.SetRequired(key, false)
+	}
+	enableSFTP := storeType == "sftp"
+	for _, key := range storeSFTPFields {
+		f.SetDisabled(key, !enableSFTP)
+		f.SetRequired(key, false)
+	}
+
+	for _, key := range storeEncFields {
+		f.SetDisabled(key, true)
+		f.SetRequired(key, false)
+	}
+	switch f.Value(FieldEncryptionMode) {
+	case EncPassword:
+		f.SetDisabled(FieldPasswordSecret, false)
+		f.SetRequired(FieldPasswordSecret, true)
+	case EncPlatform:
+		f.SetDisabled(FieldPlatformSecret, false)
+		f.SetRequired(FieldPlatformSecret, true)
+	case EncKMS:
+		f.SetDisabled(FieldKMSKeyARN, false)
+		f.SetRequired(FieldKMSKeyARN, true)
+		f.SetDisabled(FieldKMSRegion, false)
+		f.SetDisabled(FieldKMSEndpoint, false)
+	}
+}
+
+func (s *storeFormState) submit(f *Form) (string, error) {
+	name := strings.TrimSpace(f.Value(FieldStoreName))
+	if s.editing {
+		name = s.originalName
+	} else {
+		if name == "" {
+			return "", NewFieldError(FieldStoreName, "store name is required")
+		}
+		if err := s.backend.ValidateStoreName(name); err != nil {
+			return "", NewFieldError(FieldStoreName, err.Error())
+		}
+		if s.backend.StoreExists(name) {
+			return "", NewFieldError(FieldStoreName, fmt.Sprintf("store %q already exists", name))
+		}
+	}
+
+	storeType := f.Value(FieldStoreType)
+	uri, err := s.backend.ComposeStore(storeType, f.TrimmedValue(FieldStoreValue))
+	if err != nil {
+		return "", NewFieldError(FieldStoreValue, err.Error())
+	}
+	if uri == "" {
+		return "", NewFieldError(FieldStoreValue, "store details are required")
+	}
+
+	// Validate the format of any secret references that are visible.
+	for _, key := range storeSecretRefFields {
+		if f.field(key).Disabled {
+			continue
+		}
+		if v := f.TrimmedValue(key); v != "" {
+			if err := s.backend.ValidateSecretRef(v); err != nil {
+				return "", NewFieldError(key, err.Error())
+			}
+		}
+	}
+
+	switch f.Value(FieldEncryptionMode) {
+	case EncPassword:
+		if f.TrimmedValue(FieldPasswordSecret) == "" {
+			return "", NewFieldError(FieldPasswordSecret, "password secret reference is required")
+		}
+	case EncPlatform:
+		if f.TrimmedValue(FieldPlatformSecret) == "" {
+			return "", NewFieldError(FieldPlatformSecret, "platform key secret reference is required")
+		}
+	case EncKMS:
+		if f.TrimmedValue(FieldKMSKeyARN) == "" {
+			return "", NewFieldError(FieldKMSKeyARN, "KMS key ARN is required")
+		}
+	}
+
+	values := make(map[string]string, len(allStoreFieldKeys)+1)
+	for _, key := range allStoreFieldKeys {
+		values[key] = f.TrimmedValue(key)
+	}
+	values[FieldStoreURI] = uri
+	if err := s.backend.SaveStore(name, values, s.editing); err != nil {
+		return "", err
+	}
+	return name, nil
+}

--- a/internal/tui/forms/store_test.go
+++ b/internal/tui/forms/store_test.go
@@ -1,0 +1,162 @@
+package forms
+
+import (
+	"errors"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type stubStoreBackend struct {
+	saved       map[string]string
+	savedName   string
+	savedEdit   bool
+	exists      map[string]bool
+	saveErr     error
+	secretErr   error
+	composeErr  error
+}
+
+func newStubStoreBackend() *stubStoreBackend {
+	return &stubStoreBackend{exists: map[string]bool{}}
+}
+
+func (b *stubStoreBackend) StoreDetailLabel(t string) string {
+	if t == "local" {
+		return "Path"
+	}
+	return "Bucket/Prefix"
+}
+func (b *stubStoreBackend) StoreExample(string) string { return "example" }
+func (b *stubStoreBackend) ComposeStore(t, v string) (string, error) {
+	if b.composeErr != nil {
+		return "", b.composeErr
+	}
+	if v == "" {
+		return "", nil
+	}
+	return t + ":" + v, nil
+}
+func (b *stubStoreBackend) ValidateStoreName(string) error { return nil }
+func (b *stubStoreBackend) StoreExists(name string) bool   { return b.exists[name] }
+func (b *stubStoreBackend) ValidateSecretRef(string) error { return b.secretErr }
+func (b *stubStoreBackend) SaveStore(name string, values map[string]string, editing bool) error {
+	if b.saveErr != nil {
+		return b.saveErr
+	}
+	b.saved = values
+	b.savedName = name
+	b.savedEdit = editing
+	return nil
+}
+
+func focusKey(f *Form, key string) *Form {
+	for range f.fields {
+		if f.FocusedKey() == key {
+			return f
+		}
+		f, _ = f.Update(tea.KeyMsg{Type: tea.KeyTab})
+	}
+	return f
+}
+
+func TestStoreForm_CreateLocalSaves(t *testing.T) {
+	b := newStubStoreBackend()
+	f := NewStoreForm(b, "", nil, false)
+	f = typeInto(f, "mystore")           // name
+	f = focusKey(f, FieldStoreValue)
+	f = typeInto(f, "/backups")
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if !f.Done() || f.Canceled() {
+		t.Fatalf("expected save; done=%v canceled=%v", f.Done(), f.Canceled())
+	}
+	if b.savedName != "mystore" {
+		t.Fatalf("savedName=%q want mystore", b.savedName)
+	}
+	if b.saved[FieldStoreURI] != "local:/backups" {
+		t.Fatalf("uri=%q want local:/backups", b.saved[FieldStoreURI])
+	}
+}
+
+func TestStoreForm_S3FieldsHiddenForLocal(t *testing.T) {
+	b := newStubStoreBackend()
+	f := NewStoreForm(b, "", nil, false)
+	// Local store type: S3 region field must be disabled (hidden).
+	if !f.field(FieldS3Region).Disabled {
+		t.Fatalf("S3 region should be hidden for a local store")
+	}
+	// Switch to s3: move to store_type and cycle right.
+	f = focusKey(f, FieldStoreType)
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyRight}) // local -> s3
+	if f.Value(FieldStoreType) != "s3" {
+		t.Fatalf("store_type=%q want s3", f.Value(FieldStoreType))
+	}
+	if f.field(FieldS3Region).Disabled {
+		t.Fatalf("S3 region should be visible for an s3 store")
+	}
+}
+
+func TestStoreForm_PasswordModeRequiresSecret(t *testing.T) {
+	b := newStubStoreBackend()
+	f := NewStoreForm(b, "", nil, false)
+	f = typeInto(f, "s")
+	f = focusKey(f, FieldStoreValue)
+	f = typeInto(f, "/data")
+	// Set encryption mode to password.
+	f = focusKey(f, FieldEncryptionMode)
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyRight}) // none -> password
+	if f.Value(FieldEncryptionMode) != EncPassword {
+		t.Fatalf("mode=%q want password", f.Value(FieldEncryptionMode))
+	}
+	// Submit without a password ref must fail on that field.
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if f.Done() {
+		t.Fatalf("submit should fail when password ref missing")
+	}
+	if f.FocusedKey() != FieldPasswordSecret {
+		t.Fatalf("focus=%q want password_secret", f.FocusedKey())
+	}
+	// Provide a ref and submit.
+	f = typeInto(f, "env://CLOUDSTIC_PASSWORD")
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if !f.Done() || b.saved == nil {
+		t.Fatalf("submit should succeed with a password ref; done=%v", f.Done())
+	}
+	if b.saved[FieldPasswordSecret] != "env://CLOUDSTIC_PASSWORD" {
+		t.Fatalf("password_secret=%q", b.saved[FieldPasswordSecret])
+	}
+}
+
+func TestStoreForm_InvalidSecretRefRejected(t *testing.T) {
+	b := newStubStoreBackend()
+	b.secretErr = errors.New("invalid secret reference")
+	f := NewStoreForm(b, "", nil, false)
+	f = typeInto(f, "s")
+	f = focusKey(f, FieldStoreType)
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyRight}) // s3
+	f = focusKey(f, FieldStoreValue)
+	f = typeInto(f, "bucket")
+	f = focusKey(f, FieldS3AccessKey)
+	f = typeInto(f, "not-a-ref")
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if f.Done() {
+		t.Fatalf("submit should fail on invalid secret ref")
+	}
+	if f.FocusedKey() != FieldS3AccessKey {
+		t.Fatalf("focus=%q want s3 access key", f.FocusedKey())
+	}
+}
+
+func TestStoreForm_EditLocksName(t *testing.T) {
+	b := newStubStoreBackend()
+	initial := map[string]string{FieldStoreType: "local", FieldStoreValue: "/old"}
+	f := NewStoreForm(b, "existing", initial, true)
+	if f.FocusedKey() == FieldStoreName {
+		t.Fatalf("edit form should not focus the locked name field")
+	}
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if !f.Done() || !b.savedEdit || b.savedName != "existing" {
+		t.Fatalf("edit save: done=%v edit=%v name=%q", f.Done(), b.savedEdit, b.savedName)
+	}
+}

--- a/internal/tui/forms_bridge.go
+++ b/internal/tui/forms_bridge.go
@@ -6,16 +6,48 @@ import (
 	"github.com/cloudstic/cli/internal/tui/forms"
 )
 
-// FormsBackend is the domain boundary the model uses for profile management.
-// It extends the profile form's own backend with the delete and config-reload
-// operations the model orchestrates around a form. The cmd package implements
-// it by reusing the existing source/options/validation/save helpers.
+// FormsBackend is the domain boundary the model uses for profile and store
+// management. It combines the profile and store form backends with the delete,
+// config-reload, and edit-seed operations the model orchestrates around a form.
+// The cmd package implements it by reusing the existing source/store/options/
+// validation/save helpers.
 type FormsBackend interface {
 	forms.ProfileBackend
+	forms.StoreBackend
+	// InitialStoreValues seeds an edit-store form with an existing store's
+	// field values.
+	InitialStoreValues(name string) map[string]string
 	// DeleteProfile removes a profile from the profiles file.
 	DeleteProfile(name string) error
 	// Reload re-reads the profiles config after a mutation.
 	Reload() (*engine.ProfilesConfig, error)
+}
+
+// formFrame is one level of the (possibly nested) form overlay. intent records
+// why the frame was pushed, so its result can be applied to the parent frame.
+type formFrame struct {
+	form   *forms.Form
+	intent forms.Intent
+}
+
+func (m Model) activeForm() *forms.Form {
+	if len(m.formStack) == 0 {
+		return nil
+	}
+	return m.formStack[len(m.formStack)-1].form
+}
+
+func (m Model) pushForm(form *forms.Form, intent forms.Intent) Model {
+	m.formStack = append(m.formStack, formFrame{form: form, intent: intent})
+	return m
+}
+
+func (m Model) popForm() Model {
+	if len(m.formStack) == 0 {
+		return m
+	}
+	m.formStack = m.formStack[:len(m.formStack)-1]
+	return m
 }
 
 // WithForms enables the profile create/edit/delete flows (issue #340). Without
@@ -74,8 +106,9 @@ func (m Model) openCreateProfile() (Model, tea.Cmd) {
 	if m.forms == nil {
 		return m, nil
 	}
-	m.form = forms.NewProfileForm(m.forms, "", "", "", "", false)
-	return m, m.form.Init()
+	form := forms.NewProfileForm(m.forms, "", "", "", "", false)
+	m = m.pushForm(form, forms.Intent{})
+	return m, form.Init()
 }
 
 // openEditProfile opens the edit form for the selected profile.
@@ -87,8 +120,9 @@ func (m Model) openEditProfile() (Model, tea.Cmd) {
 	if !ok {
 		return m, nil
 	}
-	m.form = forms.NewProfileForm(m.forms, profile.Name, profile.Source, profile.StoreRef, profile.AuthRef, true)
-	return m, m.form.Init()
+	form := forms.NewProfileForm(m.forms, profile.Name, profile.Source, profile.StoreRef, profile.AuthRef, true)
+	m = m.pushForm(form, forms.Intent{})
+	return m, form.Init()
 }
 
 // openDeleteProfile opens a delete confirmation for the selected profile.
@@ -108,22 +142,81 @@ func (m Model) openDeleteProfile() (Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m Model) updateForm(msg tea.Msg) (tea.Model, tea.Cmd) {
-	form, cmd := m.form.Update(msg)
-	m.form = form
+func (m Model) updateForms(msg tea.Msg) (tea.Model, tea.Cmd) {
+	top := len(m.formStack) - 1
+	form, cmd := m.formStack[top].form.Update(msg)
+	m.formStack[top].form = form
+
+	// A navigation intent opens a nested form instead of completing.
+	if intent, ok := form.TakeIntent(); ok {
+		return m.openNestedForm(intent)
+	}
 	if !form.Done() {
 		return m, cmd
 	}
+	return m.completeTopForm()
+}
 
-	canceled := form.Canceled()
-	result := form.Result()
-	m.form = nil
+// openNestedForm pushes the form requested by a parent form's intent.
+func (m Model) openNestedForm(intent forms.Intent) (tea.Model, tea.Cmd) {
+	switch intent.Name {
+	case forms.IntentCreateStore:
+		form := forms.NewStoreForm(m.forms, "", nil, false)
+		m = m.pushForm(form, intent)
+		return m, form.Init()
+	case forms.IntentEditStore:
+		form := forms.NewStoreForm(m.forms, intent.Value, m.forms.InitialStoreValues(intent.Value), true)
+		m = m.pushForm(form, intent)
+		return m, form.Init()
+	}
+	return m, nil
+}
+
+// completeTopForm pops the finished top form and either applies its result to
+// the parent frame (nested) or commits the change (root).
+func (m Model) completeTopForm() (tea.Model, tea.Cmd) {
+	top := m.formStack[len(m.formStack)-1]
+	canceled := top.form.Canceled()
+	result := top.form.Result()
+	m = m.popForm()
+
+	// Nested form: hand its result back to the parent form.
+	if len(m.formStack) > 0 {
+		if !canceled && result != "" {
+			m = m.applyNestedResult(top.intent, result)
+		}
+		return m, nil
+	}
+
+	// Root form (profile create/edit): commit.
 	if canceled {
 		m.activity = managementActivity(ActivityStatusIdle, "Profile form", "canceled")
 		return m, nil
 	}
 	m.activity = managementActivity(ActivityStatusSuccess, "Save profile", "saved \""+result+"\"")
 	return m, m.reloadConfigCmd(result)
+}
+
+// applyNestedResult injects a completed nested form's result into the parent
+// form. A saved store refreshes the profile form's store selector and selects
+// the new/edited store.
+func (m Model) applyNestedResult(intent forms.Intent, result string) Model {
+	parent := m.activeForm()
+	if parent == nil {
+		return m
+	}
+	switch intent.Name {
+	case forms.IntentCreateStore, forms.IntentEditStore:
+		parent.SetOptions("store", storeSelectorOptions(m.forms.StoreOptions()))
+		parent.SetValue("store", result)
+	}
+	return m
+}
+
+// storeSelectorOptions mirrors the profile form's store options (existing
+// stores plus the create sentinel).
+func storeSelectorOptions(stores []string) []string {
+	return append(append([]string{}, stores...), forms.CreateStoreOption)
 }
 
 func (m Model) updateConfirm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {

--- a/internal/tui/forms_bridge_test.go
+++ b/internal/tui/forms_bridge_test.go
@@ -6,15 +6,18 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/cloudstic/cli/internal/engine"
+	"github.com/cloudstic/cli/internal/tui/forms"
 )
 
 // stubFormsBackend implements FormsBackend for model-level tests.
 type stubFormsBackend struct {
-	stores     []string
-	cfg        *engine.ProfilesConfig
-	saved      bool
-	deleted    string
-	reloadHits int
+	stores      []string
+	cfg         *engine.ProfilesConfig
+	saved       bool
+	deleted     string
+	reloadHits  int
+	savedStore  string
+	storeExists map[string]bool
 }
 
 func (b *stubFormsBackend) StoreOptions() []string                 { return b.stores }
@@ -52,6 +55,25 @@ func (b *stubFormsBackend) Reload() (*engine.ProfilesConfig, error) {
 	return b.cfg, nil
 }
 
+// StoreBackend methods.
+func (b *stubFormsBackend) StoreDetailLabel(string) string { return "Path" }
+func (b *stubFormsBackend) StoreExample(string) string     { return "" }
+func (b *stubFormsBackend) ComposeStore(t, v string) (string, error) {
+	if v == "" {
+		return "", nil
+	}
+	return t + ":" + v, nil
+}
+func (b *stubFormsBackend) ValidateStoreName(string) error { return nil }
+func (b *stubFormsBackend) StoreExists(name string) bool   { return b.storeExists[name] }
+func (b *stubFormsBackend) ValidateSecretRef(string) error { return nil }
+func (b *stubFormsBackend) SaveStore(name string, _ map[string]string, _ bool) error {
+	b.savedStore = name
+	b.stores = append(b.stores, name)
+	return nil
+}
+func (b *stubFormsBackend) InitialStoreValues(string) map[string]string { return nil }
+
 func formsTestDashboard() Dashboard {
 	return Dashboard{
 		SelectedProfile: "alpha",
@@ -71,7 +93,7 @@ func TestModel_OpenCreateProfileForm(t *testing.T) {
 
 	next, _ := m.Update(keyPress("n"))
 	m = next.(Model)
-	if m.form == nil {
+	if m.activeForm() == nil {
 		t.Fatalf("pressing n should open the create form")
 	}
 	if !strings.Contains(m.View(), "Create Profile") {
@@ -105,7 +127,7 @@ func TestModel_CreateProfileSavesAndReloads(t *testing.T) {
 	if !backend.saved {
 		t.Fatalf("SaveProfile was not called")
 	}
-	if m.form != nil {
+	if m.activeForm() != nil {
 		t.Fatalf("form should close after a successful save")
 	}
 	if cmd == nil {
@@ -168,8 +190,69 @@ func TestModel_FormKeysNoOpWithoutBackend(t *testing.T) {
 	m := NewModel(formsTestDashboard())
 	next, cmd := m.Update(keyPress("n"))
 	m = next.(Model)
-	if m.form != nil || cmd != nil {
+	if m.activeForm() != nil || cmd != nil {
 		t.Fatalf("form keys must be a no-op without a forms backend")
+	}
+}
+
+func TestModel_NestedCreateStoreFromProfileForm(t *testing.T) {
+	backend := &stubFormsBackend{stores: []string{"s1"}, cfg: &engine.ProfilesConfig{}}
+	m := NewModel(formsTestDashboard()).WithForms(backend)
+
+	// Open the create-profile form.
+	next, _ := m.Update(keyPress("n"))
+	m = next.(Model)
+	if len(m.formStack) != 1 {
+		t.Fatalf("form stack depth=%d want 1", len(m.formStack))
+	}
+
+	// Navigate to the store field and select the create sentinel, then Enter.
+	form := m.activeForm()
+	for form.FocusedKey() != "store" {
+		next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+		m = next.(Model)
+		form = m.activeForm()
+	}
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyLeft}) // wrap to "+ Create store"
+	m = next.(Model)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+
+	// A nested store form should now be on top of the stack.
+	if len(m.formStack) != 2 {
+		t.Fatalf("nested store form not pushed; depth=%d\n%s", len(m.formStack), m.View())
+	}
+	if !strings.Contains(m.View(), "Create Store") {
+		t.Fatalf("view should show the nested store form\n%s", m.View())
+	}
+
+	// Fill the store form: name + path, then submit.
+	for _, r := range "newstore" {
+		next, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = next.(Model)
+	}
+	store := m.activeForm()
+	for store.FocusedKey() != forms.FieldStoreValue {
+		next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+		m = next.(Model)
+		store = m.activeForm()
+	}
+	for _, r := range "/srv" {
+		next, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = next.(Model)
+	}
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+
+	if backend.savedStore != "newstore" {
+		t.Fatalf("store not saved; savedStore=%q", backend.savedStore)
+	}
+	// Back to the profile form, with the new store selected.
+	if len(m.formStack) != 1 {
+		t.Fatalf("should return to the profile form; depth=%d", len(m.formStack))
+	}
+	if got := m.activeForm().Value("store"); got != "newstore" {
+		t.Fatalf("profile store field=%q want newstore selected after nested create", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
Add the **store create/edit form** to `internal/tui/forms` and wire the **nested store management** the profile form needs (#232) — the store half of #350.

- **`forms/store.go`** — a type-driven store form: local/s3/b2/sftp connection fields, an encryption-mode selector with password / platform / KMS sub-fields, **visible-field filtering** (fields for the non-selected type/mode are disabled and hidden), and per-field validation, all behind a `StoreBackend` boundary.
- **`forms/form.go`** — a generic **`Interrupt` hook + `Intent`**, letting a form yield to its host to open a nested form instead of completing.
- **`forms/profile.go`** — the store selector gains a **`+ Create store`** sentinel and an **`e`-to-edit** action that yield create/edit-store intents.
- **model** — a **form stack** replaces the single form pointer; a nested store form opened from the profile form hands its result (the saved store) back to the profile selector, which is refreshed and reselected.
- **cmd adapter** — implements `StoreBackend` by reusing `tuiStoreConfig`, `parseStoreURI`, `secretref`, and `TUIService.SaveStore`, and seeds edit forms from the existing `ProfileStore`.

This unblocks the real pain point: you can now create a profile even with **no stores configured**, by creating one inline.

**Scope:** secret references are typed directly for now (e.g. `env://CLOUDSTIC_PASSWORD`), which is fully functional. The **guided secret-ref sub-form** (env vs writable backends, store-a-value flow) is the remaining slice of #350 and lands next. Still gated behind `cloudstic tui -bubbletea`.

Part of #132, #350
Closes #232

## Verification
- `env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./internal/tui ./internal/tui/forms` passes — adds store-form tests (create/edit, type-driven field visibility, password-mode required secret, invalid-ref rejection) and a model-level **nested create-store-from-profile** flow test
- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./cmd/cloudstic` passes
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./cmd/cloudstic/... ./internal/tui/...` — 0 issues
- `go build ./...` passes

## Reviewer notes
- **Nesting mechanism**: the generic `Form.Interrupt` hook returns an `Intent` (e.g. `create_store`) which the model turns into a pushed `formFrame`. On completion the model pops and, for a nested frame, applies the result to the parent form (`SetOptions`/`SetValue` on the store selector). Max depth today is profile → store (2); the stack generalizes to the secret sub-form next.
- **Field-value contract**: the store form collects values into a `map[string]string` keyed by exported `forms.Field*` constants; the cmd adapter assembles a `ProfileStore` from that map, clearing connection/encryption fields irrelevant to the selected type/mode (mirroring the legacy store form).
- Same testing posture as the earlier Phase 2 PRs — no headless tea-program smoke test; `Update`/`View`, field derivation, validation, and the nested flow are covered by direct unit tests (race-clean). Verified the rendered store form visually (type-driven S3/password fields appear/hide correctly) via a scratch render.
