### PR TITLE
test: prove the public contracts from a real external module (RFC 0022)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,6 +6,10 @@ codecov:
 # reports them as 0% however heavily they are used.
 ignore:
   - "pkg/store/storetest/**"
+  # The external-module fixture (RFC 0022). It is a separate Go module built by
+  # a test to prove the public contracts are implementable from outside; it is
+  # never linked into this module, so it has no coverage to report.
+  - "internal/apicheck/testdata/**"
 
 coverage:
   status:

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -231,11 +231,14 @@ The backup engine (`internal/engine/backup.go`) interacts with sources as follow
 ## Implementing a new source
 
 A source can live **in its own Go module** — you do not need to fork or vendor
-Cloudstic. The `Source` contract lives in `pkg/source`, which depends on nothing
-outside the standard library, and the `FileMeta`/`SourceInfo` types it is
-written in are re-exported from the root `cloudstic` package as type aliases.
-Because a Go type alias denotes the identical type, a `FileMeta` you construct
-satisfies the interface exactly.
+Cloudstic. The `Source` contract lives in `pkg/source`, which re-exports the
+types it is written in (`FileMeta`, `SourceInfo`, `FileType`) as Go type
+aliases. An alias denotes the identical type, so a `source.FileMeta` you
+construct satisfies the interface exactly.
+
+Importing `pkg/source` is all you need, and it costs no third-party
+dependencies — the provider SDKs live in the per-provider subpackages, not in
+the contract.
 
 ```go
 package mysource
@@ -244,26 +247,25 @@ import (
     "context"
     "io"
 
-    cloudstic "github.com/cloudstic/cli"
     "github.com/cloudstic/cli/pkg/source"
 )
 
 type Source struct{ /* ... */ }
 
-func (s *Source) Walk(ctx context.Context, cb func(cloudstic.FileMeta) error) error {
+func (s *Source) Walk(ctx context.Context, cb func(source.FileMeta) error) error {
     // Parents MUST be emitted before their children.
-    return cb(cloudstic.FileMeta{
+    return cb(source.FileMeta{
         FileID: "docs/report.pdf", // stable + unique: this is the HAMT key
         Name:   "report.pdf",
-        Type:   cloudstic.FileTypeFile,
+        Type:   source.FileTypeFile,
         Size:   1234,
     })
 }
 
 func (s *Source) GetFileStream(fileID string) (io.ReadCloser, error) { /* ... */ }
 
-func (s *Source) Info() cloudstic.SourceInfo {
-    return cloudstic.SourceInfo{
+func (s *Source) Info() source.SourceInfo {
+    return source.SourceInfo{
         Type:     "com.example.mysource", // namespace third-party types
         Identity: "stable-container-id",  // stable across runs: drives lineage
         PathID:   "/selected/root",

--- a/internal/apicheck/external_test.go
+++ b/internal/apicheck/external_test.go
@@ -1,0 +1,127 @@
+package apicheck
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// externalModDir is a real Go module, with its own go.mod and a replace
+// directive pointing at this checkout. It lives under testdata/ so the go tool
+// ignores it during normal builds.
+const externalModDir = "testdata/externalmod"
+
+// TestExternalModuleImplementsPublicContracts is the acceptance test for
+// RFC 0022: a module outside github.com/cloudstic/cli must be able to implement
+// source.Source, source.IncrementalSource and store.ObjectStore.
+//
+// It compiles the fixture rather than asserting anything about this module's
+// own types, because that is the only thing that actually proves the claim —
+// Go's internal/ rule is enforced at build time, from the importing module's
+// path. The fixture's interface satisfaction is asserted by `var _ Iface =
+// (*T)(nil)` declarations inside it, so a compile is a full check.
+func TestExternalModuleImplementsPublicContracts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("compiles a separate module; skipped under -short")
+	}
+	requireGoToolchain(t)
+
+	out, err := runGo(t, externalModDir, "build", "./...")
+	if err != nil {
+		t.Fatalf("an external module must be able to implement the public contracts, "+
+			"but building the fixture failed: %v\n%s", err, out)
+	}
+}
+
+// TestExternalModuleImportsNoInternalPackage guards the boundary from the
+// outside: the fixture must reach the contracts without naming any internal/
+// package directly. Transitive internal/ dependencies are fine and expected —
+// Go permits them, and they are what the alias re-exports rely on.
+func TestExternalModuleImportsNoInternalPackage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("shells out to go list; skipped under -short")
+	}
+	requireGoToolchain(t)
+
+	out, err := runGo(t, externalModDir, "list", "-f", "{{join .Imports \"\\n\"}}", "./...")
+	if err != nil {
+		t.Fatalf("go list: %v\n%s", err, out)
+	}
+	for _, imp := range strings.Split(strings.TrimSpace(out), "\n") {
+		imp = strings.TrimSpace(imp)
+		if imp == "" {
+			continue
+		}
+		if isInternalPath(imp) {
+			t.Errorf("the fixture imports %q directly; an external module cannot do that, "+
+				"so whatever it needs from there must be re-exported from a public package", imp)
+		}
+	}
+}
+
+// TestExternalContractsPullNoVendorSDK pins the other half of RFC 0022: the
+// contract packages stay cheap to depend on. Importing them to write a source
+// or a store must not drag in a provider SDK the caller never asked for.
+func TestExternalContractsPullNoVendorSDK(t *testing.T) {
+	if testing.Short() {
+		t.Skip("shells out to go list; skipped under -short")
+	}
+	requireGoToolchain(t)
+
+	// Substrings of import paths that indicate a vendor SDK. Matching on the
+	// path keeps this readable when the list grows.
+	vendorSDKs := []string{
+		"github.com/aws/aws-sdk-go",
+		"google.golang.org/api",
+		"google.golang.org/grpc",
+		"google.golang.org/protobuf",
+		"cloud.google.com/go",
+		"golang.org/x/oauth2",
+	}
+
+	for _, pkg := range []string{
+		"github.com/cloudstic/cli/pkg/source",
+		"github.com/cloudstic/cli/pkg/store",
+	} {
+		out, err := runGo(t, ".", "list", "-deps", pkg)
+		if err != nil {
+			t.Fatalf("go list -deps %s: %v\n%s", pkg, err, out)
+		}
+		for _, dep := range strings.Split(out, "\n") {
+			dep = strings.TrimSpace(dep)
+			for _, sdk := range vendorSDKs {
+				if strings.HasPrefix(dep, sdk) {
+					t.Errorf("%s depends on %s; the contract packages must stay free of "+
+						"provider SDKs so implementing one costs nothing extra", pkg, dep)
+				}
+			}
+		}
+	}
+}
+
+func requireGoToolchain(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("no go toolchain on PATH")
+	}
+}
+
+// runGo runs the go tool in dir, which is interpreted relative to this
+// package's directory.
+func runGo(t *testing.T, dir string, args ...string) (string, error) {
+	t.Helper()
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		t.Fatalf("abs %s: %v", dir, err)
+	}
+	cmd := exec.Command("go", args...)
+	cmd.Dir = abs
+	// Inherit the ambient environment so GOCACHE/GOMODCACHE/GOFLAGS set by CI
+	// apply, and keep the network out of it: everything resolves through the
+	// replace directive and the module cache.
+	cmd.Env = append(os.Environ(), "GOFLAGS=-mod=mod")
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}

