### PR TITLE
refactor(profile): de-duplicate profile-resolution helpers

### DIFF
--- a/client.go
+++ b/client.go
@@ -550,6 +550,18 @@ func SaveProfilesFile(path string, cfg *ProfilesConfig) error {
 	return engine.SaveProfilesFile(path, cfg)
 }
 
+// LoadProfilesFileOrEmpty loads profiles from path, treating a missing file
+// as an empty, version-1 config rather than an error.
+func LoadProfilesFileOrEmpty(path string) (*ProfilesConfig, error) {
+	return engine.LoadProfilesFileOrEmpty(path)
+}
+
+// EnsureProfilesMaps guarantees cfg's map fields are non-nil, so callers can
+// write into them unconditionally.
+func EnsureProfilesMaps(cfg *ProfilesConfig) {
+	engine.EnsureProfilesMaps(cfg)
+}
+
 // ---------------------------------------------------------------------------
 // Restore
 // ---------------------------------------------------------------------------

--- a/cmd/cloudstic/cmd_backup.go
+++ b/cmd/cloudstic/cmd_backup.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"io"
-	"os"
 	"slices"
 	"strings"
 	"time"
@@ -205,17 +203,11 @@ func ensureDefaultAuthRefForCloudBackup(a *backupArgs) error {
 		authRef := defaultAuthRef
 		a.authRef = authRef
 
-		cfg, loadErr := cloudstic.LoadProfilesFile(a.profilesFile)
+		cfg, loadErr := loadProfilesOrInit(a.profilesFile)
 		if loadErr != nil {
-			if errors.Is(loadErr, os.ErrNotExist) {
-				cfg = &cloudstic.ProfilesConfig{Version: 1}
-			} else {
-				return fmt.Errorf("load profiles for default auth: %w", loadErr)
-			}
+			return fmt.Errorf("load profiles for default auth: %w", loadErr)
 		}
-		if cfg.Auth == nil {
-			cfg.Auth = map[string]cloudstic.ProfileAuth{}
-		}
+		ensureProfilesMaps(cfg)
 
 		tokenPath := getToken()
 		if tokenPath == "" {
@@ -309,6 +301,14 @@ func runBackupWithProfiles(r *runner, ctx context.Context, base *backupArgs) int
 	return 0
 }
 
+// mergeProfileBackupArgs folds profile p's fields into a copy of base,
+// wherever the corresponding flag was not passed explicitly. It is the
+// backup-specific counterpart to config.go's applyProfileStore: that function
+// covers a profile's store, folded in later via g.profile when
+// resolveClientConfig runs; this one covers everything else a backup profile
+// can carry (source, tags, excludes, native-source credentials, auth). Both
+// apply the same "explicit flag beats profile value" precedence, just against
+// different field shapes.
 func mergeProfileBackupArgs(base *backupArgs, profileName string, p cloudstic.BackupProfile, cfg *cloudstic.ProfilesConfig) (*backupArgs, error) {
 	g := cloneGlobalFlags(base.globalFlags)
 	a := *base
@@ -368,10 +368,11 @@ func mergeProfileBackupArgs(base *backupArgs, profileName string, p cloudstic.Ba
 	// The store itself is not folded in here. Naming the profile is enough:
 	// resolveClientConfig looks it up when the client is opened, so the store
 	// definition is applied in exactly one place and parsed flags stay intact.
-	if p.Store != "" {
-		if _, ok := cfg.Stores[p.Store]; !ok {
-			return nil, fmt.Errorf("profile %q references unknown store %q", profileName, p.Store)
-		}
+	// lookupProfileStore (config.go) is the same check loadProfileStore
+	// performs at that point; it's repeated here only to fail fast, before
+	// spending effort on a backup that would fail at store-open time anyway.
+	if _, err := lookupProfileStore(cfg, profileName, p); err != nil {
+		return nil, err
 	}
 	g.profile = profileName
 

--- a/cmd/cloudstic/cmd_profile.go
+++ b/cmd/cloudstic/cmd_profile.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 
@@ -16,11 +15,7 @@ import (
 const defaultProfilesFilename = "profiles.yaml"
 
 func defaultProfilesPath() (string, error) {
-	configDir, err := paths.ConfigDir()
-	if err != nil {
-		return "", fmt.Errorf("resolve config dir: %w", err)
-	}
-	return filepath.Join(configDir, defaultProfilesFilename), nil
+	return paths.ProfilesPath(defaultProfilesFilename, true)
 }
 
 type profileShowArgs struct {

--- a/cmd/cloudstic/cmd_setup.go
+++ b/cmd/cloudstic/cmd_setup.go
@@ -4,28 +4,22 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 	"strings"
 
 	cloudstic "github.com/cloudstic/cli"
 	"github.com/cloudstic/cli/internal/engine"
+	"github.com/cloudstic/cli/internal/paths"
 	"github.com/jedib0t/go-pretty/v6/table"
 )
 
 var planWorkstationSetup = cloudstic.PlanWorkstationSetup
 
 func defaultProfilesPathNoCreate() string {
-	if path := os.Getenv("CLOUDSTIC_PROFILES_FILE"); path != "" {
-		return path
+	path, err := paths.ProfilesPath(defaultProfilesFilename, false)
+	if err != nil {
+		return defaultProfilesFilename
 	}
-	if dir := os.Getenv("CLOUDSTIC_CONFIG_DIR"); dir != "" {
-		return filepath.Join(dir, defaultProfilesFilename)
-	}
-	if dir, err := os.UserConfigDir(); err == nil {
-		return filepath.Join(dir, "cloudstic", defaultProfilesFilename)
-	}
-	return defaultProfilesFilename
+	return path
 }
 
 type setupWorkstationArgs struct {

--- a/cmd/cloudstic/completion_dynamic.go
+++ b/cmd/cloudstic/completion_dynamic.go
@@ -2,16 +2,14 @@ package main
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"io"
-	"os"
 
 	cloudstic "github.com/cloudstic/cli"
 )
 
-var completionLoadProfilesFile = cloudstic.LoadProfilesFile
+var completionLoadProfilesFile = cloudstic.LoadProfilesFileOrEmpty
 
 type completionQueryArgs struct{ values []string }
 
@@ -73,9 +71,6 @@ func completionAuthNames(args []string) ([]string, error) {
 func completionLoadProfilesConfig(path string) (*cloudstic.ProfilesConfig, error) {
 	cfg, err := completionLoadProfilesFile(path)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return &cloudstic.ProfilesConfig{Version: 1}, nil
-		}
 		return nil, err
 	}
 	ensureProfilesMaps(cfg)

--- a/cmd/cloudstic/config.go
+++ b/cmd/cloudstic/config.go
@@ -173,12 +173,22 @@ func loadProfileStore(g *globalFlags) (*cloudstic.ProfileStore, error) {
 	if !ok {
 		return nil, fmt.Errorf("unknown profile %q", g.profile)
 	}
+	return lookupProfileStore(cfg, g.profile, p)
+}
+
+// lookupProfileStore returns profileName's referenced store, or nil if the
+// profile names no store. Shared by loadProfileStore above, which resolves it
+// fully to fold into a running command's config, and cmd_backup.go's
+// mergeProfileBackupArgs, which only needs the existence check: the store
+// itself is deliberately applied later, when resolveClientConfig runs for the
+// backup that's actually about to happen (see mergeProfileBackupArgs).
+func lookupProfileStore(cfg *cloudstic.ProfilesConfig, profileName string, p cloudstic.BackupProfile) (*cloudstic.ProfileStore, error) {
 	if p.Store == "" {
 		return nil, nil
 	}
 	s, ok := cfg.Stores[p.Store]
 	if !ok {
-		return nil, fmt.Errorf("profile %q references unknown store %q", g.profile, p.Store)
+		return nil, fmt.Errorf("profile %q references unknown store %q", profileName, p.Store)
 	}
 	return &s, nil
 }
@@ -187,6 +197,12 @@ func loadProfileStore(g *globalFlags) (*cloudstic.ProfileStore, error) {
 // alone, for callers that address a store by name rather than through parsed
 // flags (store verify, store init, the TUI). Nothing was passed on the command
 // line, so every value comes from the profile.
+//
+// Not to be confused with tuiClientConfig (cmd_tui_activity.go), a thin
+// quiet-mode wrapper around this same function, or with
+// applyExistingStoreDefaults (store_builder_helpers.go), which prefills
+// `store new`'s flags from an existing store entry for editing — an unrelated
+// concept despite the similar name.
 func clientConfigFromProfileStore(s cloudstic.ProfileStore) (clientConfig, error) {
 	cfg := clientConfig{packfile: true}
 	cfg.store.s3.region = defaultS3Region
@@ -201,6 +217,15 @@ func clientConfigFromProfileStore(s cloudstic.ProfileStore) (clientConfig, error
 // values win over the profile. Secret references are resolved here, so a
 // missing secret surfaces as an error at resolution time rather than as an
 // empty credential at connect time.
+//
+// This only covers store fields. Backup-specific profile fields that aren't
+// part of a store — source, tags, excludes, native-source credentials, auth —
+// go through cmd_backup.go's mergeProfileBackupArgs instead, applying the
+// same "explicit flag beats profile value" precedence via its own
+// flagProvided checks. The two aren't merged into one mechanism because their
+// field types differ enough (bools, string slices, multi-field auth
+// resolution vs. plain strings here) that forcing a shared table would
+// obscure more than it clarifies.
 func applyProfileStore(cfg *clientConfig, s cloudstic.ProfileStore, provided func(string) bool) error {
 	if !provided("store") && s.URI != "" {
 		cfg.store.uri = s.URI

--- a/cmd/cloudstic/profile_builder_helpers.go
+++ b/cmd/cloudstic/profile_builder_helpers.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"errors"
 	"fmt"
-	"os"
 	"regexp"
 	"sort"
 
@@ -33,26 +31,11 @@ func profilesFileFlag(target *string) flagSpec {
 }
 
 func loadProfilesOrInit(path string) (*cloudstic.ProfilesConfig, error) {
-	cfg, err := cloudstic.LoadProfilesFile(path)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return &cloudstic.ProfilesConfig{Version: 1}, nil
-		}
-		return nil, err
-	}
-	return cfg, nil
+	return cloudstic.LoadProfilesFileOrEmpty(path)
 }
 
 func ensureProfilesMaps(cfg *cloudstic.ProfilesConfig) {
-	if cfg.Stores == nil {
-		cfg.Stores = map[string]cloudstic.ProfileStore{}
-	}
-	if cfg.Profiles == nil {
-		cfg.Profiles = map[string]cloudstic.BackupProfile{}
-	}
-	if cfg.Auth == nil {
-		cfg.Auth = map[string]cloudstic.ProfileAuth{}
-	}
+	cloudstic.EnsureProfilesMaps(cfg)
 }
 
 func sortedKeys[T any](m map[string]T) []string {

--- a/internal/app/tui_service.go
+++ b/internal/app/tui_service.go
@@ -2,9 +2,7 @@ package app
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"os"
 
 	cloudstic "github.com/cloudstic/cli"
 	"github.com/cloudstic/cli/internal/engine"
@@ -161,26 +159,11 @@ func (s *TUIService) loadConfig(profilesFile string) (*cloudstic.ProfilesConfig,
 }
 
 func loadProfilesConfig(path string) (*cloudstic.ProfilesConfig, error) {
-	cfg, err := cloudstic.LoadProfilesFile(path)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return &cloudstic.ProfilesConfig{Version: 1}, nil
-		}
-		return nil, err
-	}
-	return cfg, nil
+	return cloudstic.LoadProfilesFileOrEmpty(path)
 }
 
 func ensureProfilesMaps(cfg *cloudstic.ProfilesConfig) {
-	if cfg.Stores == nil {
-		cfg.Stores = map[string]cloudstic.ProfileStore{}
-	}
-	if cfg.Profiles == nil {
-		cfg.Profiles = map[string]cloudstic.BackupProfile{}
-	}
-	if cfg.Auth == nil {
-		cfg.Auth = map[string]cloudstic.ProfileAuth{}
-	}
+	cloudstic.EnsureProfilesMaps(cfg)
 }
 
 func profileNeedsInit(profile tui.ProfileCard) bool {

--- a/internal/engine/profiles.go
+++ b/internal/engine/profiles.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -187,6 +188,37 @@ func LoadProfilesFile(path string) (*ProfilesConfig, error) {
 		return nil, fmt.Errorf("validate profiles file %q: %w", path, err)
 	}
 	return norm, nil
+}
+
+// LoadProfilesFileOrEmpty loads profiles from path, treating a missing file
+// as an empty, version-1 config rather than an error. Callers that only read
+// or manage profiles (list, setup, the TUI) want this; callers running a
+// command against a named profile want LoadProfilesFile's hard error, since a
+// silently-empty config there would misreport "unknown profile" instead of
+// "no profiles file".
+func LoadProfilesFileOrEmpty(path string) (*ProfilesConfig, error) {
+	cfg, err := LoadProfilesFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &ProfilesConfig{Version: 1}, nil
+		}
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// EnsureProfilesMaps guarantees cfg's map fields are non-nil, so callers can
+// write into them unconditionally.
+func EnsureProfilesMaps(cfg *ProfilesConfig) {
+	if cfg.Stores == nil {
+		cfg.Stores = map[string]ProfileStore{}
+	}
+	if cfg.Profiles == nil {
+		cfg.Profiles = map[string]BackupProfile{}
+	}
+	if cfg.Auth == nil {
+		cfg.Auth = map[string]ProfileAuth{}
+	}
 }
 
 // SaveProfilesFile writes a profiles YAML file atomically.

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -28,6 +28,35 @@ func ConfigDir() (string, error) {
 	return ensureDir(filepath.Join(base, appName))
 }
 
+// ProfilesPath resolves the path to a profiles file named filename inside the
+// config directory. Resolution follows ConfigDir's CLOUDSTIC_CONFIG_DIR then
+// os.UserConfigDir() precedence; CLOUDSTIC_PROFILES_FILE is deliberately not
+// consulted here, since callers that expose this as a flag default apply it
+// themselves via their own env-bound flag (so a live env value is never
+// baked into what -h displays).
+//
+// If create is true, the config directory is created as ConfigDir does. If
+// false, no filesystem access occurs — for callers that need a default value
+// before deciding whether the directory should exist (e.g. a dry-run preview
+// that must not create configuration as a side effect of being asked what it
+// would do).
+func ProfilesPath(filename string, create bool) (string, error) {
+	if create {
+		dir, err := ConfigDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(dir, filename), nil
+	}
+	if dir := os.Getenv("CLOUDSTIC_CONFIG_DIR"); dir != "" {
+		return filepath.Join(dir, filename), nil
+	}
+	if dir, err := os.UserConfigDir(); err == nil {
+		return filepath.Join(dir, appName, filename), nil
+	}
+	return filename, nil
+}
+
 // TokenPath returns the full path for a token file stored inside the config
 // directory (e.g. "google_token.json" → "~/.config/cloudstic/google_token.json").
 func TokenPath(filename string) (string, error) {


### PR DESCRIPTION
## Summary
- Collapse three independent copies of "tolerantly load profiles.yaml, treating a missing file as empty" (`cmd/cloudstic/profile_builder_helpers.go`, `internal/app/tui_service.go`, `cmd/cloudstic/completion_dynamic.go`) into one implementation: `cloudstic.LoadProfilesFileOrEmpty` / `cloudstic.EnsureProfilesMaps` (`internal/engine/profiles.go`, re-exported at root), with the three call sites now thin delegates.
- Collapse two independent copies of "resolve the default profiles-file path" (`cmd_profile.go`, `cmd_setup.go`) into `paths.ProfilesPath(filename, create)` in `internal/paths`.
- Share the "does this profile's store exist" check between `config.go`'s `loadProfileStore` and `cmd_backup.go`'s `mergeProfileBackupArgs` via a new `lookupProfileStore` helper, instead of two copies of the same error text.
- Add cross-referencing doc comments between `applyProfileStore` (config.go) and `mergeProfileBackupArgs` (cmd_backup.go) explaining the split: store fields flow through `resolveClientConfig`; everything else a backup profile carries (source, tags, native-source creds, auth) flows through the backup-specific merge. Also note `clientConfigFromProfileStore` vs. the similarly-named-but-unrelated `tuiClientConfig`/`applyExistingStoreDefaults`.

No behavior change intended — every touched wrapper keeps its existing name/signature so call sites were untouched; error text for known failure paths (unknown profile, missing store reference, missing profiles file) is unchanged. Deliberately out of scope: unifying `r.fail`-style vs. wrapped-`error`-style profile-not-found wording (correct-for-context Go idiom, not accidental drift), and a generic table-driven rewrite of `mergeProfileBackupArgs` (its field shapes are heterogeneous enough that forcing `applyProfileStore`'s table pattern would add indirection without a real clarity win).

## Verification
- `env GOCACHE=/tmp/cloudstic-gocache go build ./...`
- `env GOCACHE=/tmp/cloudstic-gocache go vet ./...`
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./cmd/cloudstic/... ./internal/app/... ./internal/paths/... ./internal/engine/... .`
- `env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./...` (full suite, including hermetic e2e)