### PR TITLE
fix(secretref): cache native secret resolutions to prompt once per process

### DIFF
--- a/internal/secretref/cache_test.go
+++ b/internal/secretref/cache_test.go
@@ -1,0 +1,143 @@
+package secretref
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// countingBackend counts Resolve calls and can gate them so concurrent callers
+// pile up, exercising singleflight.
+type countingBackend struct {
+	value   string
+	calls   atomic.Int64
+	release chan struct{} // if non-nil, Resolve blocks until closed
+	entered chan struct{} // if non-nil, signaled once per Resolve entry
+}
+
+func (b *countingBackend) Resolve(_ context.Context, _ Ref) (string, error) {
+	b.calls.Add(1)
+	if b.entered != nil {
+		b.entered <- struct{}{}
+	}
+	if b.release != nil {
+		<-b.release
+	}
+	return b.value, nil
+}
+
+func TestResolver_CachesNativeScheme(t *testing.T) {
+	b := &countingBackend{value: "sekret"}
+	r := NewResolver(map[string]Backend{"keychain": b})
+
+	for range 3 {
+		got, err := r.Resolve(context.Background(), "keychain://cloudstic/store/prod/password")
+		if err != nil || got != "sekret" {
+			t.Fatalf("resolve = %q, %v", got, err)
+		}
+	}
+	if n := b.calls.Load(); n != 1 {
+		t.Fatalf("keychain backend called %d times; want 1 (cached)", n)
+	}
+}
+
+func TestResolver_DoesNotCacheEnv(t *testing.T) {
+	values := map[string]string{"CLOUDSTIC_PASSWORD": "a"}
+	var lookups atomic.Int64
+	r := NewResolver(map[string]Backend{"env": NewEnvBackend(func(name string) (string, bool) {
+		lookups.Add(1)
+		v, ok := values[name]
+		return v, ok
+	})})
+
+	for range 3 {
+		if _, err := r.Resolve(context.Background(), "env://CLOUDSTIC_PASSWORD"); err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+	}
+	if n := lookups.Load(); n != 3 {
+		t.Fatalf("env lookups=%d; want 3 (env must not be cached)", n)
+	}
+}
+
+func TestResolver_ConcurrentResolveDeduplicates(t *testing.T) {
+	const n = 24
+	b := &countingBackend{
+		value:   "sekret",
+		release: make(chan struct{}),
+		entered: make(chan struct{}, 1),
+	}
+	r := NewResolver(map[string]Backend{"keychain": b})
+
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	for range n {
+		wg.Go(func() {
+			v, err := r.Resolve(context.Background(), "keychain://cloudstic/store/prod/password")
+			if err == nil && v != "sekret" {
+				err = errNonMatch
+			}
+			errs <- err
+		})
+	}
+
+	// Wait until the single in-flight backend call has started, then release it
+	// so all waiters share its result.
+	<-b.entered
+	close(b.release)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent resolve error: %v", err)
+		}
+	}
+	if got := b.calls.Load(); got != 1 {
+		t.Fatalf("backend called %d times under concurrency; want 1 (singleflight)", got)
+	}
+}
+
+func TestResolver_StoreWriteThroughAvoidsResolve(t *testing.T) {
+	b := &writeThroughBackend{stored: map[string]string{}}
+	r := NewResolver(map[string]Backend{"keychain": b})
+
+	ref := "keychain://cloudstic/store/prod/password"
+	if err := r.Store(context.Background(), ref, "written"); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	got, err := r.Resolve(context.Background(), ref)
+	if err != nil || got != "written" {
+		t.Fatalf("resolve after store = %q, %v; want written", got, err)
+	}
+	if n := b.calls.Load(); n != 0 {
+		t.Fatalf("backend Resolve called %d times; want 0 (served from write-through cache)", n)
+	}
+}
+
+type writeThroughBackend struct {
+	countingBackend
+	mu     sync.Mutex
+	stored map[string]string
+}
+
+func (b *writeThroughBackend) Scheme() string      { return "keychain" }
+func (b *writeThroughBackend) DisplayName() string { return "Test Keychain" }
+func (b *writeThroughBackend) WriteSupported() bool { return true }
+func (b *writeThroughBackend) DefaultRef(string, string) string {
+	return "keychain://cloudstic/store/prod/password"
+}
+func (b *writeThroughBackend) Exists(_ context.Context, ref Ref) (bool, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	_, ok := b.stored[ref.Raw]
+	return ok, nil
+}
+func (b *writeThroughBackend) Store(_ context.Context, ref Ref, value string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.stored[ref.Raw] = value
+	return nil
+}
+
+var errNonMatch = &Error{Kind: KindBackendUnavailable, Detail: "value mismatch"}

--- a/internal/secretref/secretref.go
+++ b/internal/secretref/secretref.go
@@ -8,6 +8,9 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync"
+
+	"golang.org/x/sync/singleflight"
 )
 
 type ErrorKind string
@@ -113,17 +116,59 @@ type WritableBackend interface {
 }
 
 // Resolver routes secret references by scheme.
