### PR TITLE
feat(tui): guided secret-ref form, completing the forms port (RFC 0012)

### DIFF
--- a/cmd/cloudstic/cmd_tui_bubbletea_secret.go
+++ b/cmd/cloudstic/cmd_tui_bubbletea_secret.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"strings"
+
+	"github.com/cloudstic/cli/internal/secretref"
+)
+
+// Secret-ref form backend (tui/forms.SecretBackend), implemented over the
+// shared secretref resolver.
+
+func (b *bubbleFormsBackend) secretResolver() *secretref.Resolver {
+	if tuiSecretResolver != nil {
+		return tuiSecretResolver
+	}
+	return secretref.NewDefaultResolver()
+}
+
+func (b *bubbleFormsBackend) StorageOptions() []string {
+	options := []string{"env"}
+	for _, backend := range b.secretResolver().WritableBackends() {
+		options = append(options, backend.Scheme())
+	}
+	return options
+}
+
+func (b *bubbleFormsBackend) DefaultRef(scheme, storeName, account string) string {
+	for _, backend := range b.secretResolver().WritableBackends() {
+		if backend.Scheme() == scheme {
+			return backend.DefaultRef(storeName, account)
+		}
+	}
+	return ""
+}
+
+func (b *bubbleFormsBackend) ParseRef(ref string) (string, string, bool) {
+	parsed, err := secretref.Parse(ref)
+	if err != nil {
+		return "", "", false
+	}
+	if parsed.Scheme == "env" {
+		return "env", strings.TrimLeft(parsed.Path, "/"), true
+	}
+	return parsed.Scheme, "", true
+}
+
+func (b *bubbleFormsBackend) ValidateRef(ref string) error {
+	_, err := secretref.Parse(ref)
+	return err
+}
+
+func (b *bubbleFormsBackend) StoreSecret(ref, value string) error {
+	return b.secretResolver().Store(context.Background(), ref, value)
+}

