### PR TITLE
feat(engine): add ErrRepoLocked sentinel for repo-lock conflicts

### DIFF
--- a/client.go
+++ b/client.go
@@ -940,6 +940,11 @@ func (c *Client) ForgetPolicy(ctx context.Context, opts ...ForgetOption) (*Polic
 
 type RepoLock = engine.RepoLock
 
+// ErrRepoLocked means Backup, Restore, or Prune could not proceed because the
+// repository is held by another operation. Use errors.Is(err, ErrRepoLocked)
+// to detect the condition and prompt the caller toward BreakLock.
+var ErrRepoLocked = engine.ErrRepoLocked
+
 func (c *Client) BreakLock(ctx context.Context) ([]*RepoLock, error) {
 	return engine.BreakRepoLock(ctx, c.store)
 }

--- a/client.go
+++ b/client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cloudstic/cli/internal/engine"
 	"github.com/cloudstic/cli/internal/logger"
 	"github.com/cloudstic/cli/internal/repoconfig"
+	"github.com/cloudstic/cli/internal/secretref"
 	"github.com/cloudstic/cli/internal/ui"
 	"github.com/cloudstic/cli/pkg/crypto"
 	"github.com/cloudstic/cli/pkg/keychain"
@@ -707,6 +708,20 @@ func PlanWorkstationSetup(ctx context.Context, opts ...WorkstationSetupOption) (
 func ApplyWorkstationSetupPlan(cfg *ProfilesConfig, plan *WorkstationSetupPlan) (*WorkstationApplyResult, error) {
 	return engine.ApplyWorkstationSetupPlan(cfg, plan)
 }
+
+// SecretRefError reports a malformed scheme://path secret reference (e.g. in
+// one of a profile's *_secret fields). Use errors.As to inspect it and Kind
+// to branch on the failure mode.
+type SecretRefError = secretref.Error
+
+// SecretRefErrorKind categorizes a SecretRefError.
+type SecretRefErrorKind = secretref.ErrorKind
+
+const (
+	SecretRefInvalid            = secretref.KindInvalidRef
+	SecretRefNotFound           = secretref.KindNotFound
+	SecretRefBackendUnavailable = secretref.KindBackendUnavailable
+)
 
 // LoadProfilesFile parses a backup profiles YAML file.
 func LoadProfilesFile(path string) (*ProfilesConfig, error) {

--- a/client_test.go
+++ b/client_test.go
@@ -3,6 +3,8 @@ package cloudstic
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"path/filepath"
 	"testing"
 
 	"github.com/cloudstic/cli/internal/core"
@@ -524,5 +526,34 @@ func TestClient_Cat_WithCompression(t *testing.T) {
 	if len(rawData) >= len(largeJSON) {
 		t.Logf("Warning: Compressed data (%d bytes) not smaller than original (%d bytes)",
 			len(rawData), len(largeJSON))
+	}
+}
+
+// TestSaveProfilesFile_SecretRefErrorIsInspectable confirms SecretRefError is
+// actually reachable through errors.As on a public entry point: a malformed
+// secret reference in a profile fails validation inside internal/engine and
+// internal/secretref, neither of which a library consumer can import, so
+// SecretRefError is the only way to inspect it programmatically rather than
+// just displaying the message.
+func TestSaveProfilesFile_SecretRefErrorIsInspectable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "profiles.yaml")
+	cfg := &ProfilesConfig{
+		Version: 1,
+		Stores: map[string]ProfileStore{
+			"prod": {URI: "local:./store", PasswordSecret: "invalid"},
+		},
+	}
+
+	err := SaveProfilesFile(path, cfg)
+	if err == nil {
+		t.Fatal("SaveProfilesFile: expected a validation error")
+	}
+
+	var refErr *SecretRefError
+	if !errors.As(err, &refErr) {
+		t.Fatalf("errors.As(err, &SecretRefError) failed on: %v", err)
+	}
+	if refErr.Kind != SecretRefInvalid {
+		t.Errorf("Kind = %v, want %v", refErr.Kind, SecretRefInvalid)
 	}
 }

--- a/cmd/cloudstic/runner.go
+++ b/cmd/cloudstic/runner.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"os"
 	"os/exec"
+
+	"github.com/cloudstic/cli/internal/engine"
 )
 
 const (
@@ -102,8 +104,15 @@ func (r *runner) fail(format string, args ...any) int {
 	message, exitCode := fmt.Sprintf(format, args...), exitFailure
 	for _, arg := range args {
 		err, ok := arg.(error)
-		if ok && errors.Is(err, context.Canceled) {
+		if !ok {
+			continue
+		}
+		if errors.Is(err, context.Canceled) {
 			message, exitCode = "Interrupted.", exitInterrupted
+			break
+		}
+		if errors.Is(err, engine.ErrRepoLocked) {
+			message += " Run `cloudstic break-lock` to remove a stale lock left by a crashed process."
 			break
 		}
 	}

--- a/cmd/cloudstic/runner_test.go
+++ b/cmd/cloudstic/runner_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/cloudstic/cli/internal/engine"
 )
 
 func TestRunnerFailInterrupted(t *testing.T) {
@@ -20,6 +22,21 @@ func TestRunnerFailInterrupted(t *testing.T) {
 	}
 	if got, want := errOut.String(), "Interrupted.\n"; got != want {
 		t.Fatalf("stderr = %q, want %q", got, want)
+	}
+}
+
+func TestRunnerFailRepoLocked(t *testing.T) {
+	var errOut bytes.Buffer
+	r := newRunner(nil)
+	r.errOut = &errOut
+
+	err := fmt.Errorf("acquire shared lock: %w", engine.ErrRepoLocked)
+	code := r.fail("Backup failed: %v", err)
+	if code != exitFailure {
+		t.Fatalf("fail() exit code = %d, want %d", code, exitFailure)
+	}
+	if got := errOut.String(); !strings.Contains(got, "break-lock") {
+		t.Fatalf("stderr = %q, want a break-lock hint", got)
 	}
 }
 

--- a/internal/engine/find_collect.go
+++ b/internal/engine/find_collect.go
@@ -192,6 +192,18 @@ func sortFileVersions(versions []FileVersion) {
 		if versions[i].LastSeen != versions[j].LastSeen {
 			return versions[i].LastSeen > versions[j].LastSeen
 		}
+		// LastSeen is an ISO8601 timestamp truncated to the second, so two
+		// snapshots taken within the same second — routine in a fast backup
+		// loop or a test — compare equal here. Snapshots[0].Seq (the version's
+		// newest holding snapshot; sortedSnapshotRefs already put it first) is
+		// a monotonic counter with no such resolution limit, and is what
+		// actually decides which version is newer in that case. Falling
+		// through to Mtime below without this would let two versions edited
+		// in the same second get ordered by their content hash instead —
+		// deterministic, but unrelated to recency.
+		if si, sj := lastSnapshotSeq(versions[i]), lastSnapshotSeq(versions[j]); si != sj {
+			return si > sj
+		}
 		if versions[i].Mtime != versions[j].Mtime {
 			return versions[i].Mtime > versions[j].Mtime
 		}
@@ -200,4 +212,13 @@ func sortFileVersions(versions []FileVersion) {
 		}
 		return versions[i].Ref < versions[j].Ref
 	})
+}
+
+// lastSnapshotSeq returns the sequence number of the newest snapshot holding
+// v, or 0 if v is (unexpectedly) held by none.
+func lastSnapshotSeq(v FileVersion) int {
+	if len(v.Snapshots) == 0 {
+		return 0
+	}
+	return v.Snapshots[0].Seq
 }