--- a/internal/apicheck/testdata/externalmod/go.mod
+++ b/internal/apicheck/testdata/externalmod/go.mod
@@ -1,0 +1,10 @@
+// A stand-in for a third-party module implementing Cloudstic's public
+// contracts. It lives under testdata/ so the go tool ignores it, and is built
+// by TestExternalModuleImplementsPublicContracts.
+module example.com/externalmod
+
+go 1.26.0
+
+require github.com/cloudstic/cli v0.0.0
+
+replace github.com/cloudstic/cli => ../../../..

--- a/internal/apicheck/testdata/externalmod/source.go
+++ b/internal/apicheck/testdata/externalmod/source.go
@@ -1,0 +1,77 @@
+package externalmod
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/cloudstic/cli/pkg/source"
+)
+
+// Source implements source.Source using only github.com/cloudstic/cli/pkg/source.
+// That single import is the whole point: no internal/ package, and no provider
+// SDK pulled in transitively.
+type Source struct{ files map[string]string }
+
+var (
+	_ source.Source            = (*Source)(nil)
+	_ source.IncrementalSource = (*Source)(nil)
+)
+
+func (s *Source) Walk(ctx context.Context, cb func(source.FileMeta) error) error {
+	// Parents before children, per the contract.
+	if err := cb(source.FileMeta{FileID: "docs", Name: "docs", Type: source.FileTypeFolder}); err != nil {
+		return err
+	}
+	for name, body := range s.files {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := cb(source.FileMeta{
+			FileID:  "docs/" + name,
+			Name:    name,
+			Type:    source.FileTypeFile,
+			Parents: []string{"docs"},
+			Size:    int64(len(body)),
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Source) GetFileStream(fileID string) (io.ReadCloser, error) {
+	body, ok := s.files[strings.TrimPrefix(fileID, "docs/")]
+	if !ok {
+		return nil, fmt.Errorf("no such file: %s", fileID)
+	}
+	return io.NopCloser(strings.NewReader(body)), nil
+}
+
+func (s *Source) Info() source.SourceInfo {
+	return source.SourceInfo{
+		Type:     "com.example.externalmod",
+		Identity: "fixture",
+		PathID:   "/docs",
+		Path:     "/docs",
+	}
+}
+
+func (s *Source) Size(context.Context) (*source.SourceSize, error) {
+	var total int64
+	for _, b := range s.files {
+		total += int64(len(b))
+	}
+	return &source.SourceSize{Bytes: total, Files: int64(len(s.files))}, nil
+}
+
+func (s *Source) GetStartPageToken() (string, error) { return "t0", nil }
+
+func (s *Source) WalkChanges(ctx context.Context, token string, cb func(source.FileChange) error) (string, error) {
+	err := cb(source.FileChange{
+		Type: source.ChangeUpsert,
+		Meta: source.FileMeta{FileID: "docs/new.txt", Name: "new.txt", Type: source.FileTypeFile},
+	})
+	return "t1", err
+}

--- a/internal/apicheck/testdata/externalmod/store.go
+++ b/internal/apicheck/testdata/externalmod/store.go
@@ -1,0 +1,108 @@
+package externalmod
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/cloudstic/cli/pkg/store"
+)
+
+// Store implements store.ObjectStore using only
+// github.com/cloudstic/cli/pkg/store — no internal/ package, and no AWS SDK.
+//
+// It also implements RangeGetter, the optional capability interface a backend
+// opts into so PackStore can read a packfile footer without transferring the
+// whole pack.
+type Store struct {
+	mu   sync.RWMutex
+	data map[string][]byte
+}
+
+var (
+	_ store.ObjectStore = (*Store)(nil)
+	_ store.RangeGetter = (*Store)(nil)
+)
+
+func (s *Store) Put(_ context.Context, key string, data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.data == nil {
+		s.data = map[string][]byte{}
+	}
+	// Copy: the contract says Put must not retain the caller's slice.
+	s.data[key] = append([]byte(nil), data...)
+	return nil
+}
+
+func (s *Store) Get(_ context.Context, key string) ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	d, ok := s.data[key]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", store.ErrNotFound, key)
+	}
+	return append([]byte(nil), d...), nil
+}
+
+func (s *Store) GetRange(_ context.Context, key string, offset, length int64) ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	d, ok := s.data[key]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", store.ErrNotFound, key)
+	}
+	if offset < 0 || length < 0 || offset+length > int64(len(d)) {
+		return nil, fmt.Errorf("range %d+%d out of bounds for %s", offset, length, key)
+	}
+	return append([]byte(nil), d[offset:offset+length]...), nil
+}
+
+func (s *Store) Exists(_ context.Context, key string) (bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	_, ok := s.data[key]
+	return ok, nil
+}
+
+func (s *Store) Delete(_ context.Context, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.data, key)
+	return nil
+}
+
+func (s *Store) List(_ context.Context, prefix string) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var keys []string
+	for k := range s.data {
+		if strings.HasPrefix(k, prefix) {
+			keys = append(keys, k)
+		}
+	}
+	return keys, nil
+}
+
+func (s *Store) Size(_ context.Context, key string) (int64, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	d, ok := s.data[key]
+	if !ok {
+		return 0, fmt.Errorf("%w: %s", store.ErrNotFound, key)
+	}
+	return int64(len(d)), nil
+}
+
+func (s *Store) TotalSize(context.Context) (int64, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var total int64
+	for _, d := range s.data {
+		total += int64(len(d))
+	}
+	return total, nil
+}
+
+func (s *Store) Flush(context.Context) error { return nil }