--- a/internal/tui/forms/secret.go
+++ b/internal/tui/forms/secret.go
@@ -1,0 +1,156 @@
+package forms
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Secret form field keys.
+const (
+	FieldSecretStorage = "storage"
+	FieldSecretRef     = "ref"
+	FieldSecretValue   = "value"
+)
+
+// StorageEnv is the built-in storage option that saves only an environment
+// variable reference (the secret value stays outside profiles.yaml).
+const StorageEnv = "env"
+
+// SecretFieldInfo describes the secret a secret-ref form configures. It is
+// carried from the store field being edited.
+type SecretFieldInfo struct {
+	// Label names the secret in prose, e.g. "S3 access key".
+	Label string
+	// DefaultEnvName is the suggested environment variable name.
+	DefaultEnvName string
+	// DefaultAccount is the account/key hint passed to writable backends.
+	DefaultAccount string
+}
+
+// SecretBackend is the domain boundary for the secret-ref form. The cmd
+// package implements it over the secretref resolver.
+type SecretBackend interface {
+	// StorageOptions returns the selectable storage schemes: "env" plus the
+	// available writable backend schemes (keychain, secret-service, …).
+	StorageOptions() []string
+	// DefaultRef returns a suggested reference for a writable backend scheme.
+	DefaultRef(scheme, storeName, account string) string
+	// ParseRef reports a reference's scheme, and for env refs the variable
+	// name; ok is false when the reference does not parse.
+	ParseRef(ref string) (scheme, envName string, ok bool)
+	// ValidateRef validates a reference's format.
+	ValidateRef(ref string) error
+	// StoreSecret stores value under the reference in its backend.
+	StoreSecret(ref, value string) error
+}
+
+// NewSecretForm builds the guided secret-reference form. It lets the user keep
+// the secret outside profiles.yaml as an env reference, or store the value in a
+// platform backend and save the resulting reference.
+func NewSecretForm(backend SecretBackend, spec SecretFieldInfo, storeName, existingRef string) *Form {
+	if storeName == "" {
+		storeName = "store"
+	}
+	storage, refValue := initialSecretSelection(backend, spec, existingRef)
+
+	fields := []Field{
+		newSelectField(FieldSecretStorage, "Storage", backend.StorageOptions(), storage, true),
+		newTextField(FieldSecretRef, "Env Var", refValue, true),
+		newTextField(FieldSecretValue, "Secret Value", "", false),
+	}
+	f := New("Configure Secret", fmt.Sprintf("Choose where %s should be stored.", spec.Label), fields)
+	sf := &secretFormState{backend: backend, spec: spec, storeName: storeName, existingRef: existingRef}
+	f.OnChange = sf.onChange
+	f.Submit = sf.submit
+	sf.refresh(f)
+	f.focusFirst()
+	return f
+}
+
+func initialSecretSelection(backend SecretBackend, spec SecretFieldInfo, existingRef string) (string, string) {
+	if existingRef != "" {
+		if scheme, envName, ok := backend.ParseRef(existingRef); ok {
+			if scheme == StorageEnv {
+				return StorageEnv, envName
+			}
+			return scheme, existingRef
+		}
+	}
+	return StorageEnv, spec.DefaultEnvName
+}
+
+type secretFormState struct {
+	backend     SecretBackend
+	spec        SecretFieldInfo
+	storeName   string
+	existingRef string
+}
+
+func (s *secretFormState) onChange(f *Form, changedKey string) {
+	if changedKey == FieldSecretStorage {
+		s.refresh(f)
+	}
+}
+
+func (s *secretFormState) refresh(f *Form) {
+	storage := f.Value(FieldSecretStorage)
+	if storage == StorageEnv {
+		f.SetLabel(FieldSecretRef, "Env Var")
+		f.SetRequired(FieldSecretRef, true)
+		if ref := f.Value(FieldSecretRef); strings.Contains(ref, "://") || strings.TrimSpace(ref) == "" {
+			f.SetValue(FieldSecretRef, s.spec.DefaultEnvName)
+		}
+		f.SetValue(FieldSecretValue, "")
+		f.SetDisabled(FieldSecretValue, true)
+		f.SetRequired(FieldSecretValue, false)
+		f.SetHelp(FieldSecretRef, fmt.Sprintf("Saves only a reference like env://%s; the value stays outside profiles.yaml.", s.spec.DefaultEnvName))
+		return
+	}
+
+	f.SetLabel(FieldSecretRef, "Reference")
+	f.SetRequired(FieldSecretRef, true)
+	if scheme, _, ok := s.backend.ParseRef(f.Value(FieldSecretRef)); !ok || scheme != storage {
+		f.SetValue(FieldSecretRef, s.backend.DefaultRef(storage, s.storeName, s.spec.DefaultAccount))
+	}
+	f.SetDisabled(FieldSecretValue, false)
+	f.SetRequired(FieldSecretValue, true)
+	f.SetHelp(FieldSecretRef, fmt.Sprintf("The value is stored now and the %s:// reference is saved in profiles.yaml.", storage))
+}
+
+func (s *secretFormState) submit(f *Form) (string, error) {
+	storage := f.Value(FieldSecretStorage)
+	rawRef := strings.TrimSpace(f.Value(FieldSecretRef))
+
+	if storage == StorageEnv {
+		if rawRef == "" {
+			return "", NewFieldError(FieldSecretRef, "environment variable name is required")
+		}
+		ref := "env://" + rawRef
+		if err := s.backend.ValidateRef(ref); err != nil {
+			return "", NewFieldError(FieldSecretRef, err.Error())
+		}
+		return ref, nil
+	}
+
+	if rawRef == "" {
+		return "", NewFieldError(FieldSecretRef, "reference is required")
+	}
+	if err := s.backend.ValidateRef(rawRef); err != nil {
+		return "", NewFieldError(FieldSecretRef, err.Error())
+	}
+	if scheme, _, _ := s.backend.ParseRef(rawRef); scheme != storage {
+		return "", NewFieldError(FieldSecretRef, fmt.Sprintf("reference must use %s://", storage))
+	}
+
+	value := f.Value(FieldSecretValue)
+	if value == "" {
+		if rawRef == s.existingRef {
+			return rawRef, nil // unchanged reference, value already stored
+		}
+		return "", NewFieldError(FieldSecretValue, "secret value is required")
+	}
+	if err := s.backend.StoreSecret(rawRef, value); err != nil {
+		return "", err
+	}
+	return rawRef, nil
+}

