### PR TITLE
fix(completion): re-base $words so zsh completes subcommand flags

### DIFF
--- a/cmd/cloudstic/completion.go
+++ b/cmd/cloudstic/completion.go
@@ -212,9 +212,6 @@ _cloudstic() {
 
     case "$cmd" in
 @@ZSH_CMD_FLAGS@@
-        completion)
-            _arguments ':shell:(bash zsh fish)'
-            ;;
 @@ZSH_GROUPS@@
     esac
 }

--- a/cmd/cloudstic/completion_generated.go
+++ b/cmd/cloudstic/completion_generated.go
@@ -166,12 +166,25 @@ func bashGroupArm(g command) string {
 	return b.String()
 }
 
+// zshRebaseWords re-bases zsh's $words and $CURRENT on the subcommand found at
+// index variable idx, so that _arguments sees the subcommand as the command
+// word. Without it, _arguments counts the subcommand name — and any global flag
+// typed before it — as positional arguments the command never declared, decides
+// every argument is already supplied, and offers nothing at all.
+//
+// It has to be emitted inline in each arm rather than factored into a shell
+// helper: zsh binds the completion special parameters per function scope, so a
+// helper's assignments do not reach the _arguments call in the caller.
+func zshRebaseWords(indent, idx string) string {
+	return fmt.Sprintf("%swords=(\"${(@)words[%s,-1]}\"); (( CURRENT -= %s - 1 ))\n", indent, idx, idx)
+}
+
 // zshCommandFlagCases renders one `_arguments` arm per command. Each flag
 // contributes its description, value placeholder, and completion function.
 func zshCommandFlagCases() string {
 	var b strings.Builder
 	for _, c := range generatedFlagCommands() {
-		fmt.Fprintf(&b, "        %s)\n            _arguments $global_flags", c.name)
+		fmt.Fprintf(&b, "        %s)\n%s            _arguments $global_flags", c.name, zshRebaseWords("            ", "i"))
 		for _, s := range ownSpecsOf(c) {
 			fmt.Fprintf(&b, " \\\n                '%s'", zshFlagEntry(s))
 		}
@@ -361,7 +374,8 @@ func zshGroupBlocks() string {
 			g.name, g.name, g.name)
 		fmt.Fprintf(&b, "            case \"$%s_sub\" in\n", g.name)
 		for _, child := range g.visibleChildren() {
-			fmt.Fprintf(&b, "                %s)\n                    _arguments $global_flags", child.name)
+			fmt.Fprintf(&b, "                %s)\n%s                    _arguments $global_flags",
+				child.name, zshRebaseWords("                    ", "gi"))
 			for _, s := range ownSpecsOf(child) {
 				fmt.Fprintf(&b, " \\\n                        '%s'", zshFlagEntry(s))
 			}
@@ -370,7 +384,9 @@ func zshGroupBlocks() string {
 			}
 			b.WriteString("\n                    ;;\n")
 		}
-		b.WriteString("                *)\n                    _arguments $global_flags\n                    ;;\n            esac\n            ;;\n")
+		b.WriteString("                *)\n")
+		b.WriteString(zshRebaseWords("                    ", "gi"))
+		b.WriteString("                    _arguments $global_flags\n                    ;;\n            esac\n            ;;\n")
 	}
 	return strings.TrimRight(b.String(), "\n")
 }

--- a/cmd/cloudstic/completion_test.go
+++ b/cmd/cloudstic/completion_test.go
@@ -123,7 +123,12 @@ func TestCompletionZsh(t *testing.T) {
 		"-store-ref[Existing store reference to attach to generated profiles]",
 		// Value completions (source type list still present)
 		"_cloudstic_source_prefixes",
-		"(bash zsh fish)",
+		"':shell:_cloudstic_shells'",
+		// Each subcommand arm re-bases $words before calling _arguments, which
+		// otherwise counts the subcommand name as an undeclared positional and
+		// offers nothing at all.
+		`words=("${(@)words[i,-1]}"); (( CURRENT -= i - 1 ))`,
+		`words=("${(@)words[gi,-1]}"); (( CURRENT -= gi - 1 ))`,
 	} {
 		if !strings.Contains(out, marker) {
 			t.Errorf("zsh completion missing expected marker: %q", marker)

--- a/e2e/feature_completion_runtime_test.go
+++ b/e2e/feature_completion_runtime_test.go
@@ -40,6 +40,16 @@ func TestCLI_Feature_CompletionRuntime_BackupFlags(t *testing.T) {
 	})
 }
 
