### PR TITLE
fix: keep backup -all-profiles -json output clean of plain text

### DIFF
--- a/cmd/cloudstic/cmd_backup.go
+++ b/cmd/cloudstic/cmd_backup.go
@@ -282,11 +282,13 @@ func runBackupWithProfiles(r *runner, ctx context.Context, base *backupArgs) int
 		p := cfg.Profiles[name]
 		effective, err := mergeProfileBackupArgs(base, name, p, cfg)
 		if err != nil {
-			_, _ = fmt.Fprintf(r.errOut, "[%s] profile merge failed: %v\n", name, err)
+			r.fail("[%s] profile merge failed: %v", name, err)
 			failures++
 			continue
 		}
-		_, _ = fmt.Fprintf(r.out, "\n== Running profile %s ==\n", name)
+		if !base.jsonEnabled() {
+			_, _ = fmt.Fprintf(r.out, "\n== Running profile %s ==\n", name)
+		}
 		r.client = nil // each profile may target a different store
 		if code := runSingleBackup(r, ctx, effective); code != 0 {
 			failures++

--- a/cmd/cloudstic/cmd_backup_test.go
+++ b/cmd/cloudstic/cmd_backup_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"strings"
 	"testing"
@@ -131,6 +132,31 @@ func TestBuildBackupOpts_IgnoreEmptySnapshot(t *testing.T) {
 	opts := buildBackupOpts(a, nil)
 	if len(opts) != 1 {
 		t.Fatalf("len(opts)=%d want 1", len(opts))
+	}
+}
+
+func TestRunBackup_JSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	var out strings.Builder
+	r := &runner{out: &out, errOut: &strings.Builder{}, client: &stubClient{
+		backupResult: &engine.RunResult{
+			SnapshotHash: "abc123",
+			SnapshotRef:  "snapshot/abc123",
+			FilesNew:     3,
+		},
+	}}
+
+	args := []string{"-source", "local:" + tmpDir, "-json"}
+	if code := backupCommand().execute(r.withArgs(args), context.Background(), "backup"); code != 0 {
+		t.Fatalf("runBackup() exit = %d, want 0", code)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out.String()), &got); err != nil {
+		t.Fatalf("json unmarshal: %v\noutput:\n%s", err, out.String())
+	}
+	if got["SnapshotHash"] != "abc123" {
+		t.Fatalf("expected SnapshotHash=abc123 in JSON output, got: %v", got)
 	}
 }
 

--- a/cmd/cloudstic/cmd_forget_test.go
+++ b/cmd/cloudstic/cmd_forget_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -45,6 +46,53 @@ func TestRunForget_SingleSnapshot_WithPruneResult(t *testing.T) {
 	}
 	if !strings.Contains(got, "Prune complete.") {
 		t.Errorf("expected prune stats, got:\n%s", got)
+	}
+}
+
+func TestRunForget_SingleSnapshot_JSON(t *testing.T) {
+	args := []string{"-json", "abc123"}
+	var out strings.Builder
+	r := &runner{out: &out, errOut: &strings.Builder{}, client: &stubClient{
+		forgetResult: &cloudstic.ForgetResult{Prune: nil},
+	}}
+
+	if code := forgetCommand().execute(r.withArgs(args), context.Background(), "forget"); code != 0 {
+		t.Fatalf("runForget() exit = %d, want 0", code)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out.String()), &got); err != nil {
+		t.Fatalf("json unmarshal: %v\noutput:\n%s", err, out.String())
+	}
+	if got["snapshot_id"] != "abc123" {
+		t.Fatalf("expected snapshot_id=abc123 in JSON output, got: %v", got)
+	}
+}
+
+func TestRunForget_Policy_JSON(t *testing.T) {
+	args := []string{"-json", "--keep-last", "1"}
+	var out strings.Builder
+	r := &runner{out: &out, errOut: &strings.Builder{}, client: &stubClient{
+		policyResult: &cloudstic.PolicyResult{
+			Groups: []engine.PolicyGroupResult{
+				{
+					Key:    engine.GroupKey{Source: "local", Account: "user"},
+					Remove: []engine.SnapshotEntry{{Ref: "snapshot/old1", Snap: core.Snapshot{Seq: 1}}},
+				},
+			},
+		},
+	}}
+
+	if code := forgetCommand().execute(r.withArgs(args), context.Background(), "forget"); code != 0 {
+		t.Fatalf("runForget() exit = %d, want 0", code)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out.String()), &got); err != nil {
+		t.Fatalf("json unmarshal: %v\noutput:\n%s", err, out.String())
+	}
+	if _, ok := got["groups"]; !ok {
+		t.Fatalf("expected groups key in JSON output, got: %v", got)
 	}
 }
 