--- a/internal/tui/forms/secret_test.go
+++ b/internal/tui/forms/secret_test.go
@@ -1,0 +1,120 @@
+package forms
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type stubSecretBackend struct {
+	stored   map[string]string
+	storeErr error
+}
+
+func newStubSecretBackend() *stubSecretBackend {
+	return &stubSecretBackend{stored: map[string]string{}}
+}
+
+func (b *stubSecretBackend) StorageOptions() []string { return []string{StorageEnv, "keychain"} }
+func (b *stubSecretBackend) DefaultRef(scheme, storeName, account string) string {
+	return scheme + "://" + storeName + "/" + account
+}
+func (b *stubSecretBackend) ParseRef(ref string) (string, string, bool) {
+	scheme, rest, ok := strings.Cut(ref, "://")
+	if !ok {
+		return "", "", false
+	}
+	if scheme == StorageEnv {
+		return StorageEnv, rest, true
+	}
+	return scheme, "", true
+}
+func (b *stubSecretBackend) ValidateRef(string) error { return nil }
+func (b *stubSecretBackend) StoreSecret(ref, value string) error {
+	if b.storeErr != nil {
+		return b.storeErr
+	}
+	b.stored[ref] = value
+	return nil
+}
+
+func secretSpec() SecretFieldInfo {
+	return SecretFieldInfo{Label: "repository password", DefaultEnvName: "CLOUDSTIC_PASSWORD", DefaultAccount: "password"}
+}
+
+func TestSecretForm_EnvReturnsReferenceWithoutStoring(t *testing.T) {
+	b := newStubSecretBackend()
+	f := NewSecretForm(b, secretSpec(), "mystore", "")
+	// Defaults to env storage with the suggested var name.
+	if f.Value(FieldSecretStorage) != StorageEnv {
+		t.Fatalf("storage=%q want env", f.Value(FieldSecretStorage))
+	}
+	if f.Value(FieldSecretRef) != "CLOUDSTIC_PASSWORD" {
+		t.Fatalf("ref=%q want CLOUDSTIC_PASSWORD", f.Value(FieldSecretRef))
+	}
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if !f.Done() {
+		t.Fatalf("env submit should succeed")
+	}
+	if f.Result() != "env://CLOUDSTIC_PASSWORD" {
+		t.Fatalf("result=%q want env://CLOUDSTIC_PASSWORD", f.Result())
+	}
+	if len(b.stored) != 0 {
+		t.Fatalf("env storage must not store a value, stored=%v", b.stored)
+	}
+}
+
+func TestSecretForm_BackendStoresValue(t *testing.T) {
+	b := newStubSecretBackend()
+	f := NewSecretForm(b, secretSpec(), "mystore", "")
+	// Switch storage to keychain.
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyRight})
+	if f.Value(FieldSecretStorage) != "keychain" {
+		t.Fatalf("storage=%q want keychain", f.Value(FieldSecretStorage))
+	}
+	// The ref defaults to the backend's suggestion; the value field is now
+	// enabled and required.
+	if f.field(FieldSecretValue).Disabled {
+		t.Fatalf("value field should be enabled for a writable backend")
+	}
+	// Submit with no value must fail.
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if f.Done() {
+		t.Fatalf("submit should fail without a secret value")
+	}
+	// Enter a value and submit.
+	f = focusKey(f, FieldSecretValue)
+	f = typeInto(f, "s3cr3t")
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if !f.Done() {
+		t.Fatalf("submit should succeed with a value")
+	}
+	ref := "keychain://mystore/password"
+	if b.stored[ref] != "s3cr3t" {
+		t.Fatalf("stored[%q]=%q want s3cr3t (stored=%v)", ref, b.stored[ref], b.stored)
+	}
+	if f.Result() != ref {
+		t.Fatalf("result=%q want %q", f.Result(), ref)
+	}
+}
+
+func TestSecretForm_ExistingBackendRefUnchanged(t *testing.T) {
+	b := newStubSecretBackend()
+	// Editing an existing keychain reference: submitting with no new value
+	// keeps the reference and does not re-store.
+	f := NewSecretForm(b, secretSpec(), "mystore", "keychain://mystore/password")
+	if f.Value(FieldSecretStorage) != "keychain" {
+		t.Fatalf("storage=%q want keychain from existing ref", f.Value(FieldSecretStorage))
+	}
+	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if !f.Done() {
+		t.Fatalf("submit with unchanged existing ref should succeed")
+	}
+	if f.Result() != "keychain://mystore/password" {
+		t.Fatalf("result=%q want existing ref", f.Result())
+	}
+	if len(b.stored) != 0 {
+		t.Fatalf("unchanged ref must not re-store")
+	}
+}

