### PR TITLE
feat(tui): restore mouse click support in the Bubble Tea TUI (RFC 0012)

### DIFF
--- a/cmd/cloudstic/cmd_tui_bubbletea.go
+++ b/cmd/cloudstic/cmd_tui_bubbletea.go
@@ -49,6 +49,7 @@ func runBubbleTeaTUI(r *runner, ctx context.Context, profilesFile string) int {
 		tea.WithInput(stdin),
 		tea.WithOutput(r.out),
 		tea.WithAltScreen(),
+		tea.WithMouseCellMotion(),
 	}
 	if err := tuiRunBubbleTea(ctx, model, opts...); err != nil {
 		return r.fail("TUI exited with error: %v", err)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -47,6 +47,12 @@ type Model struct {
 	formStack []formFrame
 	confirm   *confirmState
 
+	// regions holds the clickable rows recorded during the last render, so
+	// mouse clicks map to profiles/actions without re-deriving the layout
+	// (issue: legacy mouse support). It is a pointer so the value-receiver
+	// View can populate it.
+	regions *clickRegions
+
 	// reload, when non-nil, is run when the user presses "r". It returns a
 	// DashboardLoadedMsg or DashboardLoadError. The read-only launcher can
 	// leave it nil for a static snapshot.
@@ -60,6 +66,7 @@ func NewModel(d Dashboard) Model {
 		view:      ProfileViewSummary,
 		theme:     newTheme(),
 		probes:    map[string]StoreProbe{},
+		regions:   newClickRegions(),
 	}
 	m.selected = indexOfSelected(d)
 	return m
@@ -127,6 +134,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleActionUpdate(msg)
 	case configReloadedMsg:
 		return m.handleConfigReloaded(msg)
+	case tea.MouseMsg:
+		return m.handleMouse(msg)
 	case tea.KeyMsg:
 		if m.activeForm() != nil {
 			return m.updateForms(msg)
@@ -236,16 +245,21 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m Model) View() string {
 	width := m.viewWidth()
+	// Overlays cover the dashboard, so any recorded click targets are stale.
+	m.regions.reset()
 	if form := m.activeForm(); form != nil {
 		return strings.Join([]string{m.renderTitle(), form.View(), m.renderFooter()}, "\n")
 	}
 	if m.confirm != nil {
 		return strings.Join([]string{m.renderTitle(), m.renderConfirm(), m.renderFooter()}, "\n")
 	}
+	title := m.renderTitle()
+	overview := m.renderOverview(width)
+	yPanes := lipgloss.Height(title) + lipgloss.Height(overview)
 	sections := []string{
-		m.renderTitle(),
-		m.renderOverview(width),
-		m.renderPanes(width),
+		title,
+		overview,
+		m.renderPanes(width, yPanes),
 		m.renderActivitySection(width),
 		m.renderFooter(),
 	}
@@ -304,15 +318,30 @@ func (m Model) renderOverview(width int) string {
 	return m.panel("Overview", stats, m.fullContentWidth(width))
 }
 
+// panelBodyOffset is the number of rows between a panel's top edge and its
+// first body line: top border + title + blank line.
+const panelBodyOffset = 3
+
 // renderPanes lays out the Profiles and Selection panels side by side, or
-// stacked vertically on narrow terminals (responsive, per RFC 0012 Style).
-func (m Model) renderPanes(width int) string {
+// stacked vertically on narrow terminals (responsive, per RFC 0012 Style). It
+// records click regions relative to yTop so mouse clicks map to profile rows
+// and action buttons.
+func (m Model) renderPanes(width, yTop int) string {
 	profiles := m.renderProfileListBody()
-	selection := m.renderSelectionBody()
+	selectionBody, actionRows := m.selectionLines()
+	selection := strings.Join(selectionBody, "\n")
+
 	if width < 80 {
 		fw := m.fullContentWidth(width)
-		return m.panel("Profiles", profiles, fw) + "\n" + m.panel("Selection", selection, fw)
+		left := m.panel("Profiles", profiles, fw)
+		right := m.panel("Selection", selection, fw)
+		total := fw + 4
+		m.recordProfileRegions(yTop, 0, total)
+		selectionTop := yTop + lipgloss.Height(left)
+		m.recordActionRegions(actionRows, selectionTop, 0, total)
+		return left + "\n" + right
 	}
+
 	leftW, rightW := m.paneWidths(width)
 	h := max(
 		lipgloss.Height(m.theme.panelTitle.Render("Profiles")+"\n\n"+profiles),
@@ -320,7 +349,33 @@ func (m Model) renderPanes(width int) string {
 	)
 	left := m.panelH("Profiles", profiles, leftW, h)
 	right := m.panelH("Selection", selection, rightW, h)
+
+	leftTotal := leftW + 4
+	rightX := leftTotal + 2 // 2-col gap between panels
+	m.recordProfileRegions(yTop, 0, leftTotal)
+	m.recordActionRegions(actionRows, yTop, rightX, rightX+rightW+4)
 	return lipgloss.JoinHorizontal(lipgloss.Top, left, "  ", right)
+}
+
+// recordProfileRegions maps each profile row's absolute Y to its index, for
+// clicks landing within [x0, x1).
+func (m Model) recordProfileRegions(yTop, x0, x1 int) {
+	if len(m.dashboard.Profiles) == 0 {
+		return
+	}
+	for i := range m.dashboard.Profiles {
+		m.regions.profileRows[yTop+panelBodyOffset+i] = i
+	}
+	m.regions.profilesX0, m.regions.profilesX1 = x0, x1
+}
+
+// recordActionRegions maps each action-button row's absolute Y to its key, for
+// clicks landing within [x0, x1).
+func (m Model) recordActionRegions(actionRows map[int]string, yTop, x0, x1 int) {
+	for bodyIdx, key := range actionRows {
+		m.regions.actionRows[yTop+panelBodyOffset+bodyIdx] = key
+	}
+	m.regions.selectionX0, m.regions.selectionX1 = x0, x1
 }
 
 func (m Model) paneWidths(width int) (int, int) {
@@ -361,10 +416,13 @@ func (m Model) renderBadge(profile ProfileCard, width int) string {
 	return "[" + m.theme.stateStyle(profile.Status).Render(inner) + "]"
 }
 
-func (m Model) renderSelectionBody() string {
+// selectionLines builds the Selection panel body and, alongside it, a map from
+// body line index to the action key on that line, so mouse hit-testing does not
+// re-derive the layout.
+func (m Model) selectionLines() ([]string, map[int]string) {
 	profile, ok := m.currentProfile()
 	if !ok {
-		return m.theme.subtle.Render("No profile selected.")
+		return []string{m.theme.subtle.Render("No profile selected.")}, nil
 	}
 	lines := []string{
 		m.theme.selected.Render(profile.Name),
@@ -376,8 +434,25 @@ func (m Model) renderSelectionBody() string {
 	} else {
 		lines = append(lines, m.renderSummary(profile)...)
 	}
-	lines = append(lines, m.renderActionButtons(profile)...)
-	return strings.Join(lines, "\n")
+
+	actionRows := map[int]string{}
+	buttons := selectedProfileActionButtons(profile)
+	if len(buttons) > 0 {
+		lines = append(lines, "")
+		for _, b := range buttons {
+			label := b.Label
+			if !b.Enabled {
+				label = m.theme.subtle.Render(label)
+			} else {
+				actionRows[len(lines)] = b.Key
+			}
+			lines = append(lines, "  "+m.theme.key.Render("["+b.Key+"]")+" "+label)
+			if !b.Enabled && b.Reason != "" {
+				lines = append(lines, m.theme.subtle.Render("      "+b.Reason))
+			}
+		}
+	}
+	return lines, actionRows
 }
 
 func (m Model) renderTabs() string {
@@ -419,25 +494,6 @@ func (m Model) renderSummary(profile ProfileCard) []string {
 
 func (m Model) detailRow(label, value string) string {
 	return m.theme.label.Render(padRight(label, 8)) + "  " + value
-}
-
-func (m Model) renderActionButtons(profile ProfileCard) []string {
-	buttons := selectedProfileActionButtons(profile)
-	if len(buttons) == 0 {
-		return nil
-	}
-	lines := []string{""}
-	for _, b := range buttons {
-		label := b.Label
-		if !b.Enabled {
-			label = m.theme.subtle.Render(label)
-		}
-		lines = append(lines, "  "+m.theme.key.Render("["+b.Key+"]")+" "+label)
-		if !b.Enabled && b.Reason != "" {
-			lines = append(lines, m.theme.subtle.Render("      "+b.Reason))
-		}
-	}
-	return lines
 }
 
 func (m Model) renderActivitySection(width int) string {

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -1,0 +1,99 @@
+package tui
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// clickRegions records the clickable rows of the last render so mouse clicks
+// map back to profiles and action buttons. Coordinates are absolute terminal
+// cells (0-indexed). It is populated during View and read during Update, which
+// run sequentially on the Bubble Tea event loop.
+type clickRegions struct {
+	profileRows map[int]int    // absolute Y -> profile index
+	actionRows  map[int]string // absolute Y -> action key
+	// Column ranges [x0, x1) the profile / selection panels occupy, used to
+	// disambiguate the two side-by-side panels that share Y coordinates.
+	profilesX0, profilesX1   int
+	selectionX0, selectionX1 int
+}
+
+func newClickRegions() *clickRegions {
+	return &clickRegions{
+		profileRows: map[int]int{},
+		actionRows:  map[int]string{},
+	}
+}
+
+func (r *clickRegions) reset() {
+	if r == nil {
+		return
+	}
+	clear(r.profileRows)
+	clear(r.actionRows)
+	r.profilesX0, r.profilesX1 = 0, 0
+	r.selectionX0, r.selectionX1 = 0, 0
+}
+
+func (r *clickRegions) profileAt(x, y int) (int, bool) {
+	if r == nil {
+		return 0, false
+	}
+	idx, ok := r.profileRows[y]
+	if !ok || x < r.profilesX0 || x >= r.profilesX1 {
+		return 0, false
+	}
+	return idx, true
+}
+
+func (r *clickRegions) actionAt(x, y int) (string, bool) {
+	if r == nil {
+		return "", false
+	}
+	key, ok := r.actionRows[y]
+	if !ok || x < r.selectionX0 || x >= r.selectionX1 {
+		return "", false
+	}
+	return key, true
+}
+
+// handleMouse routes a mouse event: wheel scrolls the profile selection, and a
+// left click selects a profile or triggers an action button.
+func (m Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	// Overlays own the screen; the dashboard is not clickable underneath.
+	if m.activeForm() != nil || m.confirm != nil {
+		return m, nil
+	}
+	switch {
+	case msg.Button == tea.MouseButtonWheelUp:
+		if m.selected > 0 {
+			m.selected--
+		}
+		return m, nil
+	case msg.Button == tea.MouseButtonWheelDown:
+		if m.selected < len(m.dashboard.Profiles)-1 {
+			m.selected++
+		}
+		return m, nil
+	case msg.Button == tea.MouseButtonLeft && msg.Action == tea.MouseActionPress:
+		return m.handleClick(msg.X, msg.Y)
+	}
+	return m, nil
+}
+
+func (m Model) handleClick(x, y int) (tea.Model, tea.Cmd) {
+	if idx, ok := m.regions.profileAt(x, y); ok {
+		if idx >= 0 && idx < len(m.dashboard.Profiles) {
+			m.selected = idx
+		}
+		return m, nil
+	}
+	if key, ok := m.regions.actionAt(x, y); ok {
+		switch key {
+		case "b", "c":
+			return m.startAction(key)
+		case "e":
+			return m.openEditProfile()
+		case "d":
+			return m.openDeleteProfile()
+		}
+	}
+	return m, nil
+}

--- a/internal/tui/mouse_test.go
+++ b/internal/tui/mouse_test.go
@@ -1,0 +1,141 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func mouseDashboard() Dashboard {
+	ready := deriveProfileActions(ProfileStatusReady, StoreHealthReady)
+	return Dashboard{
+		ProfileCount: 3, StoreCount: 1, SelectedProfile: "alpha", SelectedView: ProfileViewSummary,
+		Profiles: []ProfileCard{
+			{Name: "alpha", Source: "local:/a", StoreRef: "s1", Enabled: true, Status: ProfileStatusReady,
+				StoreHealth: StoreHealthReady, Reachability: StoreReachabilityReachable, Repository: RepositoryStateInitialized, Actions: ready},
+			{Name: "beta", Source: "local:/b", StoreRef: "s1", Enabled: true, Status: ProfileStatusReady,
+				StoreHealth: StoreHealthReady, Reachability: StoreReachabilityReachable, Repository: RepositoryStateInitialized, Actions: ready},
+			{Name: "gamma", Source: "local:/c", StoreRef: "s1", Enabled: true, Status: ProfileStatusReady,
+				StoreHealth: StoreHealthReady, Reachability: StoreReachabilityReachable, Repository: RepositoryStateInitialized, Actions: ready},
+		},
+	}
+}
+
+func leftClick(m Model, x, y int) Model {
+	next, _ := m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonLeft, X: x, Y: y})
+	return next.(Model)
+}
+
+// firstRow returns an absolute Y whose recorded profile index matches idx.
+func profileRowY(m Model, idx int) (int, bool) {
+	for y, i := range m.regions.profileRows {
+		if i == idx {
+			return y, true
+		}
+	}
+	return 0, false
+}
+
+func actionRowY(m Model, key string) (int, bool) {
+	for y, k := range m.regions.actionRows {
+		if k == key {
+			return y, true
+		}
+	}
+	return 0, false
+}
+
+func TestMouse_ClickProfileSelects(t *testing.T) {
+	m := NewModel(mouseDashboard())
+	m.width = 92
+	_ = m.View() // populate regions
+	y, ok := profileRowY(m, 2)
+	if !ok {
+		t.Fatalf("no recorded row for profile 2\nregions=%v", m.regions.profileRows)
+	}
+	m = leftClick(m, 3, y)
+	if m.selected != 2 {
+		t.Fatalf("selected=%d want 2 after clicking gamma's row", m.selected)
+	}
+}
+
+func TestMouse_ClickOutsidePanelIgnored(t *testing.T) {
+	m := NewModel(mouseDashboard())
+	m.width = 92
+	_ = m.View()
+	y, _ := profileRowY(m, 2)
+	// Same row, but an x far to the right of the profiles panel.
+	m = leftClick(m, m.regions.profilesX1+5, y)
+	if m.selected != 0 {
+		t.Fatalf("selected=%d want 0 (click outside the profiles panel should be ignored)", m.selected)
+	}
+}
+
+func TestMouse_ClickActionButtonStartsAction(t *testing.T) {
+	runner := &stubRunner{updates: []ActionUpdate{
+		{Panel: ActivityPanel{Status: ActivityStatusRunning}},
+		{Panel: ActivityPanel{Status: ActivityStatusSuccess}, Done: true},
+	}}
+	m := NewModel(mouseDashboard()).WithRunner(runner)
+	m.width = 92
+	_ = m.View()
+	y, ok := actionRowY(m, "b")
+	if !ok {
+		t.Fatalf("no recorded action row for b\nregions=%v", m.regions.actionRows)
+	}
+	x := m.regions.selectionX0 + 3
+	next, cmd := m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonLeft, X: x, Y: y})
+	m = next.(Model)
+	if !m.running {
+		t.Fatalf("clicking the backup button should start an action")
+	}
+	if runner.started != ActionKindBackup {
+		t.Fatalf("started=%q want backup", runner.started)
+	}
+	if cmd == nil {
+		t.Fatalf("action click should return a listen command")
+	}
+}
+
+func TestMouse_ClickEditButtonOpensForm(t *testing.T) {
+	m := NewModel(mouseDashboard()).WithForms(&stubFormsBackend{stores: []string{"s1"}})
+	m.width = 92
+	_ = m.View()
+	y, ok := actionRowY(m, "e")
+	if !ok {
+		t.Fatalf("no recorded action row for e")
+	}
+	m = leftClick(m, m.regions.selectionX0+3, y)
+	if m.activeForm() == nil {
+		t.Fatalf("clicking edit should open the profile form")
+	}
+}
+
+func TestMouse_WheelScrollsSelection(t *testing.T) {
+	m := NewModel(mouseDashboard())
+	m.width = 92
+	next, _ := m.Update(tea.MouseMsg{Button: tea.MouseButtonWheelDown})
+	m = next.(Model)
+	if m.selected != 1 {
+		t.Fatalf("wheel down selected=%d want 1", m.selected)
+	}
+	next, _ = m.Update(tea.MouseMsg{Button: tea.MouseButtonWheelUp})
+	m = next.(Model)
+	if m.selected != 0 {
+		t.Fatalf("wheel up selected=%d want 0", m.selected)
+	}
+}
+
+func TestMouse_IgnoredWhileFormOpen(t *testing.T) {
+	m := NewModel(mouseDashboard()).WithForms(&stubFormsBackend{stores: []string{"s1"}})
+	m.width = 92
+	_ = m.View()
+	y, _ := profileRowY(m, 2)
+	// Open a form, then a click must not change the underlying selection.
+	m, _ = m.openCreateProfile()
+	_ = m.View() // clears regions
+	m = leftClick(m, 3, y)
+	if m.selected != 0 {
+		t.Fatalf("clicks must be ignored while a form is open; selected=%d", m.selected)
+	}
+}


### PR DESCRIPTION
## Summary
Restore the legacy TUI's mouse interactions in the Bubble Tea renderer, using Bubble Tea's built-in mouse events instead of the hand-rolled CSI/SGR byte parser.

- **Enable mouse** (cell motion) in the program.
- **Left-click a profile row** to select it.
- **Left-click an action button** (`[b]`/`[c]`/`[e]`/`[d]`) to run backup/check or open the edit/delete flow.
- **Mouse wheel** scrolls the profile selection.
- Clicks are ignored while a form or confirm overlay is open.

**Stacked on #354** (base branch `feat/tui-bubbletea-secret-forms`); the mouse code is independent of the secret-form work. Still gated behind `cloudstic tui -bubbletea`.

Part of #132 (RFC 0012, Phase 2)

## How hit-testing avoids the legacy drift hazard
The RFC 0012 review flagged the legacy mouse code for maintaining a **parallel layout function** (`LayoutDashboardWidth`) that had to stay byte-for-byte in sync with the real renderer, and could go stale across a resize. This implementation instead **records click regions during the render pass that produces the frame**: `renderPanes` writes each profile row's and action button's absolute cell coordinate (plus each panel's column range) into a `clickRegions` struct as it lays them out. `Update` reads those regions on the next mouse event. There is no second layout function to drift, and regions are recomputed every frame, so a resize can't desync them. Overlays clear the regions so stale targets aren't clickable underneath.

## Verification
- `env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./internal/tui` passes — adds mouse tests: click-selects-profile, click-outside-panel-ignored, click-action-button-starts-action, click-edit-opens-form, wheel-scroll, and clicks-ignored-while-form-open
- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./cmd/cloudstic` passes
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./cmd/cloudstic/... ./internal/tui/...` — 0 issues
- `go build ./...` passes
- Verified coordinates against a rendered frame: profile rows and `[b]/[c]/[e]/[d]` buttons resolve to the exact rows shown, and the two side-by-side panels are disambiguated by column range.

## Reviewer notes
- `clickRegions` is a pointer field on the model so the value-receiver `View` can populate it; both `View` and `Update` run on the single Bubble Tea event-loop goroutine, so there's no concurrent access.
- Click uses `MouseActionPress` (matching the legacy behavior) rather than release, so a single event fires per click.
- Bubble Tea reports 0-indexed cell coordinates (upper-left = 0,0), which the region offsets assume.