--- a/pkg/source/interface.go
+++ b/pkg/source/interface.go
@@ -7,6 +7,27 @@ import (
 	"github.com/cloudstic/cli/internal/core"
 )
 
+// The types the Source contract is written in, re-exported so an
+// implementation in another module can name them without reaching for the root
+// cloudstic package — which pulls in every provider SDK. A Go alias denotes the
+// identical type, so these are interchangeable with cloudstic.FileMeta and
+// friends; importing this package alone is enough to write a source, and costs
+// no third-party dependencies.
+type (
+	// FileMeta is the per-file metadata a source emits during Walk.
+	FileMeta = core.FileMeta
+	// SourceInfo describes the origin of a snapshot, returned by Info.
+	SourceInfo = core.SourceInfo
+	// FileType distinguishes a file from a folder.
+	FileType = core.FileType
+)
+
+// FileType values.
+const (
+	FileTypeFile   = core.FileTypeFile
+	FileTypeFolder = core.FileTypeFolder
+)
+
 // SourceSize holds the total size of a source.
 type SourceSize struct {
 	Bytes int64 `json:"bytes"`


### PR DESCRIPTION
> **Stacked on [#385](https://github.com/Cloudstic/cli/pull/385)** — base is `claude/store-contract-split`, so this diff shows only the stage-4 work. GitHub retargets it to `main` when #385 merges.

Part of #378 — closes #382

## Summary

- Add `internal/apicheck/testdata/externalmod`: a **real Go module** (own `go.mod`, `replace` directive) implementing `source.Source`, `source.IncrementalSource`, `store.ObjectStore` and `store.RangeGetter`. It lives under `testdata/` so the go tool ignores it
- Three tests drive it: building it proves the contracts are satisfiable from outside; `go list` proves it names no `internal/` package; `go list -deps` proves the contract packages still pull in no provider SDK
- **Re-export `FileMeta`, `SourceInfo`, `FileType` from `pkg/source`**, and update `docs/sources.md` to the lighter import
- Exclude the fixture from coverage (it is never linked into this module)

## Why a fixture instead of an assertion

Go enforces the `internal/` rule **at build time, from the importing module’s path**. Nothing asserted about this module’s own types can prove an external module compiles — only compiling one can. I had verified this by hand twice during stages 2 and 3; this makes it a standing check.

Both guards were confirmed to bite by breaking them on purpose:

```
./source.go:18:31: *Source does not implement source.Source (missing method Info)
source.go:9:2: use of internal package github.com/cloudstic/cli/internal/core not allowed
```

That second one is the exact error this RFC set out to remove.

## A gap the fixture exposed

Writing it surfaced that stage 2’s dependency win was **unreachable in practice**. To implement `Source` you must name `FileMeta` — and only the root `cloudstic` package aliased it:

```bash
go list -deps github.com/cloudstic/cli | grep -cE "aws-sdk-go|google.golang.org|grpc"   # 57
go list -deps github.com/cloudstic/cli/pkg/source | grep -cE "aws-sdk-go|google..."      # 0
```

So every source implementor was forced to import a package dragging in 57 provider packages, defeating the split for exactly the use case it targeted. `pkg/source` now re-exports the three types, so implementors import it alone at no third-party cost.

## Verification

```bash
env GOCACHE=/tmp/cloudstic-gocache go test -count=1 -race ./...
env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run --timeout=5m
```

Full `-race` suite green; lint reports 0 issues.