+func TestCLI_Feature_CompletionRuntime_GroupedSubcommandFlags(t *testing.T) {
+	runCompletionShellMatrix(t, completionScenario{
+		name:  "grouped_subcommand_flags",
+		words: []string{"cloudstic", "key", "passwd", "-"},
+		assert: func(t *testing.T, out string) {
+			assertCompletionContains(t, out, "-new-password")
+		},
+	})
+}
+
 func TestCLI_Feature_CompletionRuntime_ProfileValues(t *testing.T) {
 	runCompletionShellMatrix(t, completionScenario{
 		name:  "profile_values",
@@ -153,72 +163,73 @@ complete --do-complete `+shellQuote(line)+`
 `)
 }
 
+// runZsh drives a real interactive zsh through a pseudo-terminal and captures
+// what pressing TAB actually offers.
+//
+// Calling _cloudstic directly with stubbed _describe/_arguments would be
+// simpler, but it would only assert which specification strings the script
+// passes along, not that zsh's completion system does anything with them. That
+// blind spot hid a bug in which every subcommand offered nothing at all:
+// _arguments completes relative to the command word, and the script never
+// re-based $words on the subcommand before calling it.
 func (rt completionRuntime) runZsh(t *testing.T, words []string) string {
 	t.Helper()
-	scriptBody := `_cloudstic`
-	switch {
-	case len(words) >= 2 && words[1] == "":
-		scriptBody = `
-_describe() {
-    local arrname="${@: -1}"
-    eval "print -l -- \${${arrname}[@]}"
-}
-_arguments() { return 0 }
-_cloudstic
-`
-	case len(words) >= 3 && words[1] == "backup" && words[2] == "":
-		scriptBody = `
-_describe() { return 0 }
-_arguments() { print -l -- "$@" }
-_cloudstic
-`
-	case len(words) >= 3 && words[1] == "backup" && words[2] == "-":
-		scriptBody = `
-_describe() { return 0 }
-_arguments() { print -l -- "$@" }
-_cloudstic
-`
-	case len(words) >= 4 && words[1] == "backup" && words[2] == "-profile" && words[3] == "":
-		scriptBody = `
-PREFIX=""
-_cloudstic_query profile-names
-`
-	case len(words) >= 3 && words[1] == "-store" && words[2] == "":
-		scriptBody = `
-compadd() {
-    local arg
-    for arg in "$@"; do
-        case "$arg" in
-            -*) ;;
-            *) print -r -- "$arg" ;;
-        esac
-    done
-}
-_cloudstic_store_prefixes
-`
-	}
-	return runShell(t, "zsh", append(append([]string{}, rt.env...), zshHomeEnv(t)...), rt.pathPrelude("zsh")+`
+
+	home := t.TempDir()
+	rc := rt.pathPrelude("zsh") + `
+export CLOUDSTIC_PROFILES_FILE=` + shellQuote(envValue(rt.env, "CLOUDSTIC_PROFILES_FILE")) + `
 autoload -Uz compinit
-compinit -i -d "$HOME/.zcompdump"
-source <("`+rt.bin+`" completion zsh)
-words=(`+zshWords(words)+`)
-CURRENT=`+strconv.Itoa(len(words))+`
-`+scriptBody+`
+compinit -u -d ` + shellQuote(filepath.Join(home, ".zcompdump")) + `
+source <(` + shellQuote(rt.bin) + ` completion zsh)
+PS1=';;;'
+`
+	if err := os.WriteFile(filepath.Join(home, ".zshrc"), []byte(rc), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Two TABs: the first inserts any unambiguous common prefix, the second
+	// lists whatever candidates remain.
+	line := strings.Join(words, " ") + "\t\t"
+	return runShell(t, "zsh", rt.env, `
+emulate -L zsh
+zmodload zsh/zpty
+
+# Read until the pty has been quiet for a short while: completion runs
+# asynchronously inside the child shell, so there is no output marker to wait
+# for.
+drain() {
+    local chunk all=
+    local -i idle=0
+    while (( idle < 40 )); do
+        if zpty -rt comp chunk 2>/dev/null; then
+            all+=$chunk
+            idle=0
+        else
+            (( idle++ ))
+            sleep 0.05
+        fi
+    done
+    print -rn -- "$all"
+}
+
+zpty -b comp `+shellQuote("HOME="+home+" ZDOTDIR="+home+" zsh -i")+`
+sleep 2
+drain >/dev/null
+zpty -w -n comp `+shellQuote(line)+`
+sleep 1
+drain
+zpty -d comp
 `)
 }
 
-func zshHomeEnv(t *testing.T) []string {
-	t.Helper()
-	tmp := t.TempDir()
-	return []string{"HOME=" + tmp, "ZDOTDIR=" + tmp}
-}
-
-func zshWords(words []string) string {
-	var quoted []string
-	for _, word := range words {
-		quoted = append(quoted, shellQuote(word))
+// envValue returns the value of key in a KEY=VALUE environment slice.
+func envValue(env []string, key string) string {
+	for _, kv := range env {
+		if value, ok := strings.CutPrefix(kv, key+"="); ok {
+			return value
+		}
 	}
-	return strings.Join(quoted, " ")
+	return ""
 }
 
 func shellQuote(s string) string {

--- a/e2e/feature_completion_runtime_test.go
+++ b/e2e/feature_completion_runtime_test.go
@@ -179,7 +179,7 @@ func (rt completionRuntime) runZsh(t *testing.T, words []string) string {
 	rc := rt.pathPrelude("zsh") + `
 export CLOUDSTIC_PROFILES_FILE=` + shellQuote(envValue(rt.env, "CLOUDSTIC_PROFILES_FILE")) + `
 autoload -Uz compinit
-compinit -u -d ` + shellQuote(filepath.Join(home, ".zcompdump")) + `
+compinit -C -d ` + shellQuote(filepath.Join(home, ".zcompdump")) + `
 source <(` + shellQuote(rt.bin) + ` completion zsh)
 PS1=';;;'
 `
@@ -212,7 +212,10 @@ drain() {
     print -rn -- "$all"
 }
 
-zpty -b comp `+shellQuote("HOME="+home+" ZDOTDIR="+home+" zsh -i")+`
+# Disable global startup files so the host's /etc/zshrc cannot initialize
+# completion before our isolated test configuration. In particular, CI images
+# may run compinit interactively and abort while waiting for a security prompt.
+zpty -b comp `+shellQuote("HOME="+home+" ZDOTDIR="+home+" zsh -d -i")+`
 sleep 2
 drain >/dev/null
 zpty -w -n comp `+shellQuote(line)+`


### PR DESCRIPTION
## Summary

- Re-base zsh's `$words`/`$CURRENT` on the subcommand before each `_arguments` call, so subcommand flags are offered at all. The generated script dispatches subcommands itself but left `words[1]` as `cloudstic`, so `_arguments` read the subcommand name (`backup`) as the first positional argument, found no positional spec to match it, concluded every argument was already supplied, and offered nothing — silently, with just a bell. Every subcommand and grouped subcommand was affected (`backup`, `restore`, `key passwd`, …); bash and fish have no command-word notion and were unaffected.
- Slice `$words` from the index where the subcommand was found rather than a plain `shift`, so global flags typed before it are handled too (`cloudstic -store local:/tmp backup <TAB>`).
- Emit the re-basing inline in each arm instead of factoring it into a shell helper. zsh binds the completion special parameters per function scope, so a helper's assignments to `words`/`CURRENT` never reach the caller's `_arguments` — verified both ways: the helper form debug-printed correctly re-based values and still completed nothing. The reason is recorded in a code comment so it does not get "simplified" back.
- Drop a hardcoded `completion)` arm that was dead code shadowed by the generated one (zsh takes the first matching `case` arm). The generated arm offers the same `bash zsh fish` values via `_cloudstic_shells`.
- Rewrite the e2e zsh runtime harness to drive a real interactive zsh through a pty. It previously stubbed `_arguments` (`_arguments() { print -l -- "$@" }`), so it only asserted which spec strings the script passed along and never that zsh did anything with them — the entire bug lived inside the real `_arguments`. Added a grouped-subcommand scenario (`cloudstic key passwd -` → `-new-password`).

Reported against 1.16 installed with Homebrew: after `cloudstic <TAB>` offered the command list correctly, selecting `backup` produced no further suggestions.

### Reviewer notes

- The new test has teeth. Reverting just `completion.go` and `completion_generated.go` makes it fail:

  ```
  --- FAIL: TestCLI_Feature_CompletionRuntime_BackupFlags/zsh
      completion missing "-profile", got: cloudstic backup -
  --- FAIL: TestCLI_Feature_CompletionRuntime_GroupedSubcommandFlags/zsh
      completion missing "-new-password", got: cloudstic key passwd -
  ```

- The pty harness spawns `zsh -i` under `zsh/zpty` with an isolated `HOME`/`ZDOTDIR`, and drains until the pty has been quiet for ~2s — completion runs asynchronously in the child, so there is no output marker to wait for. It skips when zsh is absent, like the other shells. The zsh subtests add roughly 8s each.
- No on-disk format or repository-compatibility surface is touched.
- Users on 1.16 will need their installed `_cloudstic` regenerated and a fresh shell (`rm ~/.zcompdump*` if it looks stale) once this ships.

## Verification

Confirmed manually in zsh 5.9 that `cloudstic backup <TAB>`, `cloudstic backup -<TAB>`, `cloudstic key passwd -<TAB>`, `cloudstic backup -profile <TAB>` (dynamic profile names), `cloudstic backup -source <TAB>`, `cloudstic completion <TAB>`, and `cloudstic -store local:/tmp backup -<TAB>` all complete.

- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./cmd/cloudstic ./e2e`
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./cmd/cloudstic/... ./e2e/...`