--- a/cmd/cloudstic/cmd_init_test.go
+++ b/cmd/cloudstic/cmd_init_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -60,6 +62,25 @@ func TestPrintInitResult_NoEncryption(t *testing.T) {
 	}
 	if !strings.Contains(got, "encrypted: false") {
 		t.Errorf("expected encrypted=false, got:\n%s", got)
+	}
+}
+
+func TestRunInit_JSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	var out strings.Builder
+	r := &runner{out: &out, errOut: &strings.Builder{}}
+
+	args := []string{"-store", "local:" + tmpDir, "-no-encryption", "-json"}
+	if code := initCommand().execute(r.withArgs(args), context.Background(), "init"); code != 0 {
+		t.Fatalf("runInit() exit = %d, want 0, stderr=%s", code, r.errOut.(*strings.Builder).String())
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out.String()), &got); err != nil {
+		t.Fatalf("json unmarshal: %v\noutput:\n%s", err, out.String())
+	}
+	if got["Encrypted"] != false {
+		t.Fatalf("expected Encrypted=false in JSON output, got: %v", got)
 	}
 }
 

--- a/cmd/cloudstic/cmd_key_test.go
+++ b/cmd/cloudstic/cmd_key_test.go
@@ -1,12 +1,30 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
 	cloudstic "github.com/cloudstic/cli"
 	"github.com/cloudstic/cli/pkg/keychain"
 )
+
+// initEncryptedRepoForKeyTest creates a fresh encrypted local repository and
+// returns the store/password flags needed to address it.
+func initEncryptedRepoForKeyTest(t *testing.T) (storeFlag, passwordFlag []string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	storeFlag = []string{"-store", "local:" + tmpDir}
+	passwordFlag = []string{"-password", "test-key-pass"}
+
+	args := append(append([]string{}, storeFlag...), passwordFlag...)
+	r := &runner{out: &strings.Builder{}, errOut: &strings.Builder{}}
+	if code := initCommand().execute(r.withArgs(args), context.Background(), "init"); code != 0 {
+		t.Fatalf("init failed: %s", r.errOut.(*strings.Builder).String())
+	}
+	return storeFlag, passwordFlag
+}
 
 func TestPrintKeySlots_Empty(t *testing.T) {
 	var out, errOut strings.Builder
@@ -46,5 +64,63 @@ func TestPrintKeySlots_WithSlots(t *testing.T) {
 	errStr := errOut.String()
 	if !strings.Contains(errStr, "2 key slot(s) found") {
 		t.Errorf("expected count message, got:\n%s", errStr)
+	}
+}
+
+func TestRunKeyList_JSON(t *testing.T) {
+	storeFlag, passwordFlag := initEncryptedRepoForKeyTest(t)
+
+	var out strings.Builder
+	r := &runner{out: &out, errOut: &strings.Builder{}}
+	args := append(append([]string{"list"}, storeFlag...), append(passwordFlag, "-json")...)
+	if code := keyCommand().execute(r.withArgs(args), context.Background(), "key"); code != 0 {
+		t.Fatalf("key list failed: %s", r.errOut.(*strings.Builder).String())
+	}
+
+	var got []map[string]any
+	if err := json.Unmarshal([]byte(out.String()), &got); err != nil {
+		t.Fatalf("json unmarshal: %v\noutput:\n%s", err, out.String())
+	}
+	if len(got) == 0 {
+		t.Fatalf("expected at least one key slot in JSON output, got: %v", got)
+	}
+}
+
+func TestRunAddRecoveryKey_JSON(t *testing.T) {
+	storeFlag, passwordFlag := initEncryptedRepoForKeyTest(t)
+
+	var out strings.Builder
+	r := &runner{out: &out, errOut: &strings.Builder{}}
+	args := append(append([]string{"add-recovery"}, storeFlag...), append(passwordFlag, "-json")...)
+	if code := keyCommand().execute(r.withArgs(args), context.Background(), "key"); code != 0 {
+		t.Fatalf("key add-recovery failed: %s", r.errOut.(*strings.Builder).String())
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out.String()), &got); err != nil {
+		t.Fatalf("json unmarshal: %v\noutput:\n%s", err, out.String())
+	}
+	recoveryKey, _ := got["recovery_key"].(string)
+	if recoveryKey == "" {
+		t.Fatalf("expected non-empty recovery_key in JSON output, got: %v", got)
+	}
+}
+
+func TestRunKeyPasswd_JSON(t *testing.T) {
+	storeFlag, passwordFlag := initEncryptedRepoForKeyTest(t)
+
+	var out strings.Builder
+	r := &runner{out: &out, errOut: &strings.Builder{}}
+	args := append(append([]string{"passwd"}, storeFlag...), append(passwordFlag, "-new-password", "new-key-pass", "-json")...)
+	if code := keyCommand().execute(r.withArgs(args), context.Background(), "key"); code != 0 {
+		t.Fatalf("key passwd failed: %s", r.errOut.(*strings.Builder).String())
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out.String()), &got); err != nil {
+		t.Fatalf("json unmarshal: %v\noutput:\n%s", err, out.String())
+	}
+	if got["changed"] != true {
+		t.Fatalf("expected changed=true in JSON output, got: %v", got)
 	}
 }

