### PR TITLE
feat: resolve snapshots by short hash prefix

### DIFF
--- a/client.go
+++ b/client.go
@@ -738,6 +738,11 @@ type RestoreOption = engine.RestoreOption
 type RestoreResult = engine.RestoreResult
 
 var (
+	// ErrSnapshotNotFound means no snapshot matched a requested reference.
+	ErrSnapshotNotFound = engine.ErrSnapshotNotFound
+	// ErrSnapshotRefAmbiguous means more than one snapshot matched a hash prefix.
+	ErrSnapshotRefAmbiguous = engine.ErrSnapshotRefAmbiguous
+
 	WithRestoreDryRun   = engine.WithRestoreDryRun
 	WithRestoreVerbose  = engine.WithRestoreVerbose
 	WithRestorePath     = engine.WithRestorePath
@@ -745,14 +750,16 @@ var (
 )
 
 // Restore writes the snapshot's file tree as a ZIP archive to w.
-// snapshotRef can be "", "latest", a bare hash, or "snapshot/<hash>".
+// snapshotRef can be "", "latest", a bare hash or unambiguous hash prefix, or
+// "snapshot/<hash-or-prefix>". An ambiguous prefix is rejected.
 func (c *Client) Restore(ctx context.Context, w io.Writer, snapshotRef string, opts ...RestoreOption) (*RestoreResult, error) {
 	mgr := engine.NewRestoreManager(c.store, c.reporter)
 	return mgr.Run(ctx, engine.NewZipRestoreWriter(w), snapshotRef, opts...)
 }
 
 // RestoreToDir writes the snapshot's file tree directly into outputDir.
-// snapshotRef can be "", "latest", a bare hash, or "snapshot/<hash>".
+// snapshotRef can be "", "latest", a bare hash or unambiguous hash prefix, or
+// "snapshot/<hash-or-prefix>". An ambiguous prefix is rejected.
 func (c *Client) RestoreToDir(ctx context.Context, outputDir, snapshotRef string, opts ...RestoreOption) (*RestoreResult, error) {
 	mgr := engine.NewRestoreManager(c.store, c.reporter)
 	writer, err := engine.NewFSRestoreWriter(outputDir)
@@ -785,6 +792,8 @@ type LsSnapshotResult = engine.LsSnapshotResult
 
 var WithLsVerbose = engine.WithLsVerbose
 
+// LsSnapshot lists a snapshot selected by latest, full hash, or unambiguous
+// hash prefix. An ambiguous prefix is rejected.
 func (c *Client) LsSnapshot(ctx context.Context, snapshotID string, opts ...LsSnapshotOption) (*LsSnapshotResult, error) {
 	mgr := engine.NewLsSnapshotManager(c.store)
 	return mgr.Run(ctx, snapshotID, opts...)
@@ -944,6 +953,8 @@ type DiffResult = engine.DiffResult
 
 var WithDiffVerbose = engine.WithDiffVerbose
 
+// Diff compares snapshots selected by latest, full hashes, or unambiguous hash
+// prefixes. An ambiguous prefix is rejected.
 func (c *Client) Diff(ctx context.Context, snap1, snap2 string, opts ...DiffOption) (*DiffResult, error) {
 	mgr := engine.NewDiffManager(c.store)
 	return mgr.Run(ctx, snap1, snap2, opts...)

--- a/cmd/cloudstic/cmd_find.go
+++ b/cmd/cloudstic/cmd_find.go
@@ -329,15 +329,10 @@ func printFindRestoreHint(out io.Writer, result *cloudstic.FindResult) {
 	// which is not what the first match necessarily is.
 	//
 	// The command must be runnable as printed — a hint that needs editing before
-	// it works is worse than no hint. That rules out the short display form of
-	// the snapshot hash: restore resolves its snapshot argument with a direct
-	// Get by key, not a prefix search the way find's own -snapshot selector
-	// does, so a truncated hash here would fail with "not found" the moment
-	// anyone pasted it. The full hash is printed bare, matching every other
-	// place a snapshot ID is entered on the command line (restore, ls, diff,
-	// list's own SNAPSHOT HASH column) — restore accepts "snapshot/<hash>" too,
-	// but the bare form is the one used everywhere else, so it is the one that
-	// is unambiguously safe to paste. `-output` has no short form, and an
+	// it works is worse than no hint. Use the full hash so the command remains
+	// unambiguous even if a later snapshot collides with today's short display
+	// prefix. The bare form matches every other place a snapshot ID is entered;
+	// restore accepts "snapshot/<hash>" too. `-output` has no short form, and an
 	// output path without a .zip suffix restores to a directory.
 	_, _ = fmt.Fprintf(out, "\nRestore the newest version of %s:\n  cloudstic restore -path %s %s -output ./restored\n",
 		m.Path(), m.Path(), strings.TrimPrefix(snap.Ref, "snapshot/"))

--- a/cmd/cloudstic/cmd_find.go
+++ b/cmd/cloudstic/cmd_find.go
@@ -328,14 +328,10 @@ func printFindRestoreHint(out io.Writer, result *cloudstic.FindResult) {
 	// screen, a bare "the newest version" reads as the newest of all of them,
 	// which is not what the first match necessarily is.
 	//
-	// The command must be runnable as printed — a hint that needs editing before
-	// it works is worse than no hint. Use the full hash so the command remains
-	// unambiguous even if a later snapshot collides with today's short display
-	// prefix. The bare form matches every other place a snapshot ID is entered;
-	// restore accepts "snapshot/<hash>" too. `-output` has no short form, and an
-	// output path without a .zip suffix restores to a directory.
+	// Reuse the short hash already shown in the result rows. Restore resolves an
+	// unambiguous prefix and rejects a collision instead of choosing a snapshot.
 	_, _ = fmt.Fprintf(out, "\nRestore the newest version of %s:\n  cloudstic restore -path %s %s -output ./restored\n",
-		m.Path(), m.Path(), strings.TrimPrefix(snap.Ref, "snapshot/"))
+		m.Path(), m.Path(), shortSnapshotRef(snap.Ref))
 }
 
 // plural renders a count with its noun, adding a trailing "s" for anything but

--- a/cmd/cloudstic/cmd_find_test.go
+++ b/cmd/cloudstic/cmd_find_test.go
@@ -204,17 +204,17 @@ func TestPrintFindResult_ByContentGolden(t *testing.T) {
 			Type:        core.FileTypeFile,
 			Versions: []cloudstic.FileVersion{
 				{
-					Ref: "filemeta/2c624232cdd221771294dfbb310aca000a0df6ac8b66b696d90ef06fdefb64a3",
+					Ref:  "filemeta/2c624232cdd221771294dfbb310aca000a0df6ac8b66b696d90ef06fdefb64a3",
 					Name: "report.pdf", FileID: "f1", Size: 4 << 20, Mtime: 1_769_000_000,
 					Paths:     []string{"Documents/report.pdf"},
-					Snapshots: []cloudstic.SnapshotRef{{Ref: "snapshot/410b18a2", Seq: 4, Created: "2026-07-21T09:14:00Z"}},
+					Snapshots: []cloudstic.SnapshotRef{{Ref: "snapshot/410b18a2c9e35f1a8d6b3c07e42fa19d5c8b6e2d1a0f9c8b7a6e5d4c3b2a1908", Seq: 4, Created: "2026-07-21T09:14:00Z"}},
 					LastSeen:  "2026-07-21T09:14:00Z",
 				},
 				{
-					Ref: "filemeta/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+					Ref:  "filemeta/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 					Name: "report.pdf", FileID: "f2", Size: 4 << 20, Mtime: 1_769_000_000,
 					Paths:     []string{"Backup/report.pdf"},
-					Snapshots: []cloudstic.SnapshotRef{{Ref: "snapshot/410b18a2", Seq: 4, Created: "2026-07-21T09:14:00Z"}},
+					Snapshots: []cloudstic.SnapshotRef{{Ref: "snapshot/410b18a2c9e35f1a8d6b3c07e42fa19d5c8b6e2d1a0f9c8b7a6e5d4c3b2a1908", Seq: 4, Created: "2026-07-21T09:14:00Z"}},
 					LastSeen:  "2026-07-21T09:14:00Z",
 				},
 			},
@@ -262,7 +262,7 @@ func sampleFindMatch() cloudstic.FileMatch {
 				FileID: "f1", Name: "vault.kdbx", Size: 4_404_019, Mtime: 1_784_970_840,
 				Paths: []string{"Documents/vault.kdbx"},
 				Snapshots: []cloudstic.SnapshotRef{
-					{Ref: "snapshot/410b18a2", Seq: 28, Created: "2026-07-21T09:14:00Z"},
+					{Ref: "snapshot/410b18a2c9e35f1a8d6b3c07e42fa19d5c8b6e2d1a0f9c8b7a6e5d4c3b2a1908", Seq: 28, Created: "2026-07-21T09:14:00Z"},
 					{Ref: "snapshot/4e5d5487", Seq: 22, Created: "2026-07-14T09:14:00Z"},
 				},
 				FirstSeen: "2026-07-14T09:14:00Z", LastSeen: "2026-07-21T09:14:00Z",

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -990,12 +990,8 @@ Documents/vault.kdbx  (3 versions)
 1 file, 3 versions across 28 snapshots (searched 31 snapshots in 1.8s)
 
 Restore the newest version of Documents/vault.kdbx:
-  cloudstic restore -path Documents/vault.kdbx 410b18a2c9e35f1a8d6b3c07e42fa19d5c8b6e2d1a0f9c8b7a6e5d4c3b2a1908 -output ./restored
+  cloudstic restore -path Documents/vault.kdbx 410b18a2 -output ./restored
 ```
-
-The printed command uses the full snapshot hash so it stays unambiguous even if
-the repository later gains another snapshot with the same short prefix. A
-currently unique prefix can also be passed to `restore`.
 
 A repository holds the same file many times over, and the result model collapses
 each kind of repetition differently:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -861,7 +861,9 @@ cloudstic restore -dry-run
 | `-dry-run` | `false` | Show what would be restored without writing output |
 | `-no-verify` | `false` | Skip the content-hash check on each restored file (not recommended) |
 
-The snapshot ID is a positional argument (defaults to latest if omitted).
+The snapshot ID is a positional argument (defaults to latest if omitted). A
+full hash or any unambiguous hash prefix is accepted; Cloudstic rejects a prefix
+when more than one snapshot matches it.
 
 **Integrity verification.** Every restored file is hashed as it is written and
 compared against the content hash recorded when the snapshot was taken. If they
@@ -902,6 +904,9 @@ cloudstic ls
 # List files in a specific snapshot
 cloudstic ls <snapshot-hash>
 ```
+
+The hash may be shortened to any unambiguous prefix. Cloudstic reports an error
+instead of choosing a snapshot when the prefix is ambiguous.
 
 ---
 
@@ -988,10 +993,9 @@ Restore the newest version of Documents/vault.kdbx:
   cloudstic restore -path Documents/vault.kdbx 410b18a2c9e35f1a8d6b3c07e42fa19d5c8b6e2d1a0f9c8b7a6e5d4c3b2a1908 -output ./restored
 ```
 
-The printed command uses the full snapshot hash, not the short form shown in
-the table above it: `restore` resolves its snapshot argument by an exact
-lookup, not a prefix search, so a truncated hash fails with "not found" the
-moment it is pasted.
+The printed command uses the full snapshot hash so it stays unambiguous even if
+the repository later gains another snapshot with the same short prefix. A
+currently unique prefix can also be passed to `restore`.
 
 A repository holds the same file many times over, and the result model collapses
 each kind of repetition differently:
@@ -1040,6 +1044,9 @@ cloudstic diff <snapshot-hash-1> <snapshot-hash-2>
 # Compare a snapshot against the latest
 cloudstic diff <snapshot-hash> latest
 ```
+
+Each hash may be shortened to any unambiguous prefix. Cloudstic reports an error
+instead of choosing a snapshot when a prefix is ambiguous.
 
 Shows added, modified, and removed files between the two snapshots.
 

--- a/internal/engine/diff.go
+++ b/internal/engine/diff.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"sort"
-	"strings"
 
 	"github.com/cloudstic/cli/internal/core"
 	"github.com/cloudstic/cli/internal/hamt"
@@ -135,33 +134,11 @@ func (dm *DiffManager) loadRoot(ctx context.Context, id string) (root, ref strin
 }
 
 func (dm *DiffManager) resolveSnapshot(ctx context.Context, id string) (string, error) {
-	if id == "latest" || id == "" {
-		data, err := dm.store.Get(ctx, "index/latest")
-		if err != nil {
-			return "", fmt.Errorf("get latest index: %w", err)
-		}
-		var idx core.Index
-		if err := json.Unmarshal(data, &idx); err != nil {
-			return "", err
-		}
-		return idx.LatestSnapshot, nil
-	}
-	if !strings.HasPrefix(id, "snapshot/") {
-		return "snapshot/" + id, nil
-	}
-	return id, nil
+	return resolveSnapshotRef(ctx, dm.store, id)
 }
 
 func (dm *DiffManager) loadSnapshot(ctx context.Context, ref string) (*core.Snapshot, error) {
-	data, err := getVerified(ctx, dm.store, ref)
-	if err != nil {
-		return nil, fmt.Errorf("load snapshot %s: %w", ref, err)
-	}
-	var snap core.Snapshot
-	if err := json.Unmarshal(data, &snap); err != nil {
-		return nil, err
-	}
-	return &snap, nil
+	return loadSnapshotByRef(ctx, dm.store, ref)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/find_snapshots.go
+++ b/internal/engine/find_snapshots.go
@@ -171,7 +171,7 @@ func resolveOneFindSnapshot(
 		if entry, ok := byRef[ref]; ok {
 			return entry, nil
 		}
-		return SnapshotEntry{}, fmt.Errorf("no snapshots in repository")
+		return SnapshotEntry{}, snapshotNotFoundError(selector)
 	}
 
 	ref := selector
@@ -192,8 +192,8 @@ func resolveOneFindSnapshot(
 	case 1:
 		return matches[0], nil
 	case 0:
-		return SnapshotEntry{}, fmt.Errorf("snapshot %q not found", selector)
+		return SnapshotEntry{}, snapshotNotFoundError(selector)
 	default:
-		return SnapshotEntry{}, fmt.Errorf("snapshot %q is ambiguous: %d snapshots share that prefix", selector, len(matches))
+		return SnapshotEntry{}, snapshotRefAmbiguousError(selector, len(matches))
 	}
 }

--- a/internal/engine/find_test.go
+++ b/internal/engine/find_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -610,6 +611,9 @@ func TestFind_SnapshotSelectors(t *testing.T) {
 			WithFindPattern("notes.txt"), WithFindSnapshots("deadbeef"))
 		if err == nil {
 			t.Fatal("want an error for an unknown snapshot")
+		}
+		if !errors.Is(err, ErrSnapshotNotFound) {
+			t.Fatalf("error = %v, want errors.Is(err, ErrSnapshotNotFound)", err)
 		}
 	})
 }

--- a/internal/engine/ls_snapshot.go
+++ b/internal/engine/ls_snapshot.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"sort"
-	"strings"
 
 	"github.com/cloudstic/cli/internal/core"
 	"github.com/cloudstic/cli/internal/hamt"
@@ -100,30 +99,16 @@ func (lm *LsSnapshotManager) Run(ctx context.Context, snapshotID string, opts ..
 // ---------------------------------------------------------------------------
 
 func (lm *LsSnapshotManager) resolveSnapshot(ctx context.Context, id string) (*core.Snapshot, string, error) {
-	ref := id
-	if ref == "latest" || ref == "" {
-		data, err := lm.store.Get(ctx, "index/latest")
-		if err != nil {
-			return nil, "", fmt.Errorf("get latest index: %w", err)
-		}
-		var idx core.Index
-		if err := json.Unmarshal(data, &idx); err != nil {
-			return nil, "", fmt.Errorf("parse index: %w", err)
-		}
-		ref = idx.LatestSnapshot
-	} else if !strings.HasPrefix(ref, "snapshot/") {
-		ref = "snapshot/" + ref
+	ref, err := resolveSnapshotRef(ctx, lm.store, id)
+	if err != nil {
+		return nil, "", err
 	}
 
-	data, err := getVerified(ctx, lm.store, ref)
+	snap, err := loadSnapshotByRef(ctx, lm.store, ref)
 	if err != nil {
-		return nil, "", fmt.Errorf("load snapshot %s: %w", ref, err)
+		return nil, "", err
 	}
-	var snap core.Snapshot
-	if err := json.Unmarshal(data, &snap); err != nil {
-		return nil, "", fmt.Errorf("parse snapshot: %w", err)
-	}
-	return &snap, ref, nil
+	return snap, ref, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/restore.go
+++ b/internal/engine/restore.go
@@ -737,29 +737,16 @@ func filterByPath(sorted []core.FileMeta, byID map[string]core.FileMeta, pathFil
 // ---------------------------------------------------------------------------
 
 func (rm *RestoreManager) resolveSnapshot(ctx context.Context, ref string) (*core.Snapshot, string, error) {
-	if ref == "" || ref == "latest" {
-		data, err := rm.store.Get(ctx, "index/latest")
-		if err != nil {
-			return nil, "", fmt.Errorf("cannot find latest index: %w", err)
-		}
-		var idx core.Index
-		if err := json.Unmarshal(data, &idx); err != nil {
-			return nil, "", err
-		}
-		ref = idx.LatestSnapshot
-	} else if !strings.HasPrefix(ref, "snapshot/") {
-		ref = "snapshot/" + ref
-	}
-
-	data, err := getVerified(ctx, rm.store, ref)
+	ref, err := resolveSnapshotRef(ctx, rm.store, ref)
 	if err != nil {
-		return nil, "", fmt.Errorf("load snapshot %s: %w", ref, err)
-	}
-	var snap core.Snapshot
-	if err := json.Unmarshal(data, &snap); err != nil {
 		return nil, "", err
 	}
-	return &snap, ref, nil
+
+	snap, err := loadSnapshotByRef(ctx, rm.store, ref)
+	if err != nil {
+		return nil, "", err
+	}
+	return snap, ref, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/snapshot_resolution_test.go
+++ b/internal/engine/snapshot_resolution_test.go
@@ -1,0 +1,229 @@
+package engine
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/cloudstic/cli/internal/core"
+	"github.com/cloudstic/cli/internal/ui"
+	"github.com/cloudstic/cli/pkg/store"
+)
+
+type listRejectingStore struct {
+	store.ObjectStore
+}
+
+func (s *listRejectingStore) List(context.Context, string) ([]string, error) {
+	panic("List called while resolving a full snapshot hash")
+}
+
+func TestSnapshotReadersDoNotListForFullHash(t *testing.T) {
+	ctx := context.Background()
+	base := NewMockStore()
+	ref := putSnapshot(t, base, &core.Snapshot{Seq: 1})
+	s := &listRejectingStore{ObjectStore: base}
+
+	tests := []struct {
+		name    string
+		resolve func(string) error
+	}{
+		{
+			name: "restore",
+			resolve: func(selector string) error {
+				_, _, err := NewRestoreManager(s, ui.NewNoOpReporter()).resolveSnapshot(ctx, selector)
+				return err
+			},
+		},
+		{
+			name: "ls",
+			resolve: func(selector string) error {
+				_, _, err := NewLsSnapshotManager(s).resolveSnapshot(ctx, selector)
+				return err
+			},
+		},
+		{
+			name: "diff",
+			resolve: func(selector string) error {
+				_, err := NewDiffManager(s).resolveSnapshot(ctx, selector)
+				return err
+			},
+		},
+	}
+
+	selectors := []struct {
+		name  string
+		value string
+	}{
+		{name: "qualified", value: ref},
+		{name: "bare", value: strings.TrimPrefix(ref, "snapshot/")},
+	}
+	for _, tt := range tests {
+		for _, selector := range selectors {
+			t.Run(tt.name+"/"+selector.name, func(t *testing.T) {
+				if err := tt.resolve(selector.value); err != nil {
+					t.Fatalf("resolve full hash: %v", err)
+				}
+			})
+		}
+	}
+}
+
+func TestSnapshotReadersResolveUniqueHashPrefix(t *testing.T) {
+	ctx := context.Background()
+	s := NewMockStore()
+	ref := putSnapshot(t, s, &core.Snapshot{Seq: 1})
+	prefix := strings.TrimPrefix(ref, "snapshot/")[:8]
+
+	tests := []struct {
+		name    string
+		resolve func(string) (string, error)
+	}{
+		{
+			name: "restore",
+			resolve: func(selector string) (string, error) {
+				_, resolved, err := NewRestoreManager(s, ui.NewNoOpReporter()).resolveSnapshot(ctx, selector)
+				return resolved, err
+			},
+		},
+		{
+			name: "ls",
+			resolve: func(selector string) (string, error) {
+				_, resolved, err := NewLsSnapshotManager(s).resolveSnapshot(ctx, selector)
+				return resolved, err
+			},
+		},
+		{
+			name: "diff",
+			resolve: func(selector string) (string, error) {
+				return NewDiffManager(s).resolveSnapshot(ctx, selector)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.resolve(prefix)
+			if err != nil {
+				t.Fatalf("resolve %q: %v", prefix, err)
+			}
+			if got != ref {
+				t.Fatalf("resolved ref = %q, want %q", got, ref)
+			}
+		})
+	}
+}
+
+func TestSnapshotReadersRejectAmbiguousHashPrefix(t *testing.T) {
+	ctx := context.Background()
+	s := NewMockStore()
+	const (
+		prefix = "abc12345"
+		ref1   = "snapshot/abc1234511111111111111111111111111111111111111111111111111111111"
+		ref2   = "snapshot/abc1234522222222222222222222222222222222222222222222222222222222"
+	)
+	if err := s.Put(ctx, ref1, []byte("first")); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Put(ctx, ref2, []byte("second")); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		resolve func(string) error
+	}{
+		{
+			name: "restore",
+			resolve: func(selector string) error {
+				_, _, err := NewRestoreManager(s, ui.NewNoOpReporter()).resolveSnapshot(ctx, selector)
+				return err
+			},
+		},
+		{
+			name: "ls",
+			resolve: func(selector string) error {
+				_, _, err := NewLsSnapshotManager(s).resolveSnapshot(ctx, selector)
+				return err
+			},
+		},
+		{
+			name: "diff",
+			resolve: func(selector string) error {
+				_, err := NewDiffManager(s).resolveSnapshot(ctx, selector)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.resolve(prefix)
+			if err == nil {
+				t.Fatalf("resolve %q succeeded, want ambiguity error", prefix)
+			}
+			if !strings.Contains(err.Error(), "ambiguous") {
+				t.Fatalf("resolve %q error = %q, want ambiguity error", prefix, err)
+			}
+			if !errors.Is(err, ErrSnapshotRefAmbiguous) {
+				t.Fatalf("resolve %q error = %q, want errors.Is(err, ErrSnapshotRefAmbiguous)", prefix, err)
+			}
+		})
+	}
+}
+
+func TestSnapshotReadersReturnNotFoundSentinel(t *testing.T) {
+	ctx := context.Background()
+	s := NewMockStore()
+
+	tests := []struct {
+		name    string
+		resolve func(string) error
+	}{
+		{
+			name: "restore",
+			resolve: func(selector string) error {
+				_, _, err := NewRestoreManager(s, ui.NewNoOpReporter()).resolveSnapshot(ctx, selector)
+				return err
+			},
+		},
+		{
+			name: "ls",
+			resolve: func(selector string) error {
+				_, _, err := NewLsSnapshotManager(s).resolveSnapshot(ctx, selector)
+				return err
+			},
+		},
+		{
+			name: "diff",
+			resolve: func(selector string) error {
+				_, _, err := NewDiffManager(s).loadRoot(ctx, selector)
+				return err
+			},
+		},
+	}
+	selectors := []struct {
+		name  string
+		value string
+	}{
+		{name: "short-prefix", value: "deadbeef"},
+		{name: "full-hash", value: strings.Repeat("f", sha256.Size*2)},
+		{name: "latest", value: "latest"},
+	}
+
+	for _, tt := range tests {
+		for _, selector := range selectors {
+			t.Run(tt.name+"/"+selector.name, func(t *testing.T) {
+				err := tt.resolve(selector.value)
+				if err == nil {
+					t.Fatalf("resolve %q succeeded, want not-found error", selector.value)
+				}
+				if !errors.Is(err, ErrSnapshotNotFound) {
+					t.Fatalf("resolve %q error = %q, want errors.Is(err, ErrSnapshotNotFound)", selector.value, err)
+				}
+			})
+		}
+	}
+}

--- a/internal/engine/snapshots.go
+++ b/internal/engine/snapshots.go
@@ -2,10 +2,12 @@ package engine
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -17,6 +19,13 @@ import (
 var snapLog = logger.New("snapshots", logger.ColorCyan)
 
 const snapshotCatalogKey = "index/snapshots"
+
+var (
+	// ErrSnapshotNotFound means no snapshot matched a requested reference.
+	ErrSnapshotNotFound = errors.New("snapshot not found")
+	// ErrSnapshotRefAmbiguous means more than one snapshot matched a hash prefix.
+	ErrSnapshotRefAmbiguous = errors.New("snapshot reference is ambiguous")
+)
 
 // ---------------------------------------------------------------------------
 // Snapshot catalog (index/snapshots)
@@ -285,6 +294,71 @@ func fetchSnapshots(s store.ObjectStore, keys []string) (map[string]core.Snapsho
 // index/latest helpers
 // ---------------------------------------------------------------------------
 
+// resolveSnapshotRef resolves latest, a full snapshot ref, a bare hash, or an
+// unambiguous hash prefix to a fully-qualified snapshot ref.
+func resolveSnapshotRef(ctx context.Context, s store.ObjectStore, selector string) (string, error) {
+	if selector == "" || selector == "latest" {
+		ref, _, err := resolveLatestContext(ctx, s)
+		if err != nil {
+			return "", err
+		}
+		if ref == "" {
+			return "", snapshotNotFoundError("latest")
+		}
+		return ref, nil
+	}
+
+	refPrefix := selector
+	if !strings.HasPrefix(refPrefix, "snapshot/") {
+		refPrefix = "snapshot/" + refPrefix
+	}
+	if len(refPrefix) == len("snapshot/")+sha256.Size*2 {
+		return refPrefix, nil
+	}
+
+	matches, err := s.List(ctx, refPrefix)
+	if err != nil {
+		return "", fmt.Errorf("list snapshots matching %q: %w", selector, err)
+	}
+	for _, ref := range matches {
+		if ref == refPrefix {
+			return ref, nil
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return "", snapshotNotFoundError(selector)
+	case 1:
+		return matches[0], nil
+	default:
+		return "", snapshotRefAmbiguousError(selector, len(matches))
+	}
+}
+
+func snapshotNotFoundError(selector string) error {
+	return fmt.Errorf("%w: %q", ErrSnapshotNotFound, selector)
+}
+
+func snapshotRefAmbiguousError(selector string, matches int) error {
+	return fmt.Errorf("%w: %q matches %d snapshots", ErrSnapshotRefAmbiguous, selector, matches)
+}
+
+func loadSnapshotByRef(ctx context.Context, s store.ObjectStore, ref string) (*core.Snapshot, error) {
+	data, err := getVerified(ctx, s, ref)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, snapshotNotFoundError(strings.TrimPrefix(ref, "snapshot/"))
+		}
+		return nil, fmt.Errorf("load snapshot %s: %w", ref, err)
+	}
+	var snap core.Snapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return nil, fmt.Errorf("parse snapshot %s: %w", ref, err)
+	}
+	return &snap, nil
+}
+
 // resolveLatest reads index/latest and returns the snapshot ref it points to.
 // Returns ("", 0, nil) on a fresh repository (no index/latest yet). Any other
 // read or decode failure is returned as an error rather than treated as a
@@ -292,7 +366,11 @@ func fetchSnapshots(s store.ObjectStore, keys []string) (map[string]core.Snapsho
 // exist", and confusing the two would silently reset the sequence number and
 // downgrade the next backup from incremental to a full rescan.
 func resolveLatest(s store.ObjectStore) (ref string, seq int, err error) {
-	data, err := s.Get(context.Background(), "index/latest")
+	return resolveLatestContext(context.Background(), s)
+}
+
+func resolveLatestContext(ctx context.Context, s store.ObjectStore) (ref string, seq int, err error) {
+	data, err := s.Get(ctx, "index/latest")
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return "", 0, nil


### PR DESCRIPTION
## Summary

- Resolve `restore`, `ls`, and `diff` snapshot arguments from any unambiguous hash prefix while preserving `latest`, bare hashes, and qualified refs.
- Reject ambiguous prefixes and expose `ErrSnapshotNotFound` and `ErrSnapshotRefAmbiguous` for stable `errors.Is` handling across snapshot readers and `find` selectors.
- Bypass snapshot listing for full SHA-256 refs and cover unique, ambiguous, missing, latest, and no-list resolution paths.
- Shorten the restore hint printed by `find` to the same eight-character hash shown in its result rows, with an end-to-end test that runs the hint verbatim.
- Update the user guide to describe prefix behavior and the shorter restore hint.

## Verification

- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./...`
- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./cmd/cloudstic`
- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./e2e -run TestCLI_Feature_FindLocatesDeletedFileAndPrintsAWorkingRestore`
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-lint-cache golangci-lint run ./...`
- `npx --yes markdownlint-cli2 docs/user-guide.md`
- `git diff --check`