+//
+// Resolutions from interactive native stores (macOS Keychain, Windows
+// Credential Manager, Linux Secret Service) are cached in-process and
+// deduplicated with singleflight. This matters for unsigned/dev builds, where
+// the OS cannot persist an "always allow" ACL keyed to the binary's code
+// signature and so re-prompts on every keychain access: without the cache, the
+// concurrent store probes and per-action re-probes would each pop a separate
+// password dialog. With it, a given reference prompts at most once per process.
 type Resolver struct {
 	backends map[string]Backend
+
+	mu    sync.Mutex
+	cache map[string]string
+	group singleflight.Group
 }
 
 // NewResolver creates a resolver from scheme backends.
 func NewResolver(backends map[string]Backend) *Resolver {
-	r := &Resolver{backends: map[string]Backend{}}
+	r := &Resolver{backends: map[string]Backend{}, cache: map[string]string{}}
 	for scheme, b := range backends {
 		r.backends[strings.ToLower(scheme)] = b
 	}
 	return r
+}
+
+// cachedScheme reports whether a scheme's resolutions should be cached. Only
+// the interactive native stores are cached; env/file/config-token resolution is
+// cheap, silent, and may legitimately change within a process.
+func cachedScheme(scheme string) bool {
+	switch scheme {
+	case "keychain", "wincred", "secret-service":
+		return true
+	}
+	return false
+}
+
+func (r *Resolver) cacheGet(key string) (string, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	v, ok := r.cache[key]
+	return v, ok
+}
+
+func (r *Resolver) cacheSet(key, value string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cache[key] = value
+}
+
+func (r *Resolver) cacheInvalidate(key string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.cache, key)
 }
 
 // NewDefaultResolver builds the standard resolver with built-in env, file,
@@ -145,7 +190,39 @@ func (r *Resolver) Resolve(ctx context.Context, raw string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if cachedScheme(parsed.Scheme) {
+		return r.resolveCached(ctx, parsed, backend)
+	}
+	return resolveBackend(ctx, parsed, backend)
+}
 
+// resolveCached serves a cacheable resolution from the in-process cache, or
+// performs exactly one backend call for concurrent callers via singleflight and
+// caches the successful result. Errors are never cached, so a denied or failed
+// prompt can be retried.
+func (r *Resolver) resolveCached(ctx context.Context, parsed Ref, backend Backend) (string, error) {
+	key := parsed.Raw
+	if v, ok := r.cacheGet(key); ok {
+		return v, nil
+	}
+	v, err, _ := r.group.Do(key, func() (any, error) {
+		if v, ok := r.cacheGet(key); ok {
+			return v, nil
+		}
+		value, err := resolveBackend(ctx, parsed, backend)
+		if err != nil {
+			return "", err
+		}
+		r.cacheSet(key, value)
+		return value, nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return v.(string), nil
+}
+
+func resolveBackend(ctx context.Context, parsed Ref, backend Backend) (string, error) {
 	value, err := backend.Resolve(ctx, parsed)
 	if err != nil {
 		var refErr *Error
@@ -199,6 +276,9 @@ func (r *Resolver) SaveBlob(ctx context.Context, raw string, data []byte) error 
 		}
 		return errorf(KindBackendUnavailable, parsed.Raw, err.Error(), err)
 	}
+	if cachedScheme(parsed.Scheme) {
+		r.cacheSet(parsed.Raw, string(data))
+	}
 	return nil
 }
 
@@ -221,6 +301,7 @@ func (r *Resolver) DeleteBlob(ctx context.Context, raw string) error {
 		}
 		return errorf(KindBackendUnavailable, parsed.Raw, err.Error(), err)
 	}
+	r.cacheInvalidate(parsed.Raw)
 	return nil
 }
 
@@ -255,6 +336,9 @@ func (r *Resolver) Store(ctx context.Context, raw, value string) error {
 			return err
 		}
 		return errorf(KindBackendUnavailable, parsed.Raw, err.Error(), err)
+	}
+	if cachedScheme(parsed.Scheme) {
+		r.cacheSet(parsed.Raw, value)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
Resolving a native secret reference (macOS Keychain / Windows Credential Manager / Linux Secret Service) now **caches the value in-process** and **deduplicates concurrent resolutions with singleflight**, so a given reference prompts **at most once per process**.

**Why:** on an unsigned or dev build, the OS cannot persist an "always allow" ACL keyed to the binary's code signature, so it re-prompts on *every* keychain access. The TUI's concurrent store probes (and the per-action re-probes) therefore popped a separate password dialog each — the multiple-prompt behavior reported for `go run`/dev builds. A properly signed release build was already prompt-once via the persisted ACL; this makes dev builds behave the same. It also reduces keychain round-trips generally (also benefits plain CLI commands that touch the same secret more than once).

- Caching is scoped to the interactive native stores only; `env`/`file`/`config-token` resolution stays **uncached** (cheap, silent, and may legitimately change within a process).
- **Errors are never cached**, so a denied or failed prompt can be retried.
- `Store`/`SaveBlob` **write through** to the cache and `DeleteBlob` **invalidates** it, so a freshly written secret is not re-prompted and a deleted one is not served stale.

## Verification
- `env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./internal/secretref` passes — adds tests: native scheme cached (backend called once across repeats), env not cached (lookup called every time), concurrent resolves deduplicated to one backend call (singleflight, gated), and store write-through avoids a resolve
- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./cmd/cloudstic ./internal/engine ./pkg/keychain` passes (secret-resolving call sites unaffected)
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./internal/secretref/...` — 0 issues
- `go build ./...` passes

## Reviewer notes
- The cache lives on the `Resolver`, which is the single chokepoint for value resolution; it does not change any backend interface, so `WritableBackends`/`Store`/`Exists` and the direct-backend tests are untouched.
- Existing keychain/secret-service unit tests call the backend `Resolve` directly (not through the `Resolver`), so they see no caching; the resolver tests use `env`/`native` schemes, which are not cached.
- Concurrency: `cache` is mutex-guarded and lookups go through `singleflight` so N simultaneous resolves of the same reference make exactly one backend call (one prompt). Race-tested.
- Independent of the in-flight TUI PRs (#354/#355); based directly on main.