--- a/cmd/cloudstic/cmd_prune_test.go
+++ b/cmd/cloudstic/cmd_prune_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -56,6 +57,30 @@ func TestRunPrune_DryRun(t *testing.T) {
 	}
 	if !strings.Contains(got, "would delete") {
 		t.Errorf("expected 'would delete' in output, got:\n%s", got)
+	}
+}
+
+func TestRunPrune_JSON(t *testing.T) {
+	args := []string{"-json"}
+	var out strings.Builder
+	r := &runner{out: &out, errOut: &strings.Builder{}, client: &stubClient{
+		pruneResult: &cloudstic.PruneResult{
+			ObjectsScanned: 100,
+			ObjectsDeleted: 10,
+			BytesReclaimed: 2048,
+		},
+	}}
+
+	if code := pruneCommand().execute(r.withArgs(args), context.Background(), "prune"); code != 0 {
+		t.Fatalf("runPrune() exit = %d, want 0", code)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out.String()), &got); err != nil {
+		t.Fatalf("json unmarshal: %v\noutput:\n%s", err, out.String())
+	}
+	if got["ObjectsDeleted"] != float64(10) {
+		t.Fatalf("expected ObjectsDeleted=10 in JSON output, got: %v", got)
 	}
 }
 

--- a/cmd/cloudstic/cmd_restore_test.go
+++ b/cmd/cloudstic/cmd_restore_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -84,6 +86,30 @@ func TestPrintRestoreSummary_DryRun(t *testing.T) {
 	}
 	if strings.Contains(got, "Output:") {
 		t.Errorf("dry run should not show output path, got:\n%s", got)
+	}
+}
+
+func TestRunRestore_JSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	var out strings.Builder
+	r := &runner{out: &out, errOut: &strings.Builder{}, client: &stubClient{
+		restoreResult: &cloudstic.RestoreResult{
+			SnapshotRef:  "snapshot/abc123",
+			FilesWritten: 5,
+		},
+	}}
+
+	args := []string{"-format", "dir", "-output", tmpDir, "-json"}
+	if code := restoreCommand().execute(r.withArgs(args), context.Background(), "restore"); code != 0 {
+		t.Fatalf("runRestore() exit = %d, want 0", code)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out.String()), &got); err != nil {
+		t.Fatalf("json unmarshal: %v\noutput:\n%s", err, out.String())
+	}
+	if got["SnapshotRef"] != "snapshot/abc123" {
+		t.Fatalf("expected SnapshotRef in JSON output, got: %v", got)
 	}
 }
 