--- a/internal/tui/forms/store.go
+++ b/internal/tui/forms/store.go
@@ -3,7 +3,30 @@ package forms
 import (
 	"fmt"
 	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
+
+// IntentEditSecret is yielded when the user configures a store secret field
+// (Ctrl+E), opening the nested secret-ref form.
+const IntentEditSecret = "edit_secret"
+
+// storeSecretFieldSpecs maps each secret store field to the secret it holds, so
+// the secret-ref form can suggest sensible env-var and account defaults.
+var storeSecretFieldSpecs = map[string]SecretFieldInfo{
+	FieldS3AccessKey:    {Label: "S3 access key", DefaultEnvName: "AWS_ACCESS_KEY_ID", DefaultAccount: "s3-access-key"},
+	FieldS3SecretKey:    {Label: "S3 secret key", DefaultEnvName: "AWS_SECRET_ACCESS_KEY", DefaultAccount: "s3-secret-key"},
+	FieldSFTPPassword:   {Label: "SFTP password", DefaultEnvName: "CLOUDSTIC_STORE_SFTP_PASSWORD", DefaultAccount: "store-sftp-password"},
+	FieldSFTPKey:        {Label: "SFTP key path", DefaultEnvName: "CLOUDSTIC_STORE_SFTP_KEY", DefaultAccount: "store-sftp-key"},
+	FieldPasswordSecret: {Label: "repository password", DefaultEnvName: "CLOUDSTIC_PASSWORD", DefaultAccount: "password"},
+	FieldPlatformSecret: {Label: "platform key", DefaultEnvName: "CLOUDSTIC_ENCRYPTION_KEY", DefaultAccount: "encryption-key"},
+}
+
+// StoreSecretFieldSpec returns the secret spec for a store field key.
+func StoreSecretFieldSpec(fieldKey string) (SecretFieldInfo, bool) {
+	spec, ok := storeSecretFieldSpecs[fieldKey]
+	return spec, ok
+}
 
 // Store form field keys. They are shared with the cmd-side StoreBackend adapter
 // (which assembles a ProfileStore from the collected values), so both sides
@@ -124,9 +147,23 @@ func NewStoreForm(backend StoreBackend, existingName string, initial map[string]
 	sf := &storeFormState{backend: backend, editing: editing, originalName: existingName}
 	f.OnChange = sf.onChange
 	f.Submit = sf.submit
+	f.Interrupt = sf.interrupt
 	sf.refresh(f)
 	f.focusFirst()
 	return f
+}
+
+// interrupt opens the nested secret-ref form when Ctrl+E is pressed on a
+// visible secret field.
+func (s *storeFormState) interrupt(f *Form, key tea.KeyMsg) (Intent, bool) {
+	if key.Type != tea.KeyCtrlE {
+		return Intent{}, false
+	}
+	fieldKey := f.FocusedKey()
+	if _, ok := storeSecretFieldSpecs[fieldKey]; ok && !f.field(fieldKey).Disabled {
+		return Intent{Name: IntentEditSecret, Value: fieldKey}, true
+	}
+	return Intent{}, false
 }
 
 type storeFormState struct {
@@ -159,6 +196,9 @@ func (s *storeFormState) refresh(f *Form) {
 	for _, key := range storeSFTPFields {
 		f.SetDisabled(key, !enableSFTP)
 		f.SetRequired(key, false)
+	}
+	for key := range storeSecretFieldSpecs {
+		f.SetHelp(key, "Ctrl+E to store the secret and save a reference.")
 	}
 
 	for _, key := range storeEncFields {

--- a/internal/tui/forms_bridge.go
+++ b/internal/tui/forms_bridge.go
@@ -14,6 +14,7 @@ import (
 type FormsBackend interface {
 	forms.ProfileBackend
 	forms.StoreBackend
+	forms.SecretBackend
 	// InitialStoreValues seeds an edit-store form with an existing store's
 	// field values.
 	InitialStoreValues(name string) map[string]string
@@ -168,8 +169,27 @@ func (m Model) openNestedForm(intent forms.Intent) (tea.Model, tea.Cmd) {
 		form := forms.NewStoreForm(m.forms, intent.Value, m.forms.InitialStoreValues(intent.Value), true)
 		m = m.pushForm(form, intent)
 		return m, form.Init()
+	case forms.IntentEditSecret:
+		return m.openSecretForm(intent)
 	}
 	return m, nil
+}
+
+// openSecretForm pushes the guided secret-ref form for a store secret field.
+func (m Model) openSecretForm(intent forms.Intent) (tea.Model, tea.Cmd) {
+	parent := m.activeForm() // the store form
+	if parent == nil {
+		return m, nil
+	}
+	spec, ok := forms.StoreSecretFieldSpec(intent.Value)
+	if !ok {
+		return m, nil
+	}
+	storeName := parent.TrimmedValue(forms.FieldStoreName)
+	existingRef := parent.TrimmedValue(intent.Value)
+	form := forms.NewSecretForm(m.forms, spec, storeName, existingRef)
+	m = m.pushForm(form, intent)
+	return m, form.Init()
 }
 
 // completeTopForm pops the finished top form and either applies its result to
@@ -209,6 +229,9 @@ func (m Model) applyNestedResult(intent forms.Intent, result string) Model {
 	case forms.IntentCreateStore, forms.IntentEditStore:
 		parent.SetOptions("store", storeSelectorOptions(m.forms.StoreOptions()))
 		parent.SetValue("store", result)
+	case forms.IntentEditSecret:
+		// intent.Value is the store form's secret field key.
+		parent.SetValue(intent.Value, result)
 	}
 	return m
 }

--- a/internal/tui/forms_bridge_test.go
+++ b/internal/tui/forms_bridge_test.go
@@ -15,9 +15,10 @@ type stubFormsBackend struct {
 	cfg         *engine.ProfilesConfig
 	saved       bool
 	deleted     string
-	reloadHits  int
-	savedStore  string
-	storeExists map[string]bool
+	reloadHits   int
+	savedStore   string
+	storeExists  map[string]bool
+	storedSecret string
 }
 
 func (b *stubFormsBackend) StoreOptions() []string                 { return b.stores }
@@ -73,6 +74,24 @@ func (b *stubFormsBackend) SaveStore(name string, _ map[string]string, _ bool) e
 	return nil
 }
 func (b *stubFormsBackend) InitialStoreValues(string) map[string]string { return nil }
+
+// SecretBackend methods.
+func (b *stubFormsBackend) StorageOptions() []string { return []string{"env", "keychain"} }
+func (b *stubFormsBackend) DefaultRef(scheme, storeName, account string) string {
+	return scheme + "://" + storeName + "/" + account
+}
+func (b *stubFormsBackend) ParseRef(ref string) (string, string, bool) {
+	scheme, rest, ok := strings.Cut(ref, "://")
+	if !ok {
+		return "", "", false
+	}
+	if scheme == "env" {
+		return "env", rest, true
+	}
+	return scheme, "", true
+}
+func (b *stubFormsBackend) ValidateRef(string) error         { return nil }
+func (b *stubFormsBackend) StoreSecret(ref, value string) error { b.storedSecret = ref; return nil }
 
 func formsTestDashboard() Dashboard {
 	return Dashboard{
@@ -183,6 +202,64 @@ func TestModel_DeleteProfileCancel(t *testing.T) {
 	}
 	if backend.deleted != "" {
 		t.Fatalf("no deletion should occur on cancel, got %q", backend.deleted)
+	}
+}
+
+func TestModel_NestedEditSecretFromStoreForm(t *testing.T) {
+	backend := &stubFormsBackend{stores: []string{"s1"}, cfg: &engine.ProfilesConfig{}}
+	m := NewModel(formsTestDashboard()).WithForms(backend)
+
+	// Open profile form, jump to store field, open a nested create-store form.
+	next, _ := m.Update(keyPress("n"))
+	m = next.(Model)
+	form := m.activeForm()
+	for form.FocusedKey() != "store" {
+		next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+		m = next.(Model)
+		form = m.activeForm()
+	}
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyLeft}) // "+ Create store"
+	m = next.(Model)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if len(m.formStack) != 2 {
+		t.Fatalf("store form not opened; depth=%d", len(m.formStack))
+	}
+
+	// In the store form, set encryption to password and focus the password ref.
+	store := m.activeForm()
+	for store.FocusedKey() != forms.FieldEncryptionMode {
+		next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+		m = next.(Model)
+		store = m.activeForm()
+	}
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyRight}) // none -> password
+	m = next.(Model)
+	store = m.activeForm()
+	for store.FocusedKey() != forms.FieldPasswordSecret {
+		next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+		m = next.(Model)
+		store = m.activeForm()
+	}
+
+	// Ctrl+E opens the nested secret form.
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlE})
+	m = next.(Model)
+	if len(m.formStack) != 3 {
+		t.Fatalf("secret form not opened; depth=%d\n%s", len(m.formStack), m.View())
+	}
+	if !strings.Contains(m.View(), "Configure Secret") {
+		t.Fatalf("view should show the secret form\n%s", m.View())
+	}
+
+	// Accept the default env reference (Enter).
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if len(m.formStack) != 2 {
+		t.Fatalf("should return to the store form; depth=%d", len(m.formStack))
+	}
+	if got := m.activeForm().Value(forms.FieldPasswordSecret); got != "env://CLOUDSTIC_PASSWORD" {
+		t.Fatalf("password secret field=%q want env://CLOUDSTIC_PASSWORD", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
Add the **guided secret-reference form** and its nesting from the store form — the final slice of #350/#340. With this, the `-bubbletea` renderer reaches parity with the legacy forms.

- **`forms/secret.go`** — a guided secret form behind a `SecretBackend` boundary. It either keeps the secret **outside** `profiles.yaml` as an `env://` reference, or **stores the value** in a writable backend (keychain / secret-service / …) and saves the resulting `scheme://` reference. Switching the Storage selector drives which fields show and whether a secret value is required.
- **`forms/store.go`** — each secret store field yields an `edit_secret` intent on **Ctrl+E**, carrying a per-field spec (default env var + account name), e.g. the password field suggests `CLOUDSTIC_PASSWORD`.
- **model** — `openNestedForm`/`applyNestedResult` handle the **third nesting level** (profile → store → secret), writing the resulting reference back into the store form's secret field.
- **cmd adapter** implements `SecretBackend` over the shared `secretref` resolver (`WritableBackends`, `DefaultRef`, `Parse`, `Store`).

Still gated behind `cloudstic tui -bubbletea`.

Part of #132
Closes #350, #340

## Verification
- `env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./internal/tui ./internal/tui/forms` passes — adds secret-form tests (env returns a ref without storing; a writable backend stores the value and returns its ref; an unchanged existing ref is not re-stored) and a model-level **profile → store → secret** three-level nested-flow test
- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./cmd/cloudstic` passes
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./cmd/cloudstic/... ./internal/tui/...` — 0 issues
- `go build ./...` passes

## Reviewer notes
- **Trigger key**: the secret sub-form opens with **Ctrl+E** on a visible secret field (not `e`, which the legacy form used but which now types into the Unicode text field). The field help advertises it.
- **env vs writable**: for `env` storage the form saves only the reference and never touches the secret value; for a writable backend it requires a value and calls `StoreSecret` (except when re-submitting an unchanged existing reference, where the value is assumed already stored).
- **Milestone**: this closes out the RFC 0012 Phase 2 step-3 forms port (profile #351, store #353, secret this PR). Remaining Phase 2 work is #341 — deleting the legacy hand-rolled engine and finalizing the shared theme / `NO_COLOR`.
- Same testing posture as the prior Phase 2 PRs (no headless tea-program smoke test; behavior covered by direct unit tests, race-clean).