--- a/internal/engine/find_test.go
+++ b/internal/engine/find_test.go
@@ -250,6 +250,40 @@ func TestFind_EditedFileYieldsOrderedVersions(t *testing.T) {
 	}
 }
 
+// TestFind_EditedFileWithinSameSecondStaysOrderedBySeq guards against a real
+// regression: three snapshots taken within the same wall-clock second (routine
+// for a fast backup loop, and reproduced by e2e/feature_find_test.go on a quick
+// CI runner) all carry an identical Created timestamp. If the edited file's
+// Mtime also ties — plausible at one-second resolution — sortFileVersions had
+// nothing left to fall back on but the filemeta ref's hash, which sorts newest
+// and oldest by coincidence rather than by recency. Snapshots[0].Seq (set by
+// sortedSnapshotRefs) doesn't have that resolution problem and must decide it
+// instead.
+func TestFind_EditedFileWithinSameSecondStaysOrderedBySeq(t *testing.T) {
+	r := newFindRepo(t)
+	src := localSource("./docs")
+	docs := folder("d1", "Documents")
+	vault := file("f1", "vault.kdbx", "d1").withMtime(1_700_000_000)
+
+	const sameSecond = "2026-01-01T00:00:00Z"
+	r.snapshot(sameSecond, src, docs, vault.withSize(100))
+	r.snapshot(sameSecond, src, docs, vault.withSize(100))
+	r.snapshot(sameSecond, src, docs, vault.withSize(200).withContent("v2"))
+
+	result := r.runFind(WithFindPattern("vault.kdbx"))
+
+	versions := result.Matches[0].Versions
+	if len(versions) != 2 {
+		t.Fatalf("want 2 versions, got %d: %s", len(versions), renderMatches(result.Matches))
+	}
+	if versions[0].Size != 200 {
+		t.Errorf("newest version size = %d, want 200 (the edit, from the 3rd snapshot)", versions[0].Size)
+	}
+	if got := len(versions[1].Snapshots); got != 2 {
+		t.Errorf("the unchanged version spans 2 snapshots, got %d", got)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Axis 3: several copies of the same content inside one snapshot
 // ---------------------------------------------------------------------------

--- a/internal/engine/repolock.go
+++ b/internal/engine/repolock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -11,6 +12,13 @@ import (
 
 	"github.com/cloudstic/cli/pkg/store"
 )
+
+// ErrRepoLocked is wrapped into every error that means the repository is
+// currently held by another operation (exclusive or shared), as opposed to
+// an I/O failure that merely prevented telling whether it is locked. Callers
+// use errors.Is(err, ErrRepoLocked) to distinguish the two and point the user
+// at `break-lock` instead of a generic failure message.
+var ErrRepoLocked = errors.New("repository is locked")
 
 // The lock path must be distinct from the shared lock directory on local filesystems.
 // We use index/lock.exclusive for the exclusive lock and index/lock.shared/ for shared locks.
@@ -111,8 +119,8 @@ func AcquireRepoLock(ctx context.Context, s store.ObjectStore, operation string)
 	}
 	if !lock.ownsLock(current) {
 		return nil, nil, fmt.Errorf(
-			"repository is locked by %s (operation: %s) — lost lock race",
-			current.Holder, current.Operation,
+			"%w by %s (operation: %s) — lost lock race",
+			ErrRepoLocked, current.Holder, current.Operation,
 		)
 	}
 
@@ -269,7 +277,7 @@ func checkExclusiveLock(ctx context.Context, s store.ObjectStore) error {
 			return fmt.Errorf("cannot determine whether the repository is locked: %w", existsErr)
 		}
 		if exists {
-			return fmt.Errorf("repository holds an unreadable exclusive lock: %w", err)
+			return fmt.Errorf("%w: exclusive lock present but unreadable: %w", ErrRepoLocked, err)
 		}
 		return nil
 	}
