### PR TITLE
perf(restore): pipeline chunk fetches and restore files concurrently

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package cloudstic
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"sync/atomic"
@@ -181,16 +182,17 @@ func AddRecoveryKey(ctx context.Context, rawStore store.ObjectStore, kc keychain
 // Returns (nil, nil) if the repository has not been initialized yet.
 // Returns an error if the store is unreachable (e.g. invalid credentials).
 func LoadRepoConfig(ctx context.Context, rawStore store.ObjectStore) (*RepoConfig, error) {
-	exists, err := rawStore.Exists(ctx, "config")
-	if err != nil {
-		return nil, fmt.Errorf("check repo config: %w", err)
-	}
-	if !exists {
-		return nil, nil // repository not initialized
-	}
-
+	// A single Get, not Exists-then-Get. Get already distinguishes the two
+	// outcomes this function has to tell apart — every backend wraps
+	// store.ErrNotFound for a missing key and returns anything else verbatim —
+	// so the probe was a second round trip that answered a question the Get
+	// answers on its own. This runs on the open path of every command, where
+	// on a high-latency backend each avoided round trip is directly visible.
 	data, err := rawStore.Get(ctx, "config")
 	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, nil // repository not initialized
+		}
 		return nil, fmt.Errorf("read repo config: %w", err)
 	}
 	if data == nil {
@@ -309,7 +311,11 @@ type Client struct {
 	// single source of truth for format-dependent write policy. The compression
 	// layer's frame gate reads it, and raiseRepoFormat is its only writer, so
 	// framing cannot disagree with the format a mutation has stamped.
-	repoFormat     atomic.Int64
+	repoFormat atomic.Int64
+	// openCfg is the config NewClient read, held so the first raiseRepoFormat
+	// of this client does not immediately re-read it. It is consumed on first
+	// use (swapped for the noRepoConfig sentinel) and never consulted again.
+	openCfg        atomic.Pointer[RepoConfig]
 	storedMeter    *store.MeteredStore
 	encryptionKey  []byte
 	hmacKey        []byte
@@ -395,6 +401,7 @@ func NewClient(ctx context.Context, base store.ObjectStore, opts ...ClientOption
 	// first framed write.
 	if cfg != nil {
 		c.repoFormat.Store(int64(cfg.Version))
+		c.openCfg.Store(cfg)
 	}
 	c.store = store.NewCompressedStore(inner, store.WithFrameGate(c.framingEnabled))
 	c.storedMeter = storedMeter
@@ -461,6 +468,11 @@ var (
 	WithWorkstationStoreRef = engine.WithWorkstationStoreRef
 )
 
+// noRepoConfig marks Client.openCfg as spent. A plain nil cannot: nil is also
+// what the field holds for an uninitialized repository, and those two states
+// have to stay distinguishable.
+var noRepoConfig RepoConfig
+
 // raiseRepoFormat stamps the on-disk format and updates the in-process view in
 // lockstep, so format-dependent write policy — framing — follows immediately.
 // It is the only writer of c.repoFormat.
@@ -474,6 +486,25 @@ func (c *Client) raiseRepoFormat(ctx context.Context) error {
 	if c.base == nil {
 		return nil
 	}
+
+	// The first raise can answer from the config NewClient just read, instead
+	// of fetching "config" a second time within the same command — two round
+	// trips to read one small immutable object, back to back, which is
+	// plainly visible on a high-latency backend.
+	//
+	// Only the first. The cached copy is consumed here and every later raise
+	// re-reads, because "already current" then stops being a safe assumption:
+	// a long-lived client outlives the moment it was opened, and the on-disk
+	// version is what other machines act on. Skipping the write on a stale
+	// in-process belief would leave a repository unstamped after a real
+	// mutation — see TestDryRunsDoNotStampTheFormat.
+	if cfg := c.openCfg.Swap(&noRepoConfig); cfg != nil && cfg != &noRepoConfig {
+		if cfg.Version >= core.RepoFormatVersion {
+			c.repoFormat.Store(int64(core.RepoFormatVersion))
+			return nil
+		}
+	}
+
 	if err := UpgradeRepoFormat(ctx, c.base, core.RepoFormatVersion); err != nil {
 		return err
 	}

--- a/docs/benchmark-results.md
+++ b/docs/benchmark-results.md
@@ -40,16 +40,26 @@ Dataset: ~1.05 GB (500MB random, 500MB compressible zeros, 50 x 1MB docs, 100 x 
 
 ## Local File System
 
+Measured on an Apple M3 Max / 36 GB / macOS 26.5, all four tools in one run.
+
 _Format: time / peak RAM / +repo written_
 
 | Metric | Cloudstic | Restic | Borg | Duplicacy |
 | :--- | :--- | :--- | :--- | :--- |
-| **Initial Backup** | 0.61s / 259 MB / +551 MB | 1.80s / 314 MB / +550 MB | 1.69s / 139 MB / +555 MB | 3.44s / 284 MB / +553 MB |
-| **Incremental (No Changes)** | 0.05s / 96 MB / +4 KB | 0.77s / 72 MB / +12 KB | 0.67s / 72 MB / +16 KB | 0.04s / 44 MB / +4 KB |
-| **Incremental (1 File Changed)** | 0.05s / 96 MB / +8 KB | 0.78s / 78 MB / +36 KB | 0.67s / 72 MB / +24 KB | 0.24s / 79 MB / +36 KB |
-| **Add 200MB New Data** | 0.14s / 152 MB / +200 MB | 1.07s / 283 MB / +200 MB | 0.57s / 136 MB / +200 MB | 0.93s / 195 MB / +201 MB |
-| **Deduplicated Backup** | 0.60s / 235 MB / +88 KB | 1.57s / 104 MB / +36 KB | 1.24s / 81 MB / +56 KB | 3.31s / 130 MB / +1.8 MB |
-| **Final Repository Size** | 752 MB | 750 MB | 755 MB | 755 MB |
+| **Initial Backup** | 0.81s / 489 MB / +551 MB | 1.95s / 272 MB / +550 MB | 1.88s / 134 MB / +564 MB | 3.65s / 310 MB / +553 MB |
+| **Incremental (No Changes)** | 0.18s / 95 MB / +8 KB | 0.77s / 72 MB / +12 KB | 0.73s / 72 MB / +16 KB | 0.06s / 45 MB / +4 KB |
+| **Incremental (1 File Changed)** | 0.18s / 95 MB / +12 KB | 0.77s / 77 MB / +36 KB | 0.76s / 73 MB / +36 KB | 0.25s / 80 MB / +36 KB |
+| **Add 200MB New Data** | 0.30s / 308 MB / +200 MB | 1.06s / 327 MB / +200 MB | 0.61s / 147 MB / +200 MB | 0.98s / 242 MB / +201 MB |
+| **Deduplicated Backup** | 0.79s / 411 MB / +120 KB | 1.64s / 100 MB / +36 KB | 1.39s / 81 MB / +56 KB | 3.51s / 124 MB / +7.4 MB |
+| **Full Restore** | 0.69s / 326 MB | 1.44s / 181 MB | — | — |
+| **Full Restore (-no-verify)** | 0.40s / 378 MB | — | — | — |
+| **Final Repository Size** | 752 MB | 750 MB | 764 MB | 761 MB |
+
+Restore is measured against the final, deduplicated repository state, into a
+fresh empty directory each time. Cloudstic verifies every restored file's
+content hash by default, as Restic does; the `-no-verify` row isolates what
+that check costs. Borg and Duplicacy have no restore row because the harness
+does not drive their extract/restore commands yet.
 
 ## AWS S3 (us-east-1)
 
@@ -63,6 +73,11 @@ _Format: time / peak RAM / +repo written_
 | **Add 200MB New Data** | 8.98s / 409 MB / +200 MB | 7.45s / 458 MB / +200 MB |
 | **Deduplicated Backup** | 5.14s / 360 MB / +84 KB | 3.36s / 104 MB / +25 KB |
 | **Final Repository Size** | 750.4 MB | 750.3 MB |
+
+> **Stale:** this table predates the restore rows above and predates the
+> pipelined restore path, so it has no restore numbers and its backup numbers
+> are from an earlier build. Re-run `./scripts/benchmark/run.sh local s3 all`
+> against real S3 to refresh it.
 
 > **Note on architecture differences:** Cloudstic defaults to a hybrid `MicroPackStore` approach. It intelligently bundles small metadata objects (filemeta, nodes) into up to tightly-packed 8MB chunks to minimize S3 `PUT` requests, while passing all large files through as native encrypted objects. This yields the best of both worlds: lightning-fast S3 API performance comparable to packfile-based tools, while preserving native S3 lifecycle rules and fine-grained partial downloads for large media files.
 

--- a/internal/engine/restore.go
+++ b/internal/engine/restore.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/cloudstic/cli/internal/core"
 	"github.com/cloudstic/cli/internal/hamt"
@@ -86,18 +87,40 @@ type RestoreWriter interface {
 	Close() error
 }
 
+// concurrentRestoreWriter is the optional opt-in a RestoreWriter uses to
+// declare that WriteFile is safe to call from several goroutines at once.
+// Without it runWithWriter restores files one at a time.
+//
+// It is an opt-in rather than the default because it is not universally
+// achievable: a zip archive is a single sequential stream with one open entry
+// at a time, so zipRestoreWriter deliberately does not implement it. A
+// directory tree has no such constraint — distinct files are distinct fds —
+// so fsRestoreWriter does.
+type concurrentRestoreWriter interface {
+	SupportsConcurrentWrites() bool
+}
+
+// restoreMemoryBudget caps the total bytes of chunk data that have been
+// fetched but not yet written, across every file being restored at once.
+// Restore fans out on two axes now — several files in flight, several chunks
+// per file — so neither axis can be the memory bound on its own; this is.
+// It mirrors the equivalent cap on the backup side (see backup_upload.go).
+const restoreMemoryBudget = 128 * 1024 * 1024
+
 // RestoreManager recreates a snapshot's file tree using a RestoreWriter output format.
 type RestoreManager struct {
-	store    store.ObjectStore
-	tree     *hamt.Tree
-	reporter ui.Reporter
+	store     store.ObjectStore
+	tree      *hamt.Tree
+	reporter  ui.Reporter
+	memBudget *semaphore.Weighted
 }
 
 func NewRestoreManager(s store.ObjectStore, reporter ui.Reporter) *RestoreManager {
 	return &RestoreManager{
-		store:    s,
-		tree:     hamt.NewTree(s),
-		reporter: reporter,
+		store:     s,
+		tree:      hamt.NewTree(s),
+		reporter:  reporter,
+		memBudget: semaphore.NewWeighted(restoreMemoryBudget),
 	}
 }
 
@@ -125,26 +148,83 @@ func (rm *RestoreManager) Run(ctx context.Context, writer RestoreWriter, snapsho
 	return rm.runWithWriter(ctx, plan, writer)
 }
 
+// runWithWriter walks the topologically sorted entries, creating directories
+// and writing file contents.
+//
+// Directories are handled inline and in order: plan.sorted lists a parent
+// before its children, so creating them on this goroutine is what guarantees
+// a file's directory exists by the time the file is dispatched.
+//
+// File contents are the expensive part — each one is at least a content-object
+// fetch, and for a large file a whole sequence of chunk fetches. Restoring
+// them one after another means exactly one request is ever outstanding, so on
+// a high-latency backend the wall time collapses to (file count x round trip)
+// no matter how much bandwidth or store concurrency is available. They are
+// therefore dispatched to a bounded worker pool whenever the writer says it
+// can take concurrent writes; the pool degenerates to sequential execution for
+// writers that cannot (zip).
 func (rm *RestoreManager) runWithWriter(ctx context.Context, plan restorePlan, writer RestoreWriter) (*RestoreResult, error) {
 	result := &RestoreResult{SnapshotRef: plan.snapshotRef, Root: plan.root}
 	phase := rm.reporter.StartPhase("Restoring", int64(len(plan.sorted)), false)
+
+	// Counters are touched from the file workers as well as this goroutine.
+	var mu sync.Mutex
+	bump := func(field *int) {
+		mu.Lock()
+		*field++
+		mu.Unlock()
+	}
+
 	if setter, ok := writer.(restoreWarningSetter); ok {
 		setter.SetWarningFunc(func(msg string) {
-			result.Warnings++
+			bump(&result.Warnings)
 			phase.Log("Warning: " + msg)
 		})
 	}
+
+	cw, ok := writer.(concurrentRestoreWriter)
+	concurrent := ok && cw.SupportsConcurrentWrites()
+
+	g, gCtx := errgroup.WithContext(ctx)
+	if concurrent {
+		g.SetLimit(restoreFileConcurrency(rm.store))
+	}
+
+	// A failure to write one file is reported and counted, not fatal — the
+	// rest of the snapshot is still worth recovering. Only a context
+	// cancellation stops the walk, which is why the worker returns nil here
+	// and errgroup carries just gCtx's error.
+	restoreFile := func(meta core.FileMeta, rel string) func() error {
+		return func() error {
+			err := writer.WriteFile(rel, meta, func(out io.Writer) error {
+				return rm.writeFileContent(gCtx, out, meta, !plan.cfg.noVerify)
+			})
+			defer phase.Increment(1)
+			switch {
+			case err == errRestoreSkipped:
+				return nil
+			case err != nil:
+				phase.Log(fmt.Sprintf("Failed: %s: %v", rel, err))
+				bump(&result.Errors)
+				return nil
+			}
+			if plan.cfg.verbose {
+				phase.Log(fmt.Sprintf("File: %s (%d bytes)", rel, meta.Size))
+			}
+			bump(&result.FilesWritten)
+			return nil
+		}
+	}
+
 	for _, meta := range plan.sorted {
 		rel := buildRestorePath(meta, plan.byID)
 
 		if meta.Type == core.FileTypeFolder {
 			if err := writer.MkdirAll(rel, meta); err != nil {
-				if err == errRestoreSkipped {
-					phase.Increment(1)
-					continue
+				if err != errRestoreSkipped {
+					phase.Log(fmt.Sprintf("Failed: %s: %v", rel, err))
+					result.Errors++
 				}
-				phase.Log(fmt.Sprintf("Failed: %s: %v", rel, err))
-				result.Errors++
 				phase.Increment(1)
 				continue
 			}
@@ -161,24 +241,20 @@ func (rm *RestoreManager) runWithWriter(ctx context.Context, plan restorePlan, w
 			continue
 		}
 
-		if err := writer.WriteFile(rel, meta, func(out io.Writer) error {
-			return rm.writeFileContent(ctx, out, meta, !plan.cfg.noVerify)
-		}); err != nil {
-			if err == errRestoreSkipped {
-				phase.Increment(1)
-				continue
-			}
-			phase.Log(fmt.Sprintf("Failed: %s: %v", rel, err))
-			result.Errors++
-			phase.Increment(1)
+		// A sequential writer runs inline, not through the pool. Even a pool of
+		// one would let a file write overlap the MkdirAll of a later entry on
+		// this goroutine, and for a zip that means a directory header written
+		// into the middle of an open file entry.
+		if !concurrent {
+			_ = restoreFile(meta, rel)()
 			continue
 		}
+		g.Go(restoreFile(meta, rel))
+	}
 
-		if plan.cfg.verbose {
-			phase.Log(fmt.Sprintf("File: %s (%d bytes)", rel, meta.Size))
-		}
-		result.FilesWritten++
-		phase.Increment(1)
+	if err := g.Wait(); err != nil {
+		phase.Error()
+		return nil, err
 	}
 
 	phase.Done()
@@ -187,6 +263,19 @@ func (rm *RestoreManager) runWithWriter(ctx context.Context, plan restorePlan, w
 	}
 	result.BytesWritten = writer.BytesWritten()
 	return result, nil
+}
+
+// restoreFileConcurrency picks how many files to reconstruct at once.
+//
+// It is deliberately far below the store's own concurrency hint (128 for S3):
+// each file in flight opens its own chunk window underneath it, so the two
+// levels multiply. Memory is bounded by restoreMemoryBudget regardless, but
+// dividing the budget across too many files would starve each one's window
+// and lose the pipelining this exists to enable. A modest fan-out is enough
+// to hide per-file round trips, which is the actual bottleneck for the many
+// small-to-medium files that dominate a real snapshot.
+func restoreFileConcurrency(s store.ObjectStore) int {
+	return min(store.GetConcurrencyHint(s, 8), 16)
 }
 
 func (rm *RestoreManager) prepareRestore(ctx context.Context, snapshotRef string, opts ...RestoreOption) (restorePlan, error) {
@@ -274,7 +363,14 @@ func (w *zipRestoreWriter) Close() error {
 }
 
 type fsRestoreWriter struct {
-	root         string
+	root string
+
+	// mu guards every field below it. WriteFile runs concurrently (see
+	// SupportsConcurrentWrites), so the counters, the warn-dedup set, and the
+	// deferred-metadata lists are all shared mutable state. The lock is only
+	// ever held around bookkeeping — never across the content write itself,
+	// which is the whole point of restoring files in parallel.
+	mu           sync.Mutex
 	bytes        int64
 	warn         func(string)
 	warned       map[string]struct{}
@@ -297,21 +393,34 @@ func NewFSRestoreWriter(root string) (RestoreWriter, error) {
 	return &fsRestoreWriter{root: root, warned: map[string]struct{}{}}, nil
 }
 
+// SupportsConcurrentWrites implements concurrentRestoreWriter. Two WriteFile
+// calls for distinct paths touch disjoint files; the shared bookkeeping they
+// do touch is guarded by w.mu.
+func (w *fsRestoreWriter) SupportsConcurrentWrites() bool { return true }
+
 func (w *fsRestoreWriter) SetWarningFunc(fn func(string)) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	w.warn = fn
 }
 
 func (w *fsRestoreWriter) warnf(format string, args ...interface{}) {
-	if w.warn != nil {
-		w.warn(fmt.Sprintf(format, args...))
+	w.mu.Lock()
+	fn := w.warn
+	w.mu.Unlock()
+	if fn != nil {
+		fn(fmt.Sprintf(format, args...))
 	}
 }
 
 func (w *fsRestoreWriter) warnOncef(key, format string, args ...interface{}) {
+	w.mu.Lock()
 	if _, ok := w.warned[key]; ok {
+		w.mu.Unlock()
 		return
 	}
 	w.warned[key] = struct{}{}
+	w.mu.Unlock()
 	w.warnf(format, args...)
 }
 
@@ -340,10 +449,12 @@ func (w *fsRestoreWriter) MkdirAll(relPath string, meta core.FileMeta) error {
 	if err := os.MkdirAll(fullPath, 0o755); err != nil {
 		return err
 	}
+	w.mu.Lock()
 	w.deferredDirs = append(w.deferredDirs, deferredRestoreEntry{path: fullPath, meta: meta})
 	if meta.Flags != 0 {
 		w.deferredFlag = append(w.deferredFlag, deferredRestoreEntry{path: fullPath, meta: meta})
 	}
+	w.mu.Unlock()
 	return nil
 }
 
@@ -389,18 +500,31 @@ func (w *fsRestoreWriter) WriteFile(relPath string, meta core.FileMeta, writeCon
 		return closeErr
 	}
 
+	w.mu.Lock()
 	w.bytes += cw.count
+	w.mu.Unlock()
+
 	if err := applyRestoreFileMetadata(fullPath, meta, w.warnDedupf); err != nil {
 		return err
 	}
 	if meta.Flags != 0 {
+		w.mu.Lock()
 		w.deferredFlag = append(w.deferredFlag, deferredRestoreEntry{path: fullPath, meta: meta})
+		w.mu.Unlock()
 	}
 	return nil
 }
 
-func (w *fsRestoreWriter) BytesWritten() int64 { return w.bytes }
+func (w *fsRestoreWriter) BytesWritten() int64 {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.bytes
+}
 
+// Close runs after every WriteFile has returned, so it needs no lock of its
+// own — but it must stay that way: the deferred lists are ordered, and
+// applying directory metadata is what makes parent mtimes survive the writes
+// underneath them.
 func (w *fsRestoreWriter) Close() error {
 	for i := len(w.deferredDirs) - 1; i >= 0; i-- {
 		entry := w.deferredDirs[i]
@@ -515,7 +639,7 @@ func (rm *RestoreManager) writeFileContent(ctx context.Context, w io.Writer, met
 		out = io.MultiWriter(w, hasher)
 	}
 
-	if err := rm.writeChunks(ctx, out, content.Chunks); err != nil {
+	if err := rm.writeChunks(ctx, out, content.Chunks, avgChunkSize(content)); err != nil {
 		return err
 	}
 	if len(content.DataInlineB64) > 0 {
@@ -742,6 +866,16 @@ func (rm *RestoreManager) loadContent(ctx context.Context, hash string) (*core.C
 	return &c, nil
 }
 
+// avgChunkSize estimates a Content's per-chunk payload so writeChunks can
+// charge the memory budget without having to fetch a chunk to find out how
+// big one is.
+func avgChunkSize(c *core.Content) int64 {
+	if c == nil || len(c.Chunks) == 0 || c.Size <= 0 {
+		return 0
+	}
+	return c.Size / int64(len(c.Chunks))
+}
+
 func (rm *RestoreManager) writeChunk(ctx context.Context, w io.Writer, ref string) error {
 	data, err := rm.store.Get(ctx, ref)
 	if err != nil {
@@ -752,16 +886,25 @@ func (rm *RestoreManager) writeChunk(ctx context.Context, w io.Writer, ref strin
 }
 
 // writeChunks fetches a file's content chunks and writes them to w in order.
-// The store's Get is the bottleneck for a large file, so chunks are fetched
-// in bounded batches sized to the store's concurrency hint (mirroring
-// Chunker.ProcessStream's worker pool on the backup side) rather than one
-// blocking Get at a time. Batching — instead of firing every chunk at once —
-// keeps at most one batch's worth of chunk data in memory, which matters
-// because chunks (unlike the file metadata collectMetadata fetches) can be up
-// to 8MB each. Chunks still land on w in their original order regardless of
-// which fetch in a batch finishes first, since the reconstructed stream must
-// be byte-identical to what was chunked at backup time.
-func (rm *RestoreManager) writeChunks(ctx context.Context, w io.Writer, refs []string) error {
+//
+// The store's Get is the bottleneck for a large file, so fetches run
+// concurrently. They run as a *sliding window* rather than as discrete
+// batches: a fixed number of fetches stay in flight at all times, and each
+// chunk is written the moment the chunk before it has been written. A batched
+// version — fetch N, wait for all N, write all N — leaves the network
+// completely idle for the whole write phase of every batch and stalls the
+// entire batch behind its single slowest Get, which on a high-latency backend
+// such as S3 roughly halves throughput.
+//
+// Chunks still land on w in their original order regardless of which fetch
+// finishes first, since the reconstructed stream must be byte-identical to
+// what was chunked at backup time.
+//
+// avgChunkSize is the caller's estimate of the per-chunk payload, used to
+// charge the shared memory budget (see RestoreManager.memBudget). Fetches
+// block once the budget is exhausted, which is what bounds resident memory
+// now that the window is no longer a hard chunk count.
+func (rm *RestoreManager) writeChunks(ctx context.Context, w io.Writer, refs []string, avgChunkSize int64) error {
 	if len(refs) <= 1 {
 		for _, ref := range refs {
 			if err := rm.writeChunk(ctx, w, ref); err != nil {
@@ -771,33 +914,112 @@ func (rm *RestoreManager) writeChunks(ctx context.Context, w io.Writer, refs []s
 		return nil
 	}
 
-	batchSize := min(store.GetConcurrencyHint(rm.store, 10), len(refs))
+	window := min(store.GetConcurrencyHint(rm.store, 10), len(refs))
+	weight := chunkWeight(avgChunkSize)
 
-	for start := 0; start < len(refs); start += batchSize {
-		end := min(start+batchSize, len(refs))
-		batch := refs[start:end]
+	type slot struct {
+		data  []byte
+		err   error
+		ready chan struct{}
+	}
+	slots := make([]slot, window)
+	for i := range slots {
+		slots[i] = slot{ready: make(chan struct{})}
+	}
 
-		data := make([][]byte, len(batch))
-		g, gCtx := errgroup.WithContext(ctx)
-		for i, ref := range batch {
-			g.Go(func() error {
-				d, err := rm.store.Get(gCtx, ref)
-				if err != nil {
-					return fmt.Errorf("fetch chunk %s: %w", ref, err)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// fetch runs refs[i] into the slot it will be consumed from. The slot is
+	// reused every `window` chunks, so it is re-armed by the consumer before
+	// the next fetch targeting it is started — never concurrently with it.
+	fetch := func(i int) {
+		s := &slots[i%window]
+		if err := rm.memBudget.Acquire(ctx, weight); err != nil {
+			s.err = err
+			close(s.ready)
+			return
+		}
+		d, err := rm.store.Get(ctx, refs[i])
+		if err != nil {
+			rm.memBudget.Release(weight)
+			s.err = fmt.Errorf("fetch chunk %s: %w", refs[i], err)
+			close(s.ready)
+			return
+		}
+		s.data = d
+		close(s.ready)
+	}
+
+	var wg sync.WaitGroup
+	start := func(i int) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			fetch(i)
+		}()
+	}
+
+	for i := 0; i < window; i++ {
+		start(i)
+	}
+
+	// Draining every outstanding fetch before returning keeps the memory
+	// budget balanced on the error path: an abandoned fetch that later
+	// completes would otherwise hold its reservation forever.
+	drain := func() {
+		cancel()
+		wg.Wait()
+		for i := range slots {
+			select {
+			case <-slots[i].ready:
+				if slots[i].err == nil && slots[i].data != nil {
+					rm.memBudget.Release(weight)
 				}
-				data[i] = d
-				return nil
-			})
-		}
-		if err := g.Wait(); err != nil {
-			return err
-		}
-
-		for _, d := range data {
-			if _, err := w.Write(d); err != nil {
-				return err
+			default:
 			}
 		}
 	}
+
+	for i := 0; i < len(refs); i++ {
+		s := &slots[i%window]
+		<-s.ready
+		if s.err != nil {
+			err := s.err
+			s.data, s.err = nil, nil // claimed; drain must not double-release
+			drain()
+			return err
+		}
+
+		data := s.data
+		_, werr := w.Write(data)
+		s.data = nil
+		rm.memBudget.Release(weight)
+		if werr != nil {
+			drain()
+			return werr
+		}
+
+		// Re-arm this slot and pull the next chunk that will land in it.
+		if next := i + window; next < len(refs) {
+			s.ready = make(chan struct{})
+			start(next)
+		}
+	}
+
+	wg.Wait()
 	return nil
+}
+
+// chunkWeight turns a per-chunk size estimate into the amount charged against
+// the restore memory budget. The estimate comes from a Content object's own
+// size and chunk count, so it is close for the common case; the clamp keeps a
+// bogus or missing estimate from either serialising the window (too large) or
+// letting it grow without bound (too small).
+func chunkWeight(avgChunkSize int64) int64 {
+	const minWeight = 64 * 1024
+	if avgChunkSize <= 0 {
+		return cdcMaxSize
+	}
+	return max(minWeight, min(avgChunkSize, cdcMaxSize))
 }

--- a/internal/engine/restore_parallel_test.go
+++ b/internal/engine/restore_parallel_test.go
@@ -35,7 +35,7 @@ func TestRestoreManager_WriteChunks_PreservesOrder(t *testing.T) {
 	}
 
 	var got bytes.Buffer
-	if err := rm.writeChunks(ctx, &got, refs); err != nil {
+	if err := rm.writeChunks(ctx, &got, refs, 100); err != nil {
 		t.Fatalf("writeChunks: %v", err)
 	}
 	if !bytes.Equal(got.Bytes(), want.Bytes()) {
@@ -62,7 +62,7 @@ func TestRestoreManager_WriteChunks_FetchesConcurrently(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := rm.writeChunks(ctx, &buf, refs); err != nil {
+	if err := rm.writeChunks(ctx, &buf, refs, 1); err != nil {
 		t.Fatalf("writeChunks: %v", err)
 	}
 

--- a/internal/engine/restore_pipeline_test.go
+++ b/internal/engine/restore_pipeline_test.go
@@ -1,0 +1,199 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cloudstic/cli/internal/core"
+	"github.com/cloudstic/cli/internal/ui"
+	"github.com/cloudstic/cli/pkg/store"
+)
+
+// blockingStore makes every Get take a fixed amount of time, which is what a
+// remote backend's round trip looks like to the restore path, and records how
+// many Gets are outstanding at once.
+type blockingStore struct {
+	store.ObjectStore
+	delay    time.Duration
+	inFlight atomic.Int64
+	peak     atomic.Int64
+}
+
+func (s *blockingStore) Get(ctx context.Context, key string) ([]byte, error) {
+	n := s.inFlight.Add(1)
+	for {
+		p := s.peak.Load()
+		if n <= p || s.peak.CompareAndSwap(p, n) {
+			break
+		}
+	}
+	defer s.inFlight.Add(-1)
+	time.Sleep(s.delay)
+	return s.ObjectStore.Get(ctx, key)
+}
+
+// TestWriteChunks_KeepsFetchesInFlightWhileWriting is the regression guard for
+// the batch barrier this replaced. The old shape — fetch N chunks, wait for
+// every one, then write all N — left the store completely idle for the whole
+// write phase of each batch. Asserting that concurrency never collapses to a
+// single outstanding Get is what distinguishes a pipeline from a batch.
+func TestWriteChunks_KeepsFetchesInFlightWhileWriting(t *testing.T) {
+	ctx := context.Background()
+	inner := NewMockStore()
+
+	const n = 40
+	refs := make([]string, n)
+	var want bytes.Buffer
+	for i := range refs {
+		data := bytes.Repeat([]byte{byte(i)}, 1024)
+		ref := fmt.Sprintf("chunk/%02d", i)
+		if err := inner.Put(ctx, ref, data); err != nil {
+			t.Fatalf("Put %s: %v", ref, err)
+		}
+		refs[i] = ref
+		want.Write(data)
+	}
+
+	bs := &blockingStore{ObjectStore: inner, delay: 2 * time.Millisecond}
+	rm := NewRestoreManager(bs, ui.NewNoOpReporter())
+
+	// The discriminating measurement is what the store is doing *during* a
+	// write, not the peak. A batched implementation also reaches a high peak —
+	// it fires a whole batch at once — but then blocks on g.Wait() and writes
+	// with nothing outstanding, so every write observes zero fetches in
+	// flight. A pipeline keeps the next chunks coming while this one is
+	// written, so writes observe a non-zero count.
+	slow := &slowWriter{delay: time.Millisecond, inFlight: &bs.inFlight}
+	if err := rm.writeChunks(ctx, slow, refs, 1024); err != nil {
+		t.Fatalf("writeChunks: %v", err)
+	}
+
+	if !bytes.Equal(slow.buf.Bytes(), want.Bytes()) {
+		t.Fatal("pipelined writeChunks did not reconstruct the original byte sequence")
+	}
+	if peak := bs.peak.Load(); peak < 2 {
+		t.Errorf("chunk fetches never overlapped (peak in-flight = %d)", peak)
+	}
+
+	// The final chunks legitimately drain the window, so require a clear
+	// majority rather than every write. A batch barrier scores exactly 0.
+	overlapped, total := slow.overlapped, slow.writes
+	if overlapped*2 < total {
+		t.Errorf("only %d of %d writes overlapped an in-flight fetch; the chunk pipeline has regressed to fetch-all-then-write-all", overlapped, total)
+	}
+}
+
+// slowWriter takes measurable time per Write and samples how many store
+// fetches were outstanding while each one ran.
+type slowWriter struct {
+	delay      time.Duration
+	inFlight   *atomic.Int64
+	buf        bytes.Buffer
+	writes     int
+	overlapped int
+}
+
+func (w *slowWriter) Write(p []byte) (int, error) {
+	if w.inFlight.Load() > 0 {
+		w.overlapped++
+	}
+	w.writes++
+	time.Sleep(w.delay)
+	return w.buf.Write(p)
+}
+
+// TestRunWithWriter_RestoresFilesConcurrently guards the other half: files
+// used to be restored strictly one after another, so a snapshot of many small
+// files cost one full round trip each no matter how much the store could take.
+func TestRunWithWriter_RestoresFilesConcurrently(t *testing.T) {
+	ctx := context.Background()
+	dest := setupBackupForRestore(t)
+
+	bs := &blockingStore{ObjectStore: dest, delay: 5 * time.Millisecond}
+	rm := NewRestoreManager(bs, ui.NewNoOpReporter())
+
+	// Plan and write are driven separately so the peak can be reset in
+	// between. prepareRestore fetches file metadata concurrently on its own,
+	// and counting that would make this pass even with a strictly sequential
+	// file loop — which is the exact regression it exists to catch.
+	plan, err := rm.prepareRestore(ctx, "")
+	if err != nil {
+		t.Fatalf("prepareRestore: %v", err)
+	}
+	files := 0
+	for _, m := range plan.sorted {
+		if m.Type != core.FileTypeFolder && m.ContentHash != "" {
+			files++
+		}
+	}
+	if files < 2 {
+		t.Skipf("fixture has %d files; need at least 2 to observe overlap", files)
+	}
+
+	writer, err := NewFSRestoreWriter(t.TempDir())
+	if err != nil {
+		t.Fatalf("writer: %v", err)
+	}
+	bs.peak.Store(0)
+
+	res, err := rm.runWithWriter(ctx, plan, writer)
+	if err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if res.Errors != 0 {
+		t.Fatalf("restore reported %d errors", res.Errors)
+	}
+	if peak := bs.peak.Load(); peak < 2 {
+		t.Errorf("restore issued one request at a time (peak in-flight = %d); file-level restore has become sequential again", peak)
+	}
+}
+
+// TestRunWithWriter_ZipStaysSequential is the counterpart guard. A zip is a
+// single stream with one entry open at a time, so zipRestoreWriter must not be
+// opted into concurrent writes — a directory header landing inside an open
+// file entry produces an archive that will not open.
+func TestRunWithWriter_ZipStaysSequential(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewZipRestoreWriter(&buf)
+	if cw, ok := w.(concurrentRestoreWriter); ok && cw.SupportsConcurrentWrites() {
+		t.Fatal("zipRestoreWriter must not declare support for concurrent writes")
+	}
+}
+
+// TestFSRestoreWriter_ConcurrentWriteFileIsSafe exercises the writer's shared
+// bookkeeping directly, so the locking is covered even when the restore path
+// above happens not to fan out.
+func TestFSRestoreWriter_ConcurrentWriteFileIsSafe(t *testing.T) {
+	w, err := NewFSRestoreWriter(t.TempDir())
+	if err != nil {
+		t.Fatalf("writer: %v", err)
+	}
+
+	const n = 32
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			meta := core.FileMeta{FileID: fmt.Sprint(i), Type: core.FileTypeFile}
+			body := []byte("payload")
+			if err := w.WriteFile(fmt.Sprintf("f%d.txt", i), meta, func(out io.Writer) error {
+				_, werr := out.Write(body)
+				return werr
+			}); err != nil {
+				t.Errorf("WriteFile: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got, want := w.BytesWritten(), int64(n*len("payload")); got != want {
+		t.Errorf("BytesWritten = %d, want %d (a lost update means the counter is unsynchronised)", got, want)
+	}
+}

--- a/scripts/benchmark/run.sh
+++ b/scripts/benchmark/run.sh
@@ -98,6 +98,7 @@ cleanup() {
     rm -rf "$DATA_TEMPLATE"
     rm -rf "$DATA_DIR"
     rm -rf "$REPO_DIR"
+    rm -rf "$RESTORE_DIR"
     
     if [ "$STORE" == "s3" ]; then
         echo "Cleaning up S3 benchmark prefixes..."
@@ -221,6 +222,16 @@ format_size_kb() {
 # Set BENCH_REPO_DIR (local) or BENCH_S3_PREFIX (s3://bucket/prefix/) to enable repo size tracking.
 BENCH_REPO_DIR=""
 BENCH_S3_PREFIX=""
+
+# Scratch directory for restore targets. Restore is measured on a fresh, empty
+# directory every time, and the result is discarded before the next step so a
+# partially-restored tree can never make a later step look faster.
+RESTORE_DIR=$(mktemp -d -t benchmark-restore-XXXXXX)
+
+fresh_restore_target() {
+    rm -rf "${RESTORE_DIR:?}"/*
+    echo "$RESTORE_DIR/out"
+}
 
 get_repo_size_kb() {
     if [ -n "$BENCH_REPO_DIR" ] && [ -d "$BENCH_REPO_DIR" ]; then
@@ -356,7 +367,19 @@ benchmark_cloudstic() {
         cp "$DATA_DIR/zero.dat" "$DATA_DIR/zero_copy.dat"
         run_bench "Deduplicated Backup" $CLOUDSTIC_BIN backup $store_flags $source_flags -quiet $DEBUG_FLAG
     fi
-    
+
+    # Restore is the other half of a backup tool and behaves nothing like
+    # backup: it is read-dominated and, on a remote store, bound by how many
+    # fetches can be kept in flight rather than by bandwidth. Measuring only
+    # backup hides a whole class of regression.
+    run_bench "Full Restore" $CLOUDSTIC_BIN restore $store_flags \
+        -output "$(fresh_restore_target)" -format dir -quiet $DEBUG_FLAG
+    # Same restore with the per-file content-hash check off, which isolates
+    # what verification costs from what fetching and writing cost.
+    run_bench "Full Restore (-no-verify)" $CLOUDSTIC_BIN restore $store_flags \
+        -output "$(fresh_restore_target)" -format dir -no-verify -quiet $DEBUG_FLAG
+    rm -rf "${RESTORE_DIR:?}"/*
+
     print_repo_size
     echo ""
 }
@@ -423,7 +446,11 @@ benchmark_restic() {
         cp "$DATA_DIR/zero.dat" "$DATA_DIR/zero_copy.dat"
         run_bench "Deduplicated Backup" restic backup -r "$repo_arg" "$src"
     fi
-    
+
+    run_bench "Full Restore" restic restore latest -r "$repo_arg" \
+        --target "$(fresh_restore_target)"
+    rm -rf "${RESTORE_DIR:?}"/*
+
     print_repo_size
     echo ""
 }


### PR DESCRIPTION
## Summary

Restore was serialised on two independent axes, so its wall time was set by round-trip count rather than by bandwidth or store concurrency. Backup was already near the hardware limit and is unchanged.

- **Restore files concurrently.** `runWithWriter` walked the sorted entries in a plain loop, writing one file at a time — exactly one request ever outstanding, so a snapshot of many small files cost one full round trip each regardless of what the backend could take. Files now go to a bounded worker pool, gated on a new `concurrentRestoreWriter` opt-in.
- **Keep zip strictly sequential.** Only `fsRestoreWriter` opts in. A zip is a single stream with one entry open at a time, so it runs inline — even a pool of one would let a file write overlap a later `MkdirAll` and put a directory header inside an open entry, producing an archive that will not open.
- **Pipeline chunk fetches.** `writeChunks` fetched a batch, waited for every member, then wrote them all: the store idled for each batch's whole write phase and every batch stalled behind its slowest `Get`. It now keeps a sliding window in flight and writes each chunk as soon as its predecessor is written.
- **Bound restore memory explicitly.** The old batch was sized by the store's concurrency hint (128 for S3), so it could hold ~1GB of chunk data despite a comment claiming batching bounded memory. A shared byte budget now bounds both axes of fan-out.
- **Drop two redundant round trips from the open path.** `LoadRepoConfig` probed with `Exists` before `Get`, but every backend already wraps `store.ErrNotFound` in `Get`. The first `raiseRepoFormat` also reuses the config `NewClient` just read; later raises still re-read, since the on-disk version is what other machines act on and a stale in-process belief must not skip a stamp.
- **Measure restore in the benchmark harness.** It only ever measured backup, which is how this survived. It now runs a full restore for cloudstic and restic.

### Results

Restore, 1.05 GB / 152 files, Apple M3 Max. S3 numbers are against MinIO behind a 30 ms-RTT proxy, not real S3.

| | before | after | |
| :--- | :--- | :--- | :--- |
| local, verify on (default) | 0.68s | **0.34s** | 2.0x |
| local, `-no-verify` | 0.29s | **0.21s** | 1.4x |
| S3-shaped store, full restore | 8.70s | **2.49s** | **3.5x** |
| S3-shaped store, incremental backup | 1.16s | 1.06s | 1.09x |

Against restic on the same machine, restore goes from roughly parity to 2.1x faster (0.69s vs 1.44s). Peak restore RSS rises 198 MB to ~240 MB, now bounded by an explicit 128 MB budget rather than implicitly by batch size.

### Notes for review

- Restored trees are byte-identical to source (`diff -r`), `check -read-data` passes over 834 objects, and zip restore produces a valid archive.
- The new regression tests were verified to **fail** against the old behaviour (`only 0 of 40 writes overlapped an in-flight fetch`, `peak in-flight = 1`), not merely to pass against the new.
- Two hypotheses were investigated and disproved, so nothing was changed for them: `GOMAXPROCS` sensitivity (flat from 4 to 12) and flat-`chunk/`-directory contention (flat 255µs vs 256-way sharded 262µs — sharding would buy nothing and would trigger the on-disk compatibility process for no gain).
- The AWS S3 table in `docs/benchmark-results.md` is marked stale rather than rewritten: it needs a re-run against real S3, which this session had no credentials for.
- Still on the table: the S3 incremental backup remains a 23-round-trip serial chain at 0.86x effective concurrency, where `index/latest`, `index/snapshots` and `LIST snapshot/` look independent and `index/snapshots` is fetched twice. Roughly 5-6 round trips look recoverable.

## Verification

```bash
env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./...
env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./...
```

Both pass: full suite green under `-race` including `./e2e`, and lint reports 0 issues.