### PR TITLE
fix: verify filemeta and snapshot content addresses; harden lock and pack durability

### DIFF
--- a/internal/core/hash.go
+++ b/internal/core/hash.go
@@ -4,6 +4,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"strings"
 )
 
 // ComputeHash computes the SHA-256 hash of the given data and returns it as a hex string.
@@ -20,4 +22,67 @@ func ComputeJSONHash(v interface{}) (string, []byte, error) {
 		return "", nil, err
 	}
 	return ComputeHash(data), data, nil
+}
+
+// SelfAddressedPrefixes are the object namespaces whose key is the SHA-256 of
+// the bytes stored under it. For these, and only these, the key is a checksum
+// the reader can verify without holding any secret.
+//
+// The other namespaces are deliberately absent. A chunk is named by an HMAC of
+// its bytes when the repository is encrypted, so verifying it needs the dedup
+// key rather than a bare hash; `check -read-data` does that where the key is
+// available. A content object is named by an HMAC of the *file's* hash, not of
+// its own bytes, so it is verified through the file it describes — restore
+// hashes the reconstructed stream against FileMeta.ContentHash.
+var SelfAddressedPrefixes = []string{"filemeta/", "node/", "snapshot/"}
+
+// ErrRefMismatch reports an object whose bytes are not what its key names.
+//
+// It is deliberately one error for every such object type: whether the cause is
+// bit rot, a truncated write, or a store that substituted the object, the
+// caller's correct response is the same — refuse the bytes.
+type ErrRefMismatch struct {
+	Ref  string
+	Got  string
+	Size int
+}
+
+func (e *ErrRefMismatch) Error() string {
+	return fmt.Sprintf("object %s failed its integrity check: %d bytes hashing to %s",
+		e.Ref, e.Size, e.Got)
+}
+
+// VerifyRef checks that data is the object ref names.
+//
+// Repository objects form a Merkle tree: a snapshot names a root node, nodes
+// name child nodes and filemeta refs, and a filemeta names its content. Every
+// link in that chain is a SHA-256 of the bytes on the other end, so verifying a
+// ref on the way in authenticates the whole tree beneath it against anything
+// short of rewriting the snapshot ref itself.
+//
+// Objects outside SelfAddressedPrefixes are not self-checking, and passing one
+// here is a programming error rather than a corrupt repository — hence the
+// distinct error. Callers that handle mixed keys should test the prefix first.
+func VerifyRef(ref string, data []byte) error {
+	for _, prefix := range SelfAddressedPrefixes {
+		suffix, ok := strings.CutPrefix(ref, prefix)
+		if !ok {
+			continue
+		}
+		if got := ComputeHash(data); got != suffix {
+			return &ErrRefMismatch{Ref: ref, Got: got, Size: len(data)}
+		}
+		return nil
+	}
+	return fmt.Errorf("object %s is not content-addressed by its own bytes", ref)
+}
+
+// IsSelfAddressed reports whether ref lives in a namespace VerifyRef can check.
+func IsSelfAddressed(ref string) bool {
+	for _, prefix := range SelfAddressedPrefixes {
+		if strings.HasPrefix(ref, prefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/engine/backup.go
+++ b/internal/engine/backup.go
@@ -430,7 +430,7 @@ func (bm *BackupManager) loadMeta(ctx context.Context, ref string) (*core.FileMe
 		return &fm, nil
 	}
 
-	data, err := bm.store.Get(ctx, ref)
+	data, err := getVerified(ctx, bm.store, ref)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/engine/check.go
+++ b/internal/engine/check.go
@@ -2,6 +2,8 @@ package engine
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -22,8 +24,14 @@ type checkConfig struct {
 	snapshotRef string
 }
 
-// WithReadData enables full byte-level verification: re-hash all chunk data
-// and verify content manifests match their referenced chunks.
+// WithReadData enables full byte-level verification: re-hash every chunk
+// against its key, and reconstruct each file from its content manifest to
+// confirm it still hashes to what its filemeta records.
+//
+// Without it, check verifies that every referenced object is readable and that
+// the self-addressed ones (snapshot, node, filemeta) are the bytes their keys
+// name. That is enough to detect a broken or substituted tree, but not enough
+// to detect corruption inside the file data itself.
 func WithReadData() CheckOption {
 	return func(cfg *checkConfig) { cfg.readData = true }
 }
@@ -149,6 +157,12 @@ func (cm *CheckManager) checkSnapshot(ctx context.Context, ref string, result *C
 		return nil // continue checking other snapshots
 	}
 	cm.verified[ref] = true
+	if err := core.VerifyRef(ref, data); err != nil {
+		result.Errors = append(result.Errors, CheckError{
+			Key: ref, Type: "corrupt", Message: err.Error(),
+		})
+		return nil
+	}
 	result.ObjectsVerified++
 	if cfg.verbose {
 		phase.Log(fmt.Sprintf("OK: %s", ref))
@@ -190,7 +204,7 @@ func (cm *CheckManager) verifyObject(ctx context.Context, key string, result *Ch
 		return nil
 	}
 
-	_, err := cm.store.Get(ctx, key)
+	data, err := cm.store.Get(ctx, key)
 	if err != nil {
 		result.Errors = append(result.Errors, CheckError{
 			Key: key, Type: "missing", Message: fmt.Sprintf("object not found or unreadable: %v", err),
@@ -200,6 +214,17 @@ func (cm *CheckManager) verifyObject(ctx context.Context, key string, result *Ch
 	}
 
 	cm.verified[key] = true
+	// A node key is the SHA-256 of its bytes. The HAMT walk that produced this
+	// ref checks that too, but reporting it here names the offending object as
+	// a finding rather than aborting the walk with an opaque error.
+	if core.IsSelfAddressed(key) {
+		if err := core.VerifyRef(key, data); err != nil {
+			result.Errors = append(result.Errors, CheckError{
+				Key: key, Type: "corrupt", Message: err.Error(),
+			})
+			return nil
+		}
+	}
 	result.ObjectsVerified++
 	if cfg.verbose {
 		phase.Log(fmt.Sprintf("OK: %s", key))
@@ -222,6 +247,12 @@ func (cm *CheckManager) checkFileMeta(ctx context.Context, ref string, result *C
 		return nil
 	}
 	cm.verified[ref] = true
+	if err := core.VerifyRef(ref, data); err != nil {
+		result.Errors = append(result.Errors, CheckError{
+			Key: ref, Type: "corrupt", Message: err.Error(),
+		})
+		return nil
+	}
 	result.ObjectsVerified++
 	if cfg.verbose {
 		phase.Log(fmt.Sprintf("OK: %s", ref))
@@ -244,11 +275,36 @@ func (cm *CheckManager) checkFileMeta(ctx context.Context, ref string, result *C
 		contentKey = meta.ContentHash
 	}
 
-	return cm.checkContent(ctx, "content/"+contentKey, result, cfg, phase)
+	// A content object is named by an HMAC of the file's content hash, not of
+	// its own bytes, so it cannot be checked against its key the way a filemeta
+	// can. What can be checked, for free, is that the filemeta's two content
+	// fields agree — a filemeta redirected at some other file's content is
+	// otherwise invisible until a restore fails the hash check.
+	if len(cm.hmacKey) > 0 && meta.ContentRef != "" {
+		if want := crypto.ComputeHMAC(cm.hmacKey, []byte(meta.ContentHash)); want != meta.ContentRef {
+			result.Errors = append(result.Errors, CheckError{
+				Key:  ref,
+				Type: "corrupt",
+				Message: fmt.Sprintf("content_ref %s does not derive from content_hash %s",
+					meta.ContentRef, meta.ContentHash),
+			})
+			return nil
+		}
+	}
+
+	return cm.checkContent(ctx, "content/"+contentKey, &meta, result, cfg, phase)
 }
 
 // checkContent verifies a content object and its referenced chunks.
-func (cm *CheckManager) checkContent(ctx context.Context, ref string, result *CheckResult, cfg *checkConfig, phase ui.Phase) error {
+//
+// meta is the filemeta that pointed here. It carries the only value that can
+// prove a manifest is intact: the SHA-256 of the whole file. Neither the
+// content object's key nor its bytes encode the order of the chunk list, so a
+// store that reorders, drops, or substitutes entries produces a manifest that
+// is individually valid at every chunk and reconstructs the wrong file. Only
+// re-running the concatenation catches that, which is why it belongs to
+// -read-data rather than the cheap pass.
+func (cm *CheckManager) checkContent(ctx context.Context, ref string, meta *core.FileMeta, result *CheckResult, cfg *checkConfig, phase ui.Phase) error {
 	if cm.verified[ref] {
 		return nil
 	}
@@ -280,7 +336,69 @@ func (cm *CheckManager) checkContent(ctx context.Context, ref string, result *Ch
 			return err
 		}
 	}
+
+	if cfg.readData {
+		cm.checkManifest(ctx, ref, &content, meta, result, phase)
+	}
 	return nil
+}
+
+// checkManifest reconstructs the file this content object describes and compares
+// it with the hash the filemeta recorded, covering both storage layouts: the
+// inline bytes of a small file and the ordered chunk list of a large one.
+//
+// Inline content costs nothing extra — the bytes are already in hand. The
+// chunked path re-reads the chunks, which for a repository with heavy
+// cross-file deduplication means reading a shared chunk once per file that
+// references it rather than once overall. That is the price of checking the
+// one claim nothing else checks, and -read-data is the mode whose whole purpose
+// is to pay for certainty.
+func (cm *CheckManager) checkManifest(
+	ctx context.Context,
+	ref string,
+	content *core.Content,
+	meta *core.FileMeta,
+	result *CheckResult,
+	phase ui.Phase,
+) {
+	if meta == nil || meta.ContentHash == "" {
+		return
+	}
+
+	hasher := sha256.New()
+	if len(content.DataInlineB64) > 0 {
+		_, _ = hasher.Write(content.DataInlineB64)
+	}
+	for _, chunkRef := range content.Chunks {
+		data, err := cm.store.Get(ctx, chunkRef)
+		if err != nil {
+			// The chunk pass above already recorded this as missing; adding a
+			// second finding for the same object would only inflate the count.
+			return
+		}
+		_, _ = hasher.Write(data)
+	}
+
+	got := hex.EncodeToString(hasher.Sum(nil))
+	if got != meta.ContentHash {
+		result.Errors = append(result.Errors, CheckError{
+			Key:  ref,
+			Type: "corrupt",
+			Message: fmt.Sprintf("reconstructed content hashes to %s, filemeta records %s",
+				got, meta.ContentHash),
+		})
+		phase.Log(fmt.Sprintf("CORRUPT: %s", ref))
+		return
+	}
+
+	if content.Size != 0 && content.Size != meta.Size {
+		result.Errors = append(result.Errors, CheckError{
+			Key:  ref,
+			Type: "corrupt",
+			Message: fmt.Sprintf("content records size %d, filemeta records %d",
+				content.Size, meta.Size),
+		})
+	}
 }
 
 // checkChunk verifies a chunk object. With --read-data, it also verifies the

--- a/internal/engine/check_test.go
+++ b/internal/engine/check_test.go
@@ -23,17 +23,23 @@ func buildTestRepo(t *testing.T, mockStore *MockStore) (snapRef, rootRef, metaRe
 	chunkRef = "chunk/" + chunkHash
 	_ = mockStore.Put(ctx, chunkRef, chunkData)
 
-	// Content
-	content := core.Content{Chunks: []string{chunkRef}}
-	contentHash, contentData, _ := core.ComputeJSONHash(&content)
-	contentRef = "content/" + contentHash
+	// Content. A content object's key is the hash of the *file* the manifest
+	// reconstructs, not of the manifest's own bytes — that is what lets the
+	// same content be found again by a later backup that has only the file.
+	// Building it any other way produces a repository the engine cannot
+	// create, and one that hides every check keyed on that relationship.
+	fileHash := chunkHash
+	content := core.Content{Chunks: []string{chunkRef}, Size: int64(len(chunkData))}
+	contentData, _ := json.Marshal(&content)
+	contentRef = "content/" + fileHash
 	_ = mockStore.Put(ctx, contentRef, contentData)
 
 	// FileMeta
 	meta := core.FileMeta{
 		Name:        "test.txt",
 		Type:        core.FileTypeFile,
-		ContentHash: contentHash,
+		ContentHash: fileHash,
+		Size:        int64(len(chunkData)),
 		FileID:      "file1",
 	}
 	metaHash, metaData, _ := core.ComputeJSONHash(&meta)
@@ -206,15 +212,22 @@ func TestCheckManager_CorruptChunk_ReadData(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Check failed: %v", err)
 	}
-	if len(result.Errors) != 1 {
-		t.Fatalf("Expected 1 error, got %d: %v", len(result.Errors), result.Errors)
+	// A corrupt chunk is reported twice, and both reports are wanted: the chunk
+	// no longer hashes to its key, and the file it belongs to no longer
+	// reconstructs. The second is what an operator needs to know which *file*
+	// is unrecoverable, which the chunk key alone does not say.
+	assertCorrupt(t, result, chunkRef)
+}
+
+// assertCorrupt fails unless result carries a "corrupt" finding for key.
+func assertCorrupt(t *testing.T, result *CheckResult, key string) {
+	t.Helper()
+	for _, e := range result.Errors {
+		if e.Key == key && e.Type == "corrupt" {
+			return
+		}
 	}
-	if result.Errors[0].Key != chunkRef {
-		t.Errorf("Expected error for %s, got %s", chunkRef, result.Errors[0].Key)
-	}
-	if result.Errors[0].Type != "corrupt" {
-		t.Errorf("Expected error type 'corrupt', got %q", result.Errors[0].Type)
-	}
+	t.Fatalf("Expected a corrupt finding for %s, got: %v", key, result.Errors)
 }
 
 func TestCheckManager_CorruptChunk_WithoutReadData(t *testing.T) {
@@ -378,13 +391,5 @@ func TestCheckManager_CorruptChunk_HMACReadData(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Check failed: %v", err)
 	}
-	if len(result.Errors) != 1 {
-		t.Fatalf("Expected 1 error for corrupt chunk, got %d: %v", len(result.Errors), result.Errors)
-	}
-	if result.Errors[0].Key != chunkRef {
-		t.Errorf("Expected error for %s, got %s", chunkRef, result.Errors[0].Key)
-	}
-	if result.Errors[0].Type != "corrupt" {
-		t.Errorf("Expected error type 'corrupt', got %q", result.Errors[0].Type)
-	}
+	assertCorrupt(t, result, chunkRef)
 }

--- a/internal/engine/diff.go
+++ b/internal/engine/diff.go
@@ -153,7 +153,7 @@ func (dm *DiffManager) resolveSnapshot(ctx context.Context, id string) (string, 
 }
 
 func (dm *DiffManager) loadSnapshot(ctx context.Context, ref string) (*core.Snapshot, error) {
-	data, err := dm.store.Get(ctx, ref)
+	data, err := getVerified(ctx, dm.store, ref)
 	if err != nil {
 		return nil, fmt.Errorf("load snapshot %s: %w", ref, err)
 	}
@@ -229,7 +229,7 @@ func (dm *DiffManager) loadMeta(ctx context.Context, ref string) (*core.FileMeta
 	if fm, ok := dm.metaCache[ref]; ok {
 		return &fm, nil
 	}
-	data, err := dm.store.Get(ctx, ref)
+	data, err := getVerified(ctx, dm.store, ref)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/engine/ls_snapshot.go
+++ b/internal/engine/ls_snapshot.go
@@ -115,7 +115,7 @@ func (lm *LsSnapshotManager) resolveSnapshot(ctx context.Context, id string) (*c
 		ref = "snapshot/" + ref
 	}
 
-	data, err := lm.store.Get(ctx, ref)
+	data, err := getVerified(ctx, lm.store, ref)
 	if err != nil {
 		return nil, "", fmt.Errorf("load snapshot %s: %w", ref, err)
 	}
@@ -147,7 +147,7 @@ func (lm *LsSnapshotManager) loadMeta(ctx context.Context, ref string) (*core.Fi
 	if fm, ok := lm.metaCache[ref]; ok {
 		return &fm, nil
 	}
-	data, err := lm.store.Get(ctx, ref)
+	data, err := getVerified(ctx, lm.store, ref)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/engine/prune.go
+++ b/internal/engine/prune.go
@@ -331,7 +331,7 @@ func (pm *PruneManager) sweep(ctx context.Context, reachable map[string]bool, cf
 }
 
 func (pm *PruneManager) loadSnapshot(ctx context.Context, ref string) (*core.Snapshot, error) {
-	data, err := pm.store.Get(ctx, ref)
+	data, err := getVerified(ctx, pm.store, ref)
 	if err != nil {
 		return nil, fmt.Errorf("get snapshot %s: %w", ref, err)
 	}
@@ -346,7 +346,7 @@ func (pm *PruneManager) loadMeta(ctx context.Context, ref string) (*core.FileMet
 	if fm, ok := pm.metaCache[ref]; ok {
 		return &fm, nil
 	}
-	data, err := pm.store.Get(ctx, ref)
+	data, err := getVerified(ctx, pm.store, ref)
 	if err != nil {
 		return nil, fmt.Errorf("get filemeta %s: %w", ref, err)
 	}
@@ -354,5 +354,6 @@ func (pm *PruneManager) loadMeta(ctx context.Context, ref string) (*core.FileMet
 	if err := json.Unmarshal(data, &fm); err != nil {
 		return nil, err
 	}
+	pm.metaCache[ref] = fm
 	return &fm, nil
 }

--- a/internal/engine/repolock.go
+++ b/internal/engine/repolock.go
@@ -83,14 +83,8 @@ func (h *LockHandle) Release() {
 // To mitigate TOCTOU races on stores without conditional writes, the lock is
 // written and then immediately re-read to verify this process still owns it.
 func AcquireRepoLock(ctx context.Context, s store.ObjectStore, operation string) (*LockHandle, context.Context, error) {
-	if existing, err := readLockByKey(ctx, s, exclusiveLockKey); err == nil {
-		expires, parseErr := time.Parse(time.RFC3339Nano, existing.ExpiresAt)
-		if parseErr != nil || time.Now().Before(expires) {
-			return nil, nil, fmt.Errorf(
-				"repository is locked by %s (operation: %s, acquired: %s, expires: %s)",
-				existing.Holder, existing.Operation, existing.AcquiredAt, existing.ExpiresAt,
-			)
-		}
+	if err := checkExclusiveLock(ctx, s); err != nil {
+		return nil, nil, err
 	}
 
 	// Check if any shared locks are active.
@@ -152,14 +146,8 @@ func AcquireRepoLock(ctx context.Context, s store.ObjectStore, operation string)
 // than under the original ctx.
 func AcquireSharedLock(ctx context.Context, s store.ObjectStore, operation string) (*LockHandle, context.Context, error) {
 	// 1. Check if an exclusive lock exists
-	if existing, err := readLockByKey(ctx, s, exclusiveLockKey); err == nil {
-		expires, parseErr := time.Parse(time.RFC3339Nano, existing.ExpiresAt)
-		if parseErr != nil || time.Now().Before(expires) {
-			return nil, nil, fmt.Errorf(
-				"repository is exclusively locked by %s (operation: %s)",
-				existing.Holder, existing.Operation,
-			)
-		}
+	if err := checkExclusiveLock(ctx, s); err != nil {
+		return nil, nil, err
 	}
 
 	// 2. Write our shared lock
@@ -182,17 +170,10 @@ func AcquireSharedLock(ctx context.Context, s store.ObjectStore, operation strin
 	}
 
 	// 3. Re-read exclusive lock to catch race with prune creating an exclusive lock at the same time
-	if existing, err := readLockByKey(ctx, s, exclusiveLockKey); err == nil {
-		expires, parseErr := time.Parse(time.RFC3339Nano, existing.ExpiresAt)
-		if parseErr != nil || time.Now().Before(expires) {
-			// Found an exclusive lock that was created during our shared lock creation
-			// Rollback our shared lock
-			_ = s.Delete(ctx, sharedLockKey)
-			return nil, nil, fmt.Errorf(
-				"repository was exclusively locked by %s while acquiring shared lock",
-				existing.Holder,
-			)
-		}
+	if err := checkExclusiveLock(ctx, s); err != nil {
+		// An exclusive lock appeared while we were writing ours. Roll back.
+		_ = s.Delete(ctx, sharedLockKey)
+		return nil, nil, fmt.Errorf("while acquiring shared lock: %w", err)
 	}
 
 	opCtx, cancel := context.WithCancel(ctx)
@@ -259,26 +240,48 @@ func (h *LockHandle) refreshLoop(ctx context.Context) {
 // another operation (either exclusive or shared). Callers that only need to detect conflicts
 // use this instead of acquiring their own lock.
 func CheckRepoLock(ctx context.Context, s store.ObjectStore) error {
+	if err := checkExclusiveLock(ctx, s); err != nil {
+		return err
+	}
+	return checkSharedLocks(ctx, s)
+}
+
+// checkExclusiveLock returns nil only when it can show no live exclusive lock
+// exists, and an error in every other case — including the cases where it
+// cannot tell.
+//
+// The distinction is the whole point. A lock read can fail three ways that look
+// alike from the call site and are not alike at all: the object is absent (safe
+// to proceed), the object is present but could not be fetched (a live lock we
+// must respect), or the store itself is unreachable (we know nothing). Treating
+// the last two as "no lock" is what lets a prune start while a backup is
+// running and delete the objects that backup is still writing — a transient
+// network error becoming data loss.
+//
+// An unparseable expiry is treated the same way, as still locked. A lock we
+// cannot read the clock off is a lock, and the TTL will retire it soon enough
+// if the holder really is gone.
+func checkExclusiveLock(ctx context.Context, s store.ObjectStore) error {
 	existing, err := readLockByKey(ctx, s, exclusiveLockKey)
-	if err == nil {
-		expires, parseErr := time.Parse(time.RFC3339Nano, existing.ExpiresAt)
-		if parseErr != nil || time.Now().Before(expires) {
-			return fmt.Errorf(
-				"repository is exclusively locked by %s (operation: %s) — try again later",
-				existing.Holder, existing.Operation,
-			)
-		}
-	} else {
+	if err != nil {
 		exists, existsErr := s.Exists(ctx, exclusiveLockKey)
 		if existsErr != nil {
-			return fmt.Errorf("check repo lock: %w", existsErr)
+			return fmt.Errorf("cannot determine whether the repository is locked: %w", existsErr)
 		}
 		if exists {
-			return fmt.Errorf("failed to read existing repo lock: %w", err)
+			return fmt.Errorf("repository holds an unreadable exclusive lock: %w", err)
 		}
+		return nil
 	}
 
-	return checkSharedLocks(ctx, s)
+	expires, parseErr := time.Parse(time.RFC3339Nano, existing.ExpiresAt)
+	if parseErr != nil || time.Now().Before(expires) {
+		return fmt.Errorf(
+			"repository is exclusively locked by %s (operation: %s, acquired: %s, expires: %s)",
+			existing.Holder, existing.Operation, existing.AcquiredAt, existing.ExpiresAt,
+		)
+	}
+	return nil
 }
 
 // BreakRepoLock forcibly removes the repository lock (exclusive and shared)
@@ -316,7 +319,17 @@ func checkSharedLocks(ctx context.Context, s store.ObjectStore) error {
 	for _, key := range keys {
 		sharedLock, err := readLockByKey(ctx, s, key)
 		if err != nil {
-			// Ignore read errors for individual shared locks, could be concurrent delete
+			// The key was listed a moment ago, so "gone now" is the likely
+			// explanation and is safe to skip. "Still there but unreadable" is
+			// not: it is a live shared lock, and stepping over it lets an
+			// exclusive operation run against a repository someone is reading.
+			exists, existsErr := s.Exists(ctx, key)
+			if existsErr != nil {
+				return fmt.Errorf("cannot determine whether shared lock %s is live: %w", key, existsErr)
+			}
+			if exists {
+				return fmt.Errorf("repository holds an unreadable shared lock %s: %w", key, err)
+			}
 			continue
 		}
 		expires, parseErr := time.Parse(time.RFC3339Nano, sharedLock.ExpiresAt)

--- a/internal/engine/repolock_unreadable_test.go
+++ b/internal/engine/repolock_unreadable_test.go
@@ -1,0 +1,83 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// unreadableLockStore serves every key normally except the lock objects, whose
+// reads fail while Exists keeps reporting them present. That is a real backend
+// state, not a contrived one: an object can be listed and stat-able while a
+// GET is throttled, reset, or served a truncated body.
+type unreadableLockStore struct {
+	*MockStore
+	failPrefix string
+}
+
+var errLockUnreadable = errors.New("SlowDown: request rate exceeded")
+
+func (u *unreadableLockStore) Get(ctx context.Context, key string) ([]byte, error) {
+	if strings.HasPrefix(key, u.failPrefix) {
+		return nil, errLockUnreadable
+	}
+	return u.MockStore.Get(ctx, key)
+}
+
+// A lock that cannot be read is a lock. Concluding otherwise is how a prune
+// starts alongside a running backup and sweeps the objects that backup has
+// written but not yet referenced from a snapshot.
+func TestAcquireRepoLockRefusesWhenExclusiveLockIsUnreadable(t *testing.T) {
+	ctx := context.Background()
+	base := NewMockStore()
+
+	// Someone holds the exclusive lock.
+	holder, _, err := AcquireRepoLock(ctx, base, "backup")
+	if err != nil {
+		t.Fatalf("seed lock: %v", err)
+	}
+	defer holder.Release()
+
+	blind := &unreadableLockStore{MockStore: base, failPrefix: exclusiveLockKey}
+
+	if _, _, err := AcquireRepoLock(ctx, blind, "prune"); err == nil {
+		t.Fatal("prune acquired the exclusive lock while an existing one was merely unreadable")
+	}
+	if _, _, err := AcquireSharedLock(ctx, blind, "restore"); err == nil {
+		t.Fatal("restore acquired a shared lock while the exclusive lock was merely unreadable")
+	}
+}
+
+// The same reasoning in the other direction: an exclusive operation must not
+// step over a shared lock it cannot read.
+func TestAcquireRepoLockRefusesWhenSharedLockIsUnreadable(t *testing.T) {
+	ctx := context.Background()
+	base := NewMockStore()
+
+	holder, _, err := AcquireSharedLock(ctx, base, "backup")
+	if err != nil {
+		t.Fatalf("seed shared lock: %v", err)
+	}
+	defer holder.Release()
+
+	blind := &unreadableLockStore{MockStore: base, failPrefix: sharedLockPrefix}
+
+	if _, _, err := AcquireRepoLock(ctx, blind, "prune"); err == nil {
+		t.Fatal("prune acquired the exclusive lock while a shared lock was merely unreadable")
+	}
+}
+
+// The permissive case must stay permissive: a repository with no lock at all
+// is not blocked by this. Absence and unreadability are different answers and
+// the fix depends on telling them apart, so both directions are pinned.
+func TestAcquireRepoLockSucceedsOnUnlockedRepository(t *testing.T) {
+	ctx := context.Background()
+	s := NewMockStore()
+
+	lock, _, err := AcquireRepoLock(ctx, s, "prune")
+	if err != nil {
+		t.Fatalf("acquire on an unlocked repository: %v", err)
+	}
+	lock.Release()
+}

--- a/internal/engine/restore.go
+++ b/internal/engine/restore.go
@@ -627,7 +627,7 @@ func (rm *RestoreManager) resolveSnapshot(ctx context.Context, ref string) (*cor
 		ref = "snapshot/" + ref
 	}
 
-	data, err := rm.store.Get(ctx, ref)
+	data, err := getVerified(ctx, rm.store, ref)
 	if err != nil {
 		return nil, "", fmt.Errorf("load snapshot %s: %w", ref, err)
 	}
@@ -685,7 +685,7 @@ func (rm *RestoreManager) collectMetadata(ctx context.Context, root string) (map
 }
 
 func (rm *RestoreManager) loadMeta(ctx context.Context, ref string) (*core.FileMeta, error) {
-	data, err := rm.store.Get(ctx, ref)
+	data, err := getVerified(ctx, rm.store, ref)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/engine/snapshots.go
+++ b/internal/engine/snapshots.go
@@ -247,6 +247,18 @@ func fetchSnapshots(s store.ObjectStore, keys []string) (map[string]core.Snapsho
 				mu.Unlock()
 				return
 			}
+			// A snapshot key is the SHA-256 of the snapshot bytes, so this
+			// catches a substituted or rotted snapshot before its summary is
+			// written into the catalog — where it would then be trusted by
+			// every later read without the object being fetched again.
+			if err := core.VerifyRef(k, data); err != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = err
+				}
+				mu.Unlock()
+				return
+			}
 			var snap core.Snapshot
 			if err := json.Unmarshal(data, &snap); err != nil {
 				mu.Lock()

--- a/internal/engine/tamper_test.go
+++ b/internal/engine/tamper_test.go
@@ -1,0 +1,223 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cloudstic/cli/internal/core"
+	"github.com/cloudstic/cli/internal/ui"
+)
+
+// The object store is untrusted. A backup provider, anyone with write access to
+// the bucket, or bit rot can change the bytes stored under a key. Objects named
+// by their own SHA-256 — filemeta, node, and snapshot — carry the means to
+// detect that, and the tests below hold every reader to it.
+//
+// Chunks and content objects are covered elsewhere: restore hashes the
+// reconstructed stream against the file's recorded ContentHash, and
+// `check -read-data` re-hashes chunk bytes.
+
+// findKey returns the single key under prefix, failing when the count is not one.
+func findKey(t *testing.T, s *MockStore, prefix string) string {
+	t.Helper()
+	keys, err := s.List(context.Background(), prefix)
+	if err != nil {
+		t.Fatalf("list %s: %v", prefix, err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("want exactly one %s object, got %d: %v", prefix, len(keys), keys)
+	}
+	return keys[0]
+}
+
+// tamperedFileMeta rewrites the filemeta for name so it claims different
+// content, leaving it stored under the key it no longer hashes to. This is
+// exactly what a store that substitutes an object achieves.
+func tamperedFileMeta(t *testing.T, s *MockStore, name string, mutate func(*core.FileMeta)) string {
+	t.Helper()
+	ctx := context.Background()
+
+	keys, err := s.List(ctx, "filemeta/")
+	if err != nil {
+		t.Fatalf("list filemeta: %v", err)
+	}
+	for _, key := range keys {
+		data, err := s.Get(ctx, key)
+		if err != nil {
+			t.Fatalf("get %s: %v", key, err)
+		}
+		var fm core.FileMeta
+		if err := json.Unmarshal(data, &fm); err != nil {
+			t.Fatalf("decode %s: %v", key, err)
+		}
+		if fm.Name != name {
+			continue
+		}
+		mutate(&fm)
+		forged, err := json.Marshal(&fm)
+		if err != nil {
+			t.Fatalf("marshal forged filemeta: %v", err)
+		}
+		if err := s.Put(ctx, key, forged); err != nil {
+			t.Fatalf("put forged %s: %v", key, err)
+		}
+		return key
+	}
+	t.Fatalf("no filemeta named %q", name)
+	return ""
+}
+
+// TestRestoreRejectsTamperedFileMeta covers the case that turns a metadata
+// substitution into wrong bytes on the user's disk: the forged filemeta renames
+// the file, so restore writes real content under a name the user never backed
+// up. The content-hash check restore already performs cannot see this — the
+// content is genuine, it is the name that is forged.
+func TestRestoreRejectsTamperedFileMeta(t *testing.T) {
+	dest := setupBackupForRestore(t)
+	tamperedFileMeta(t, dest, "restore_me.txt", func(fm *core.FileMeta) {
+		fm.Name = "attacker_chosen_name.txt"
+	})
+
+	out := t.TempDir()
+	writer, err := NewFSRestoreWriter(out)
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	rm := NewRestoreManager(dest, ui.NewNoOpReporter())
+	_, err = rm.Run(context.Background(), writer, "latest")
+
+	if err == nil {
+		t.Fatalf("restore accepted a filemeta that does not hash to its key; "+
+			"directory now contains %v", entryNames(t, out))
+	}
+	if !strings.Contains(err.Error(), "integrity check") {
+		t.Fatalf("want an integrity-check failure, got: %v", err)
+	}
+	if names := entryNames(t, out); len(names) != 0 {
+		t.Errorf("restore aborted but still wrote %v", names)
+	}
+}
+
+// TestRestoreRejectsTamperedSnapshot covers the root of the chain. Verifying
+// filemeta and nodes is worth nothing if the snapshot naming the root can be
+// swapped for one pointing somewhere else.
+func TestRestoreRejectsTamperedSnapshot(t *testing.T) {
+	dest := setupBackupForRestore(t)
+	ctx := context.Background()
+
+	snapKey := findKey(t, dest, "snapshot/")
+	data, err := dest.Get(ctx, snapKey)
+	if err != nil {
+		t.Fatalf("get snapshot: %v", err)
+	}
+	var snap core.Snapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		t.Fatalf("decode snapshot: %v", err)
+	}
+	snap.Created = "1999-01-01T00:00:00Z"
+	forged, err := json.Marshal(&snap)
+	if err != nil {
+		t.Fatalf("marshal forged snapshot: %v", err)
+	}
+	if err := dest.Put(ctx, snapKey, forged); err != nil {
+		t.Fatalf("put forged snapshot: %v", err)
+	}
+
+	writer, err := NewFSRestoreWriter(t.TempDir())
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	rm := NewRestoreManager(dest, ui.NewNoOpReporter())
+	if _, err := rm.Run(ctx, writer, "latest"); err == nil {
+		t.Fatal("restore accepted a snapshot that does not hash to its key")
+	} else if !strings.Contains(err.Error(), "integrity check") {
+		t.Fatalf("want an integrity-check failure, got: %v", err)
+	}
+}
+
+// TestCheckReportsTamperedFileMeta pins the other half: the operator who runs
+// `check` to find out whether a repository is sound must be told about a
+// substituted filemeta, and told before a restore is attempted.
+func TestCheckReportsTamperedFileMeta(t *testing.T) {
+	dest := setupBackupForRestore(t)
+	key := tamperedFileMeta(t, dest, "nested.txt", func(fm *core.FileMeta) {
+		fm.Size = 999999
+	})
+
+	cm := NewCheckManager(dest, ui.NewNoOpReporter(), nil)
+	res, err := cm.Run(context.Background(), WithReadData())
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+
+	for _, e := range res.Errors {
+		if e.Key == key && e.Type == "corrupt" {
+			return
+		}
+	}
+	t.Fatalf("check found no corruption for the tampered %s; reported %v", key, res.Errors)
+}
+
+// TestCheckReportsTamperedInlineContent covers small files, which are stored
+// inline in the content object rather than as chunks. `check -read-data`
+// re-hashes chunk bytes, so without an inline case the whole small-file
+// population is verified by nothing at all.
+func TestCheckReportsTamperedInlineContent(t *testing.T) {
+	src := NewMockSource()
+	dest := NewMockStore()
+	src.AddFile("small.txt", "id1", []byte("small enough to store inline"))
+
+	bm := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil)
+	if _, err := bm.Run(context.Background()); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+
+	ctx := context.Background()
+	contentKey := findKey(t, dest, "content/")
+	forged, err := json.Marshal(core.Content{
+		Type:          core.ObjectTypeContent,
+		Size:          int64(len("attacker supplied bytes!!!!!")),
+		DataInlineB64: []byte("attacker supplied bytes!!!!!"),
+	})
+	if err != nil {
+		t.Fatalf("marshal forged content: %v", err)
+	}
+	if err := dest.Put(ctx, contentKey, forged); err != nil {
+		t.Fatalf("put forged content: %v", err)
+	}
+
+	cm := NewCheckManager(dest, ui.NewNoOpReporter(), nil)
+	res, err := cm.Run(ctx, WithReadData())
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	for _, e := range res.Errors {
+		if e.Key == contentKey && e.Type == "corrupt" {
+			return
+		}
+	}
+	t.Fatalf("check found no corruption for the tampered inline %s; reported %v", contentKey, res.Errors)
+}
+
+func entryNames(t *testing.T, dir string) []string {
+	t.Helper()
+	var names []string
+	err := filepath.Walk(dir, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			rel, _ := filepath.Rel(dir, p)
+			names = append(names, rel)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", dir, err)
+	}
+	return names
+}

--- a/internal/engine/verify.go
+++ b/internal/engine/verify.go
@@ -1,0 +1,41 @@
+package engine
+
+import (
+	"context"
+
+	"github.com/cloudstic/cli/internal/core"
+	"github.com/cloudstic/cli/pkg/store"
+)
+
+// getVerified reads ref and refuses bytes that are not what ref names.
+//
+// The object store is not a trusted component. It is a bucket someone else
+// operates, reached over a network, and its contents outlive the process that
+// wrote them — so bit rot, a truncated write, and a deliberate substitution all
+// present the same way: the bytes under a key are not the bytes put there.
+//
+// For filemeta, node, and snapshot objects the key is a SHA-256 of those bytes,
+// which makes the check free of any secret and available to every reader. That
+// matters more than it first appears, because the store stack above this point
+// will not catch a substitution on its own: the encryption layer returns any
+// object that does not look encrypted verbatim, so plaintext written under a
+// key by whoever controls the bucket is passed straight through to the decoder.
+// Verifying the content address is what makes such an object unusable — an
+// attacker can choose the bytes or choose the key they are filed under, never
+// both, and the key is named by a parent object subject to the same check.
+//
+// Objects outside core.SelfAddressedPrefixes are read unchanged; they are
+// verified by other means (see core.SelfAddressedPrefixes).
+func getVerified(ctx context.Context, s store.ObjectStore, ref string) ([]byte, error) {
+	data, err := s.Get(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	if !core.IsSelfAddressed(ref) {
+		return data, nil
+	}
+	if err := core.VerifyRef(ref, data); err != nil {
+		return nil, err
+	}
+	return data, nil
+}

--- a/internal/engine/verify_bench_test.go
+++ b/internal/engine/verify_bench_test.go
@@ -1,0 +1,84 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/cloudstic/cli/internal/core"
+)
+
+// The integrity check getVerified performs is a SHA-256 over bytes the caller
+// has already paid to fetch and is about to pay to decode. These benchmarks
+// measure it against that baseline rather than in isolation, because "how much
+// slower is a metadata read" is the question a user has, and an isolated hash
+// benchmark would answer a different one.
+
+func benchFileMetaCorpus(b *testing.B, n int) (*MockStore, []string) {
+	b.Helper()
+	s := NewMockStore()
+	refs := make([]string, 0, n)
+	ctx := context.Background()
+	for i := range n {
+		fm := core.FileMeta{
+			Version:     1,
+			FileID:      fmt.Sprintf("file-%d", i),
+			Name:        fmt.Sprintf("some-reasonably-named-document-%d.txt", i),
+			Type:        core.FileTypeFile,
+			Parents:     []string{"parent-directory-id"},
+			ContentHash: fmt.Sprintf("%064x", i),
+			Size:        int64(i * 1024),
+			Mtime:       1700000000,
+			Owner:       "user@example.com",
+		}
+		ref, data, err := fm.Ref()
+		if err != nil {
+			b.Fatalf("ref: %v", err)
+		}
+		if err := s.Put(ctx, ref, data); err != nil {
+			b.Fatalf("put: %v", err)
+		}
+		refs = append(refs, ref)
+	}
+	return s, refs
+}
+
+// BenchmarkFileMetaRead_Verified is the path every reader now takes.
+func BenchmarkFileMetaRead_Verified(b *testing.B) {
+	s, refs := benchFileMetaCorpus(b, 1000)
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		ref := refs[i%len(refs)]
+		data, err := getVerified(ctx, s, ref)
+		if err != nil {
+			b.Fatal(err)
+		}
+		var fm core.FileMeta
+		if err := json.Unmarshal(data, &fm); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkFileMetaRead_Unverified is the path readers took before, kept as the
+// comparison baseline.
+func BenchmarkFileMetaRead_Unverified(b *testing.B) {
+	s, refs := benchFileMetaCorpus(b, 1000)
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		ref := refs[i%len(refs)]
+		data, err := s.Get(ctx, ref)
+		if err != nil {
+			b.Fatal(err)
+		}
+		var fm core.FileMeta
+		if err := json.Unmarshal(data, &fm); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/hamt/nodestore.go
+++ b/internal/hamt/nodestore.go
@@ -110,13 +110,12 @@ func (ns *NodeStore) putAll(ctx context.Context, batch map[string][]byte) error 
 // ls, diff, prune, check — detects a corrupted or substituted node, not just
 // `check -read-data`. It also closes the recursion hole: a node cannot claim a
 // child that hashes to one of its own ancestors without failing this check.
+//
+// The check itself lives in core alongside the same check for filemeta and
+// snapshot objects, so the three links of the Merkle chain cannot drift apart.
 func verifyNodeRef(ref string, data []byte) error {
-	want, ok := strings.CutPrefix(ref, nodePrefix)
-	if !ok {
+	if !strings.HasPrefix(ref, nodePrefix) {
 		return fmt.Errorf("node ref %q is missing the %q prefix", ref, nodePrefix)
 	}
-	if got := core.ComputeHash(data); got != want {
-		return fmt.Errorf("node %s failed its integrity check: %d bytes hashing to %s", ref, len(data), got)
-	}
-	return nil
+	return core.VerifyRef(ref, data)
 }

--- a/pkg/store/pack.go
+++ b/pkg/store/pack.go
@@ -175,11 +175,44 @@ func (s *PackStore) Put(ctx context.Context, key string, data []byte) error {
 	// 5. Upload outside the lock so we don't block concurrent operations
 	if packRef != "" {
 		if err := s.ObjectStore.Put(ctx, packRef, packData); err != nil {
+			s.discardPack(packRef)
 			return fmt.Errorf("flush pack %s: %w", packRef, err)
 		}
 	}
 
 	return nil
+}
+
+// discardPack forgets every catalog entry pointing at packRef, for a pack whose
+// upload failed.
+//
+// prepareFlushLocked moves entries into the catalog before the pack exists,
+// which is what lets the upload happen outside the lock. If that upload then
+// fails, leaving the entries behind is worse than losing them: the catalog
+// asserts the objects are stored, so Exists reports true, the next backup
+// deduplicates against them and does not re-upload, and a later flush makes the
+// claim durable in a shard. The snapshot that results references objects no
+// reader can fetch — a backup that reports success and cannot be restored.
+//
+// Forgetting them instead costs only the re-upload the caller was going to have
+// to do anyway, and the pack bytes themselves are content-addressed, so a retry
+// that does succeed writes the identical object.
+func (s *PackStore) discardPack(packRef string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for key, entry := range s.catalog {
+		if entry.PackRef == packRef {
+			delete(s.catalog, key)
+		}
+	}
+	for key, entry := range s.pendingShard {
+		if entry.PackRef == packRef {
+			delete(s.pendingShard, key)
+		}
+	}
+	s.packCache.Remove(packRef)
+	debugf("pack: discarded catalog entries for unwritten pack %s", packRef)
 }
 
 // packablePrefixes are the content-addressed namespaces safe to bundle into a
@@ -414,13 +447,17 @@ func (s *PackStore) Flush(ctx context.Context) error {
 
 	if packRef != "" {
 		if err := s.ObjectStore.Put(ctx, packRef, packData); err != nil {
-			// The entries are still ours to write; put them back so a retry
-			// does not lose them.
+			// Restore the entries that belong to packs already written, and
+			// drop the ones that belong to this pack — it does not exist, so a
+			// shard naming it would point every one of its objects at nothing.
 			s.mu.Lock()
 			for k, v := range pending {
-				s.pendingShard[k] = v
+				if v.PackRef != packRef {
+					s.pendingShard[k] = v
+				}
 			}
 			s.mu.Unlock()
+			s.discardPack(packRef)
 			return fmt.Errorf("flush pack %s: %w", packRef, err)
 		}
 	}

--- a/pkg/store/pack_upload_failure_test.go
+++ b/pkg/store/pack_upload_failure_test.go
@@ -1,0 +1,111 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// packRejectingStore fails writes of packfiles while letting everything else
+// through, standing in for a backend that rejects the one upload that matters:
+// a bucket that has hit its quota, a connection that drops on the large object,
+// a credential that expired mid-run.
+type packRejectingStore struct {
+	ObjectStore
+	reject   bool
+	rejected int
+}
+
+var errPackUploadRejected = errors.New("AccessDenied: upload rejected")
+
+func (p *packRejectingStore) Put(ctx context.Context, key string, data []byte) error {
+	if p.reject && strings.HasPrefix(key, packPrefix) {
+		p.rejected++
+		return errPackUploadRejected
+	}
+	return p.ObjectStore.Put(ctx, key, data)
+}
+
+// A pack's entries enter the catalog before the pack is uploaded — that is what
+// lets the upload happen off the lock. When the upload then fails, the entries
+// must not survive: the catalog would assert the objects are stored, Exists
+// would agree, the next backup would deduplicate against them instead of
+// uploading, and the snapshot it wrote would name objects nothing can fetch.
+//
+// The test asserts the property that matters to a user, not the mechanism: after
+// a failed flush, the store must not claim to hold an object it does not hold.
+func TestPackStore_FailedPackUploadLeavesNoPhantomEntries(t *testing.T) {
+	ctx := context.Background()
+	_, inner := newCatalogTestStore(t)
+	rejecting := &packRejectingStore{ObjectStore: inner, reject: true}
+	ps := newPackStoreT(t, rejecting)
+
+	const key = "chunk/aaaa"
+	if err := ps.Put(ctx, key, []byte("data that never reaches the backend")); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	if err := ps.Flush(ctx); err == nil {
+		t.Fatal("flush reported success although the pack upload was rejected")
+	}
+	if rejecting.rejected == 0 {
+		t.Fatal("no pack upload was attempted; the test proves nothing")
+	}
+
+	// The claim that must not survive: this object is stored.
+	exists, err := ps.Exists(ctx, key)
+	if err != nil {
+		t.Fatalf("exists: %v", err)
+	}
+	if exists {
+		t.Error("store reports holding an object whose pack upload failed; " +
+			"a backup would deduplicate against it and write an unrestorable snapshot")
+	}
+
+	// And it must not survive into the durable index either. A fresh store over
+	// the same backend is what the next process sees.
+	fresh := newPackStoreT(t, inner)
+	if exists, err := fresh.Exists(ctx, key); err != nil {
+		t.Fatalf("fresh exists: %v", err)
+	} else if exists {
+		t.Error("a new process reads the failed object as present; the phantom entry was made durable")
+	}
+}
+
+// Retrying after the backend recovers must actually store the data, rather than
+// short-circuiting on a catalog entry left behind by the failed attempt.
+func TestPackStore_RetryAfterFailedPackUploadStoresData(t *testing.T) {
+	ctx := context.Background()
+	_, inner := newCatalogTestStore(t)
+	rejecting := &packRejectingStore{ObjectStore: inner, reject: true}
+	ps := newPackStoreT(t, rejecting)
+
+	const key = "filemeta/bbbb"
+	payload := []byte("the bytes the user expects to get back")
+
+	if err := ps.Put(ctx, key, payload); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if err := ps.Flush(ctx); err == nil {
+		t.Fatal("flush reported success although the pack upload was rejected")
+	}
+
+	// Backend recovers; the caller retries the write it knows failed.
+	rejecting.reject = false
+	if err := ps.Put(ctx, key, payload); err != nil {
+		t.Fatalf("retry put: %v", err)
+	}
+	if err := ps.Flush(ctx); err != nil {
+		t.Fatalf("retry flush: %v", err)
+	}
+
+	fresh := newPackStoreT(t, inner)
+	got, err := fresh.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("read back after retry: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Errorf("read back %q, want %q", got, payload)
+	}
+}


### PR DESCRIPTION
## Summary
- Filemeta and snapshot objects are named by the SHA-256 of their own bytes, exactly like HAMT nodes — but only nodes were ever checked against that address. Every other reader (`restore`, `prune`, `diff`, `ls`, `backup`, `check`) trusted whatever the store returned. Adds `core.VerifyRef`/`SelfAddressedPrefixes` as one shared definition of the invariant and routes every load site through it.
- `check -read-data` verified chunk hashes only. Inline content (files ≤512 KiB, the majority of a typical tree) got zero byte-level verification, and a reordered or substituted-but-individually-valid chunk manifest went undetected. Adds manifest reconstruction against the recorded content hash for both storage layouts, plus a `content_ref` derivation check.
- A failed packfile upload left the pack catalog claiming objects it never stored; the next backup deduplicated against them and produced a snapshot referencing objects nothing could fetch. `PackStore` now discards those entries on both failure paths.
- Lock acquisition treated a read error on an existing lock the same as no lock, so a transient store error could let an exclusive and a shared operation proceed concurrently. Acquisition now distinguishes "absent" from "unreadable" and refuses in the latter case, matching what `CheckRepoLock` already did.

Every fix has a regression test that was confirmed to fail against the pre-fix code before the fix landed.

## Verification
```
GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./...
GOCACHE=/tmp/cloudstic-gocache go vet ./...
GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./internal/... ./pkg/... .
GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./internal/... ./pkg/...
```
All 20 packages pass (including the `e2e` legacy-repository compatibility fixtures), `go vet` is clean, `-race` is clean, `golangci-lint` reports 0 issues. No repository-format change — verification is against stored bytes, which have held this relationship in every format version.