@@ -277,8 +285,8 @@ func checkExclusiveLock(ctx context.Context, s store.ObjectStore) error {
 	expires, parseErr := time.Parse(time.RFC3339Nano, existing.ExpiresAt)
 	if parseErr != nil || time.Now().Before(expires) {
 		return fmt.Errorf(
-			"repository is exclusively locked by %s (operation: %s, acquired: %s, expires: %s)",
-			existing.Holder, existing.Operation, existing.AcquiredAt, existing.ExpiresAt,
+			"%w (exclusive) by %s (operation: %s, acquired: %s, expires: %s)",
+			ErrRepoLocked, existing.Holder, existing.Operation, existing.AcquiredAt, existing.ExpiresAt,
 		)
 	}
 	return nil
@@ -328,15 +336,15 @@ func checkSharedLocks(ctx context.Context, s store.ObjectStore) error {
 				return fmt.Errorf("cannot determine whether shared lock %s is live: %w", key, existsErr)
 			}
 			if exists {
-				return fmt.Errorf("repository holds an unreadable shared lock %s: %w", key, err)
+				return fmt.Errorf("%w: shared lock %s present but unreadable: %w", ErrRepoLocked, key, err)
 			}
 			continue
 		}
 		expires, parseErr := time.Parse(time.RFC3339Nano, sharedLock.ExpiresAt)
 		if parseErr != nil || time.Now().Before(expires) {
 			return fmt.Errorf(
-				"repository is locked (shared) by %s (operation: %s)",
-				sharedLock.Holder, sharedLock.Operation,
+				"%w (shared) by %s (operation: %s)",
+				ErrRepoLocked, sharedLock.Holder, sharedLock.Operation,
 			)
 		}
 	}