--- a/e2e/feature_profiles_test.go
+++ b/e2e/feature_profiles_test.go
@@ -1,7 +1,10 @@
 package e2e
 
 import (
+	"bytes"
+	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -93,5 +96,152 @@ func TestCLI_Feature_ProfilesLocalStore(t *testing.T) {
 	out = run(t, bin, "list", "--store", "local:"+storeDir, "--password", password)
 	if !strings.Contains(out, src1) || !strings.Contains(out, src2) {
 		t.Fatalf("expected both profile sources in list output after -all-profiles, got:\n%s", out)
+	}
+}
+
+// TestCLI_Feature_ProfilesAllProfilesJSON verifies that 'backup -all-profiles
+// -json' keeps stdout as a clean stream of JSON documents (no "== Running
+// profile" banner interleaved), and that a per-profile merge failure is
+// reported as a JSON error on stderr rather than plain text, consistent with
+// every other command's -json contract.
+func TestCLI_Feature_ProfilesAllProfilesJSON(t *testing.T) {
+	if !shouldRun(Hermetic) {
+		t.Skip("skipping hermetic test")
+	}
+
+	bin := buildBinary(t)
+	src1 := t.TempDir()
+	storeDir := t.TempDir()
+	profilesPath := filepath.Join(t.TempDir(), "profiles.yaml")
+
+	writeFile(t, src1, "alpha.txt", "from profile one")
+
+	passwordEnv := "E2E_PROFILE_PASSWORD"
+	password := "e2e-profile-pass"
+
+	run(t, bin,
+		"store", "new",
+		"-profiles-file", profilesPath,
+		"-name", "main",
+		"-uri", "local:"+storeDir,
+		"-password-secret", "env://"+passwordEnv,
+	)
+	// "temp" only exists long enough for "profile new" to accept it as a
+	// valid store-ref; it's then deleted below to leave "broken" with a
+	// dangling reference, the same state a user reaches by removing a store
+	// entry a profile still points at.
+	run(t, bin,
+		"store", "new",
+		"-profiles-file", profilesPath,
+		"-name", "temp",
+		"-uri", "local:"+t.TempDir(),
+		"-password-secret", "env://"+passwordEnv,
+	)
+	run(t, bin,
+		"profile", "new",
+		"-profiles-file", profilesPath,
+		"-name", "ok",
+		"-source", "local:"+src1,
+		"-store-ref", "main",
+	)
+	run(t, bin,
+		"profile", "new",
+		"-profiles-file", profilesPath,
+		"-name", "broken",
+		"-source", "local:"+src1,
+		"-store-ref", "temp",
+	)
+	removeYAMLStoreBlock(t, profilesPath, "temp")
+
+	run(t, bin, "init", "--store", "local:"+storeDir, "--password", password)
+
+	cmd := exec.Command(bin,
+		"backup",
+		"-profiles-file", profilesPath,
+		"-all-profiles",
+		"-json",
+	)
+	cmd.Env = append(cleanEnv(), passwordEnv+"="+password)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	err := cmd.Run()
+	if err == nil {
+		t.Fatalf("expected backup -all-profiles -json to fail (the \"broken\" profile has an unknown store), succeeded instead.\nstdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
+	}
+
+	if strings.Contains(stdout.String(), "== Running profile") {
+		t.Fatalf("stdout leaked the human-readable profile banner under -json:\n%s", stdout.String())
+	}
+
+	// stdout must be exclusively JSON documents (the "ok" profile's backup
+	// result) -- no stray plain text interleaved.
+	dec := json.NewDecoder(&stdout)
+	sawResult := false
+	for dec.More() {
+		var v any
+		if err := dec.Decode(&v); err != nil {
+			t.Fatalf("stdout is not a clean JSON stream: %v\nremaining stdout:\n%s", err, stdout.String())
+		}
+		sawResult = true
+	}
+	if !sawResult {
+		t.Fatalf("expected at least one JSON result on stdout from the successful profile, got none")
+	}
+
+	// stderr must report the merge failure as a JSON error, not raw text.
+	if strings.Contains(stderr.String(), "profile merge failed") && !strings.Contains(stderr.String(), `"error"`) {
+		t.Fatalf("stderr has a bare (non-JSON) merge-failure message under -json:\n%s", stderr.String())
+	}
+	stderrDec := json.NewDecoder(&stderr)
+	sawMergeError := false
+	for stderrDec.More() {
+		var e struct {
+			Error string `json:"error"`
+		}
+		if err := stderrDec.Decode(&e); err != nil {
+			t.Fatalf("stderr is not a clean JSON stream: %v\nremaining stderr:\n%s", err, stderr.String())
+		}
+		if strings.Contains(e.Error, "broken") && strings.Contains(e.Error, "profile merge failed") {
+			sawMergeError = true
+		}
+	}
+	if !sawMergeError {
+		t.Fatalf("expected a JSON error mentioning the \"broken\" profile's merge failure on stderr, got:\n%s", stderr.String())
+	}
+}
+
+// removeYAMLStoreBlock deletes the named entry (and its indented body) from
+// the "stores:" mapping in profilesPath, leaving any profile that referenced
+// it with a dangling store-ref.
+func removeYAMLStoreBlock(t *testing.T, profilesPath, name string) {
+	t.Helper()
+	raw, err := os.ReadFile(profilesPath)
+	if err != nil {
+		t.Fatalf("read profiles file: %v", err)
+	}
+	lines := strings.Split(string(raw), "\n")
+	header := "    " + name + ":"
+	out := make([]string, 0, len(lines))
+	skipping := false
+	removed := false
+	for _, line := range lines {
+		if line == header {
+			skipping = true
+			removed = true
+			continue
+		}
+		if skipping {
+			if strings.HasPrefix(line, "        ") {
+				continue
+			}
+			skipping = false
+		}
+		out = append(out, line)
+	}
+	if !removed {
+		t.Fatalf("store entry %q not found in profiles file:\n%s", name, raw)
+	}
+	if err := os.WriteFile(profilesPath, []byte(strings.Join(out, "\n")), 0o600); err != nil {
+		t.Fatalf("write profiles file: %v", err)
 	}
 }

--- a/internal/tui/shell.go
+++ b/internal/tui/shell.go
@@ -58,7 +58,7 @@ func LayoutDashboardWidth(d Dashboard, width int) DashboardLayout {
 	y := 1
 	y += 3 // title, subtitle, blank
 	y += len(boxLinesExact("Overview", []string{
-		fmt.Sprintf("%sProfiles%s %d   %sStores%s %d   %sAuth%s %d", ui.Cyan, ui.Reset, d.ProfileCount, ui.Cyan, ui.Reset, d.StoreCount, ui.Cyan, ui.Reset, d.AuthCount),
+		fmt.Sprintf("%s %d   %s %d   %s %d", ui.Style(ui.Cyan, "Profiles"), d.ProfileCount, ui.Style(ui.Cyan, "Stores"), d.StoreCount, ui.Style(ui.Cyan, "Auth"), d.AuthCount),
 	}, panelWidth(width)))
 
 	profilesWidth, detailWidth := splitPaneWidths(width)
@@ -95,15 +95,15 @@ func LayoutDashboardWidth(d Dashboard, width int) DashboardLayout {
 
 func dashboardLinesWidth(d Dashboard, width int) []string {
 	lines := []string{
-		fmt.Sprintf("%s%s%s", ui.Bold, "Cloudstic TUI", ui.Reset),
-		fmt.Sprintf("%sOperator dashboard for profiles, stores, and auth.%s", ui.Dim, ui.Reset),
+		ui.Style(ui.Bold, "Cloudstic TUI"),
+		ui.Style(ui.Dim, "Operator dashboard for profiles, stores, and auth."),
 		"",
 	}
 
 	stats := []string{
-		fmt.Sprintf("%sProfiles%s %d", ui.Cyan, ui.Reset, d.ProfileCount),
-		fmt.Sprintf("%sStores%s %d", ui.Cyan, ui.Reset, d.StoreCount),
-		fmt.Sprintf("%sAuth%s %d", ui.Cyan, ui.Reset, d.AuthCount),
+		fmt.Sprintf("%s %d", ui.Style(ui.Cyan, "Profiles"), d.ProfileCount),
+		fmt.Sprintf("%s %d", ui.Style(ui.Cyan, "Stores"), d.StoreCount),
+		fmt.Sprintf("%s %d", ui.Style(ui.Cyan, "Auth"), d.AuthCount),
 	}
 	lines = append(lines, boxLinesExact("Overview", []string{strings.Join(stats, "   ")}, panelWidth(width))...)
 
@@ -117,7 +117,7 @@ func dashboardLinesWidth(d Dashboard, width int) []string {
 	)...)
 
 	lines = append(lines, boxLinesExact("Activity", renderActivityPanel(d.Activity), panelWidth(width))...)
-	footer := fmt.Sprintf("%sUse ↑/↓ to select a profile. Press s/h to switch views, b to backup/init, c to check, n to create, e to edit, d to delete, q to quit.%s", ui.Dim, ui.Reset)
+	footer := ui.Style(ui.Dim, "Use ↑/↓ to select a profile. Press s/h to switch views, b to backup/init, c to check, n to create, e to edit, d to delete, q to quit.")
 	if width > 0 {
 		footer = truncateVisible(footer, width)
 	}
@@ -126,7 +126,7 @@ func dashboardLinesWidth(d Dashboard, width int) []string {
 }
 
 func boxLinesExact(title string, lines []string, width int) []string {
-	titleLine := fmt.Sprintf("%s%s%s", ui.Bold, title, ui.Reset)
+	titleLine := ui.Style(ui.Bold, title)
 	if width <= 0 {
 		width = visibleLen(titleLine)
 		for _, line := range lines {
@@ -172,7 +172,7 @@ func renderColumnLines(left, right []string) []string {
 
 func renderProfileList(d Dashboard) []string {
 	if len(d.Profiles) == 0 {
-		return []string{fmt.Sprintf("%sNo profiles configured.%s", ui.Dim, ui.Reset)}
+		return []string{ui.Style(ui.Dim, "No profiles configured.")}
 	}
 	nameWidth, badgeWidth := profileListWidths(d.Profiles)
 	lines := make([]string, 0, len(d.Profiles))
@@ -207,7 +207,7 @@ func renderActivityPanel(activity ActivityPanel) []string {
 	}
 	lines = append(lines, activity.Lines...)
 	if len(lines) == 0 {
-		return []string{fmt.Sprintf("%sNo recent activity.%s", ui.Dim, ui.Reset)}
+		return []string{ui.Style(ui.Dim, "No recent activity.")}
 	}
 	return lines
 }
@@ -215,10 +215,10 @@ func renderActivityPanel(activity ActivityPanel) []string {
 func renderSelectedProfile(d Dashboard) ([]string, map[int]string) {
 	profile, ok := selectedProfileCard(d)
 	if !ok {
-		return []string{fmt.Sprintf("%sNo profile selected.%s", ui.Dim, ui.Reset)}, nil
+		return []string{ui.Style(ui.Dim, "No profile selected.")}, nil
 	}
 	lines := []string{
-		fmt.Sprintf("%s%s%s", ui.Bold, profile.Name, ui.Reset),
+		ui.Style(ui.Bold, profile.Name),
 		renderProfileViewTabs(d.SelectedView),
 		"",
 	}
@@ -282,7 +282,7 @@ func renderModalOverlay(w io.Writer, modal Modal, screenWidth, screenHeight int)
 func modalLines(modal Modal, width int) []string {
 	lines := []string{}
 	if modal.Subtitle != "" {
-		lines = append(lines, fmt.Sprintf("%s%s%s", ui.Dim, modal.Subtitle, ui.Reset), "")
+		lines = append(lines, ui.Style(ui.Dim, modal.Subtitle), "")
 	}
 	labelWidth := modalLabelWidth(modal)
 	for i, field := range modal.Fields {
@@ -290,15 +290,15 @@ func modalLines(modal Modal, width int) []string {
 		hasError := modal.ErrorField == field.Key && modal.Error != ""
 		prefix := "  "
 		if selected {
-			prefix = fmt.Sprintf("%s› %s", ui.Cyan, ui.Reset)
+			prefix = ui.Style(ui.Cyan, "› ")
 		}
 		labelText := field.Label
 		if field.Required && !field.Disabled {
-			labelText += " " + ui.Yellow + "*" + ui.Reset
+			labelText += " " + ui.Style(ui.Yellow, "*")
 		}
-		label := fmt.Sprintf("%s%s%s", ui.Dim, labelText, ui.Reset)
+		label := ui.Style(ui.Dim, labelText)
 		if selected {
-			label = fmt.Sprintf("%s%s%s", ui.Cyan, labelText, ui.Reset)
+			label = ui.Style(ui.Cyan, labelText)
 		}
 		if hasError {
 			label = labelText
@@ -309,7 +309,7 @@ func modalLines(modal Modal, width int) []string {
 		}
 		lines = append(lines, fmt.Sprintf("%s%s%s  %s", prefix, label, strings.Repeat(" ", padding), modalFieldValue(field, selected)))
 		if hasError {
-			lines = append(lines, fmt.Sprintf("  %s%s%s", ui.Red, modal.Error, ui.Reset))
+			lines = append(lines, "  "+ui.Style(ui.Red, modal.Error))
 		}
 	}
 	if len(modal.Message) > 0 {
@@ -322,14 +322,14 @@ func modalLines(modal Modal, width int) []string {
 		if len(lines) > 0 {
 			lines = append(lines, "")
 		}
-		lines = append(lines, fmt.Sprintf("%s%s%s", ui.Red, modal.Error, ui.Reset))
+		lines = append(lines, ui.Style(ui.Red, modal.Error))
 	}
 	if modal.Hint != "" {
 		if len(lines) > 0 {
 			lines = append(lines, "")
 		}
-		lines = append(lines, fmt.Sprintf("%sFields marked * are required.%s", ui.Dim, ui.Reset))
-		lines = append(lines, fmt.Sprintf("%s%s%s", ui.Dim, modal.Hint, ui.Reset))
+		lines = append(lines, ui.Style(ui.Dim, "Fields marked * are required."))
+		lines = append(lines, ui.Style(ui.Dim, modal.Hint))
 	}
 	return boxLinesExact(modal.Title, lines, width)
 }
@@ -350,7 +350,7 @@ func modalLabelWidth(modal Modal) int {
 
 func modalFieldValue(field ModalField, selected bool) string {
 	if field.Disabled {
-		return fmt.Sprintf("%snot required%s", ui.Dim, ui.Reset)
+		return ui.Style(ui.Dim, "not required")
 	}
 	switch field.Kind {
 	case ModalFieldSelect:
@@ -359,17 +359,16 @@ func modalFieldValue(field ModalField, selected bool) string {
 			value = "none"
 		}
 		if selected {
-			return fmt.Sprintf("%s<%s>%s  %s←/→%s", ui.Cyan, value, ui.Reset, ui.Dim, ui.Reset)
+			return fmt.Sprintf("%s  %s", ui.Style(ui.Cyan, "<"+value+">"), ui.Style(ui.Dim, "←/→"))
 		}
 		return fmt.Sprintf("[%s]", value)
 	default:
 		value := field.Value
 		if value == "" {
-			value = fmt.Sprintf("%s<empty>%s", ui.Dim, ui.Reset)
+			value = ui.Style(ui.Dim, "<empty>")
 		}
 		if selected {
-			cursor := fmt.Sprintf("%s_%s", ui.Cyan, ui.Reset)
-			return fmt.Sprintf("%s%s%s", value, cursor, "")
+			return value + ui.Style(ui.Cyan, "_")
 		}
 		return value
 	}
@@ -405,13 +404,13 @@ func modalLayout(screenWidth int) (startX int, width int) {
 func profileHeaderLine(profile ProfileCard, selected bool, nameWidth, badgeWidth int) string {
 	prefix := "  "
 	if selected {
-		prefix = fmt.Sprintf("%s› %s", ui.Cyan, ui.Reset)
+		prefix = ui.Style(ui.Cyan, "› ")
 	}
 	namePadding := nameWidth - visibleLen(profile.Name)
 	if namePadding < 0 {
 		namePadding = 0
 	}
-	return fmt.Sprintf("%s%s%s%s%s  %s", prefix, ui.Bold, profile.Name, ui.Reset, strings.Repeat(" ", namePadding), profileStateBadge(profile, badgeWidth))
+	return fmt.Sprintf("%s%s%s  %s", prefix, ui.Style(ui.Bold, profile.Name), strings.Repeat(" ", namePadding), profileStateBadge(profile, badgeWidth))
 }
 
 func profileListWidths(profiles []ProfileCard) (nameWidth, badgeWidth int) {
@@ -681,16 +680,16 @@ func truncateVisible(s string, limit int) string {
 func profileStateLabel(profile ProfileCard) string {
 	switch profile.Status {
 	case ProfileStatusDisabled:
-		return fmt.Sprintf("%sdisabled%s", ui.Dim, ui.Reset)
+		return ui.Style(ui.Dim, "disabled")
 	case ProfileStatusWarning:
-		return fmt.Sprintf("%swarning%s", ui.Cyan, ui.Reset)
+		return ui.Style(ui.Cyan, "warning")
 	case ProfileStatusError:
 		return "error"
 	default:
 		if profile.Enabled {
-			return fmt.Sprintf("%senabled%s", ui.Green, ui.Reset)
+			return ui.Style(ui.Green, "enabled")
 		}
-		return fmt.Sprintf("%sdisabled%s", ui.Dim, ui.Reset)
+		return ui.Style(ui.Dim, "disabled")
 	}
 }
 
@@ -748,9 +747,9 @@ func renderProfileViewTabs(selected ProfileView) string {
 	history := "[h] History"
 	switch selected {
 	case ProfileViewSummary:
-		summary = fmt.Sprintf("%s[s] Summary%s", ui.Cyan, ui.Reset)
+		summary = ui.Style(ui.Cyan, "[s] Summary")
 	case ProfileViewHistory:
-		history = fmt.Sprintf("%s[h] History%s", ui.Cyan, ui.Reset)
+		history = ui.Style(ui.Cyan, "[h] History")
 	}
 	return fmt.Sprintf("  %s  %s", summary, history)
 }
@@ -758,11 +757,11 @@ func renderProfileViewTabs(selected ProfileView) string {
 func renderProfileHistory(profile ProfileCard) []string {
 	if len(profile.History) == 0 {
 		return []string{
-			fmt.Sprintf("%sNo snapshots found for this profile.%s", ui.Dim, ui.Reset),
+			ui.Style(ui.Dim, "No snapshots found for this profile."),
 		}
 	}
 	lines := []string{
-		fmt.Sprintf("%sRecent snapshots for this profile:%s", ui.Dim, ui.Reset),
+		ui.Style(ui.Dim, "Recent snapshots for this profile:"),
 	}
 	limit := len(profile.History)
 	if limit > 8 {
@@ -786,7 +785,7 @@ func appendProfileActionButtons(lines []string, profile ProfileCard) ([]string, 
 			}
 			lines = append(lines, renderActionButton(button))
 			if !button.Enabled && button.Reason != "" {
-				lines = append(lines, fmt.Sprintf("  %s%s%s", ui.Dim, button.Reason, ui.Reset))
+				lines = append(lines, "  "+ui.Style(ui.Dim, button.Reason))
 			}
 		}
 	}
@@ -847,10 +846,10 @@ func profileCheckSummary(activity ActivityPanel, profile ProfileCard) string {
 }
 
 func renderActionButton(button actionButton) string {
-	key := fmt.Sprintf("%s[%s]%s", ui.Cyan, button.Key, ui.Reset)
+	key := ui.Style(ui.Cyan, "["+button.Key+"]")
 	label := button.Label
 	if button.Enabled {
 		return fmt.Sprintf("  %s %s", key, label)
 	}
-	return fmt.Sprintf("  %s %s%s%s", key, ui.Dim, label, ui.Reset)
+	return fmt.Sprintf("  %s %s", key, ui.Style(ui.Dim, label))
 }

--- a/internal/ui/term.go
+++ b/internal/ui/term.go
@@ -17,6 +17,11 @@ const (
 	Reset  = logger.ColorReset
 )
 
+// Style wraps text in the given color, resetting after it.
+func Style(color, text string) string {
+	return color + text + Reset
+}
+
 // TermWriter provides helpers for styled terminal output.
 type TermWriter struct{ W io.Writer }
 


### PR DESCRIPTION
## Summary
- Fix `backup -all-profiles -json`: it leaked a plain-text `== Running profile X ==` banner onto stdout and a raw-text merge-failure message onto stderr, breaking the `-json` contract (single JSON document on stdout, JSON-shaped errors on stderr) every other command honors. The banner is now gated on `!jsonEnabled()`, and merge failures route through `r.fail` for the same `{"error": ...}` shape as every other failure path.
- Add `-json` success-path tests for `backup`, `restore`, `prune`, `forget` (single snapshot + policy), `init`, and `key list`/`add-recovery`/`passwd` — an audit across every repo command found none of these had any automated coverage of their `-json` output before this (only JSON *error* paths were tested for `backup`).
- Add `ui.Style(color, text)` to `internal/ui` and use it in `internal/tui/shell.go` in place of ~35 hand-rolled `fmt.Sprintf("%s%s%s", ui.Color, text, ui.Reset)` call sites. Pure cleanup, no behavior change — verified byte-identical against the existing golden/render tests.

## Verification
- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./...`
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./cmd/cloudstic/... ./internal/ui/... ./internal/tui/... ./e2e/...`
- Confirmed the new e2e test (`TestCLI_Feature_ProfilesAllProfilesJSON`) actually catches the regression: reverting the `cmd_backup.go` fix makes it fail with the leaked banner in stdout.