--- a/internal/engine/repolock_test.go
+++ b/internal/engine/repolock_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -475,8 +476,11 @@ func TestAcquireSharedLock_ConflictWithExclusive(t *testing.T) {
 	if err == nil {
 		t.Fatal("shared lock should fail if exclusive lock exists")
 	}
-	if !strings.Contains(err.Error(), "exclusively locked") {
-		t.Errorf("error should mention exclusively locked, got: %v", err)
+	if !errors.Is(err, ErrRepoLocked) {
+		t.Errorf("error should wrap ErrRepoLocked, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "(exclusive)") {
+		t.Errorf("error should mention the exclusive lock, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `engine.ErrRepoLocked`, wrapped into the repository-lock error paths in `internal/engine/repolock.go` that mean the repo is genuinely held by another operation (lost-lock-race, an unreadable-but-live exclusive/shared lock, and the normal "still valid" exclusive/shared cases) — as opposed to an I/O failure that merely prevented telling whether it's locked, which stays unwrapped.
- `runner.fail` (the shared error-printing path used by `backup`/`restore`/`prune`) now appends a "Run `cloudstic break-lock`..." hint whenever `errors.Is(err, engine.ErrRepoLocked)`, mirroring the existing `context.Canceled` → "Interrupted." special-case.
- Re-export it as `ErrRepoLocked` in `client.go`, next to `BreakLock`, following the existing `ErrSnapshotNotFound`/`ErrSnapshotRefAmbiguous` pattern — library consumers can't import `internal/engine`, so without this they'd have no way to detect the condition programmatically.
- **Audited every other sentinel/typed error in the codebase for the same gap** and found one more: `LoadProfilesFile`/`SaveProfilesFile` (both public) wrap `internal/secretref`'s validation failure with `%w`, but that package is also internal and unimportable, so a consumer had no way to `errors.As` into it and branch on the failure kind. Re-exported as `SecretRefError`/`SecretRefErrorKind` + `SecretRefInvalid`/`SecretRefNotFound`/`SecretRefBackendUnavailable`. Sentinels in `pkg/store`, `pkg/crypto`, and `pkg/keychain` don't need this treatment since those packages aren't internal and are already directly importable.
- Sentinel's message ("repository is locked") now matches the exact phrase `docs/user-guide.md` already tells users to watch for.
- **Fix an unrelated CI failure found on this branch**: `sortFileVersions` (`internal/engine/find_collect.go`) fell through to comparing the filemeta ref's hash when both a version's `LastSeen` (second-resolution) and `Mtime` tied, which has no relationship to recency — this let `TestCLI_Feature_Find/find_across_snapshots/local_to_local` flake whenever three snapshots landed in the same wall-clock second. Fixed by breaking the tie on `Snapshots[0].Seq` (monotonic, no resolution limit) before falling back further; added `TestFind_EditedFileWithinSameSecondStaysOrderedBySeq`, confirmed to fail without the fix and pass with it.

## Verification
- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 . ./internal/engine/... ./cmd/cloudstic/...`
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run . ./internal/engine/... ./cmd/cloudstic/...`
- `go build ./...`
- `go test -count=1 ./...` (full suite, including hermetic e2e)
- `go test -run 'TestCLI_Feature_Find$/find_across_snapshots/local_to_local' -count=5 ./e2e` (reproduced the CI flake pre-fix, passes reliably post-fix)