### PR TITLE
refactor: extract profiles and workstation setup out of internal/engine (RFC 0022)

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -17,17 +17,6 @@ import (
 
 type BackupOption = engine.BackupOption
 type BackupResult = engine.RunResult
-type ProfilesConfig = engine.ProfilesConfig
-type ProfileStore = engine.ProfileStore
-type ProfileAuth = engine.ProfileAuth
-type BackupProfile = engine.BackupProfile
-type DiscoveredSource = engine.DiscoveredSource
-type WorkstationSetupPlan = engine.WorkstationSetupPlan
-type WorkstationSetupOption = engine.WorkstationSetupOption
-type WorkstationApplyResult = engine.WorkstationApplyResult
-type WorkstationProfileDraft = engine.WorkstationProfileDraft
-type WorkstationFolderCandidate = engine.WorkstationFolderCandidate
-type WorkstationCoverageSummary = engine.WorkstationCoverageSummary
 
 var (
 	WithVerbose             = engine.WithVerbose
@@ -37,9 +26,6 @@ var (
 	WithGenerator           = engine.WithGenerator
 	WithMeta                = engine.WithMeta
 	WithExcludeHash         = engine.WithExcludeHash
-	WithWorkstationProfiles = engine.WithWorkstationProfiles
-	WithWorkstationStoreRef = engine.WithWorkstationStoreRef
-	WithWorkstationDryRun   = engine.WithWorkstationDryRun
 )
 
 // noRepoConfig marks Client.openCfg as spent. A plain nil cannot: nil is also
@@ -133,18 +119,6 @@ func (c *Client) Backup(ctx context.Context, src source.Source, opts ...BackupOp
 	return result, nil
 }
 
-func (c *Client) DiscoverSources(ctx context.Context) ([]DiscoveredSource, error) {
-	return engine.DiscoverSources(ctx)
-}
-
-func PlanWorkstationSetup(ctx context.Context, opts ...WorkstationSetupOption) (*WorkstationSetupPlan, error) {
-	return engine.PlanWorkstationSetup(ctx, opts...)
-}
-
-func ApplyWorkstationSetupPlan(cfg *ProfilesConfig, plan *WorkstationSetupPlan) (*WorkstationApplyResult, error) {
-	return engine.ApplyWorkstationSetupPlan(cfg, plan)
-}
-
 // SecretRefError reports a malformed scheme://path secret reference (e.g. in
 // one of a profile's *_secret fields). Use errors.As to inspect it and Kind
 // to branch on the failure mode.
@@ -169,25 +143,3 @@ type SecretRef = secretref.Ref
 // WritableSecretBackend is a secret backend that supports writing new values,
 // as returned by SecretResolver.WritableBackends.
 type WritableSecretBackend = secretref.WritableBackend
-
-// LoadProfilesFile parses a backup profiles YAML file.
-func LoadProfilesFile(path string) (*ProfilesConfig, error) {
-	return engine.LoadProfilesFile(path)
-}
-
-// SaveProfilesFile writes a backup profiles YAML file.
-func SaveProfilesFile(path string, cfg *ProfilesConfig) error {
-	return engine.SaveProfilesFile(path, cfg)
-}
-
-// LoadProfilesFileOrEmpty loads profiles from path, treating a missing file
-// as an empty, version-1 config rather than an error.
-func LoadProfilesFileOrEmpty(path string) (*ProfilesConfig, error) {
-	return engine.LoadProfilesFileOrEmpty(path)
-}
-
-// EnsureProfilesMaps guarantees cfg's map fields are non-nil, so callers can
-// write into them unconditionally.
-func EnsureProfilesMaps(cfg *ProfilesConfig) {
-	engine.EnsureProfilesMaps(cfg)
-}

--- a/client_test.go
+++ b/client_test.go
@@ -3,8 +3,6 @@ package cloudstic
 import (
 	"context"
 	"encoding/json"
-	"errors"
-	"path/filepath"
 	"testing"
 
 	"github.com/cloudstic/cli/internal/core"
@@ -227,34 +225,6 @@ func TestAddRecoveryKey_WrongCredentials(t *testing.T) {
 	}
 	if _, err := AddRecoveryKey(ctx, s, keychain.Chain{keychain.WithPassword("wrong-pass")}, AddRecoveryKeyOptions{}); err == nil {
 		t.Error("expected error with wrong credentials")
-	}
-}
-
-func TestClientDiscoverSources(t *testing.T) {
-	c := &Client{}
-	if _, err := c.DiscoverSources(context.Background()); err != nil {
-		t.Fatalf("DiscoverSources: %v", err)
-	}
-}
-
-func TestClientPlanWorkstationSetup(t *testing.T) {
-	if _, err := PlanWorkstationSetup(context.Background()); err != nil {
-		t.Fatalf("PlanWorkstationSetup: %v", err)
-	}
-}
-
-func TestApplyWorkstationSetupPlan(t *testing.T) {
-	cfg := &ProfilesConfig{}
-	result, err := ApplyWorkstationSetupPlan(cfg, &WorkstationSetupPlan{
-		Profiles: []WorkstationProfileDraft{
-			{Name: "documents", SourceURI: "local:/Users/test/Documents", StoreRef: "primary", Tags: []string{"workstation"}, Selected: true},
-		},
-	})
-	if err != nil {
-		t.Fatalf("ApplyWorkstationSetupPlan: %v", err)
-	}
-	if result.ProfilesCreated != 1 || cfg.Profiles["documents"].Store != "primary" {
-		t.Fatalf("unexpected apply result: %#v %#v", result, cfg)
 	}
 }
 
@@ -526,34 +496,5 @@ func TestClient_Cat_WithCompression(t *testing.T) {
 	if len(rawData) >= len(largeJSON) {
 		t.Logf("Warning: Compressed data (%d bytes) not smaller than original (%d bytes)",
 			len(rawData), len(largeJSON))
-	}
-}
-
-// TestSaveProfilesFile_SecretRefErrorIsInspectable confirms SecretRefError is
-// actually reachable through errors.As on a public entry point: a malformed
-// secret reference in a profile fails validation inside internal/engine and
-// internal/secretref, neither of which a library consumer can import, so
-// SecretRefError is the only way to inspect it programmatically rather than
-// just displaying the message.
-func TestSaveProfilesFile_SecretRefErrorIsInspectable(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "profiles.yaml")
-	cfg := &ProfilesConfig{
-		Version: 1,
-		Stores: map[string]ProfileStore{
-			"prod": {URI: "local:./store", PasswordSecret: "invalid"},
-		},
-	}
-
-	err := SaveProfilesFile(path, cfg)
-	if err == nil {
-		t.Fatal("SaveProfilesFile: expected a validation error")
-	}
-
-	var refErr *SecretRefError
-	if !errors.As(err, &refErr) {
-		t.Fatalf("errors.As(err, &SecretRefError) failed on: %v", err)
-	}
-	if refErr.Kind != SecretRefInvalid {
-		t.Errorf("Kind = %v, want %v", refErr.Kind, SecretRefInvalid)
 	}
 }

--- a/cmd/cloudstic/client_iface.go
+++ b/cmd/cloudstic/client_iface.go
@@ -11,7 +11,6 @@ import (
 // cloudsticClient is the interface commands use to interact with the repository.
 type cloudsticClient interface {
 	Backup(ctx context.Context, src source.Source, opts ...cloudstic.BackupOption) (*cloudstic.BackupResult, error)
-	DiscoverSources(ctx context.Context) ([]cloudstic.DiscoveredSource, error)
 	Restore(ctx context.Context, w io.Writer, snapshotRef string, opts ...cloudstic.RestoreOption) (*cloudstic.RestoreResult, error)
 	RestoreToDir(ctx context.Context, outputDir, snapshotRef string, opts ...cloudstic.RestoreOption) (*cloudstic.RestoreResult, error)
 	List(ctx context.Context, opts ...cloudstic.ListOption) (*cloudstic.ListResult, error)

--- a/cmd/cloudstic/cmd_auth.go
+++ b/cmd/cloudstic/cmd_auth.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	cloudstic "github.com/cloudstic/cli"
+	"github.com/cloudstic/cli/pkg/profile"
 )
 
 type authListArgs struct{ profilesFile string }
@@ -18,7 +18,7 @@ func declareAuthListArgs(_ *globalFlags) (*authListArgs, commandInput) {
 }
 
 func runAuthList(r *runner, ctx context.Context, a *authListArgs) int {
-	cfg, err := cloudstic.LoadProfilesFile(a.profilesFile)
+	cfg, err := profile.Load(a.profilesFile)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return 0
@@ -44,7 +44,7 @@ func declareAuthShowArgs(_ *globalFlags) (*authShowArgs, commandInput) {
 }
 
 func runAuthShow(r *runner, ctx context.Context, a *authShowArgs) int {
-	cfg, err := cloudstic.LoadProfilesFile(a.profilesFile)
+	cfg, err := profile.Load(a.profilesFile)
 	if err != nil {
 		return r.fail("Failed to load profiles: %v", err)
 	}
@@ -131,7 +131,7 @@ func runAuthNew(r *runner, ctx context.Context, a *authNewArgs) int {
 		}
 	}
 
-	auth := cloudstic.ProfileAuth{Provider: a.provider}
+	auth := profile.Auth{Provider: a.provider}
 	if a.provider == "google" {
 		if a.googleTokenFile == "" && a.googleTokenRef == "" {
 			def := defaultAuthTokenRef("google", a.name)
@@ -185,7 +185,7 @@ func runAuthNew(r *runner, ctx context.Context, a *authNewArgs) int {
 	ensureProfilesMaps(cfg)
 	cfg.Auth[a.name] = auth
 
-	if err := cloudstic.SaveProfilesFile(a.profilesFile, cfg); err != nil {
+	if err := profile.Save(a.profilesFile, cfg); err != nil {
 		return r.fail("Failed to save profiles: %v", err)
 	}
 	_, _ = fmt.Fprintf(r.out, "Auth %q saved in %s\n", a.name, a.profilesFile)
@@ -209,7 +209,7 @@ func declareAuthLoginArgs(_ *globalFlags) (*authLoginArgs, commandInput) {
 }
 
 func runAuthLogin(r *runner, ctx context.Context, a *authLoginArgs) int {
-	cfg, err := cloudstic.LoadProfilesFile(a.profilesFile)
+	cfg, err := profile.Load(a.profilesFile)
 	if err != nil {
 		return r.fail("Failed to load profiles: %v", err)
 	}

--- a/cmd/cloudstic/cmd_auth_test.go
+++ b/cmd/cloudstic/cmd_auth_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	cloudstic "github.com/cloudstic/cli"
+	"github.com/cloudstic/cli/pkg/profile"
 )
 
 func TestRunAuthNewAndListAndShow(t *testing.T) {
@@ -258,8 +258,8 @@ func TestRunAuthNew_DerivesDefaultTokenRef(t *testing.T) {
 func TestPromptAuthSelection_DerivesTokenRef(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("CLOUDSTIC_CONFIG_DIR", tmpDir)
-	cfg := &cloudstic.ProfilesConfig{
-		Auth: make(map[string]cloudstic.ProfileAuth),
+	cfg := &profile.Config{
+		Auth: make(map[string]profile.Auth),
 	}
 
 	r := &runner{

--- a/cmd/cloudstic/cmd_backup.go
+++ b/cmd/cloudstic/cmd_backup.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cloudstic/cli/pkg/profile"
+
 	"golang.org/x/crypto/ssh"
 
 	cloudstic "github.com/cloudstic/cli"
@@ -110,7 +112,7 @@ func runBackup(r *runner, ctx context.Context, a *backupArgs) int {
 	}
 
 	if a.authRef != "" {
-		cfg, err := cloudstic.LoadProfilesFile(a.profilesFile)
+		cfg, err := profile.Load(a.profilesFile)
 		if err != nil {
 			return r.fail("Failed to load profiles: %v", err)
 		}
@@ -249,7 +251,7 @@ func ensureDefaultAuthRefForCloudBackup(a *backupArgs) error {
 		}
 		cfg.Auth[authRef] = auth
 
-		if saveErr := cloudstic.SaveProfilesFile(a.profilesFile, cfg); saveErr != nil {
+		if saveErr := profile.Save(a.profilesFile, cfg); saveErr != nil {
 			return fmt.Errorf("save profiles with default auth: %w", saveErr)
 		}
 
@@ -262,7 +264,7 @@ func ensureDefaultAuthRefForCloudBackup(a *backupArgs) error {
 }
 
 func runBackupWithProfiles(r *runner, ctx context.Context, base *backupArgs) int {
-	cfg, err := cloudstic.LoadProfilesFile(base.profilesFile)
+	cfg, err := profile.Load(base.profilesFile)
 	if err != nil {
 		return r.fail("Failed to load profiles: %v", err)
 	}
@@ -319,7 +321,7 @@ func runBackupWithProfiles(r *runner, ctx context.Context, base *backupArgs) int
 // can carry (source, tags, excludes, native-source credentials, auth). Both
 // apply the same "explicit flag beats profile value" precedence, just against
 // different field shapes.
-func mergeProfileBackupArgs(base *backupArgs, profileName string, p cloudstic.BackupProfile, cfg *cloudstic.ProfilesConfig) (*backupArgs, error) {
+func mergeProfileBackupArgs(base *backupArgs, profileName string, p profile.Profile, cfg *profile.Config) (*backupArgs, error) {
 	g := cloneGlobalFlags(base.globalFlags)
 	a := *base
 	a.globalFlags = g
@@ -411,7 +413,7 @@ func mergeProfileBackupArgs(base *backupArgs, profileName string, p cloudstic.Ba
 	return &a, nil
 }
 
-func applyProfileAuthToBackupArgs(a *backupArgs, auth cloudstic.ProfileAuth) error {
+func applyProfileAuthToBackupArgs(a *backupArgs, auth profile.Auth) error {
 	uri, err := parseSourceURI(a.sourceURI)
 	if err != nil {
 		return fmt.Errorf("parse source URI: %w", err)

--- a/cmd/cloudstic/cmd_backup_profile_test.go
+++ b/cmd/cloudstic/cmd_backup_profile_test.go
@@ -6,14 +6,14 @@ import (
 	"strings"
 	"testing"
 
-	cloudstic "github.com/cloudstic/cli"
+	"github.com/cloudstic/cli/pkg/profile"
 )
 
 func TestMergeProfileBackupArgs_AppliesProfileAndStore(t *testing.T) {
 	profilesPath := filepath.Join(t.TempDir(), "profiles.yaml")
-	cfg := &cloudstic.ProfilesConfig{
+	cfg := &profile.Config{
 		Version: 1,
-		Stores: map[string]cloudstic.ProfileStore{
+		Stores: map[string]profile.Store{
 			"s": {
 				URI:         "s3:bucket/prefix",
 				S3Region:    "eu-west-1",
@@ -21,7 +21,7 @@ func TestMergeProfileBackupArgs_AppliesProfileAndStore(t *testing.T) {
 				S3SecretKey: "SECRET",
 			},
 		},
-		Profiles: map[string]cloudstic.BackupProfile{
+		Profiles: map[string]profile.Profile{
 			"p": {
 				Source:      "local:/data",
 				Store:       "s",
@@ -31,7 +31,7 @@ func TestMergeProfileBackupArgs_AppliesProfileAndStore(t *testing.T) {
 			},
 		},
 	}
-	if err := cloudstic.SaveProfilesFile(profilesPath, cfg); err != nil {
+	if err := profile.Save(profilesPath, cfg); err != nil {
 		t.Fatalf("SaveProfilesFile: %v", err)
 	}
 
@@ -73,12 +73,12 @@ func TestMergeProfileBackupArgs_AppliesProfileAndStore(t *testing.T) {
 
 func TestMergeProfileBackupArgs_CLIFlagsWin(t *testing.T) {
 	profilesPath := filepath.Join(t.TempDir(), "profiles.yaml")
-	cfg := &cloudstic.ProfilesConfig{
+	cfg := &profile.Config{
 		Version:  1,
-		Stores:   map[string]cloudstic.ProfileStore{"s": {URI: "s3:bucket"}},
-		Profiles: map[string]cloudstic.BackupProfile{"p": {Source: "local:/profile", Store: "s"}},
+		Stores:   map[string]profile.Store{"s": {URI: "s3:bucket"}},
+		Profiles: map[string]profile.Profile{"p": {Source: "local:/profile", Store: "s"}},
 	}
-	if err := cloudstic.SaveProfilesFile(profilesPath, cfg); err != nil {
+	if err := profile.Save(profilesPath, cfg); err != nil {
 		t.Fatalf("SaveProfilesFile: %v", err)
 	}
 
@@ -111,8 +111,8 @@ func TestMergeProfileBackupArgs_AppliesAuthRef(t *testing.T) {
 		sourceURI:   "gdrive-changes:/Docs",
 		globalFlags: newTestGlobalFlags(),
 	}
-	cfg := &cloudstic.ProfilesConfig{
-		Auth: map[string]cloudstic.ProfileAuth{
+	cfg := &profile.Config{
+		Auth: map[string]profile.Auth{
 			"google-work": {
 				Provider:        "google",
 				GoogleCreds:     "/tmp/creds.json",
@@ -120,7 +120,7 @@ func TestMergeProfileBackupArgs_AppliesAuthRef(t *testing.T) {
 			},
 		},
 	}
-	p := cloudstic.BackupProfile{Source: "gdrive-changes:/Docs", AuthRef: "google-work"}
+	p := profile.Profile{Source: "gdrive-changes:/Docs", AuthRef: "google-work"}
 
 	eff, err := mergeProfileBackupArgs(base, "p", p, cfg)
 	if err != nil {
@@ -139,8 +139,8 @@ func TestMergeProfileBackupArgs_AuthRefUnknownFails(t *testing.T) {
 		sourceURI:   "gdrive-changes:/Docs",
 		globalFlags: newTestGlobalFlags(),
 	}
-	cfg := &cloudstic.ProfilesConfig{}
-	p := cloudstic.BackupProfile{Source: "gdrive-changes:/Docs", AuthRef: "missing"}
+	cfg := &profile.Config{}
+	p := profile.Profile{Source: "gdrive-changes:/Docs", AuthRef: "missing"}
 
 	_, err := mergeProfileBackupArgs(base, "p", p, cfg)
 	if err == nil {
@@ -153,12 +153,12 @@ func TestMergeProfileBackupArgs_AuthProviderMismatchFails(t *testing.T) {
 		sourceURI:   "gdrive-changes:/Docs",
 		globalFlags: newTestGlobalFlags(),
 	}
-	cfg := &cloudstic.ProfilesConfig{
-		Auth: map[string]cloudstic.ProfileAuth{
+	cfg := &profile.Config{
+		Auth: map[string]profile.Auth{
 			"ms-work": {Provider: "onedrive", OneDriveTokenFile: "/tmp/ms.json"},
 		},
 	}
-	p := cloudstic.BackupProfile{Source: "gdrive-changes:/Docs", AuthRef: "ms-work"}
+	p := profile.Profile{Source: "gdrive-changes:/Docs", AuthRef: "ms-work"}
 
 	_, err := mergeProfileBackupArgs(base, "p", p, cfg)
 	if err == nil {
@@ -172,13 +172,13 @@ func TestMergeProfileBackupArgs_CLIAuthRefOverridesProfile(t *testing.T) {
 		authRef:     "google-alt",
 		globalFlags: testProvided(newTestGlobalFlags(), "auth-ref"),
 	}
-	cfg := &cloudstic.ProfilesConfig{
-		Auth: map[string]cloudstic.ProfileAuth{
+	cfg := &profile.Config{
+		Auth: map[string]profile.Auth{
 			"google-work": {Provider: "google", GoogleTokenFile: "/tmp/work.json"},
 			"google-alt":  {Provider: "google", GoogleTokenFile: "/tmp/alt.json"},
 		},
 	}
-	p := cloudstic.BackupProfile{Source: "gdrive-changes:/Docs", AuthRef: "google-work"}
+	p := profile.Profile{Source: "gdrive-changes:/Docs", AuthRef: "google-work"}
 
 	eff, err := mergeProfileBackupArgs(base, "p", p, cfg)
 	if err != nil {
@@ -224,7 +224,7 @@ func TestEnsureDefaultAuthRefForCloudBackup_CreatesDefaultEntry(t *testing.T) {
 	if _, err := os.Stat(profilesPath); err != nil {
 		t.Fatalf("expected profiles file to exist: %v", err)
 	}
-	cfg, err := cloudstic.LoadProfilesFile(profilesPath)
+	cfg, err := profile.Load(profilesPath)
 	if err != nil {
 		t.Fatalf("LoadProfilesFile: %v", err)
 	}
@@ -251,7 +251,7 @@ func TestApplyProfileAuthToBackupArgs_OneDrive(t *testing.T) {
 	a := &backupArgs{
 		sourceURI: "onedrive:/Documents",
 	}
-	auth := cloudstic.ProfileAuth{
+	auth := profile.Auth{
 		Provider:          "onedrive",
 		OneDriveClientID:  "my-client-id",
 		OneDriveTokenFile: "/tmp/onedrive.json",
@@ -271,7 +271,7 @@ func TestApplyProfileAuthToBackupArgs_LocalSourceFails(t *testing.T) {
 	a := &backupArgs{
 		sourceURI: "local:/data",
 	}
-	auth := cloudstic.ProfileAuth{Provider: "google"}
+	auth := profile.Auth{Provider: "google"}
 	err := applyProfileAuthToBackupArgs(a, auth)
 	if err == nil {
 		t.Fatal("expected error for local source")
@@ -287,7 +287,7 @@ func TestApplyProfileAuthToBackupArgs_CLIFlagsPreserved(t *testing.T) {
 		googleTokenFile: "cli.json",
 		globalFlags:     testProvided(&globalFlags{}, "google-token-file"),
 	}
-	auth := cloudstic.ProfileAuth{
+	auth := profile.Auth{
 		Provider:        "google",
 		GoogleTokenFile: "/tmp/profile.json",
 	}
@@ -329,7 +329,7 @@ func TestCloneGlobalFlags_Independence(t *testing.T) {
 	}
 }
 
-func applyTestProfileStore(t *testing.T, s cloudstic.ProfileStore, provided ...string) (clientConfig, error) {
+func applyTestProfileStore(t *testing.T, s profile.Store, provided ...string) (clientConfig, error) {
 	t.Helper()
 	cfg := clientConfigFromFlags(newTestGlobalFlags())
 	set := map[string]bool{}
@@ -345,7 +345,7 @@ func TestApplyProfileStore_AllFields(t *testing.T) {
 	t.Setenv("TEST_ENC_KEY", "enc-key-val")
 	t.Setenv("TEST_REC_KEY", "rec-key-val")
 
-	cfg, err := applyTestProfileStore(t, cloudstic.ProfileStore{
+	cfg, err := applyTestProfileStore(t, profile.Store{
 		URI:                 "s3:my-bucket/prefix",
 		S3Region:            "us-east-1",
 		S3Endpoint:          "https://s3.example.com",
@@ -402,7 +402,7 @@ func TestApplyProfileStore_CLIFlagOverrides(t *testing.T) {
 		g.store = "local:/cli-store"
 		return g
 	}())
-	err := applyProfileStore(&cfg, cloudstic.ProfileStore{URI: "s3:profile-bucket"},
+	err := applyProfileStore(&cfg, profile.Store{URI: "s3:profile-bucket"},
 		func(name string) bool { return name == "store" })
 	if err != nil {
 		t.Fatalf("applyProfileStore: %v", err)
@@ -415,7 +415,7 @@ func TestApplyProfileStore_CLIFlagOverrides(t *testing.T) {
 func TestApplyProfileStore_SecretRef(t *testing.T) {
 	t.Setenv("SECRET_PW", "from-secret-ref")
 
-	cfg, err := applyTestProfileStore(t, cloudstic.ProfileStore{PasswordSecret: "env://SECRET_PW"})
+	cfg, err := applyTestProfileStore(t, profile.Store{PasswordSecret: "env://SECRET_PW"})
 	if err != nil {
 		t.Fatalf("applyProfileStore: %v", err)
 	}
@@ -428,7 +428,7 @@ func TestApplyProfileStore_B2SecretRef(t *testing.T) {
 	t.Setenv("SECRET_B2_KEY_ID", "b2-id-from-env")
 	t.Setenv("SECRET_B2_APP_KEY", "b2-key-from-env")
 
-	cfg, err := applyTestProfileStore(t, cloudstic.ProfileStore{
+	cfg, err := applyTestProfileStore(t, profile.Store{
 		B2KeyIDSecret:  "env://SECRET_B2_KEY_ID",
 		B2AppKeySecret: "env://SECRET_B2_APP_KEY",
 	})
@@ -444,7 +444,7 @@ func TestApplyProfileStore_B2SecretRef(t *testing.T) {
 }
 
 func TestApplyProfileStore_InvalidSecretRef(t *testing.T) {
-	_, err := applyTestProfileStore(t, cloudstic.ProfileStore{PasswordSecret: "env:/invalid-format"})
+	_, err := applyTestProfileStore(t, profile.Store{PasswordSecret: "env:/invalid-format"})
 	if err == nil {
 		t.Fatal("expected error for invalid secret ref")
 	}
@@ -458,9 +458,9 @@ func TestApplyProfileStore_InvalidSecretRef(t *testing.T) {
 func TestMergeProfileBackupArgs_NamesProfileWithoutRewritingFlags(t *testing.T) {
 	base := &backupArgs{sourceURI: "", globalFlags: newTestGlobalFlags()}
 	baseStore := base.store
-	cfg := &cloudstic.ProfilesConfig{
-		Stores:   map[string]cloudstic.ProfileStore{"s": {URI: "s3:profile-bucket"}},
-		Profiles: map[string]cloudstic.BackupProfile{"p": {Source: "local:/data", Store: "s"}},
+	cfg := &profile.Config{
+		Stores:   map[string]profile.Store{"s": {URI: "s3:profile-bucket"}},
+		Profiles: map[string]profile.Profile{"p": {Source: "local:/data", Store: "s"}},
 	}
 	eff, err := mergeProfileBackupArgs(base, "p", cfg.Profiles["p"], cfg)
 	if err != nil {
@@ -482,8 +482,8 @@ func TestMergeProfileBackupArgs_EmptySourceFails(t *testing.T) {
 		sourceURI:   "",
 		globalFlags: newTestGlobalFlags(),
 	}
-	cfg := &cloudstic.ProfilesConfig{}
-	p := cloudstic.BackupProfile{Source: ""}
+	cfg := &profile.Config{}
+	p := profile.Profile{Source: ""}
 
 	_, err := mergeProfileBackupArgs(base, "empty", p, cfg)
 	if err == nil {
@@ -496,10 +496,10 @@ func TestMergeProfileBackupArgs_UnknownStoreFails(t *testing.T) {
 		sourceURI:   "local:/data",
 		globalFlags: newTestGlobalFlags(),
 	}
-	cfg := &cloudstic.ProfilesConfig{
-		Stores: map[string]cloudstic.ProfileStore{},
+	cfg := &profile.Config{
+		Stores: map[string]profile.Store{},
 	}
-	p := cloudstic.BackupProfile{Source: "local:/data", Store: "missing"}
+	p := profile.Profile{Source: "local:/data", Store: "missing"}
 
 	_, err := mergeProfileBackupArgs(base, "p", p, cfg)
 	if err == nil {
@@ -512,8 +512,8 @@ func TestMergeProfileBackupArgs_SkipNativeFiles(t *testing.T) {
 		sourceURI:   "gdrive:/Docs",
 		globalFlags: newTestGlobalFlags(),
 	}
-	cfg := &cloudstic.ProfilesConfig{}
-	p := cloudstic.BackupProfile{Source: "gdrive:/Docs", SkipNativeFiles: true}
+	cfg := &profile.Config{}
+	p := profile.Profile{Source: "gdrive:/Docs", SkipNativeFiles: true}
 
 	eff, err := mergeProfileBackupArgs(base, "p", p, cfg)
 	if err != nil {
@@ -529,8 +529,8 @@ func TestMergeProfileBackupArgs_ExcludeFile(t *testing.T) {
 		sourceURI:   "local:/data",
 		globalFlags: newTestGlobalFlags(),
 	}
-	cfg := &cloudstic.ProfilesConfig{}
-	p := cloudstic.BackupProfile{Source: "local:/data", ExcludeFile: "/tmp/excludes.txt"}
+	cfg := &profile.Config{}
+	p := profile.Profile{Source: "local:/data", ExcludeFile: "/tmp/excludes.txt"}
 
 	eff, err := mergeProfileBackupArgs(base, "p", p, cfg)
 	if err != nil {

--- a/cmd/cloudstic/cmd_profile.go
+++ b/cmd/cloudstic/cmd_profile.go
@@ -8,7 +8,8 @@ import (
 	"sort"
 	"strings"
 
-	cloudstic "github.com/cloudstic/cli"
+	"github.com/cloudstic/cli/pkg/profile"
+
 	"github.com/cloudstic/cli/internal/paths"
 )
 
@@ -32,7 +33,7 @@ func declareProfileShowArgs(_ *globalFlags) (*profileShowArgs, commandInput) {
 }
 
 func runProfileShow(r *runner, ctx context.Context, a *profileShowArgs) int {
-	cfg, err := cloudstic.LoadProfilesFile(a.profilesFile)
+	cfg, err := profile.Load(a.profilesFile)
 	if err != nil {
 		return r.fail("Failed to load profiles: %v", err)
 	}
@@ -55,7 +56,7 @@ func runProfileShow(r *runner, ctx context.Context, a *profileShowArgs) int {
 	return 0
 }
 
-func profileStoreAuthMode(s cloudstic.ProfileStore) string {
+func profileStoreAuthMode(s profile.Store) string {
 	if s.S3AccessKey != "" || s.S3SecretKey != "" || s.S3AccessKeySecret != "" || s.S3SecretKeySecret != "" {
 		return "static-keys"
 	}
@@ -81,7 +82,7 @@ func declareProfileListArgs(_ *globalFlags) (*profileListArgs, commandInput) {
 }
 
 func runProfileList(r *runner, ctx context.Context, a *profileListArgs) int {
-	cfg, err := cloudstic.LoadProfilesFile(a.profilesFile)
+	cfg, err := profile.Load(a.profilesFile)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return 0
@@ -224,7 +225,7 @@ func runProfileNew(r *runner, ctx context.Context, a *profileNewArgs) int {
 		if _, err := parseStoreURI(a.store); err != nil {
 			return r.fail("Invalid store URI: %v", err)
 		}
-		cfg.Stores[a.storeRef] = cloudstic.ProfileStore{URI: a.store}
+		cfg.Stores[a.storeRef] = profile.Store{URI: a.store}
 		createdStore = true
 	} else if a.storeRef != "" {
 		if _, ok := cfg.Stores[a.storeRef]; !ok {
@@ -303,7 +304,7 @@ func runProfileNew(r *runner, ctx context.Context, a *profileNewArgs) int {
 		}
 	}
 
-	p := cloudstic.BackupProfile{
+	p := profile.Profile{
 		Source:            a.source,
 		Store:             a.storeRef,
 		AuthRef:           a.authRef,
@@ -324,7 +325,7 @@ func runProfileNew(r *runner, ctx context.Context, a *profileNewArgs) int {
 	}
 	cfg.Profiles[a.name] = p
 
-	if err := cloudstic.SaveProfilesFile(a.profilesFile, cfg); err != nil {
+	if err := profile.Save(a.profilesFile, cfg); err != nil {
 		return r.fail("Failed to save profiles: %v", err)
 	}
 
@@ -335,7 +336,7 @@ func runProfileNew(r *runner, ctx context.Context, a *profileNewArgs) int {
 // promptStoreSelection prompts the user to pick an existing store or create a
 // new one. It returns the chosen store-ref name, whether a new store was
 // created, and exit code 0 on success.
-func (r *runner) promptStoreSelection(ctx context.Context, cfg *cloudstic.ProfilesConfig) (string, bool, int) {
+func (r *runner) promptStoreSelection(ctx context.Context, cfg *profile.Config) (string, bool, int) {
 	options := []string{"Create new store"}
 	for name := range cfg.Stores {
 		options = append(options, name)
@@ -374,14 +375,14 @@ func (r *runner) promptStoreSelection(ctx context.Context, cfg *cloudstic.Profil
 	if err != nil {
 		return "", false, r.fail("Failed to read store URI: %v", err)
 	}
-	cfg.Stores[refName] = cloudstic.ProfileStore{URI: uri}
+	cfg.Stores[refName] = profile.Store{URI: uri}
 	return refName, true, 0
 }
 
 // promptAuthSelection prompts the user to pick an existing auth entry (filtered
 // by provider) or create a new one. It returns the chosen auth-ref name and
 // exit code 0 on success. The new entry is added to cfg.Auth in place.
-func (r *runner) promptAuthSelection(ctx context.Context, cfg *cloudstic.ProfilesConfig, provider, profileName string) (string, int) {
+func (r *runner) promptAuthSelection(ctx context.Context, cfg *profile.Config, provider, profileName string) (string, int) {
 	options := []string{"Create new auth"}
 	for name, auth := range cfg.Auth {
 		if auth.Provider == provider {
@@ -417,7 +418,7 @@ func (r *runner) promptAuthSelection(ctx context.Context, cfg *cloudstic.Profile
 		tokenStorage = defTokenRef
 	}
 
-	auth := cloudstic.ProfileAuth{Provider: provider}
+	auth := profile.Auth{Provider: provider}
 	if strings.Contains(tokenStorage, "://") {
 		switch provider {
 		case "google":
@@ -437,7 +438,7 @@ func (r *runner) promptAuthSelection(ctx context.Context, cfg *cloudstic.Profile
 	return refName, 0
 }
 
-func prefillProfileArgs(a *profileNewArgs, p cloudstic.BackupProfile) {
+func prefillProfileArgs(a *profileNewArgs, p profile.Profile) {
 	if !a.flagProvided("source") && p.Source != "" {
 		a.source = p.Source
 	}

--- a/cmd/cloudstic/cmd_profile_test.go
+++ b/cmd/cloudstic/cmd_profile_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	cloudstic "github.com/cloudstic/cli"
+	"github.com/cloudstic/cli/pkg/profile"
 )
 
 func TestRunProfileList_Success(t *testing.T) {
@@ -357,16 +357,16 @@ func TestRunProfileNew_AuthRefRequiresCloudSource(t *testing.T) {
 func TestProfileStoreAuthMode(t *testing.T) {
 	tests := []struct {
 		name string
-		s    cloudstic.ProfileStore
+		s    profile.Store
 		want string
 	}{
-		{"s3_access_key", cloudstic.ProfileStore{S3AccessKey: "x"}, "static-keys"},
-		{"s3_profile", cloudstic.ProfileStore{S3Profile: "x"}, "aws-shared-profile"},
-		{"b2_key_id", cloudstic.ProfileStore{B2KeyID: "x"}, "b2-keys"},
-		{"b2_app_key_secret", cloudstic.ProfileStore{B2AppKeySecret: "env://B2_APP_KEY"}, "b2-keys"},
-		{"sftp_password", cloudstic.ProfileStore{StoreSFTPPassword: "x"}, "sftp"},
-		{"sftp_key", cloudstic.ProfileStore{StoreSFTPKey: "x"}, "sftp"},
-		{"empty", cloudstic.ProfileStore{}, "default-chain"},
+		{"s3_access_key", profile.Store{S3AccessKey: "x"}, "static-keys"},
+		{"s3_profile", profile.Store{S3Profile: "x"}, "aws-shared-profile"},
+		{"b2_key_id", profile.Store{B2KeyID: "x"}, "b2-keys"},
+		{"b2_app_key_secret", profile.Store{B2AppKeySecret: "env://B2_APP_KEY"}, "b2-keys"},
+		{"sftp_password", profile.Store{StoreSFTPPassword: "x"}, "sftp"},
+		{"sftp_key", profile.Store{StoreSFTPKey: "x"}, "sftp"},
+		{"empty", profile.Store{}, "default-chain"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/cloudstic/cmd_setup.go
+++ b/cmd/cloudstic/cmd_setup.go
@@ -6,14 +6,16 @@ import (
 	"io"
 	"strings"
 
+	"github.com/cloudstic/cli/pkg/profile"
+
+	"github.com/cloudstic/cli/internal/workstation"
+
 	"github.com/jedib0t/go-pretty/v6/table"
 
-	cloudstic "github.com/cloudstic/cli"
-	"github.com/cloudstic/cli/internal/engine"
 	"github.com/cloudstic/cli/internal/paths"
 )
 
-var planWorkstationSetup = cloudstic.PlanWorkstationSetup
+var planWorkstationSetup = workstation.Plan
 
 func defaultProfilesPathNoCreate() string {
 	path, err := paths.ProfilesPath(defaultProfilesFilename, false)
@@ -87,9 +89,9 @@ func runSetupWorkstation(r *runner, ctx context.Context, args *setupWorkstationA
 		}
 	}
 
-	opts := []cloudstic.WorkstationSetupOption{cloudstic.WithWorkstationProfiles(cfg)}
+	opts := []workstation.SetupOption{workstation.WithProfiles(cfg)}
 	if args.storeRef != "" {
-		opts = append(opts, cloudstic.WithWorkstationStoreRef(args.storeRef))
+		opts = append(opts, workstation.WithStoreRef(args.storeRef))
 	}
 	plan, err := planWorkstationSetup(ctx, opts...)
 	if err != nil {
@@ -104,7 +106,7 @@ func runSetupWorkstation(r *runner, ctx context.Context, args *setupWorkstationA
 		if !r.canPrompt() {
 			return r.fail("setup workstation requires an interactive terminal or -yes")
 		}
-		if err := reviewWorkstationPlan(ctx, cfg, (*engine.WorkstationSetupPlan)(plan), workstationReviewPrompts{
+		if err := reviewWorkstationPlan(ctx, cfg, (*workstation.SetupPlan)(plan), workstationReviewPrompts{
 			confirm: func(ctx context.Context, label string, defaultYes bool) (bool, error) {
 				return r.promptConfirm(ctx, label, defaultYes)
 			},
@@ -142,11 +144,11 @@ func runSetupWorkstation(r *runner, ctx context.Context, args *setupWorkstationA
 		}
 	}
 
-	result, err := cloudstic.ApplyWorkstationSetupPlan(cfg, plan)
+	result, err := workstation.Apply(cfg, plan)
 	if err != nil {
 		return r.fail("Failed to apply workstation setup plan: %v", err)
 	}
-	if err := cloudstic.SaveProfilesFile(args.profilesFile, cfg); err != nil {
+	if err := profile.Save(args.profilesFile, cfg); err != nil {
 		return r.fail("Failed to save profiles: %v", err)
 	}
 	_, _ = fmt.Fprintf(r.out, "\nSaved %d profile(s) in %s", len(result.ProfileNames), args.profilesFile)
@@ -157,7 +159,7 @@ func runSetupWorkstation(r *runner, ctx context.Context, args *setupWorkstationA
 	return 0
 }
 
-func printWorkstationSetupPlan(out io.Writer, plan *cloudstic.WorkstationSetupPlan, dryRun bool) {
+func printWorkstationSetupPlan(out io.Writer, plan *workstation.SetupPlan, dryRun bool) {
 	if dryRun {
 		_, _ = fmt.Fprintln(out, "Workstation setup plan (dry-run)")
 	} else {
@@ -192,7 +194,7 @@ func printWorkstationSetupPlan(out io.Writer, plan *cloudstic.WorkstationSetupPl
 	printWorkstationCoverage(out, plan)
 }
 
-func printWorkstationCoverage(out io.Writer, plan *cloudstic.WorkstationSetupPlan) {
+func printWorkstationCoverage(out io.Writer, plan *workstation.SetupPlan) {
 	writeWorkstationLines := func(title string, items []string) {
 		if len(items) == 0 {
 			return
@@ -224,7 +226,7 @@ type workstationReviewPrompts struct {
 	input     func(context.Context, string, string, func(string) error) (string, error)
 }
 
-func reviewWorkstationPlan(ctx context.Context, cfg *cloudstic.ProfilesConfig, plan *engine.WorkstationSetupPlan, prompts workstationReviewPrompts) error {
+func reviewWorkstationPlan(ctx context.Context, cfg *profile.Config, plan *workstation.SetupPlan, prompts workstationReviewPrompts) error {
 	if plan == nil {
 		return nil
 	}
@@ -298,7 +300,7 @@ func reviewWorkstationPlan(ctx context.Context, cfg *cloudstic.ProfilesConfig, p
 	return nil
 }
 
-func promptWorkstationProfileName(ctx context.Context, prompts workstationReviewPrompts, cfg *cloudstic.ProfilesConfig, plan *engine.WorkstationSetupPlan, index int, defaultName string) (string, error) {
+func promptWorkstationProfileName(ctx context.Context, prompts workstationReviewPrompts, cfg *profile.Config, plan *workstation.SetupPlan, index int, defaultName string) (string, error) {
 	return prompts.input(ctx, "Profile name", defaultName, func(v string) error {
 		if v == "" {
 			return fmt.Errorf("profile name is required")
@@ -313,7 +315,7 @@ func promptWorkstationProfileName(ctx context.Context, prompts workstationReview
 	})
 }
 
-func nameTakenInWorkstationPlan(cfg *cloudstic.ProfilesConfig, plan *engine.WorkstationSetupPlan, index int, name string) bool {
+func nameTakenInWorkstationPlan(cfg *profile.Config, plan *workstation.SetupPlan, index int, name string) bool {
 	if existing, ok := cfg.Profiles[name]; ok {
 		if index >= 0 {
 			current := plan.Profiles[index]
@@ -334,7 +336,7 @@ func nameTakenInWorkstationPlan(cfg *cloudstic.ProfilesConfig, plan *engine.Work
 	return false
 }
 
-func nextAvailableWorkstationProfileName(cfg *cloudstic.ProfilesConfig, plan *engine.WorkstationSetupPlan, base string) string {
+func nextAvailableWorkstationProfileName(cfg *profile.Config, plan *workstation.SetupPlan, base string) string {
 	base = sanitizeWorkstationProfileName(base)
 	if base == "" {
 		base = "workstation"
@@ -348,7 +350,7 @@ func nextAvailableWorkstationProfileName(cfg *cloudstic.ProfilesConfig, plan *en
 	}
 }
 
-func refreshWorkstationCoverage(plan *engine.WorkstationSetupPlan) {
+func refreshWorkstationCoverage(plan *workstation.SetupPlan) {
 	if plan == nil {
 		return
 	}
@@ -378,14 +380,14 @@ func refreshWorkstationCoverage(plan *engine.WorkstationSetupPlan) {
 	}
 }
 
-func workstationDraftDecisionLabel(draft cloudstic.WorkstationProfileDraft) string {
+func workstationDraftDecisionLabel(draft workstation.ProfileDraft) string {
 	if !draft.Selected {
 		return "skip"
 	}
 	return draft.Action
 }
 
-func countSelectedWorkstationProfiles(plan *cloudstic.WorkstationSetupPlan) int {
+func countSelectedWorkstationProfiles(plan *workstation.SetupPlan) int {
 	if plan == nil {
 		return 0
 	}

--- a/cmd/cloudstic/cmd_setup_test.go
+++ b/cmd/cloudstic/cmd_setup_test.go
@@ -7,14 +7,15 @@ import (
 	"strings"
 	"testing"
 
-	cloudstic "github.com/cloudstic/cli"
-	"github.com/cloudstic/cli/internal/engine"
+	"github.com/cloudstic/cli/pkg/profile"
+
+	"github.com/cloudstic/cli/internal/workstation"
 )
 
-func stubSetupWorkstationPlan(t *testing.T, plan *cloudstic.WorkstationSetupPlan, err error) {
+func stubSetupWorkstationPlan(t *testing.T, plan *workstation.SetupPlan, err error) {
 	t.Helper()
 	old := planWorkstationSetup
-	planWorkstationSetup = func(context.Context, ...cloudstic.WorkstationSetupOption) (*cloudstic.WorkstationSetupPlan, error) {
+	planWorkstationSetup = func(context.Context, ...workstation.SetupOption) (*workstation.SetupPlan, error) {
 		return plan, err
 	}
 	t.Cleanup(func() { planWorkstationSetup = old })
@@ -22,14 +23,14 @@ func stubSetupWorkstationPlan(t *testing.T, plan *cloudstic.WorkstationSetupPlan
 
 func TestRunSetupWorkstation_DryRun(t *testing.T) {
 	t.Setenv("CLOUDSTIC_CONFIG_DIR", t.TempDir())
-	stubSetupWorkstationPlan(t, &cloudstic.WorkstationSetupPlan{
+	stubSetupWorkstationPlan(t, &workstation.SetupPlan{
 		Hostname:    "testbox",
 		StoreRef:    "primary",
 		StoreAction: "use-existing",
-		Profiles: []cloudstic.WorkstationProfileDraft{
+		Profiles: []workstation.ProfileDraft{
 			{Name: "documents", SourceURI: "local:/Users/test/Documents", StoreRef: "primary", Tags: []string{"workstation"}, Action: "create", Selected: true},
 		},
-		Coverage: cloudstic.WorkstationCoverageSummary{
+		Coverage: workstation.CoverageSummary{
 			ProtectedNow:         []string{"Documents (/Users/test/Documents)"},
 			SkippedIntentionally: []string{"Downloads (/Users/test/Downloads)"},
 		},
@@ -50,7 +51,7 @@ func TestRunSetupWorkstation_DryRun(t *testing.T) {
 
 func TestRunSetupWorkstation_JSON(t *testing.T) {
 	t.Setenv("CLOUDSTIC_CONFIG_DIR", t.TempDir())
-	stubSetupWorkstationPlan(t, &cloudstic.WorkstationSetupPlan{
+	stubSetupWorkstationPlan(t, &workstation.SetupPlan{
 		Hostname: "testbox",
 	}, nil)
 	args := []string{"workstation", "-dry-run", "-json"}
@@ -67,18 +68,18 @@ func TestRunSetupWorkstation_JSON(t *testing.T) {
 }
 
 func TestRunSetupWorkstation_ApplyYes(t *testing.T) {
-	stubSetupWorkstationPlan(t, &cloudstic.WorkstationSetupPlan{
+	stubSetupWorkstationPlan(t, &workstation.SetupPlan{
 		Hostname:    "testbox",
 		StoreRef:    "primary",
 		StoreAction: "use-existing",
-		Profiles: []cloudstic.WorkstationProfileDraft{
+		Profiles: []workstation.ProfileDraft{
 			{Name: "documents", SourceURI: "local:/Users/test/Documents", StoreRef: "primary", Tags: []string{"workstation"}, Action: "create", Selected: true},
 		},
 	}, nil)
 	profilesPath := filepath.Join(t.TempDir(), "profiles.yaml")
-	if err := cloudstic.SaveProfilesFile(profilesPath, &cloudstic.ProfilesConfig{
+	if err := profile.Save(profilesPath, &profile.Config{
 		Version: 1,
-		Stores:  map[string]cloudstic.ProfileStore{"primary": {URI: "local:/repo"}},
+		Stores:  map[string]profile.Store{"primary": {URI: "local:/repo"}},
 	}); err != nil {
 		t.Fatalf("SaveProfilesFile: %v", err)
 	}
@@ -90,7 +91,7 @@ func TestRunSetupWorkstation_ApplyYes(t *testing.T) {
 	if code := setupCommand().execute(r.withArgs(args), context.Background(), "setup"); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
-	cfg, err := cloudstic.LoadProfilesFile(profilesPath)
+	cfg, err := profile.Load(profilesPath)
 	if err != nil {
 		t.Fatalf("LoadProfilesFile: %v", err)
 	}
@@ -111,12 +112,12 @@ func TestRunSetupWorkstation_RequiresStoreResolutionWithoutPrompt(t *testing.T) 
 }
 
 func TestReviewWorkstationPlan_CanSkipSources(t *testing.T) {
-	cfg := &cloudstic.ProfilesConfig{}
-	plan := &engine.WorkstationSetupPlan{
-		Profiles: []engine.WorkstationProfileDraft{
+	cfg := &profile.Config{}
+	plan := &workstation.SetupPlan{
+		Profiles: []workstation.ProfileDraft{
 			{Name: "documents", SourceURI: "local:/Users/test/Documents", Action: "create", DisplayLabel: "Documents (/Users/test/Documents)", Selected: true},
 		},
-		Coverage: engine.WorkstationCoverageSummary{
+		Coverage: workstation.CoverageSummary{
 			ProtectedNow: []string{"Documents (/Users/test/Documents)"},
 		},
 	}
@@ -143,16 +144,16 @@ func TestReviewWorkstationPlan_CanSkipSources(t *testing.T) {
 }
 
 func TestReviewWorkstationPlan_RenameUpdate(t *testing.T) {
-	cfg := &cloudstic.ProfilesConfig{
-		Profiles: map[string]cloudstic.BackupProfile{
+	cfg := &profile.Config{
+		Profiles: map[string]profile.Profile{
 			"documents": {Source: "local:/Users/test/Documents"},
 		},
 	}
-	plan := &engine.WorkstationSetupPlan{
-		Profiles: []engine.WorkstationProfileDraft{
+	plan := &workstation.SetupPlan{
+		Profiles: []workstation.ProfileDraft{
 			{Name: "documents", SourceURI: "local:/Users/test/Documents", Action: "update", DisplayLabel: "Documents (/Users/test/Documents)", Selected: true},
 		},
-		Coverage: engine.WorkstationCoverageSummary{
+		Coverage: workstation.CoverageSummary{
 			ProtectedNow: []string{"Documents (/Users/test/Documents)"},
 		},
 	}

--- a/cmd/cloudstic/cmd_source.go
+++ b/cmd/cloudstic/cmd_source.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/jedib0t/go-pretty/v6/table"
 
-	cloudstic "github.com/cloudstic/cli"
+	"github.com/cloudstic/cli/internal/workstation"
 )
 
 type sourceDiscoverArgs struct {
@@ -22,12 +22,17 @@ func declareSourceDiscoverArgs(_ *globalFlags) (*sourceDiscoverArgs, commandInpu
 	}}
 }
 
-func runSourceDiscover(r *runner, ctx context.Context, a *sourceDiscoverArgs) int {
-	if r.client == nil {
-		r.client = &cloudstic.Client{}
-	}
+// discoverSources is the seam tests replace. Discovery reads the machine's
+// real mount table, so without it the tests below would assert against
+// whatever disks the developer or CI runner happens to have attached.
+//
+// It is a package-level var rather than a method on cloudsticClient because
+// discovery needs nothing from the repository client — the method it used to
+// hang off never touched its receiver.
+var discoverSources = workstation.DiscoverSources
 
-	results, err := r.client.DiscoverSources(ctx)
+func runSourceDiscover(r *runner, ctx context.Context, a *sourceDiscoverArgs) int {
+	results, err := discoverSources(ctx)
 	if err != nil {
 		return r.fail("Failed to discover sources: %v", err)
 	}

--- a/cmd/cloudstic/cmd_source_test.go
+++ b/cmd/cloudstic/cmd_source_test.go
@@ -5,21 +5,19 @@ import (
 	"strings"
 	"testing"
 
-	cloudstic "github.com/cloudstic/cli"
+	"github.com/cloudstic/cli/internal/workstation"
 )
 
 func TestRunSourceDiscover(t *testing.T) {
-	client := &stubClient{
-		discoverResult: []cloudstic.DiscoveredSource{
-			{DisplayName: "System", SourceURI: "local:/", MountPoint: "/", Identity: "HOST-1", FsType: "apfs", Portable: false},
-			{DisplayName: "Photos", SourceURI: "local:/Volumes/Photos", MountPoint: "/Volumes/Photos", Identity: "UUID-1", FsType: "exfat", Portable: true},
-		},
-	}
+	setDiscoverSources(t, []workstation.DiscoveredSource{
+		{DisplayName: "System", SourceURI: "local:/", MountPoint: "/", Identity: "HOST-1", FsType: "apfs", Portable: false},
+		{DisplayName: "Photos", SourceURI: "local:/Volumes/Photos", MountPoint: "/Volumes/Photos", Identity: "UUID-1", FsType: "exfat", Portable: true},
+	})
 	args := []string{"discover"}
 
 	var out strings.Builder
 	var errOut strings.Builder
-	r := &runner{out: &out, errOut: &errOut, client: client}
+	r := &runner{out: &out, errOut: &errOut}
 	if code := sourceCommand().execute(r.withArgs(args), context.Background(), "source"); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
@@ -30,17 +28,15 @@ func TestRunSourceDiscover(t *testing.T) {
 }
 
 func TestRunSourceDiscover_PortableOnly(t *testing.T) {
-	client := &stubClient{
-		discoverResult: []cloudstic.DiscoveredSource{
-			{DisplayName: "System", SourceURI: "local:/", MountPoint: "/", Portable: false},
-			{DisplayName: "Photos", SourceURI: "local:/Volumes/Photos", MountPoint: "/Volumes/Photos", Portable: true},
-		},
-	}
+	setDiscoverSources(t, []workstation.DiscoveredSource{
+		{DisplayName: "System", SourceURI: "local:/", MountPoint: "/", Portable: false},
+		{DisplayName: "Photos", SourceURI: "local:/Volumes/Photos", MountPoint: "/Volumes/Photos", Portable: true},
+	})
 	args := []string{"discover", "-portable-only"}
 
 	var out strings.Builder
 	var errOut strings.Builder
-	r := &runner{out: &out, errOut: &errOut, client: client}
+	r := &runner{out: &out, errOut: &errOut}
 	if code := sourceCommand().execute(r.withArgs(args), context.Background(), "source"); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
@@ -54,16 +50,14 @@ func TestRunSourceDiscover_PortableOnly(t *testing.T) {
 }
 
 func TestRunSourceDiscover_JSON(t *testing.T) {
-	client := &stubClient{
-		discoverResult: []cloudstic.DiscoveredSource{
-			{DisplayName: "Photos", SourceURI: "local:/Volumes/Photos", MountPoint: "/Volumes/Photos", Portable: true},
-		},
-	}
+	setDiscoverSources(t, []workstation.DiscoveredSource{
+		{DisplayName: "Photos", SourceURI: "local:/Volumes/Photos", MountPoint: "/Volumes/Photos", Portable: true},
+	})
 	args := []string{"discover", "-json"}
 
 	var out strings.Builder
 	var errOut strings.Builder
-	r := &runner{out: &out, errOut: &errOut, client: client}
+	r := &runner{out: &out, errOut: &errOut}
 	if code := sourceCommand().execute(r.withArgs(args), context.Background(), "source"); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
@@ -82,4 +76,12 @@ func TestRunSourceDiscover_DefaultClient(t *testing.T) {
 	if code := sourceCommand().execute(r.withArgs(args), context.Background(), "source"); code != 0 {
 		t.Fatalf("code=%d err=%s", code, errOut.String())
 	}
+}
+
+// setDiscoverSources swaps the discovery seam for the duration of a test.
+func setDiscoverSources(t *testing.T, got []workstation.DiscoveredSource) {
+	t.Helper()
+	prev := discoverSources
+	discoverSources = func(context.Context) ([]workstation.DiscoveredSource, error) { return got, nil }
+	t.Cleanup(func() { discoverSources = prev })
 }

--- a/cmd/cloudstic/cmd_store.go
+++ b/cmd/cloudstic/cmd_store.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/cloudstic/cli/pkg/profile"
+
 	cloudstic "github.com/cloudstic/cli"
 	"github.com/cloudstic/cli/internal/ui"
 	"github.com/cloudstic/cli/pkg/secretref"
@@ -22,7 +24,7 @@ func declareStoreListArgs(_ *globalFlags) (*storeListArgs, commandInput) {
 }
 
 func runStoreList(r *runner, ctx context.Context, a *storeListArgs) int {
-	cfg, err := cloudstic.LoadProfilesFile(a.profilesFile)
+	cfg, err := profile.Load(a.profilesFile)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return 0
@@ -48,7 +50,7 @@ func declareStoreShowArgs(_ *globalFlags) (*storeShowArgs, commandInput) {
 }
 
 func runStoreShow(r *runner, ctx context.Context, a *storeShowArgs) int {
-	cfg, err := cloudstic.LoadProfilesFile(a.profilesFile)
+	cfg, err := profile.Load(a.profilesFile)
 	if err != nil {
 		return r.fail("Failed to load profiles: %v", err)
 	}
@@ -199,7 +201,7 @@ func runStoreNew(r *runner, ctx context.Context, a *storeNewArgs) int {
 
 	cfg.Stores[a.name] = buildProfileStoreFromFlags(storeFlags)
 
-	if err := cloudstic.SaveProfilesFile(a.profilesFile, cfg); err != nil {
+	if err := profile.Save(a.profilesFile, cfg); err != nil {
 		return r.fail("Failed to save profiles: %v", err)
 	}
 	_, _ = fmt.Fprintf(r.out, "Store %q saved in %s\n", a.name, a.profilesFile)
@@ -248,7 +250,7 @@ func declareStoreVerifyArgs(_ *globalFlags) (*storeVerifyArgs, commandInput) {
 }
 
 func runStoreVerify(r *runner, ctx context.Context, a *storeVerifyArgs) int {
-	cfg, err := cloudstic.LoadProfilesFile(a.profilesFile)
+	cfg, err := profile.Load(a.profilesFile)
 	if err != nil {
 		return r.fail("Failed to load profiles: %v", err)
 	}
@@ -297,7 +299,7 @@ func declareStoreInitArgs(_ *globalFlags) (*storeInitArgs, commandInput) {
 }
 
 func runStoreInit(r *runner, ctx context.Context, a *storeInitArgs) int {
-	cfg, err := cloudstic.LoadProfilesFile(a.profilesFile)
+	cfg, err := profile.Load(a.profilesFile)
 	if err != nil {
 		return r.fail("Failed to load profiles: %v", err)
 	}
@@ -337,7 +339,7 @@ type checkOrInitOptions struct {
 	assumeYes            bool
 }
 
-func checkOrInitStore(r *runner, ctx context.Context, cfg *cloudstic.ProfilesConfig, storeName, profilesFile string, opts checkOrInitOptions) error {
+func checkOrInitStore(r *runner, ctx context.Context, cfg *profile.Config, storeName, profilesFile string, opts checkOrInitOptions) error {
 	s := cfg.Stores[storeName]
 	resolved, err := clientConfigFromProfileStore(s)
 	if err != nil {
@@ -419,7 +421,7 @@ func checkOrInitStore(r *runner, ctx context.Context, cfg *cloudstic.ProfilesCon
 	return nil
 }
 
-func checkOrInitStoreWithRecovery(r *runner, ctx context.Context, cfg *cloudstic.ProfilesConfig, storeName, profilesFile string, opts checkOrInitOptions, allowSkip bool) error {
+func checkOrInitStoreWithRecovery(r *runner, ctx context.Context, cfg *profile.Config, storeName, profilesFile string, opts checkOrInitOptions, allowSkip bool) error {
 	for {
 		err := checkOrInitStore(r, ctx, cfg, storeName, profilesFile, opts)
 		if err == nil || !r.canPrompt() {
@@ -464,7 +466,7 @@ func checkOrInitStoreWithRecovery(r *runner, ctx context.Context, cfg *cloudstic
 // promptEncryptionConfig guides the user through encryption configuration
 // and saves the chosen settings to profiles.yaml. It does not build a keychain
 // or prompt for the actual password — that happens later during init.
-func (r *runner) promptEncryptionConfig(ctx context.Context, cfg *cloudstic.ProfilesConfig, storeName, profilesFile string) {
+func (r *runner) promptEncryptionConfig(ctx context.Context, cfg *profile.Config, storeName, profilesFile string) {
 	_, _ = fmt.Fprintln(r.out)
 	_, _ = fmt.Fprintln(r.out, "No encryption is configured for this store.")
 
@@ -499,19 +501,19 @@ func (r *runner) promptEncryptionConfig(ctx context.Context, cfg *cloudstic.Prof
 
 	// Save updated store config.
 	cfg.Stores[storeName] = s
-	if saveErr := cloudstic.SaveProfilesFile(profilesFile, cfg); saveErr != nil {
+	if saveErr := profile.Save(profilesFile, cfg); saveErr != nil {
 		_, _ = fmt.Fprintf(r.errOut, "Warning: could not save encryption settings: %v\n", saveErr)
 	}
 }
 
 func configureStoreEncryptionSelection(
 	ctx context.Context,
-	s cloudstic.ProfileStore,
+	s profile.Store,
 	storeName, picked string,
 	promptSecretRef func(context.Context, string, string, string, string) (string, error),
 	promptLine func(context.Context, string, string) (string, error),
 	out io.Writer,
-) (cloudstic.ProfileStore, error) {
+) (profile.Store, error) {
 	switch picked {
 	case "Password (recommended for interactive use)":
 		secretRef, err := promptSecretRef(ctx, storeName, "repository password", "CLOUDSTIC_PASSWORD", "password")
@@ -664,7 +666,7 @@ func verifyStoreEncryptionCredentials(ctx context.Context, cfg unlockConfig, raw
 	return nil
 }
 
-func awsSSOLoginOption(s cloudstic.ProfileStore, err error) string {
+func awsSSOLoginOption(s profile.Store, err error) string {
 	if !isAWSExpiredAuthError(err) {
 		return ""
 	}
@@ -697,7 +699,7 @@ func isAWSExpiredAuthError(err error) bool {
 	return false
 }
 
-func runAWSSSOLogin(r *runner, ctx context.Context, s cloudstic.ProfileStore) error {
+func runAWSSSOLogin(r *runner, ctx context.Context, s profile.Store) error {
 	args := []string{"sso", "login"}
 	if s.S3Profile != "" {
 		args = append(args, "--profile", s.S3Profile)
@@ -740,7 +742,7 @@ func envRef(name string) string {
 	return "env://" + name
 }
 
-func storeHasExplicitEncryption(s cloudstic.ProfileStore) bool {
+func storeHasExplicitEncryption(s profile.Store) bool {
 	return s.PasswordSecret != "" || s.EncryptionKeySecret != "" || s.RecoveryKeySecret != "" ||
 		s.KMSKeyARN != ""
 }

--- a/cmd/cloudstic/cmd_store_test.go
+++ b/cmd/cloudstic/cmd_store_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cloudstic/cli/pkg/profile"
+
 	cloudstic "github.com/cloudstic/cli"
 	"github.com/cloudstic/cli/pkg/keychain"
 	"github.com/cloudstic/cli/pkg/secretref"
@@ -115,9 +117,9 @@ func TestRunStoreNew_ExistingStorePrefillsUnsetValues(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
 
-	cfg := &cloudstic.ProfilesConfig{
+	cfg := &profile.Config{
 		Version: 1,
-		Stores: map[string]cloudstic.ProfileStore{
+		Stores: map[string]profile.Store{
 			"prod": {
 				URI:            "s3:bucket/backups",
 				S3Region:       "us-east-1",
@@ -126,7 +128,7 @@ func TestRunStoreNew_ExistingStorePrefillsUnsetValues(t *testing.T) {
 			},
 		},
 	}
-	if err := cloudstic.SaveProfilesFile(profilesPath, cfg); err != nil {
+	if err := profile.Save(profilesPath, cfg); err != nil {
 		t.Fatalf("SaveProfilesFile: %v", err)
 	}
 
@@ -142,7 +144,7 @@ func TestRunStoreNew_ExistingStorePrefillsUnsetValues(t *testing.T) {
 		t.Fatalf("store new failed: %s", errOut.String())
 	}
 
-	updated, err := cloudstic.LoadProfilesFile(profilesPath)
+	updated, err := profile.Load(profilesPath)
 	if err != nil {
 		t.Fatalf("LoadProfilesFile: %v", err)
 	}
@@ -303,7 +305,7 @@ func TestCheckOrInitStore_AlreadyInitialized(t *testing.T) {
 	storePath := filepath.Join(tmpDir, "store")
 
 	// Initialize the store first.
-	s := cloudstic.ProfileStore{URI: "local:" + storePath}
+	s := profile.Store{URI: "local:" + storePath}
 	sc, err := clientConfigFromProfileStore(s)
 	if err != nil {
 		t.Fatalf("clientConfigFromProfileStore: %v", err)
@@ -318,11 +320,11 @@ func TestCheckOrInitStore_AlreadyInitialized(t *testing.T) {
 	}
 
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
-	cfg := &cloudstic.ProfilesConfig{
+	cfg := &profile.Config{
 		Version: 1,
-		Stores:  map[string]cloudstic.ProfileStore{"test": s},
+		Stores:  map[string]profile.Store{"test": s},
 	}
-	if err := cloudstic.SaveProfilesFile(profilesPath, cfg); err != nil {
+	if err := profile.Save(profilesPath, cfg); err != nil {
 		t.Fatalf("SaveProfilesFile: %v", err)
 	}
 
@@ -342,7 +344,7 @@ func TestCheckOrInitStore_InitializedEncrypted_ValidCredentials(t *testing.T) {
 	tmpDir := t.TempDir()
 	storePath := filepath.Join(tmpDir, "store")
 
-	s := cloudstic.ProfileStore{URI: "local:" + storePath}
+	s := profile.Store{URI: "local:" + storePath}
 	sc, err := clientConfigFromProfileStore(s)
 	if err != nil {
 		t.Fatalf("clientConfigFromProfileStore: %v", err)
@@ -357,7 +359,7 @@ func TestCheckOrInitStore_InitializedEncrypted_ValidCredentials(t *testing.T) {
 	}
 
 	t.Setenv("VERIFY_STORE_PASSWORD", "correct-password")
-	cfg := &cloudstic.ProfilesConfig{Version: 1, Stores: map[string]cloudstic.ProfileStore{
+	cfg := &profile.Config{Version: 1, Stores: map[string]profile.Store{
 		"test": {
 			URI:            s.URI,
 			PasswordSecret: "env://VERIFY_STORE_PASSWORD",
@@ -382,7 +384,7 @@ func TestCheckOrInitStore_InitializedEncrypted_InvalidCredentials(t *testing.T) 
 	tmpDir := t.TempDir()
 	storePath := filepath.Join(tmpDir, "store")
 
-	s := cloudstic.ProfileStore{URI: "local:" + storePath}
+	s := profile.Store{URI: "local:" + storePath}
 	sc, err := clientConfigFromProfileStore(s)
 	if err != nil {
 		t.Fatalf("clientConfigFromProfileStore: %v", err)
@@ -397,7 +399,7 @@ func TestCheckOrInitStore_InitializedEncrypted_InvalidCredentials(t *testing.T) 
 	}
 
 	t.Setenv("VERIFY_STORE_PASSWORD_BAD", "wrong-password")
-	cfg := &cloudstic.ProfilesConfig{Version: 1, Stores: map[string]cloudstic.ProfileStore{
+	cfg := &profile.Config{Version: 1, Stores: map[string]profile.Store{
 		"test": {
 			URI:            s.URI,
 			PasswordSecret: "env://VERIFY_STORE_PASSWORD_BAD",
@@ -419,7 +421,7 @@ func TestClientConfigFromProfileStore_ResolvesEnvVars(t *testing.T) {
 	t.Setenv("TEST_SK", "my-secret-key")
 	t.Setenv("TEST_PW", "s3cret")
 
-	s := cloudstic.ProfileStore{
+	s := profile.Store{
 		URI:               "s3:bucket/prefix",
 		S3Region:          "eu-west-1",
 		S3AccessKeySecret: "env://TEST_AK",
@@ -455,7 +457,7 @@ func TestClientConfigFromProfileStore_ResolvesEnvVars(t *testing.T) {
 func TestClientConfigFromProfileStore_ResolvesSecretRef(t *testing.T) {
 	t.Setenv("SECRET_AK", "secret-ak")
 
-	s := cloudstic.ProfileStore{
+	s := profile.Store{
 		URI:               "s3:bucket/prefix",
 		S3AccessKeySecret: "env://SECRET_AK",
 	}
@@ -470,7 +472,7 @@ func TestClientConfigFromProfileStore_ResolvesSecretRef(t *testing.T) {
 }
 
 func TestClientConfigFromProfileStore_InvalidSecretRefReturnsError(t *testing.T) {
-	s := cloudstic.ProfileStore{
+	s := profile.Store{
 		URI:            "s3:bucket/prefix",
 		PasswordSecret: "env:/bad-format",
 	}
@@ -1010,7 +1012,7 @@ func TestPromptSecretReferenceWithFns_DarwinEnvUnsetSwitchesToKeychain(t *testin
 }
 
 func TestCheckOrInitStore_MissingSecretAllowed(t *testing.T) {
-	cfg := &cloudstic.ProfilesConfig{Version: 1, Stores: map[string]cloudstic.ProfileStore{
+	cfg := &profile.Config{Version: 1, Stores: map[string]profile.Store{
 		"test": {
 			URI:            "local:/tmp/store",
 			PasswordSecret: "env://MISSING_STORE_PASSWORD",
@@ -1029,7 +1031,7 @@ func TestCheckOrInitStore_MissingSecretAllowed(t *testing.T) {
 }
 
 func TestCheckOrInitStore_MissingSecretAllowedSilent(t *testing.T) {
-	cfg := &cloudstic.ProfilesConfig{Version: 1, Stores: map[string]cloudstic.ProfileStore{
+	cfg := &profile.Config{Version: 1, Stores: map[string]profile.Store{
 		"test": {
 			URI:            "local:/tmp/store",
 			PasswordSecret: "env://MISSING_STORE_PASSWORD",
@@ -1050,13 +1052,13 @@ func TestCheckOrInitStore_MissingSecretAllowedSilent(t *testing.T) {
 func TestRunStoreVerify_MissingSecretFails(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
-	cfg := &cloudstic.ProfilesConfig{Version: 1, Stores: map[string]cloudstic.ProfileStore{
+	cfg := &profile.Config{Version: 1, Stores: map[string]profile.Store{
 		"test": {
 			URI:            "local:/tmp/store",
 			PasswordSecret: "env://MISSING_VERIFY_PASSWORD",
 		},
 	}}
-	if err := cloudstic.SaveProfilesFile(profilesPath, cfg); err != nil {
+	if err := profile.Save(profilesPath, cfg); err != nil {
 		t.Fatalf("SaveProfilesFile: %v", err)
 	}
 
@@ -1073,10 +1075,10 @@ func TestRunStoreVerify_MissingSecretFails(t *testing.T) {
 }
 
 func TestStoreHasExplicitEncryption(t *testing.T) {
-	if storeHasExplicitEncryption(cloudstic.ProfileStore{}) {
+	if storeHasExplicitEncryption(profile.Store{}) {
 		t.Fatal("expected false for empty store")
 	}
-	if !storeHasExplicitEncryption(cloudstic.ProfileStore{PasswordSecret: "env://CLOUDSTIC_PASSWORD"}) {
+	if !storeHasExplicitEncryption(profile.Store{PasswordSecret: "env://CLOUDSTIC_PASSWORD"}) {
 		t.Fatal("expected true when password secret is set")
 	}
 }
@@ -1105,17 +1107,17 @@ func TestIsAWSExpiredAuthError(t *testing.T) {
 func TestAWSSSOLoginOption(t *testing.T) {
 	err := errors.New("failed to refresh cached credentials, the SSO session has expired or is invalid")
 
-	got := awsSSOLoginOption(cloudstic.ProfileStore{URI: "s3:bucket", S3Profile: "work"}, err)
+	got := awsSSOLoginOption(profile.Store{URI: "s3:bucket", S3Profile: "work"}, err)
 	if got != "Run aws sso login --profile work" {
 		t.Fatalf("got %q", got)
 	}
 
-	got = awsSSOLoginOption(cloudstic.ProfileStore{URI: "s3:bucket"}, err)
+	got = awsSSOLoginOption(profile.Store{URI: "s3:bucket"}, err)
 	if got != "Run aws sso login" {
 		t.Fatalf("got %q", got)
 	}
 
-	got = awsSSOLoginOption(cloudstic.ProfileStore{URI: "s3:bucket"}, errors.New("bucket not found"))
+	got = awsSSOLoginOption(profile.Store{URI: "s3:bucket"}, errors.New("bucket not found"))
 	if got != "" {
 		t.Fatalf("expected empty option, got %q", got)
 	}
@@ -1164,7 +1166,7 @@ func TestExistingStoreInteractivePlan(t *testing.T) {
 func TestConfigureStoreEncryptionSelection_Password(t *testing.T) {
 	var out strings.Builder
 	s, err := configureStoreEncryptionSelection(context.Background(),
-		cloudstic.ProfileStore{},
+		profile.Store{},
 		"prod",
 		"Password (recommended for interactive use)",
 		func(context.Context, string, string, string, string) (string, error) {
@@ -1187,7 +1189,7 @@ func TestConfigureStoreEncryptionSelection_Password(t *testing.T) {
 func TestConfigureStoreEncryptionSelection_KMS(t *testing.T) {
 	var out strings.Builder
 	s, err := configureStoreEncryptionSelection(context.Background(),
-		cloudstic.ProfileStore{},
+		profile.Store{},
 		"prod",
 		"AWS KMS key (enterprise)",
 		func(context.Context, string, string, string, string) (string, error) { return "", nil },
@@ -1214,7 +1216,7 @@ func TestConfigureStoreEncryptionSelection_KMS(t *testing.T) {
 func TestConfigureStoreEncryptionSelection_NoEncryption(t *testing.T) {
 	var out strings.Builder
 	_, err := configureStoreEncryptionSelection(context.Background(),
-		cloudstic.ProfileStore{},
+		profile.Store{},
 		"prod",
 		"No encryption (not recommended)",
 		func(context.Context, string, string, string, string) (string, error) { return "", nil },
@@ -1231,7 +1233,7 @@ func TestConfigureStoreEncryptionSelection_NoEncryption(t *testing.T) {
 
 func TestConfigureStoreEncryptionSelection_KMSError(t *testing.T) {
 	_, err := configureStoreEncryptionSelection(context.Background(),
-		cloudstic.ProfileStore{},
+		profile.Store{},
 		"prod",
 		"AWS KMS key (enterprise)",
 		func(context.Context, string, string, string, string) (string, error) { return "", nil },
@@ -1275,9 +1277,9 @@ func TestPromptEncryptionConfig_PasswordViaEnvRef(t *testing.T) {
 	t.Setenv("MY_BACKUP_PASSWORD", "set-for-test")
 	tmp := t.TempDir()
 	profilesPath := filepath.Join(tmp, "profiles.yaml")
-	cfg := &cloudstic.ProfilesConfig{
+	cfg := &profile.Config{
 		Version: 1,
-		Stores: map[string]cloudstic.ProfileStore{
+		Stores: map[string]profile.Store{
 			"prod": {URI: "local:/tmp/store"},
 		},
 	}
@@ -1404,7 +1406,7 @@ func TestRunStoreNew_LocalStore(t *testing.T) {
 }
 
 func TestClientConfigFromProfileStore_DefaultRegion(t *testing.T) {
-	s := cloudstic.ProfileStore{
+	s := profile.Store{
 		URI: "s3:some-bucket",
 	}
 	sc, err := clientConfigFromProfileStore(s)
@@ -1417,7 +1419,7 @@ func TestClientConfigFromProfileStore_DefaultRegion(t *testing.T) {
 }
 
 func TestClientConfigFromProfileStore_SFTPFields(t *testing.T) {
-	s := cloudstic.ProfileStore{
+	s := profile.Store{
 		URI:               "sftp://user@host/path",
 		StoreSFTPPassword: "direct-pw",
 		StoreSFTPKey:      "/path/to/key",

--- a/cmd/cloudstic/cmd_tui_activity.go
+++ b/cmd/cloudstic/cmd_tui_activity.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cloudstic/cli/pkg/profile"
+
 	cloudstic "github.com/cloudstic/cli"
 	"github.com/cloudstic/cli/internal/tui"
 )
@@ -201,7 +203,7 @@ func (p tuiReporterPhase) Error() {
 
 // tuiStoreConfig resolves a store definition into a client configuration for
 // the TUI, which addresses stores by name and never parses command-line flags.
-func tuiClientConfig(storeCfg cloudstic.ProfileStore) (clientConfig, error) {
+func tuiClientConfig(storeCfg profile.Store) (clientConfig, error) {
 	cfg, err := clientConfigFromProfileStore(storeCfg)
 	if err != nil {
 		return clientConfig{}, err

--- a/cmd/cloudstic/cmd_tui_forms_backend.go
+++ b/cmd/cloudstic/cmd_tui_forms_backend.go
@@ -3,7 +3,8 @@ package main
 import (
 	"fmt"
 
-	cloudstic "github.com/cloudstic/cli"
+	"github.com/cloudstic/cli/pkg/profile"
+
 	"github.com/cloudstic/cli/internal/tui"
 )
 
@@ -14,10 +15,10 @@ import (
 type tuiFormsBackend struct {
 	r            *runner
 	profilesFile string
-	cfg          *cloudstic.ProfilesConfig
+	cfg          *profile.Config
 }
 
-func newTUIFormsBackend(r *runner, profilesFile string, cfg *cloudstic.ProfilesConfig) *tuiFormsBackend {
+func newTUIFormsBackend(r *runner, profilesFile string, cfg *profile.Config) *tuiFormsBackend {
 	return &tuiFormsBackend{r: r, profilesFile: profilesFile, cfg: cfg}
 }
 
@@ -82,7 +83,7 @@ func (b *tuiFormsBackend) ProfileExists(name string) bool {
 }
 
 func (b *tuiFormsBackend) SaveProfile(name, sourceURI, storeRef, authRef string, editing bool) error {
-	profile := cloudstic.BackupProfile{}
+	profile := profile.Profile{}
 	if editing && b.cfg != nil {
 		if existing, ok := b.cfg.Profiles[name]; ok {
 			profile = existing
@@ -98,7 +99,7 @@ func (b *tuiFormsBackend) DeleteProfile(name string) error {
 	return tuiServiceFactory(nil, b.profilesFile).DeleteProfile(b.profilesFile, name)
 }
 
-func (b *tuiFormsBackend) Reload() (*cloudstic.ProfilesConfig, error) {
+func (b *tuiFormsBackend) Reload() (*profile.Config, error) {
 	cfg, err := tuiLoadConfig(b.profilesFile)
 	if err != nil {
 		return nil, err

--- a/cmd/cloudstic/cmd_tui_profile_form.go
+++ b/cmd/cloudstic/cmd_tui_profile_form.go
@@ -3,14 +3,14 @@ package main
 import (
 	"slices"
 
-	cloudstic "github.com/cloudstic/cli"
+	"github.com/cloudstic/cli/pkg/profile"
 )
 
 // Profile-form domain helpers shared by the dashboard's forms backend
 // (cmd_tui_forms_backend.go). They translate between a profile's stored source
 // URI and the parts a form edits, and list the auth refs a source can use.
 
-func profileAuthOptions(cfg *cloudstic.ProfilesConfig, provider string) []string {
+func profileAuthOptions(cfg *profile.Config, provider string) []string {
 	options := []string{}
 	for name, auth := range cfg.Auth {
 		if auth.Provider == provider {

--- a/cmd/cloudstic/cmd_tui_run.go
+++ b/cmd/cloudstic/cmd_tui_run.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cloudstic/cli/pkg/profile"
+
 	tea "github.com/charmbracelet/bubbletea"
 
 	cloudstic "github.com/cloudstic/cli"
@@ -24,7 +26,7 @@ var tuiRunProgram = func(ctx context.Context, model tea.Model, opts ...tea.Progr
 
 // tuiLoadConfig loads the profiles config for the dashboard. It is a package
 // var so tests can supply a fixed config.
-var tuiLoadConfig = func(profilesFile string) (*cloudstic.ProfilesConfig, error) {
+var tuiLoadConfig = func(profilesFile string) (*profile.Config, error) {
 	return app.NewTUIService(nil).LoadDashboardConfig(profilesFile)
 }
 
@@ -74,7 +76,7 @@ type tuiCLIBackend struct {
 	profilesFile string
 }
 
-func (b tuiCLIBackend) LoadStoreSnapshots(ctx context.Context, storeName string, storeCfg cloudstic.ProfileStore) ([]engine.SnapshotEntry, error) {
+func (b tuiCLIBackend) LoadStoreSnapshots(ctx context.Context, storeName string, storeCfg profile.Store) ([]engine.SnapshotEntry, error) {
 	cfg, err := tuiClientConfig(storeCfg)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", storeName, err)
@@ -90,7 +92,7 @@ func (b tuiCLIBackend) LoadStoreSnapshots(ctx context.Context, storeName string,
 	return result.Snapshots, nil
 }
 
-func (b tuiCLIBackend) InitProfile(ctx context.Context, profilesFile, profileName string, profileCfg cloudstic.BackupProfile, cfg *cloudstic.ProfilesConfig) error {
+func (b tuiCLIBackend) InitProfile(ctx context.Context, profilesFile, profileName string, profileCfg profile.Profile, cfg *profile.Config) error {
 	storeCfg, ok := cfg.Stores[profileCfg.Store]
 	if !ok {
 		return fmt.Errorf("profile %q references unknown store %q", profileName, profileCfg.Store)
@@ -106,7 +108,7 @@ func (b tuiCLIBackend) InitProfile(ctx context.Context, profilesFile, profileNam
 	return nil
 }
 
-func (b tuiCLIBackend) BackupProfile(ctx context.Context, profilesFile, profileName string, profileCfg cloudstic.BackupProfile, cfg *cloudstic.ProfilesConfig, reporter cloudstic.Reporter) error {
+func (b tuiCLIBackend) BackupProfile(ctx context.Context, profilesFile, profileName string, profileCfg profile.Profile, cfg *profile.Config, reporter cloudstic.Reporter) error {
 	g := &globalFlags{profile: profileName, profilesFile: profilesFile, quiet: true}
 	base := &backupArgs{globalFlags: g}
 	effective, err := mergeProfileBackupArgs(base, profileName, profileCfg, cfg)
@@ -129,7 +131,7 @@ func (b tuiCLIBackend) BackupProfile(ctx context.Context, profilesFile, profileN
 	return nil
 }
 
-func (b tuiCLIBackend) CheckProfile(ctx context.Context, profilesFile, profileName string, profileCfg cloudstic.BackupProfile, cfg *cloudstic.ProfilesConfig, reporter cloudstic.Reporter) error {
+func (b tuiCLIBackend) CheckProfile(ctx context.Context, profilesFile, profileName string, profileCfg profile.Profile, cfg *profile.Config, reporter cloudstic.Reporter) error {
 	storeCfg, ok := cfg.Stores[profileCfg.Store]
 	if !ok {
 		return fmt.Errorf("profile %q references unknown store %q", profileName, profileCfg.Store)
@@ -158,7 +160,7 @@ type tuiStoreProber struct {
 	r *runner
 }
 
-func (p tuiStoreProber) Probe(ctx context.Context, name string, store cloudstic.ProfileStore) tui.StoreProbe {
+func (p tuiStoreProber) Probe(ctx context.Context, name string, store profile.Store) tui.StoreProbe {
 	snapshots, err := (tuiCLIBackend{r: p.r}).LoadStoreSnapshots(ctx, name, store)
 	if err != nil {
 		return tui.StoreProbe{Status: "error", Error: err.Error()}

--- a/cmd/cloudstic/cmd_tui_run_test.go
+++ b/cmd/cloudstic/cmd_tui_run_test.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	tea "github.com/charmbracelet/bubbletea"
+	"github.com/cloudstic/cli/pkg/profile"
 
-	cloudstic "github.com/cloudstic/cli"
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 func TestRunTUIProgram_Success(t *testing.T) {
@@ -16,8 +16,8 @@ func TestRunTUIProgram_Success(t *testing.T) {
 		return nil
 	})
 	defer restoreRun()
-	restoreCfg := swapTUILoadConfig(func(string) (*cloudstic.ProfilesConfig, error) {
-		return &cloudstic.ProfilesConfig{Version: 1}, nil
+	restoreCfg := swapTUILoadConfig(func(string) (*profile.Config, error) {
+		return &profile.Config{Version: 1}, nil
 	})
 	defer restoreCfg()
 
@@ -32,8 +32,8 @@ func TestRunTUIProgram_ProgramError(t *testing.T) {
 		return errors.New("boom")
 	})
 	defer restoreRun()
-	restoreCfg := swapTUILoadConfig(func(string) (*cloudstic.ProfilesConfig, error) {
-		return &cloudstic.ProfilesConfig{Version: 1}, nil
+	restoreCfg := swapTUILoadConfig(func(string) (*profile.Config, error) {
+		return &profile.Config{Version: 1}, nil
 	})
 	defer restoreCfg()
 
@@ -48,7 +48,7 @@ func TestRunTUIProgram_ProgramError(t *testing.T) {
 }
 
 func TestRunTUIProgram_ConfigError(t *testing.T) {
-	restoreCfg := swapTUILoadConfig(func(string) (*cloudstic.ProfilesConfig, error) {
+	restoreCfg := swapTUILoadConfig(func(string) (*profile.Config, error) {
 		return nil, errors.New("bad config")
 	})
 	defer restoreCfg()
@@ -69,7 +69,7 @@ func swapTUIProgramRunner(fn func(context.Context, tea.Model, ...tea.ProgramOpti
 	return func() { tuiRunProgram = prev }
 }
 
-func swapTUILoadConfig(fn func(string) (*cloudstic.ProfilesConfig, error)) func() {
+func swapTUILoadConfig(fn func(string) (*profile.Config, error)) func() {
 	prev := tuiLoadConfig
 	tuiLoadConfig = fn
 	return func() { tuiLoadConfig = prev }

--- a/cmd/cloudstic/cmd_tui_store_backend.go
+++ b/cmd/cloudstic/cmd_tui_store_backend.go
@@ -3,7 +3,8 @@ package main
 import (
 	"fmt"
 
-	cloudstic "github.com/cloudstic/cli"
+	"github.com/cloudstic/cli/pkg/profile"
+
 	"github.com/cloudstic/cli/internal/tui/forms"
 	"github.com/cloudstic/cli/pkg/secretref"
 )
@@ -83,7 +84,7 @@ func (b *tuiFormsBackend) InitialStoreValues(name string) map[string]string {
 // persists it. Connection and encryption fields irrelevant to the selected
 // type/mode are cleared, mirroring the legacy store form.
 func (b *tuiFormsBackend) SaveStore(name string, values map[string]string, editing bool) error {
-	store := cloudstic.ProfileStore{}
+	store := profile.Store{}
 	if editing && b.cfg != nil {
 		if existing, ok := b.cfg.Stores[name]; ok {
 			store = existing
@@ -104,7 +105,7 @@ func (b *tuiFormsBackend) SaveStore(name string, values map[string]string, editi
 	return nil
 }
 
-func applyStoreConnectionValues(store *cloudstic.ProfileStore, values map[string]string) {
+func applyStoreConnectionValues(store *profile.Store, values map[string]string) {
 	// Start clean; only the selected type's fields are populated.
 	store.S3Region = ""
 	store.S3Profile = ""
@@ -127,7 +128,7 @@ func applyStoreConnectionValues(store *cloudstic.ProfileStore, values map[string
 	}
 }
 
-func applyStoreEncryptionValues(store *cloudstic.ProfileStore, values map[string]string) {
+func applyStoreEncryptionValues(store *profile.Store, values map[string]string) {
 	store.PasswordSecret = ""
 	store.EncryptionKeySecret = ""
 	store.KMSKeyARN = ""

--- a/cmd/cloudstic/cmd_tui_store_form.go
+++ b/cmd/cloudstic/cmd_tui_store_form.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	cloudstic "github.com/cloudstic/cli"
+	"github.com/cloudstic/cli/pkg/profile"
 )
 
 // Store-form domain helpers shared by the dashboard's store and secret backends
@@ -121,7 +121,7 @@ func (s tuiStoreConfig) ExampleText() string {
 	}
 }
 
-func newTUIStoreEncryptionMode(existing cloudstic.ProfileStore) tuiStoreEncryptionMode {
+func newTUIStoreEncryptionMode(existing profile.Store) tuiStoreEncryptionMode {
 	switch {
 	case existing.KMSKeyARN != "":
 		return tuiStoreEncryptionKMS

--- a/cmd/cloudstic/cmd_tui_test.go
+++ b/cmd/cloudstic/cmd_tui_test.go
@@ -8,7 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	cloudstic "github.com/cloudstic/cli"
+	"github.com/cloudstic/cli/pkg/profile"
+
 	"github.com/cloudstic/cli/internal/tui/forms"
 	"github.com/cloudstic/cli/pkg/secretref"
 	secretrefbackends "github.com/cloudstic/cli/pkg/secretref/backends"
@@ -61,10 +62,10 @@ func TestTUIProfileSourceCompose(t *testing.T) {
 
 // newTestFormsBackend builds the dashboard's forms backend over a temporary
 // profiles file, returning the backend and the file's path.
-func newTestFormsBackend(t *testing.T, cfg *cloudstic.ProfilesConfig) (*tuiFormsBackend, string) {
+func newTestFormsBackend(t *testing.T, cfg *profile.Config) (*tuiFormsBackend, string) {
 	t.Helper()
 	path := t.TempDir() + "/profiles.yaml"
-	if err := cloudstic.SaveProfilesFile(path, cfg); err != nil {
+	if err := profile.Save(path, cfg); err != nil {
 		t.Fatalf("SaveProfilesFile: %v", err)
 	}
 	loaded, err := tuiLoadConfig(path)
@@ -75,9 +76,9 @@ func newTestFormsBackend(t *testing.T, cfg *cloudstic.ProfilesConfig) (*tuiForms
 }
 
 func TestInitialStoreValues_PopulatesExistingSecretFields(t *testing.T) {
-	backend, _ := newTestFormsBackend(t, &cloudstic.ProfilesConfig{
+	backend, _ := newTestFormsBackend(t, &profile.Config{
 		Version: 1,
-		Stores: map[string]cloudstic.ProfileStore{
+		Stores: map[string]profile.Store{
 			"remote": {
 				URI:               "s3:bucket/prod",
 				S3Region:          "us-east-1",
@@ -112,7 +113,7 @@ func TestInitialStoreValues_PopulatesExistingSecretFields(t *testing.T) {
 }
 
 func TestSaveStore_PersistsSecretRefsAndClearsUnusedModes(t *testing.T) {
-	backend, path := newTestFormsBackend(t, &cloudstic.ProfilesConfig{Version: 1})
+	backend, path := newTestFormsBackend(t, &profile.Config{Version: 1})
 
 	uri, err := backend.ComposeStore("s3", "bucket/prod")
 	if err != nil {
@@ -134,7 +135,7 @@ func TestSaveStore_PersistsSecretRefsAndClearsUnusedModes(t *testing.T) {
 		t.Fatalf("SaveStore: %v", err)
 	}
 
-	cfg, err := cloudstic.LoadProfilesFile(path)
+	cfg, err := profile.Load(path)
 	if err != nil {
 		t.Fatalf("LoadProfilesFile: %v", err)
 	}
@@ -160,9 +161,9 @@ func TestSaveStore_PersistsSecretRefsAndClearsUnusedModes(t *testing.T) {
 }
 
 func TestSaveStore_ClearsConnectionFieldsOfOtherTypes(t *testing.T) {
-	backend, path := newTestFormsBackend(t, &cloudstic.ProfilesConfig{
+	backend, path := newTestFormsBackend(t, &profile.Config{
 		Version: 1,
-		Stores: map[string]cloudstic.ProfileStore{
+		Stores: map[string]profile.Store{
 			"remote": {
 				URI:               "s3:bucket/prod",
 				S3Region:          "us-east-1",
@@ -182,7 +183,7 @@ func TestSaveStore_ClearsConnectionFieldsOfOtherTypes(t *testing.T) {
 		t.Fatalf("SaveStore: %v", err)
 	}
 
-	cfg, err := cloudstic.LoadProfilesFile(path)
+	cfg, err := profile.Load(path)
 	if err != nil {
 		t.Fatalf("LoadProfilesFile: %v", err)
 	}
@@ -208,7 +209,7 @@ func TestStoreSecret_WritesThroughWritableBackend(t *testing.T) {
 		"test": secretBackend,
 	})
 
-	backend, _ := newTestFormsBackend(t, &cloudstic.ProfilesConfig{Version: 1})
+	backend, _ := newTestFormsBackend(t, &profile.Config{Version: 1})
 
 	ref := backend.DefaultRef("test", "remote", "password")
 	if ref != "test://cloudstic/store/remote/password" {
@@ -223,8 +224,8 @@ func TestStoreSecret_WritesThroughWritableBackend(t *testing.T) {
 }
 
 func TestProfileAuthOptions_FiltersByProvider(t *testing.T) {
-	cfg := &cloudstic.ProfilesConfig{
-		Auth: map[string]cloudstic.ProfileAuth{
+	cfg := &profile.Config{
+		Auth: map[string]profile.Auth{
 			"work-gdrive": {Provider: "gdrive"},
 			"home-gdrive": {Provider: "gdrive"},
 			"onedrive":    {Provider: "onedrive"},

--- a/cmd/cloudstic/completion_dynamic.go
+++ b/cmd/cloudstic/completion_dynamic.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"io"
 
-	cloudstic "github.com/cloudstic/cli"
+	"github.com/cloudstic/cli/pkg/profile"
 )
 
-var completionLoadProfilesFile = cloudstic.LoadProfilesFileOrEmpty
+var completionLoadProfilesFile = profile.LoadOrEmpty
 
 type completionQueryArgs struct{ values []string }
 
@@ -68,7 +68,7 @@ func completionAuthNames(args []string) ([]string, error) {
 	return sortedKeys(cfg.Auth), nil
 }
 
-func completionLoadProfilesConfig(path string) (*cloudstic.ProfilesConfig, error) {
+func completionLoadProfilesConfig(path string) (*profile.Config, error) {
 	cfg, err := completionLoadProfilesFile(path)
 	if err != nil {
 		return nil, err

--- a/cmd/cloudstic/completion_dynamic_test.go
+++ b/cmd/cloudstic/completion_dynamic_test.go
@@ -9,18 +9,18 @@ import (
 	"reflect"
 	"testing"
 
-	cloudstic "github.com/cloudstic/cli"
+	"github.com/cloudstic/cli/pkg/profile"
 )
 
 func TestCompletionCandidates_ProfileAndAuthNames(t *testing.T) {
 	profilesPath := filepath.Join(t.TempDir(), "profiles.yaml")
-	if err := cloudstic.SaveProfilesFile(profilesPath, &cloudstic.ProfilesConfig{
+	if err := profile.Save(profilesPath, &profile.Config{
 		Version: 1,
-		Profiles: map[string]cloudstic.BackupProfile{
+		Profiles: map[string]profile.Profile{
 			"laptop": {},
 			"server": {},
 		},
-		Auth: map[string]cloudstic.ProfileAuth{
+		Auth: map[string]profile.Auth{
 			"google-work": {},
 			"ms-personal": {},
 		},
@@ -58,10 +58,10 @@ func TestCompletionCandidates_MissingProfilesFileIsEmpty(t *testing.T) {
 
 func TestRunCompletionQuery_WritesCandidates(t *testing.T) {
 	oldLoad := completionLoadProfilesFile
-	completionLoadProfilesFile = func(string) (*cloudstic.ProfilesConfig, error) {
-		return &cloudstic.ProfilesConfig{
+	completionLoadProfilesFile = func(string) (*profile.Config, error) {
+		return &profile.Config{
 			Version: 1,
-			Profiles: map[string]cloudstic.BackupProfile{
+			Profiles: map[string]profile.Profile{
 				"work": {},
 			},
 		}, nil
@@ -93,10 +93,10 @@ func TestRunCompletionQuery_WritesCandidates(t *testing.T) {
 
 func TestCompleteCommand_AcceptsForwardedFlags(t *testing.T) {
 	oldLoad := completionLoadProfilesFile
-	completionLoadProfilesFile = func(string) (*cloudstic.ProfilesConfig, error) {
-		return &cloudstic.ProfilesConfig{
+	completionLoadProfilesFile = func(string) (*profile.Config, error) {
+		return &profile.Config{
 			Version:  1,
-			Profiles: map[string]cloudstic.BackupProfile{"work": {}},
+			Profiles: map[string]profile.Profile{"work": {}},
 		}, nil
 	}
 	t.Cleanup(func() { completionLoadProfilesFile = oldLoad })

--- a/cmd/cloudstic/config.go
+++ b/cmd/cloudstic/config.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	cloudstic "github.com/cloudstic/cli"
+	"github.com/cloudstic/cli/pkg/profile"
 )
 
 // The types in this file are the resolved configuration a command runs with,
@@ -157,7 +157,7 @@ func resolveClientConfig(g *globalFlags) (clientConfig, error) {
 
 // loadProfileStore returns the store configuration for g's selected profile, or
 // nil when no profile is selected or the profile names no store.
-func loadProfileStore(g *globalFlags) (*cloudstic.ProfileStore, error) {
+func loadProfileStore(g *globalFlags) (*profile.Store, error) {
 	if g.profile == "" {
 		return nil, nil
 	}
@@ -165,7 +165,7 @@ func loadProfileStore(g *globalFlags) (*cloudstic.ProfileStore, error) {
 	if g.profilesFile != "" {
 		profilesFile = g.profilesFile
 	}
-	cfg, err := cloudstic.LoadProfilesFile(profilesFile)
+	cfg, err := profile.Load(profilesFile)
 	if err != nil {
 		return nil, fmt.Errorf("load profiles file %q: %w", profilesFile, err)
 	}
@@ -182,7 +182,7 @@ func loadProfileStore(g *globalFlags) (*cloudstic.ProfileStore, error) {
 // mergeProfileBackupArgs, which only needs the existence check: the store
 // itself is deliberately applied later, when resolveClientConfig runs for the
 // backup that's actually about to happen (see mergeProfileBackupArgs).
-func lookupProfileStore(cfg *cloudstic.ProfilesConfig, profileName string, p cloudstic.BackupProfile) (*cloudstic.ProfileStore, error) {
+func lookupProfileStore(cfg *profile.Config, profileName string, p profile.Profile) (*profile.Store, error) {
 	if p.Store == "" {
 		return nil, nil
 	}
@@ -203,7 +203,7 @@ func lookupProfileStore(cfg *cloudstic.ProfilesConfig, profileName string, p clo
 // applyExistingStoreDefaults (store_builder_helpers.go), which prefills
 // `store new`'s flags from an existing store entry for editing — an unrelated
 // concept despite the similar name.
-func clientConfigFromProfileStore(s cloudstic.ProfileStore) (clientConfig, error) {
+func clientConfigFromProfileStore(s profile.Store) (clientConfig, error) {
 	cfg := clientConfig{packfile: true}
 	cfg.store.s3.region = defaultS3Region
 	if err := applyProfileStore(&cfg, s, func(string) bool { return false }); err != nil {
@@ -226,7 +226,7 @@ func clientConfigFromProfileStore(s cloudstic.ProfileStore) (clientConfig, error
 // field types differ enough (bools, string slices, multi-field auth
 // resolution vs. plain strings here) that forcing a shared table would
 // obscure more than it clarifies.
-func applyProfileStore(cfg *clientConfig, s cloudstic.ProfileStore, provided func(string) bool) error {
+func applyProfileStore(cfg *clientConfig, s profile.Store, provided func(string) bool) error {
 	if !provided("store") && s.URI != "" {
 		cfg.store.uri = s.URI
 	}

--- a/cmd/cloudstic/config_tables.go
+++ b/cmd/cloudstic/config_tables.go
@@ -6,9 +6,10 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/cloudstic/cli/pkg/profile"
+
 	"github.com/jedib0t/go-pretty/v6/table"
 
-	cloudstic "github.com/cloudstic/cli"
 	"github.com/cloudstic/cli/internal/logger"
 	"github.com/cloudstic/cli/internal/ui"
 )
@@ -93,7 +94,7 @@ func boolLabel(v bool) string {
 	return "no"
 }
 
-func profileHealth(cfg *cloudstic.ProfilesConfig, p cloudstic.BackupProfile) (status string, details []string) {
+func profileHealth(cfg *profile.Config, p profile.Profile) (status string, details []string) {
 	status = "ready"
 	provider := profileProviderFromSource(p.Source)
 	if !p.IsEnabled() {
@@ -122,7 +123,7 @@ func profileHealth(cfg *cloudstic.ProfilesConfig, p cloudstic.BackupProfile) (st
 	return status, details
 }
 
-func authHealth(auth cloudstic.ProfileAuth) (string, []string) {
+func authHealth(auth profile.Auth) (string, []string) {
 	switch auth.Provider {
 	case "google":
 		if auth.GoogleTokenFile == "" && auth.GoogleTokenRef == "" {
@@ -139,7 +140,7 @@ func authHealth(auth cloudstic.ProfileAuth) (string, []string) {
 	}
 }
 
-func storeHealth(s cloudstic.ProfileStore) (string, []string) {
+func storeHealth(s profile.Store) (string, []string) {
 	if s.URI == "" {
 		return "error", []string{"missing uri"}
 	}
@@ -149,7 +150,7 @@ func storeHealth(s cloudstic.ProfileStore) (string, []string) {
 	return "ready", nil
 }
 
-func profilesUsingStore(cfg *cloudstic.ProfilesConfig, storeName string) []string {
+func profilesUsingStore(cfg *profile.Config, storeName string) []string {
 	var refs []string
 	for pName, p := range cfg.Profiles {
 		if p.Store == storeName {
@@ -160,7 +161,7 @@ func profilesUsingStore(cfg *cloudstic.ProfilesConfig, storeName string) []strin
 	return refs
 }
 
-func profilesUsingAuth(cfg *cloudstic.ProfilesConfig, authName string) []string {
+func profilesUsingAuth(cfg *profile.Config, authName string) []string {
 	var refs []string
 	for pName, p := range cfg.Profiles {
 		if p.AuthRef == authName {
@@ -178,7 +179,7 @@ func appendWarningRow(rows []table.Row, warnings []string) []table.Row {
 	return append(rows, table.Row{"Warnings", strings.Join(warnings, ", ")})
 }
 
-func renderStoreList(out io.Writer, cfg *cloudstic.ProfilesConfig) {
+func renderStoreList(out io.Writer, cfg *profile.Config) {
 	names := sortedKeys(cfg.Stores)
 	renderSectionHeading(out, "Stores", len(names))
 	if len(names) == 0 {
@@ -202,7 +203,7 @@ func renderStoreList(out io.Writer, cfg *cloudstic.ProfilesConfig) {
 	t.Render()
 }
 
-func renderAuthList(out io.Writer, cfg *cloudstic.ProfilesConfig) {
+func renderAuthList(out io.Writer, cfg *profile.Config) {
 	names := sortedKeys(cfg.Auth)
 	renderSectionHeading(out, "Auth", len(names))
 	if len(names) == 0 {
@@ -225,7 +226,7 @@ func renderAuthList(out io.Writer, cfg *cloudstic.ProfilesConfig) {
 	t.Render()
 }
 
-func renderProfileList(out io.Writer, cfg *cloudstic.ProfilesConfig) {
+func renderProfileList(out io.Writer, cfg *profile.Config) {
 	names := sortedKeys(cfg.Profiles)
 	renderSectionHeading(out, "Profiles", len(names))
 	if len(names) == 0 {
@@ -263,7 +264,7 @@ func dashIfEmpty(v string) string {
 	return v
 }
 
-func authTokenPath(auth cloudstic.ProfileAuth) string {
+func authTokenPath(auth profile.Auth) string {
 	if auth.GoogleTokenRef != "" {
 		return auth.GoogleTokenRef
 	}
@@ -279,7 +280,7 @@ func authTokenPath(auth cloudstic.ProfileAuth) string {
 	return "-"
 }
 
-func renderStoreShow(out io.Writer, cfg *cloudstic.ProfilesConfig, name string, s cloudstic.ProfileStore) {
+func renderStoreShow(out io.Writer, cfg *profile.Config, name string, s profile.Store) {
 	status, warnings := storeHealth(s)
 	renderSectionHeading(out, fmt.Sprintf("Store %s", name), -1)
 	renderKVTable(out, appendWarningRow([]table.Row{
@@ -333,7 +334,7 @@ func renderStoreShow(out io.Writer, cfg *cloudstic.ProfilesConfig, name string, 
 	t.Render()
 }
 
-func secretDisplayRows(s cloudstic.ProfileStore) []table.Row {
+func secretDisplayRows(s profile.Store) []table.Row {
 	var rows []table.Row
 	appendRow := func(label, value string, deprecated bool) {
 		if value == "" {
@@ -356,7 +357,7 @@ func secretDisplayRows(s cloudstic.ProfileStore) []table.Row {
 	return rows
 }
 
-func renderAuthShow(out io.Writer, cfg *cloudstic.ProfilesConfig, name string, auth cloudstic.ProfileAuth) {
+func renderAuthShow(out io.Writer, cfg *profile.Config, name string, auth profile.Auth) {
 	status, warnings := authHealth(auth)
 	renderSectionHeading(out, fmt.Sprintf("Auth %s", name), -1)
 	renderKVTable(out, appendWarningRow([]table.Row{
@@ -406,7 +407,7 @@ func renderAuthShow(out io.Writer, cfg *cloudstic.ProfilesConfig, name string, a
 	t.Render()
 }
 
-func renderProfileShow(out io.Writer, cfg *cloudstic.ProfilesConfig, name string, profile cloudstic.BackupProfile) {
+func renderProfileShow(out io.Writer, cfg *profile.Config, name string, profile profile.Profile) {
 	status, warnings := profileHealth(cfg, profile)
 	renderSectionHeading(out, fmt.Sprintf("Profile %s", name), -1)
 	renderKVTable(out, appendWarningRow([]table.Row{

--- a/cmd/cloudstic/config_test.go
+++ b/cmd/cloudstic/config_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	cloudstic "github.com/cloudstic/cli"
+	"github.com/cloudstic/cli/pkg/profile"
 )
 
 // TestResolveClientConfig_ProfileOverridesEnvironment documents and locks in
@@ -27,12 +27,12 @@ func TestResolveClientConfig_ProfileOverridesEnvironment(t *testing.T) {
 	}
 
 	profilesPath := filepath.Join(t.TempDir(), "profiles.yaml")
-	err := cloudstic.SaveProfilesFile(profilesPath, &cloudstic.ProfilesConfig{
+	err := profile.Save(profilesPath, &profile.Config{
 		Version: 1,
-		Stores: map[string]cloudstic.ProfileStore{
+		Stores: map[string]profile.Store{
 			"s": {URI: "s3:bucket", S3Region: "profile-region"},
 		},
-		Profiles: map[string]cloudstic.BackupProfile{
+		Profiles: map[string]profile.Profile{
 			"p": {Source: "local:/data", Store: "s"},
 		},
 	})
@@ -54,12 +54,12 @@ func TestResolveClientConfig_ProfileOverridesEnvironment(t *testing.T) {
 func TestResolveClientConfig_AppliesProfileStore(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
-	err := cloudstic.SaveProfilesFile(profilesPath, &cloudstic.ProfilesConfig{
+	err := profile.Save(profilesPath, &profile.Config{
 		Version: 1,
-		Stores: map[string]cloudstic.ProfileStore{
+		Stores: map[string]profile.Store{
 			"s": {URI: "s3:bucket/prefix", S3Region: "eu-west-1", S3Profile: "prod"},
 		},
-		Profiles: map[string]cloudstic.BackupProfile{
+		Profiles: map[string]profile.Profile{
 			"p": {Source: "local:/data", Store: "s"},
 		},
 	})
@@ -94,9 +94,9 @@ func TestResolveClientConfig_EncryptionFields(t *testing.T) {
 	t.Setenv("TEST_ENC_KEY", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 	t.Setenv("TEST_RECOVERY_KEY", "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about")
 
-	err := cloudstic.SaveProfilesFile(profilesPath, &cloudstic.ProfilesConfig{
+	err := profile.Save(profilesPath, &profile.Config{
 		Version: 1,
-		Stores: map[string]cloudstic.ProfileStore{
+		Stores: map[string]profile.Store{
 			"enc": {
 				URI:                 "s3:bucket/enc",
 				PasswordSecret:      "env://TEST_BACKUP_PASSWORD",
@@ -107,7 +107,7 @@ func TestResolveClientConfig_EncryptionFields(t *testing.T) {
 				KMSEndpoint:         "https://kms.example.com",
 			},
 		},
-		Profiles: map[string]cloudstic.BackupProfile{
+		Profiles: map[string]profile.Profile{
 			"p": {Source: "local:/data", Store: "enc"},
 		},
 	})
@@ -146,12 +146,12 @@ func TestResolveClientConfig_EncryptionFields(t *testing.T) {
 func TestResolveClientConfig_DoesNotOverrideExplicitStoreFlag(t *testing.T) {
 	tmpDir := t.TempDir()
 	profilesPath := filepath.Join(tmpDir, "profiles.yaml")
-	err := cloudstic.SaveProfilesFile(profilesPath, &cloudstic.ProfilesConfig{
+	err := profile.Save(profilesPath, &profile.Config{
 		Version: 1,
-		Stores: map[string]cloudstic.ProfileStore{
+		Stores: map[string]profile.Store{
 			"s": {URI: "s3:bucket/prefix"},
 		},
-		Profiles: map[string]cloudstic.BackupProfile{
+		Profiles: map[string]profile.Profile{
 			"p": {Source: "local:/data", Store: "s"},
 		},
 	})

--- a/cmd/cloudstic/profile_builder_helpers.go
+++ b/cmd/cloudstic/profile_builder_helpers.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"sort"
 
-	cloudstic "github.com/cloudstic/cli"
+	"github.com/cloudstic/cli/pkg/profile"
 )
 
 var validRefName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
@@ -30,12 +30,12 @@ func profilesFileFlag(target *string) flagSpec {
 		withEnv("CLOUDSTIC_PROFILES_FILE"), withPlaceholder("<path>"), withCompleter("_files"))
 }
 
-func loadProfilesOrInit(path string) (*cloudstic.ProfilesConfig, error) {
-	return cloudstic.LoadProfilesFileOrEmpty(path)
+func loadProfilesOrInit(path string) (*profile.Config, error) {
+	return profile.LoadOrEmpty(path)
 }
 
-func ensureProfilesMaps(cfg *cloudstic.ProfilesConfig) {
-	cloudstic.EnsureProfilesMaps(cfg)
+func ensureProfilesMaps(cfg *profile.Config) {
+	profile.EnsureMaps(cfg)
 }
 
 func sortedKeys[T any](m map[string]T) []string {

--- a/cmd/cloudstic/store_builder_helpers.go
+++ b/cmd/cloudstic/store_builder_helpers.go
@@ -1,6 +1,6 @@
 package main
 
-import cloudstic "github.com/cloudstic/cli"
+import "github.com/cloudstic/cli/pkg/profile"
 
 type storeNewFlagPtrs struct {
 	uri                 *string
@@ -27,7 +27,7 @@ type storeNewFlagPtrs struct {
 	kmsEndpoint         *string
 }
 
-func applyExistingStoreDefaults(g *globalFlags, existing cloudstic.ProfileStore, f storeNewFlagPtrs) {
+func applyExistingStoreDefaults(g *globalFlags, existing profile.Store, f storeNewFlagPtrs) {
 	if !g.flagProvided("uri") && existing.URI != "" {
 		*f.uri = existing.URI
 	}
@@ -96,8 +96,8 @@ func applyExistingStoreDefaults(g *globalFlags, existing cloudstic.ProfileStore,
 	}
 }
 
-func buildProfileStoreFromFlags(f storeNewFlagPtrs) cloudstic.ProfileStore {
-	return cloudstic.ProfileStore{
+func buildProfileStoreFromFlags(f storeNewFlagPtrs) profile.Store {
+	return profile.Store{
 		URI:                     *f.uri,
 		S3Region:                *f.s3Region,
 		S3Profile:               *f.s3Profile,

--- a/cmd/cloudstic/stub_client_test.go
+++ b/cmd/cloudstic/stub_client_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"io"
 
+	"github.com/cloudstic/cli/internal/workstation"
+
 	cloudstic "github.com/cloudstic/cli"
 	"github.com/cloudstic/cli/pkg/source"
 )
@@ -13,9 +15,7 @@ import (
 type stubClient struct {
 	backupResult    *cloudstic.BackupResult
 	backupErr       error
-	discoverResult  []cloudstic.DiscoveredSource
-	discoverErr     error
-	setupPlan       *cloudstic.WorkstationSetupPlan
+	setupPlan       *workstation.SetupPlan
 	setupPlanErr    error
 	restoreResult   *cloudstic.RestoreResult
 	restoreErr      error
@@ -46,11 +46,7 @@ func (s *stubClient) Backup(_ context.Context, _ source.Source, _ ...cloudstic.B
 	return s.backupResult, s.backupErr
 }
 
-func (s *stubClient) DiscoverSources(_ context.Context) ([]cloudstic.DiscoveredSource, error) {
-	return s.discoverResult, s.discoverErr
-}
-
-func (s *stubClient) PlanWorkstationSetup(_ context.Context, _ ...cloudstic.WorkstationSetupOption) (*cloudstic.WorkstationSetupPlan, error) {
+func (s *stubClient) PlanWorkstationSetup(_ context.Context, _ ...workstation.SetupOption) (*workstation.SetupPlan, error) {
 	return s.setupPlan, s.setupPlanErr
 }
 

--- a/internal/app/tui_service.go
+++ b/internal/app/tui_service.go
@@ -4,28 +4,30 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cloudstic/cli/pkg/profile"
+
 	cloudstic "github.com/cloudstic/cli"
 	"github.com/cloudstic/cli/internal/engine"
 	"github.com/cloudstic/cli/internal/tui"
 )
 
 type TUIBackend interface {
-	LoadStoreSnapshots(context.Context, string, cloudstic.ProfileStore) ([]engine.SnapshotEntry, error)
-	InitProfile(context.Context, string, string, cloudstic.BackupProfile, *cloudstic.ProfilesConfig) error
-	BackupProfile(context.Context, string, string, cloudstic.BackupProfile, *cloudstic.ProfilesConfig, cloudstic.Reporter) error
-	CheckProfile(context.Context, string, string, cloudstic.BackupProfile, *cloudstic.ProfilesConfig, cloudstic.Reporter) error
+	LoadStoreSnapshots(context.Context, string, profile.Store) ([]engine.SnapshotEntry, error)
+	InitProfile(context.Context, string, string, profile.Profile, *profile.Config) error
+	BackupProfile(context.Context, string, string, profile.Profile, *profile.Config, cloudstic.Reporter) error
+	CheckProfile(context.Context, string, string, profile.Profile, *profile.Config, cloudstic.Reporter) error
 }
 
 type TUIService struct {
-	loadProfiles func(string) (*cloudstic.ProfilesConfig, error)
-	saveProfiles func(string, *cloudstic.ProfilesConfig) error
+	loadProfiles func(string) (*profile.Config, error)
+	saveProfiles func(string, *profile.Config) error
 	backend      TUIBackend
 }
 
 func NewTUIService(backend TUIBackend) *TUIService {
 	return &TUIService{
 		loadProfiles: loadProfilesConfig,
-		saveProfiles: cloudstic.SaveProfilesFile,
+		saveProfiles: profile.Save,
 		backend:      backend,
 	}
 }
@@ -73,15 +75,15 @@ func (s *TUIService) RunProfileCheck(ctx context.Context, profilesFile string, p
 	return s.backend.CheckProfile(ctx, profilesFile, profile.Name, profileCfg, cfg, reporter)
 }
 
-func (s *TUIService) SaveProfile(profilesFile, name string, profile cloudstic.BackupProfile) error {
+func (s *TUIService) SaveProfile(profilesFile, name string, p profile.Profile) error {
 	cfg, err := s.loadConfig(profilesFile)
 	if err != nil {
 		return fmt.Errorf("load profiles: %w", err)
 	}
-	cfg.Profiles[name] = profile
+	cfg.Profiles[name] = p
 	save := s.saveProfiles
 	if save == nil {
-		save = cloudstic.SaveProfilesFile
+		save = profile.Save
 	}
 	if err := save(profilesFile, cfg); err != nil {
 		return fmt.Errorf("save profiles: %w", err)
@@ -100,7 +102,7 @@ func (s *TUIService) DeleteProfile(profilesFile, name string) error {
 	delete(cfg.Profiles, name)
 	save := s.saveProfiles
 	if save == nil {
-		save = cloudstic.SaveProfilesFile
+		save = profile.Save
 	}
 	if err := save(profilesFile, cfg); err != nil {
 		return fmt.Errorf("save profiles: %w", err)
@@ -108,7 +110,7 @@ func (s *TUIService) DeleteProfile(profilesFile, name string) error {
 	return nil
 }
 
-func (s *TUIService) SaveStore(profilesFile, name string, store cloudstic.ProfileStore) error {
+func (s *TUIService) SaveStore(profilesFile, name string, store profile.Store) error {
 	cfg, err := s.loadConfig(profilesFile)
 	if err != nil {
 		return fmt.Errorf("load profiles: %w", err)
@@ -116,7 +118,7 @@ func (s *TUIService) SaveStore(profilesFile, name string, store cloudstic.Profil
 	cfg.Stores[name] = store
 	save := s.saveProfiles
 	if save == nil {
-		save = cloudstic.SaveProfilesFile
+		save = profile.Save
 	}
 	if err := save(profilesFile, cfg); err != nil {
 		return fmt.Errorf("save profiles: %w", err)
@@ -127,11 +129,11 @@ func (s *TUIService) SaveStore(profilesFile, name string, store cloudstic.Profil
 // LoadDashboardConfig loads and normalizes the profiles config for the TUI.
 // The Bubble Tea renderer builds a probe-less dashboard skeleton from it and
 // then probes stores concurrently, rather than probing serially up front.
-func (s *TUIService) LoadDashboardConfig(profilesFile string) (*cloudstic.ProfilesConfig, error) {
+func (s *TUIService) LoadDashboardConfig(profilesFile string) (*profile.Config, error) {
 	return s.loadConfig(profilesFile)
 }
 
-func (s *TUIService) loadConfig(profilesFile string) (*cloudstic.ProfilesConfig, error) {
+func (s *TUIService) loadConfig(profilesFile string) (*profile.Config, error) {
 	load := s.loadProfiles
 	if load == nil {
 		load = loadProfilesConfig
@@ -144,12 +146,12 @@ func (s *TUIService) loadConfig(profilesFile string) (*cloudstic.ProfilesConfig,
 	return cfg, nil
 }
 
-func loadProfilesConfig(path string) (*cloudstic.ProfilesConfig, error) {
-	return cloudstic.LoadProfilesFileOrEmpty(path)
+func loadProfilesConfig(path string) (*profile.Config, error) {
+	return profile.LoadOrEmpty(path)
 }
 
-func ensureProfilesMaps(cfg *cloudstic.ProfilesConfig) {
-	cloudstic.EnsureProfilesMaps(cfg)
+func ensureProfilesMaps(cfg *profile.Config) {
+	profile.EnsureMaps(cfg)
 }
 
 func profileNeedsInit(profile tui.ProfileCard) bool {

--- a/internal/app/tui_service_test.go
+++ b/internal/app/tui_service_test.go
@@ -5,40 +5,42 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/cloudstic/cli/pkg/profile"
+
 	cloudstic "github.com/cloudstic/cli"
 	"github.com/cloudstic/cli/internal/engine"
 	"github.com/cloudstic/cli/internal/tui"
 )
 
 type stubTUIBackend struct {
-	loadStoreSnapshots func(context.Context, string, cloudstic.ProfileStore) ([]engine.SnapshotEntry, error)
-	initProfile        func(context.Context, string, string, cloudstic.BackupProfile, *cloudstic.ProfilesConfig) error
-	backupProfile      func(context.Context, string, string, cloudstic.BackupProfile, *cloudstic.ProfilesConfig, cloudstic.Reporter) error
-	checkProfile       func(context.Context, string, string, cloudstic.BackupProfile, *cloudstic.ProfilesConfig, cloudstic.Reporter) error
+	loadStoreSnapshots func(context.Context, string, profile.Store) ([]engine.SnapshotEntry, error)
+	initProfile        func(context.Context, string, string, profile.Profile, *profile.Config) error
+	backupProfile      func(context.Context, string, string, profile.Profile, *profile.Config, cloudstic.Reporter) error
+	checkProfile       func(context.Context, string, string, profile.Profile, *profile.Config, cloudstic.Reporter) error
 }
 
-func (b stubTUIBackend) LoadStoreSnapshots(ctx context.Context, storeName string, storeCfg cloudstic.ProfileStore) ([]engine.SnapshotEntry, error) {
+func (b stubTUIBackend) LoadStoreSnapshots(ctx context.Context, storeName string, storeCfg profile.Store) ([]engine.SnapshotEntry, error) {
 	if b.loadStoreSnapshots == nil {
 		return nil, nil
 	}
 	return b.loadStoreSnapshots(ctx, storeName, storeCfg)
 }
 
-func (b stubTUIBackend) InitProfile(ctx context.Context, profilesFile, profileName string, profileCfg cloudstic.BackupProfile, cfg *cloudstic.ProfilesConfig) error {
+func (b stubTUIBackend) InitProfile(ctx context.Context, profilesFile, profileName string, profileCfg profile.Profile, cfg *profile.Config) error {
 	if b.initProfile == nil {
 		return nil
 	}
 	return b.initProfile(ctx, profilesFile, profileName, profileCfg, cfg)
 }
 
-func (b stubTUIBackend) BackupProfile(ctx context.Context, profilesFile, profileName string, profileCfg cloudstic.BackupProfile, cfg *cloudstic.ProfilesConfig, reporter cloudstic.Reporter) error {
+func (b stubTUIBackend) BackupProfile(ctx context.Context, profilesFile, profileName string, profileCfg profile.Profile, cfg *profile.Config, reporter cloudstic.Reporter) error {
 	if b.backupProfile == nil {
 		return nil
 	}
 	return b.backupProfile(ctx, profilesFile, profileName, profileCfg, cfg, reporter)
 }
 
-func (b stubTUIBackend) CheckProfile(ctx context.Context, profilesFile, profileName string, profileCfg cloudstic.BackupProfile, cfg *cloudstic.ProfilesConfig, reporter cloudstic.Reporter) error {
+func (b stubTUIBackend) CheckProfile(ctx context.Context, profilesFile, profileName string, profileCfg profile.Profile, cfg *profile.Config, reporter cloudstic.Reporter) error {
 	if b.checkProfile == nil {
 		return nil
 	}
@@ -47,8 +49,8 @@ func (b stubTUIBackend) CheckProfile(ctx context.Context, profilesFile, profileN
 
 func TestTUIServiceLoadDashboardConfigInitializesMaps(t *testing.T) {
 	svc := NewTUIService(nil)
-	svc.loadProfiles = func(string) (*cloudstic.ProfilesConfig, error) {
-		return &cloudstic.ProfilesConfig{Version: 1}, nil
+	svc.loadProfiles = func(string) (*profile.Config, error) {
+		return &profile.Config{Version: 1}, nil
 	}
 
 	cfg, err := svc.LoadDashboardConfig("profiles.yaml")
@@ -66,19 +68,19 @@ func TestTUIServiceLoadDashboardConfigInitializesMaps(t *testing.T) {
 func TestTUIServiceRunProfileActionRunsInitWhenNeeded(t *testing.T) {
 	called := ""
 	svc := NewTUIService(stubTUIBackend{
-		initProfile: func(context.Context, string, string, cloudstic.BackupProfile, *cloudstic.ProfilesConfig) error {
+		initProfile: func(context.Context, string, string, profile.Profile, *profile.Config) error {
 			called = "init"
 			return nil
 		},
-		backupProfile: func(context.Context, string, string, cloudstic.BackupProfile, *cloudstic.ProfilesConfig, cloudstic.Reporter) error {
+		backupProfile: func(context.Context, string, string, profile.Profile, *profile.Config, cloudstic.Reporter) error {
 			called = "backup"
 			return nil
 		},
 	})
-	svc.loadProfiles = func(string) (*cloudstic.ProfilesConfig, error) {
-		return &cloudstic.ProfilesConfig{
+	svc.loadProfiles = func(string) (*profile.Config, error) {
+		return &profile.Config{
 			Version: 1,
-			Profiles: map[string]cloudstic.BackupProfile{
+			Profiles: map[string]profile.Profile{
 				"docs": {Source: "local:/docs", Store: "remote"},
 			},
 		}, nil
@@ -99,15 +101,15 @@ func TestTUIServiceRunProfileActionRunsInitWhenNeeded(t *testing.T) {
 func TestTUIServiceRunProfileActionRunsBackup(t *testing.T) {
 	called := ""
 	svc := NewTUIService(stubTUIBackend{
-		backupProfile: func(context.Context, string, string, cloudstic.BackupProfile, *cloudstic.ProfilesConfig, cloudstic.Reporter) error {
+		backupProfile: func(context.Context, string, string, profile.Profile, *profile.Config, cloudstic.Reporter) error {
 			called = "backup"
 			return nil
 		},
 	})
-	svc.loadProfiles = func(string) (*cloudstic.ProfilesConfig, error) {
-		return &cloudstic.ProfilesConfig{
+	svc.loadProfiles = func(string) (*profile.Config, error) {
+		return &profile.Config{
 			Version: 1,
-			Profiles: map[string]cloudstic.BackupProfile{
+			Profiles: map[string]profile.Profile{
 				"docs": {Source: "local:/docs", Store: "remote"},
 			},
 		}, nil
@@ -127,7 +129,7 @@ func TestTUIServiceRunProfileActionRunsBackup(t *testing.T) {
 
 func TestTUIServiceRunProfileActionPropagatesLoadError(t *testing.T) {
 	svc := NewTUIService(nil)
-	svc.loadProfiles = func(string) (*cloudstic.ProfilesConfig, error) {
+	svc.loadProfiles = func(string) (*profile.Config, error) {
 		return nil, errors.New("boom")
 	}
 
@@ -140,15 +142,15 @@ func TestTUIServiceRunProfileActionPropagatesLoadError(t *testing.T) {
 func TestTUIServiceRunProfileCheckRunsBackend(t *testing.T) {
 	called := ""
 	svc := NewTUIService(stubTUIBackend{
-		checkProfile: func(context.Context, string, string, cloudstic.BackupProfile, *cloudstic.ProfilesConfig, cloudstic.Reporter) error {
+		checkProfile: func(context.Context, string, string, profile.Profile, *profile.Config, cloudstic.Reporter) error {
 			called = "check"
 			return nil
 		},
 	})
-	svc.loadProfiles = func(string) (*cloudstic.ProfilesConfig, error) {
-		return &cloudstic.ProfilesConfig{
+	svc.loadProfiles = func(string) (*profile.Config, error) {
+		return &profile.Config{
 			Version: 1,
-			Profiles: map[string]cloudstic.BackupProfile{
+			Profiles: map[string]profile.Profile{
 				"docs": {Source: "local:/docs", Store: "remote"},
 			},
 		}, nil
@@ -169,10 +171,10 @@ func TestTUIServiceRunProfileCheckRunsBackend(t *testing.T) {
 
 func TestTUIServiceRunProfileCheckRejectsUninitializedRepo(t *testing.T) {
 	svc := NewTUIService(stubTUIBackend{})
-	svc.loadProfiles = func(string) (*cloudstic.ProfilesConfig, error) {
-		return &cloudstic.ProfilesConfig{
+	svc.loadProfiles = func(string) (*profile.Config, error) {
+		return &profile.Config{
 			Version: 1,
-			Profiles: map[string]cloudstic.BackupProfile{
+			Profiles: map[string]profile.Profile{
 				"docs": {Source: "local:/docs", Store: "remote"},
 			},
 		}, nil
@@ -189,22 +191,22 @@ func TestTUIServiceRunProfileCheckRejectsUninitializedRepo(t *testing.T) {
 
 func TestTUIServiceSaveProfilePersistsConfig(t *testing.T) {
 	svc := NewTUIService(nil)
-	svc.loadProfiles = func(string) (*cloudstic.ProfilesConfig, error) {
-		return &cloudstic.ProfilesConfig{
+	svc.loadProfiles = func(string) (*profile.Config, error) {
+		return &profile.Config{
 			Version: 1,
-			Stores: map[string]cloudstic.ProfileStore{
+			Stores: map[string]profile.Store{
 				"remote": {URI: "s3:bucket"},
 			},
-			Profiles: map[string]cloudstic.BackupProfile{},
+			Profiles: map[string]profile.Profile{},
 		}, nil
 	}
-	var saved *cloudstic.ProfilesConfig
-	svc.saveProfiles = func(_ string, cfg *cloudstic.ProfilesConfig) error {
+	var saved *profile.Config
+	svc.saveProfiles = func(_ string, cfg *profile.Config) error {
 		saved = cfg
 		return nil
 	}
 
-	err := svc.SaveProfile("profiles.yaml", "docs", cloudstic.BackupProfile{
+	err := svc.SaveProfile("profiles.yaml", "docs", profile.Profile{
 		Source: "local:/docs",
 		Store:  "remote",
 	})
@@ -221,16 +223,16 @@ func TestTUIServiceSaveProfilePersistsConfig(t *testing.T) {
 
 func TestTUIServiceDeleteProfileRemovesProfile(t *testing.T) {
 	svc := NewTUIService(nil)
-	svc.loadProfiles = func(string) (*cloudstic.ProfilesConfig, error) {
-		return &cloudstic.ProfilesConfig{
+	svc.loadProfiles = func(string) (*profile.Config, error) {
+		return &profile.Config{
 			Version: 1,
-			Profiles: map[string]cloudstic.BackupProfile{
+			Profiles: map[string]profile.Profile{
 				"docs": {Source: "local:/docs", Store: "remote"},
 			},
 		}, nil
 	}
-	var saved *cloudstic.ProfilesConfig
-	svc.saveProfiles = func(_ string, cfg *cloudstic.ProfilesConfig) error {
+	var saved *profile.Config
+	svc.saveProfiles = func(_ string, cfg *profile.Config) error {
 		saved = cfg
 		return nil
 	}
@@ -249,19 +251,19 @@ func TestTUIServiceDeleteProfileRemovesProfile(t *testing.T) {
 
 func TestTUIServiceSaveStorePersistsConfig(t *testing.T) {
 	svc := NewTUIService(nil)
-	svc.loadProfiles = func(string) (*cloudstic.ProfilesConfig, error) {
-		return &cloudstic.ProfilesConfig{
+	svc.loadProfiles = func(string) (*profile.Config, error) {
+		return &profile.Config{
 			Version: 1,
-			Stores:  map[string]cloudstic.ProfileStore{},
+			Stores:  map[string]profile.Store{},
 		}, nil
 	}
-	var saved *cloudstic.ProfilesConfig
-	svc.saveProfiles = func(_ string, cfg *cloudstic.ProfilesConfig) error {
+	var saved *profile.Config
+	svc.saveProfiles = func(_ string, cfg *profile.Config) error {
 		saved = cfg
 		return nil
 	}
 
-	err := svc.SaveStore("profiles.yaml", "remote", cloudstic.ProfileStore{URI: "local:/tmp/store"})
+	err := svc.SaveStore("profiles.yaml", "remote", profile.Store{URI: "local:/tmp/store"})
 	if err != nil {
 		t.Fatalf("SaveStore: %v", err)
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -6,9 +6,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cloudstic/cli/pkg/profile"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/cloudstic/cli/internal/engine"
 )
 
 // Model is the root Bubble Tea model for the interactive dashboard. This is
@@ -29,7 +30,7 @@ type Model struct {
 	// model probes every store concurrently on Init and rebuilds the
 	// dashboard from probes as they arrive, so the first paint shows
 	// "checking…" instead of blocking.
-	cfg    *engine.ProfilesConfig
+	cfg    *profile.Config
 	prober StoreProber
 	probes map[string]StoreProbe
 
@@ -75,7 +76,7 @@ func NewModel(d Dashboard) Model {
 // WithConfig attaches the profiles config and a store prober, enabling
 // concurrent probing on Init. The seeded dashboard should be a probe-less
 // skeleton (BuildDashboard(cfg, nil)) so the first frame renders immediately.
-func (m Model) WithConfig(cfg *engine.ProfilesConfig, prober StoreProber) Model {
+func (m Model) WithConfig(cfg *profile.Config, prober StoreProber) Model {
 	m.cfg = cfg
 	m.prober = prober
 	return m

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -4,18 +4,19 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cloudstic/cli/pkg/profile"
+
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/cloudstic/cli/internal/engine"
 )
 
 func testDashboard() Dashboard {
 	enabled := true
 	disabled := false
-	cfg := &engine.ProfilesConfig{
-		Stores: map[string]engine.ProfileStore{
+	cfg := &profile.Config{
+		Stores: map[string]profile.Store{
 			"remote": {URI: "s3:bucket/prod"},
 		},
-		Profiles: map[string]engine.BackupProfile{
+		Profiles: map[string]profile.Profile{
 			"alpha": {Source: "local:/tmp/alpha", Store: "remote", Enabled: &enabled},
 			"zeta":  {Source: "local:/tmp/zeta", Store: "remote", Enabled: &disabled},
 		},

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cloudstic/cli/pkg/profile"
+
 	"github.com/cloudstic/cli/internal/core"
 	"github.com/cloudstic/cli/internal/engine"
 )
@@ -146,9 +148,9 @@ type StoreProbe struct {
 // BuildDashboard derives the dashboard view-model from the profiles config and
 // whatever store probes have completed so far. A nil probes map yields the
 // skeleton the model renders on its first frame, before any probe returns.
-func BuildDashboard(cfg *engine.ProfilesConfig, probes map[string]StoreProbe) Dashboard {
+func BuildDashboard(cfg *profile.Config, probes map[string]StoreProbe) Dashboard {
 	if cfg == nil {
-		cfg = &engine.ProfilesConfig{}
+		cfg = &profile.Config{}
 	}
 	if probes == nil {
 		probes = map[string]StoreProbe{}
@@ -271,7 +273,7 @@ func deriveProfileActions(status ProfileStatus, storeHealth StoreHealth) []Profi
 	}
 }
 
-func profileStatus(cfg *engine.ProfilesConfig, p engine.BackupProfile, probe StoreProbe) (ProfileStatus, string) {
+func profileStatus(cfg *profile.Config, p profile.Profile, probe StoreProbe) (ProfileStatus, string) {
 	if !p.IsEnabled() {
 		return ProfileStatusDisabled, "profile disabled"
 	}
@@ -362,7 +364,7 @@ func latestBackup(sourceURI string, entries []engine.SnapshotEntry) (string, str
 	return latest.Created.Local().Format("2006-01-02 15:04"), latest.Ref, latest.Created
 }
 
-func deriveStoreHealth(cfg *engine.ProfilesConfig, p engine.BackupProfile, probe StoreProbe) StoreHealth {
+func deriveStoreHealth(cfg *profile.Config, p profile.Profile, probe StoreProbe) StoreHealth {
 	if !p.IsEnabled() {
 		return StoreHealthDisabled
 	}

--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cloudstic/cli/pkg/profile"
+
 	"github.com/cloudstic/cli/internal/core"
 	"github.com/cloudstic/cli/internal/engine"
 )
@@ -11,14 +13,14 @@ import (
 func TestBuildDashboard_SortsProfilesAndCountsSections(t *testing.T) {
 	enabled := true
 	disabled := false
-	cfg := &engine.ProfilesConfig{
-		Stores: map[string]engine.ProfileStore{
+	cfg := &profile.Config{
+		Stores: map[string]profile.Store{
 			"remote": {URI: "s3:bucket/prod"},
 		},
-		Auth: map[string]engine.ProfileAuth{
+		Auth: map[string]profile.Auth{
 			"google-work": {Provider: "google"},
 		},
-		Profiles: map[string]engine.BackupProfile{
+		Profiles: map[string]profile.Profile{
 			"zeta": {
 				Source:  "local:/tmp/zeta",
 				Store:   "remote",
@@ -100,11 +102,11 @@ func TestBuildDashboard_SortsProfilesAndCountsSections(t *testing.T) {
 }
 
 func TestBuildDashboard_NormalizesStoreProbeErrors(t *testing.T) {
-	cfg := &engine.ProfilesConfig{
-		Stores: map[string]engine.ProfileStore{
+	cfg := &profile.Config{
+		Stores: map[string]profile.Store{
 			"1": {URI: "local:/tmp/store"},
 		},
-		Profiles: map[string]engine.BackupProfile{
+		Profiles: map[string]profile.Profile{
 			"desktop": {
 				Source: "local:/tmp/Desktop",
 				Store:  "1",
@@ -145,11 +147,11 @@ func TestBuildDashboard_NormalizesStoreProbeErrors(t *testing.T) {
 }
 
 func TestBuildDashboard_UsesStoreProbeSnapshots(t *testing.T) {
-	cfg := &engine.ProfilesConfig{
-		Stores: map[string]engine.ProfileStore{
+	cfg := &profile.Config{
+		Stores: map[string]profile.Store{
 			"remote": {URI: "s3:bucket/prod"},
 		},
-		Profiles: map[string]engine.BackupProfile{
+		Profiles: map[string]profile.Profile{
 			"docs": {Source: "local:/docs", Store: "remote"},
 		},
 	}
@@ -172,11 +174,11 @@ func TestBuildDashboard_UsesStoreProbeSnapshots(t *testing.T) {
 }
 
 func TestBuildDashboard_BuildsProfileHistoryNewestFirst(t *testing.T) {
-	cfg := &engine.ProfilesConfig{
-		Stores: map[string]engine.ProfileStore{
+	cfg := &profile.Config{
+		Stores: map[string]profile.Store{
 			"remote": {URI: "s3:bucket/prod"},
 		},
-		Profiles: map[string]engine.BackupProfile{
+		Profiles: map[string]profile.Profile{
 			"docs": {Source: "local:/docs", Store: "remote"},
 		},
 	}
@@ -223,11 +225,11 @@ func TestBuildDashboard_BuildsProfileHistoryNewestFirst(t *testing.T) {
 }
 
 func TestBuildDashboard_StoreErrorBecomesWarning(t *testing.T) {
-	cfg := &engine.ProfilesConfig{
-		Stores: map[string]engine.ProfileStore{
+	cfg := &profile.Config{
+		Stores: map[string]profile.Store{
 			"remote": {URI: "s3:bucket/prod"},
 		},
-		Profiles: map[string]engine.BackupProfile{
+		Profiles: map[string]profile.Profile{
 			"docs": {Source: "local:/docs", Store: "remote"},
 		},
 	}

--- a/internal/tui/forms_bridge.go
+++ b/internal/tui/forms_bridge.go
@@ -2,8 +2,9 @@ package tui
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/cloudstic/cli/internal/engine"
+
 	"github.com/cloudstic/cli/internal/tui/forms"
+	"github.com/cloudstic/cli/pkg/profile"
 )
 
 // FormsBackend is the domain boundary the model uses for profile and store
@@ -21,7 +22,7 @@ type FormsBackend interface {
 	// DeleteProfile removes a profile from the profiles file.
 	DeleteProfile(name string) error
 	// Reload re-reads the profiles config after a mutation.
-	Reload() (*engine.ProfilesConfig, error)
+	Reload() (*profile.Config, error)
 }
 
 // formFrame is one level of the (possibly nested) form overlay. intent records
@@ -68,7 +69,7 @@ type confirmState struct {
 // configReloadedMsg carries a reloaded profiles config back into the model
 // after a form save or delete, with the profile name to reselect.
 type configReloadedMsg struct {
-	cfg        *engine.ProfilesConfig
+	cfg        *profile.Config
 	err        error
 	selectName string
 }

--- a/internal/tui/forms_bridge_test.go
+++ b/internal/tui/forms_bridge_test.go
@@ -4,26 +4,28 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cloudstic/cli/pkg/profile"
+
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/cloudstic/cli/internal/engine"
+
 	"github.com/cloudstic/cli/internal/tui/forms"
 )
 
 // stubFormsBackend implements FormsBackend for model-level tests.
 type stubFormsBackend struct {
-	stores      []string
-	cfg         *engine.ProfilesConfig
-	saved       bool
-	deleted     string
+	stores       []string
+	cfg          *profile.Config
+	saved        bool
+	deleted      string
 	reloadHits   int
 	savedStore   string
 	storeExists  map[string]bool
 	storedSecret string
 }
 
-func (b *stubFormsBackend) StoreOptions() []string                 { return b.stores }
-func (b *stubFormsBackend) ProviderForSourceType(string) string    { return "" }
-func (b *stubFormsBackend) AuthOptions(string) []string            { return nil }
+func (b *stubFormsBackend) StoreOptions() []string              { return b.stores }
+func (b *stubFormsBackend) ProviderForSourceType(string) string { return "" }
+func (b *stubFormsBackend) AuthOptions(string) []string         { return nil }
 func (b *stubFormsBackend) SourceParts(uri string) (string, string) {
 	for i := 0; i < len(uri); i++ {
 		if uri[i] == ':' {
@@ -32,9 +34,9 @@ func (b *stubFormsBackend) SourceParts(uri string) (string, string) {
 	}
 	return uri, ""
 }
-func (b *stubFormsBackend) SourceDetailLabel(string) string   { return "Path" }
-func (b *stubFormsBackend) SourceDetailRequired(string) bool  { return true }
-func (b *stubFormsBackend) SourceExample(string) string       { return "" }
+func (b *stubFormsBackend) SourceDetailLabel(string) string  { return "Path" }
+func (b *stubFormsBackend) SourceDetailRequired(string) bool { return true }
+func (b *stubFormsBackend) SourceExample(string) string      { return "" }
 func (b *stubFormsBackend) ComposeSource(t, v string) (string, error) {
 	if v == "" {
 		return "", nil
@@ -51,7 +53,7 @@ func (b *stubFormsBackend) DeleteProfile(name string) error {
 	b.deleted = name
 	return nil
 }
-func (b *stubFormsBackend) Reload() (*engine.ProfilesConfig, error) {
+func (b *stubFormsBackend) Reload() (*profile.Config, error) {
 	b.reloadHits++
 	return b.cfg, nil
 }
@@ -90,7 +92,7 @@ func (b *stubFormsBackend) ParseRef(ref string) (string, string, bool) {
 	}
 	return scheme, "", true
 }
-func (b *stubFormsBackend) ValidateRef(string) error         { return nil }
+func (b *stubFormsBackend) ValidateRef(string) error            { return nil }
 func (b *stubFormsBackend) StoreSecret(ref, value string) error { b.storedSecret = ref; return nil }
 
 func formsTestDashboard() Dashboard {
@@ -107,7 +109,7 @@ func keyPress(s string) tea.KeyMsg {
 }
 
 func TestModel_OpenCreateProfileForm(t *testing.T) {
-	backend := &stubFormsBackend{stores: []string{"s1"}, cfg: &engine.ProfilesConfig{}}
+	backend := &stubFormsBackend{stores: []string{"s1"}, cfg: &profile.Config{}}
 	m := NewModel(formsTestDashboard()).WithForms(backend)
 
 	next, _ := m.Update(keyPress("n"))
@@ -121,8 +123,8 @@ func TestModel_OpenCreateProfileForm(t *testing.T) {
 }
 
 func TestModel_CreateProfileSavesAndReloads(t *testing.T) {
-	backend := &stubFormsBackend{stores: []string{"s1"}, cfg: &engine.ProfilesConfig{}}
-	m := NewModel(formsTestDashboard()).WithForms(backend).WithConfig(&engine.ProfilesConfig{}, nil)
+	backend := &stubFormsBackend{stores: []string{"s1"}, cfg: &profile.Config{}}
+	m := NewModel(formsTestDashboard()).WithForms(backend).WithConfig(&profile.Config{}, nil)
 
 	next, _ := m.Update(keyPress("n"))
 	m = next.(Model)
@@ -163,8 +165,8 @@ func TestModel_CreateProfileSavesAndReloads(t *testing.T) {
 }
 
 func TestModel_DeleteProfileConfirmFlow(t *testing.T) {
-	backend := &stubFormsBackend{stores: []string{"s1"}, cfg: &engine.ProfilesConfig{}}
-	m := NewModel(formsTestDashboard()).WithForms(backend).WithConfig(&engine.ProfilesConfig{}, nil)
+	backend := &stubFormsBackend{stores: []string{"s1"}, cfg: &profile.Config{}}
+	m := NewModel(formsTestDashboard()).WithForms(backend).WithConfig(&profile.Config{}, nil)
 
 	next, _ := m.Update(keyPress("d"))
 	m = next.(Model)
@@ -190,7 +192,7 @@ func TestModel_DeleteProfileConfirmFlow(t *testing.T) {
 }
 
 func TestModel_DeleteProfileCancel(t *testing.T) {
-	backend := &stubFormsBackend{stores: []string{"s1"}, cfg: &engine.ProfilesConfig{}}
+	backend := &stubFormsBackend{stores: []string{"s1"}, cfg: &profile.Config{}}
 	m := NewModel(formsTestDashboard()).WithForms(backend)
 
 	next, _ := m.Update(keyPress("d"))
@@ -206,7 +208,7 @@ func TestModel_DeleteProfileCancel(t *testing.T) {
 }
 
 func TestModel_NestedEditSecretFromStoreForm(t *testing.T) {
-	backend := &stubFormsBackend{stores: []string{"s1"}, cfg: &engine.ProfilesConfig{}}
+	backend := &stubFormsBackend{stores: []string{"s1"}, cfg: &profile.Config{}}
 	m := NewModel(formsTestDashboard()).WithForms(backend)
 
 	// Open profile form, jump to store field, open a nested create-store form.
@@ -273,7 +275,7 @@ func TestModel_FormKeysNoOpWithoutBackend(t *testing.T) {
 }
 
 func TestModel_NestedCreateStoreFromProfileForm(t *testing.T) {
-	backend := &stubFormsBackend{stores: []string{"s1"}, cfg: &engine.ProfilesConfig{}}
+	backend := &stubFormsBackend{stores: []string{"s1"}, cfg: &profile.Config{}}
 	m := NewModel(formsTestDashboard()).WithForms(backend)
 
 	// Open the create-profile form.
@@ -332,4 +334,3 @@ func TestModel_NestedCreateStoreFromProfileForm(t *testing.T) {
 		t.Fatalf("profile store field=%q want newstore selected after nested create", got)
 	}
 }
-

--- a/internal/tui/probe.go
+++ b/internal/tui/probe.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"time"
 
+	"github.com/cloudstic/cli/pkg/profile"
+
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/cloudstic/cli/internal/engine"
 )
 
 // StoreProbeTimeout bounds a single store health probe so one unreachable
@@ -16,7 +17,7 @@ const StoreProbeTimeout = 15 * time.Second
 // StoreProber checks the health of a single store. Implementations must honor
 // ctx (including its deadline) and must not block past it.
 type StoreProber interface {
-	Probe(ctx context.Context, name string, store engine.ProfileStore) StoreProbe
+	Probe(ctx context.Context, name string, store profile.Store) StoreProbe
 }
 
 // probeResultMsg reports the outcome of one store probe back into the model.
@@ -27,7 +28,7 @@ type probeResultMsg struct {
 
 // probeStoreCmd probes a single store under a per-store timeout and reports the
 // result. Batching several of these yields concurrent, bounded probing.
-func probeStoreCmd(prober StoreProber, name string, store engine.ProfileStore) tea.Cmd {
+func probeStoreCmd(prober StoreProber, name string, store profile.Store) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), StoreProbeTimeout)
 		defer cancel()

--- a/internal/tui/probe_test.go
+++ b/internal/tui/probe_test.go
@@ -5,28 +5,29 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cloudstic/cli/pkg/profile"
+
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/cloudstic/cli/internal/engine"
 )
 
 type stubProber struct {
 	results map[string]StoreProbe
 }
 
-func (p stubProber) Probe(_ context.Context, name string, _ engine.ProfileStore) StoreProbe {
+func (p stubProber) Probe(_ context.Context, name string, _ profile.Store) StoreProbe {
 	if probe, ok := p.results[name]; ok {
 		return probe
 	}
 	return StoreProbe{Status: "error", Error: "no result"}
 }
 
-func probeConfig() *engine.ProfilesConfig {
+func probeConfig() *profile.Config {
 	enabled := true
-	return &engine.ProfilesConfig{
-		Stores: map[string]engine.ProfileStore{
+	return &profile.Config{
+		Stores: map[string]profile.Store{
 			"remote": {URI: "s3:bucket/prod"},
 		},
-		Profiles: map[string]engine.BackupProfile{
+		Profiles: map[string]profile.Profile{
 			"alpha": {Source: "local:/tmp/alpha", Store: "remote", Enabled: &enabled},
 		},
 	}
@@ -84,7 +85,7 @@ func TestModel_ProbeResultPreservesSelection(t *testing.T) {
 func TestProbeStoreCmd_UsesTimeout(t *testing.T) {
 	var gotDeadline bool
 	prober := deadlineProber{seen: &gotDeadline}
-	cmd := probeStoreCmd(prober, "remote", engine.ProfileStore{})
+	cmd := probeStoreCmd(prober, "remote", profile.Store{})
 	msg := cmd()
 	if _, ok := msg.(probeResultMsg); !ok {
 		t.Fatalf("probeStoreCmd returned %T want probeResultMsg", msg)
@@ -98,7 +99,7 @@ type deadlineProber struct {
 	seen *bool
 }
 
-func (p deadlineProber) Probe(ctx context.Context, _ string, _ engine.ProfileStore) StoreProbe {
+func (p deadlineProber) Probe(ctx context.Context, _ string, _ profile.Store) StoreProbe {
 	if _, ok := ctx.Deadline(); ok {
 		*p.seen = true
 	}

--- a/internal/workstation/discover.go
+++ b/internal/workstation/discover.go
@@ -1,4 +1,4 @@
-package engine
+package workstation
 
 import (
 	"context"

--- a/internal/workstation/discover_darwin.go
+++ b/internal/workstation/discover_darwin.go
@@ -1,6 +1,6 @@
 //go:build darwin
 
-package engine
+package workstation
 
 import (
 	"os/exec"

--- a/internal/workstation/discover_darwin_test.go
+++ b/internal/workstation/discover_darwin_test.go
@@ -1,6 +1,6 @@
 //go:build darwin
 
-package engine
+package workstation
 
 import "testing"
 

--- a/internal/workstation/discover_linux.go
+++ b/internal/workstation/discover_linux.go
@@ -1,6 +1,6 @@
 //go:build linux
 
-package engine
+package workstation
 
 import (
 	"os"

--- a/internal/workstation/discover_linux_test.go
+++ b/internal/workstation/discover_linux_test.go
@@ -1,6 +1,6 @@
 //go:build linux
 
-package engine
+package workstation
 
 import "testing"
 

--- a/internal/workstation/discover_stub.go
+++ b/internal/workstation/discover_stub.go
@@ -1,6 +1,6 @@
 //go:build !darwin && !linux && !windows
 
-package engine
+package workstation
 
 func discoverLocalCandidates() ([]discoverCandidate, error) {
 	return nil, nil

--- a/internal/workstation/discover_test.go
+++ b/internal/workstation/discover_test.go
@@ -1,4 +1,4 @@
-package engine
+package workstation
 
 import (
 	"context"

--- a/internal/workstation/discover_windows.go
+++ b/internal/workstation/discover_windows.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package engine
+package workstation
 
 import (
 	"strings"

--- a/internal/workstation/setup.go
+++ b/internal/workstation/setup.go
@@ -1,4 +1,4 @@
-package engine
+package workstation
 
 import (
 	"context"
@@ -9,12 +9,14 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+
+	"github.com/cloudstic/cli/pkg/profile"
 )
 
 var (
 	workstationDiscoverSourcesFunc = DiscoverSources
 	workstationUserHomeDirFunc     = os.UserHomeDir
-	workstationHostnameFunc        = os.Hostname
+	hostnameFunc                   = os.Hostname
 	workstationPathExistsFunc      = func(path string) bool {
 		info, err := os.Stat(path)
 		return err == nil && info.IsDir()
@@ -22,27 +24,27 @@ var (
 	workstationGOOS = runtime.GOOS
 )
 
-type WorkstationSetupOption func(*workstationSetupOptions)
+type SetupOption func(*setupOptions)
 
-type workstationSetupOptions struct {
-	profiles *ProfilesConfig
+type setupOptions struct {
+	profiles *profile.Config
 	storeRef string
 	dryRun   bool
 }
 
-func WithWorkstationProfiles(cfg *ProfilesConfig) WorkstationSetupOption {
-	return func(o *workstationSetupOptions) { o.profiles = cfg }
+func WithProfiles(cfg *profile.Config) SetupOption {
+	return func(o *setupOptions) { o.profiles = cfg }
 }
 
-func WithWorkstationStoreRef(name string) WorkstationSetupOption {
-	return func(o *workstationSetupOptions) { o.storeRef = strings.TrimSpace(name) }
+func WithStoreRef(name string) SetupOption {
+	return func(o *setupOptions) { o.storeRef = strings.TrimSpace(name) }
 }
 
-func WithWorkstationDryRun() WorkstationSetupOption {
-	return func(o *workstationSetupOptions) { o.dryRun = true }
+func WithDryRun() SetupOption {
+	return func(o *setupOptions) { o.dryRun = true }
 }
 
-type WorkstationFolderCandidate struct {
+type FolderCandidate struct {
 	Key      string `json:"key"`
 	Label    string `json:"label"`
 	Category string `json:"category"`
@@ -50,7 +52,7 @@ type WorkstationFolderCandidate struct {
 	Selected bool   `json:"selected"`
 }
 
-type WorkstationProfileDraft struct {
+type ProfileDraft struct {
 	Name         string   `json:"name"`
 	SourceURI    string   `json:"source_uri"`
 	StoreRef     string   `json:"store_ref,omitempty"`
@@ -60,32 +62,32 @@ type WorkstationProfileDraft struct {
 	Selected     bool     `json:"selected"`
 }
 
-type WorkstationCoverageSummary struct {
+type CoverageSummary struct {
 	ProtectedNow         []string `json:"protected_now,omitempty"`
 	SkippedIntentionally []string `json:"skipped_intentionally,omitempty"`
 	NotAvailableNow      []string `json:"not_available_now,omitempty"`
 	Warnings             []string `json:"warnings,omitempty"`
 }
 
-type WorkstationApplyResult struct {
+type ApplyResult struct {
 	ProfilesCreated int      `json:"profiles_created"`
 	ProfilesUpdated int      `json:"profiles_updated"`
 	ProfileNames    []string `json:"profile_names,omitempty"`
 }
 
-type WorkstationSetupResult struct {
-	Plan    *WorkstationSetupPlan   `json:"plan,omitempty"`
-	Applied *WorkstationApplyResult `json:"applied,omitempty"`
+type SetupResult struct {
+	Plan    *SetupPlan   `json:"plan,omitempty"`
+	Applied *ApplyResult `json:"applied,omitempty"`
 }
 
-type WorkstationSetupPlan struct {
-	Hostname        string                       `json:"hostname"`
-	StoreRef        string                       `json:"store_ref,omitempty"`
-	StoreAction     string                       `json:"store_action"`
-	Folders         []WorkstationFolderCandidate `json:"folders,omitempty"`
-	PortableSources []DiscoveredSource           `json:"portable_sources,omitempty"`
-	Profiles        []WorkstationProfileDraft    `json:"profiles,omitempty"`
-	Coverage        WorkstationCoverageSummary   `json:"coverage"`
+type SetupPlan struct {
+	Hostname        string             `json:"hostname"`
+	StoreRef        string             `json:"store_ref,omitempty"`
+	StoreAction     string             `json:"store_action"`
+	Folders         []FolderCandidate  `json:"folders,omitempty"`
+	PortableSources []DiscoveredSource `json:"portable_sources,omitempty"`
+	Profiles        []ProfileDraft     `json:"profiles,omitempty"`
+	Coverage        CoverageSummary    `json:"coverage"`
 }
 
 type workstationFolderSpec struct {
@@ -95,14 +97,14 @@ type workstationFolderSpec struct {
 	path     string
 }
 
-func PlanWorkstationSetup(ctx context.Context, opts ...WorkstationSetupOption) (*WorkstationSetupPlan, error) {
-	options := workstationSetupOptions{}
+func Plan(ctx context.Context, opts ...SetupOption) (*SetupPlan, error) {
+	options := setupOptions{}
 	for _, opt := range opts {
 		opt(&options)
 	}
 
-	cfg := normalizeProfilesConfig(options.profiles)
-	hostname, err := workstationHostnameFunc()
+	cfg := profile.Normalize(options.profiles)
+	hostname, err := hostnameFunc()
 	if err != nil {
 		return nil, fmt.Errorf("resolve hostname: %w", err)
 	}
@@ -129,7 +131,7 @@ func PlanWorkstationSetup(ctx context.Context, opts ...WorkstationSetupOption) (
 
 	storeRef, storeAction, warnings := resolveWorkstationStore(cfg, options.storeRef)
 
-	plan := &WorkstationSetupPlan{
+	plan := &SetupPlan{
 		Hostname:        hostname,
 		StoreRef:        storeRef,
 		StoreAction:     storeAction,
@@ -147,7 +149,7 @@ func PlanWorkstationSetup(ctx context.Context, opts ...WorkstationSetupOption) (
 			continue
 		}
 		name, action := nextWorkstationProfileName(cfg, usedNames, folder.Key, hostname, "local:"+folder.Path)
-		plan.Profiles = append(plan.Profiles, WorkstationProfileDraft{
+		plan.Profiles = append(plan.Profiles, ProfileDraft{
 			Name:         name,
 			SourceURI:    "local:" + folder.Path,
 			StoreRef:     storeRef,
@@ -162,7 +164,7 @@ func PlanWorkstationSetup(ctx context.Context, opts ...WorkstationSetupOption) (
 	for _, src := range portable {
 		base := sanitizeWorkstationName(firstNonEmpty(src.DriveName, src.DisplayName, filepath.Base(src.MountPoint), "portable"))
 		name, action := nextWorkstationProfileName(cfg, usedNames, base, hostname, src.SourceURI)
-		plan.Profiles = append(plan.Profiles, WorkstationProfileDraft{
+		plan.Profiles = append(plan.Profiles, ProfileDraft{
 			Name:         name,
 			SourceURI:    src.SourceURI,
 			StoreRef:     storeRef,
@@ -179,23 +181,23 @@ func PlanWorkstationSetup(ctx context.Context, opts ...WorkstationSetupOption) (
 	return plan, nil
 }
 
-func SetupWorkstation(ctx context.Context, opts ...WorkstationSetupOption) (*WorkstationSetupResult, error) {
-	options := workstationSetupOptions{}
+func Setup(ctx context.Context, opts ...SetupOption) (*SetupResult, error) {
+	options := setupOptions{}
 	for _, opt := range opts {
 		opt(&options)
 	}
 
-	plan, err := PlanWorkstationSetup(ctx, opts...)
+	plan, err := Plan(ctx, opts...)
 	if err != nil {
 		return nil, err
 	}
 
-	result := &WorkstationSetupResult{Plan: plan}
+	result := &SetupResult{Plan: plan}
 	if options.dryRun {
 		return result, nil
 	}
 
-	applied, err := ApplyWorkstationSetupPlan(options.profiles, plan)
+	applied, err := Apply(options.profiles, plan)
 	if err != nil {
 		return nil, err
 	}
@@ -203,13 +205,13 @@ func SetupWorkstation(ctx context.Context, opts ...WorkstationSetupOption) (*Wor
 	return result, nil
 }
 
-func ApplyWorkstationSetupPlan(cfg *ProfilesConfig, plan *WorkstationSetupPlan) (*WorkstationApplyResult, error) {
+func Apply(cfg *profile.Config, plan *SetupPlan) (*ApplyResult, error) {
 	if plan == nil {
 		return nil, fmt.Errorf("workstation setup plan is required")
 	}
-	cfg = normalizeProfilesConfig(cfg)
+	cfg = profile.Normalize(cfg)
 
-	result := &WorkstationApplyResult{
+	result := &ApplyResult{
 		ProfileNames: make([]string, 0, len(plan.Profiles)),
 	}
 
@@ -230,7 +232,7 @@ func ApplyWorkstationSetupPlan(cfg *ProfilesConfig, plan *WorkstationSetupPlan) 
 			result.ProfilesCreated++
 		}
 
-		cfg.Profiles[draft.Name] = BackupProfile{
+		cfg.Profiles[draft.Name] = profile.Profile{
 			Source: draft.SourceURI,
 			Store:  draft.StoreRef,
 			Tags:   slices.Clone(draft.Tags),
@@ -242,7 +244,7 @@ func ApplyWorkstationSetupPlan(cfg *ProfilesConfig, plan *WorkstationSetupPlan) 
 	return result, nil
 }
 
-func discoverWorkstationFolders() ([]WorkstationFolderCandidate, []string, error) {
+func discoverWorkstationFolders() ([]FolderCandidate, []string, error) {
 	home, err := workstationUserHomeDirFunc()
 	if err != nil {
 		return nil, nil, fmt.Errorf("resolve home directory: %w", err)
@@ -270,7 +272,7 @@ func discoverWorkstationFolders() ([]WorkstationFolderCandidate, []string, error
 		addSpec(sanitizeWorkstationName(name), name, "developer projects", name)
 	}
 
-	folders := make([]WorkstationFolderCandidate, 0, len(specs))
+	folders := make([]FolderCandidate, 0, len(specs))
 	seenPaths := map[string]struct{}{}
 	for _, spec := range specs {
 		if !workstationPathExistsFunc(spec.path) {
@@ -281,7 +283,7 @@ func discoverWorkstationFolders() ([]WorkstationFolderCandidate, []string, error
 			continue
 		}
 		seenPaths[cleanPath] = struct{}{}
-		folders = append(folders, WorkstationFolderCandidate{
+		folders = append(folders, FolderCandidate{
 			Key:      spec.key,
 			Label:    spec.label,
 			Category: spec.category,
@@ -289,7 +291,7 @@ func discoverWorkstationFolders() ([]WorkstationFolderCandidate, []string, error
 			Selected: true,
 		})
 	}
-	slices.SortFunc(folders, func(a, b WorkstationFolderCandidate) int {
+	slices.SortFunc(folders, func(a, b FolderCandidate) int {
 		if v := strings.Compare(a.Category, b.Category); v != 0 {
 			return v
 		}
@@ -305,7 +307,7 @@ func discoverWorkstationFolders() ([]WorkstationFolderCandidate, []string, error
 	return folders, skipped, nil
 }
 
-func resolveWorkstationStore(cfg *ProfilesConfig, requested string) (string, string, []string) {
+func resolveWorkstationStore(cfg *profile.Config, requested string) (string, string, []string) {
 	if requested != "" {
 		if _, ok := cfg.Stores[requested]; ok {
 			return requested, "use-existing", nil
@@ -324,7 +326,7 @@ func resolveWorkstationStore(cfg *ProfilesConfig, requested string) (string, str
 	}
 }
 
-func nextWorkstationProfileName(cfg *ProfilesConfig, used map[string]struct{}, base, hostname, sourceURI string) (string, string) {
+func nextWorkstationProfileName(cfg *profile.Config, used map[string]struct{}, base, hostname, sourceURI string) (string, string) {
 	base = sanitizeWorkstationName(base)
 	if base == "" {
 		base = "workstation"

--- a/internal/workstation/setup_test.go
+++ b/internal/workstation/setup_test.go
@@ -1,17 +1,19 @@
-package engine
+package workstation
 
 import (
 	"context"
 	"errors"
 	"reflect"
 	"testing"
+
+	"github.com/cloudstic/cli/pkg/profile"
 )
 
-func TestPlanWorkstationSetup_BuildsPreview(t *testing.T) {
+func TestPlan_BuildsPreview(t *testing.T) {
 	reset := stubWorkstationSetupEnv(t)
 	defer reset()
 
-	workstationHostnameFunc = func() (string, error) { return "MacBook-Pro", nil }
+	hostnameFunc = func() (string, error) { return "MacBook-Pro", nil }
 	workstationUserHomeDirFunc = func() (string, error) { return "/Users/test", nil }
 	workstationGOOS = "darwin"
 	workstationPathExistsFunc = func(path string) bool {
@@ -29,19 +31,19 @@ func TestPlanWorkstationSetup_BuildsPreview(t *testing.T) {
 		}, nil
 	}
 
-	cfg := &ProfilesConfig{
-		Stores: map[string]ProfileStore{
+	cfg := &profile.Config{
+		Stores: map[string]profile.Store{
 			"primary": {URI: "s3:bucket"},
 		},
-		Profiles: map[string]BackupProfile{
+		Profiles: map[string]profile.Profile{
 			"documents": {Source: "local:/Users/test/Documents"},
 			"archive":   {Source: "local:/old-archive"},
 		},
 	}
 
-	plan, err := PlanWorkstationSetup(context.Background(), WithWorkstationProfiles(cfg))
+	plan, err := Plan(context.Background(), WithProfiles(cfg))
 	if err != nil {
-		t.Fatalf("PlanWorkstationSetup: %v", err)
+		t.Fatalf("Plan: %v", err)
 	}
 
 	if plan.StoreRef != "primary" || plan.StoreAction != "use-existing" {
@@ -51,7 +53,7 @@ func TestPlanWorkstationSetup_BuildsPreview(t *testing.T) {
 		t.Fatalf("unexpected portable sources: %#v", plan.PortableSources)
 	}
 
-	gotProfiles := map[string]WorkstationProfileDraft{}
+	gotProfiles := map[string]ProfileDraft{}
 	for _, profile := range plan.Profiles {
 		gotProfiles[profile.Name] = profile
 	}
@@ -69,24 +71,24 @@ func TestPlanWorkstationSetup_BuildsPreview(t *testing.T) {
 	}
 }
 
-func TestPlanWorkstationSetup_StoreWarnings(t *testing.T) {
+func TestPlan_StoreWarnings(t *testing.T) {
 	reset := stubWorkstationSetupEnv(t)
 	defer reset()
 
-	workstationHostnameFunc = func() (string, error) { return "host", nil }
+	hostnameFunc = func() (string, error) { return "host", nil }
 	workstationUserHomeDirFunc = func() (string, error) { return "/home/test", nil }
 	workstationPathExistsFunc = func(path string) bool { return path == "/home/test/Documents" }
 	workstationDiscoverSourcesFunc = func(context.Context) ([]DiscoveredSource, error) { return nil, nil }
 
-	cfg := &ProfilesConfig{
-		Stores: map[string]ProfileStore{
+	cfg := &profile.Config{
+		Stores: map[string]profile.Store{
 			"a": {URI: "local:/a"},
 			"b": {URI: "local:/b"},
 		},
 	}
-	plan, err := PlanWorkstationSetup(context.Background(), WithWorkstationProfiles(cfg))
+	plan, err := Plan(context.Background(), WithProfiles(cfg))
 	if err != nil {
-		t.Fatalf("PlanWorkstationSetup: %v", err)
+		t.Fatalf("Plan: %v", err)
 	}
 	if plan.StoreRef != "" || plan.StoreAction != "choose-existing" {
 		t.Fatalf("unexpected store selection: %#v", plan)
@@ -96,18 +98,18 @@ func TestPlanWorkstationSetup_StoreWarnings(t *testing.T) {
 	}
 }
 
-func TestPlanWorkstationSetup_ErrorPaths(t *testing.T) {
+func TestPlan_ErrorPaths(t *testing.T) {
 	reset := stubWorkstationSetupEnv(t)
 	defer reset()
 
-	workstationHostnameFunc = func() (string, error) { return "", errors.New("boom") }
-	if _, err := PlanWorkstationSetup(context.Background()); err == nil {
+	hostnameFunc = func() (string, error) { return "", errors.New("boom") }
+	if _, err := Plan(context.Background()); err == nil {
 		t.Fatal("expected hostname error")
 	}
 
-	workstationHostnameFunc = func() (string, error) { return "host", nil }
+	hostnameFunc = func() (string, error) { return "host", nil }
 	workstationUserHomeDirFunc = func() (string, error) { return "", errors.New("no home") }
-	if _, err := PlanWorkstationSetup(context.Background()); err == nil {
+	if _, err := Plan(context.Background()); err == nil {
 		t.Fatal("expected home dir error")
 	}
 
@@ -116,25 +118,25 @@ func TestPlanWorkstationSetup_ErrorPaths(t *testing.T) {
 	workstationDiscoverSourcesFunc = func(context.Context) ([]DiscoveredSource, error) {
 		return nil, errors.New("discover failed")
 	}
-	if _, err := PlanWorkstationSetup(context.Background()); err == nil {
+	if _, err := Plan(context.Background()); err == nil {
 		t.Fatal("expected discover error")
 	}
 }
 
-func TestApplyWorkstationSetupPlan(t *testing.T) {
-	cfg := &ProfilesConfig{
-		Profiles: map[string]BackupProfile{
+func TestApply(t *testing.T) {
+	cfg := &profile.Config{
+		Profiles: map[string]profile.Profile{
 			"documents": {Source: "local:/old"},
 		},
 	}
-	result, err := ApplyWorkstationSetupPlan(cfg, &WorkstationSetupPlan{
-		Profiles: []WorkstationProfileDraft{
+	result, err := Apply(cfg, &SetupPlan{
+		Profiles: []ProfileDraft{
 			{Name: "documents", SourceURI: "local:/Users/test/Documents", StoreRef: "primary", Tags: []string{"workstation"}, Selected: true},
 			{Name: "archive", SourceURI: "local:/Volumes/Archive", StoreRef: "primary", Tags: []string{"portable", "workstation"}, Selected: true},
 		},
 	})
 	if err != nil {
-		t.Fatalf("ApplyWorkstationSetupPlan: %v", err)
+		t.Fatalf("Apply: %v", err)
 	}
 	if result.ProfilesCreated != 1 || result.ProfilesUpdated != 1 {
 		t.Fatalf("unexpected counts: %#v", result)
@@ -147,16 +149,16 @@ func TestApplyWorkstationSetupPlan(t *testing.T) {
 	}
 }
 
-func TestApplyWorkstationSetupPlan_SkipsDeselectedDrafts(t *testing.T) {
-	cfg := &ProfilesConfig{}
-	result, err := ApplyWorkstationSetupPlan(cfg, &WorkstationSetupPlan{
-		Profiles: []WorkstationProfileDraft{
+func TestApply_SkipsDeselectedDrafts(t *testing.T) {
+	cfg := &profile.Config{}
+	result, err := Apply(cfg, &SetupPlan{
+		Profiles: []ProfileDraft{
 			{Name: "documents", SourceURI: "local:/Users/test/Documents", Selected: true},
 			{Name: "desktop", SourceURI: "local:/Users/test/Desktop", Selected: false},
 		},
 	})
 	if err != nil {
-		t.Fatalf("ApplyWorkstationSetupPlan: %v", err)
+		t.Fatalf("Apply: %v", err)
 	}
 	if result.ProfilesCreated != 1 {
 		t.Fatalf("ProfilesCreated = %d, want 1", result.ProfilesCreated)
@@ -166,35 +168,35 @@ func TestApplyWorkstationSetupPlan_SkipsDeselectedDrafts(t *testing.T) {
 	}
 }
 
-func TestApplyWorkstationSetupPlan_Errors(t *testing.T) {
-	if _, err := ApplyWorkstationSetupPlan(nil, nil); err == nil {
+func TestApply_Errors(t *testing.T) {
+	if _, err := Apply(nil, nil); err == nil {
 		t.Fatal("expected nil plan error")
 	}
-	if _, err := ApplyWorkstationSetupPlan(nil, &WorkstationSetupPlan{
-		Profiles: []WorkstationProfileDraft{{Name: "", SourceURI: "local:/tmp", Selected: true}},
+	if _, err := Apply(nil, &SetupPlan{
+		Profiles: []ProfileDraft{{Name: "", SourceURI: "local:/tmp", Selected: true}},
 	}); err == nil {
 		t.Fatal("expected missing name error")
 	}
-	if _, err := ApplyWorkstationSetupPlan(nil, &WorkstationSetupPlan{
-		Profiles: []WorkstationProfileDraft{{Name: "docs", SourceURI: "", Selected: true}},
+	if _, err := Apply(nil, &SetupPlan{
+		Profiles: []ProfileDraft{{Name: "docs", SourceURI: "", Selected: true}},
 	}); err == nil {
 		t.Fatal("expected missing source error")
 	}
 }
 
-func TestSetupWorkstation_DryRun(t *testing.T) {
+func TestSetup_DryRun(t *testing.T) {
 	reset := stubWorkstationSetupEnv(t)
 	defer reset()
 
-	workstationHostnameFunc = func() (string, error) { return "host", nil }
+	hostnameFunc = func() (string, error) { return "host", nil }
 	workstationUserHomeDirFunc = func() (string, error) { return "/home/test", nil }
 	workstationPathExistsFunc = func(path string) bool { return path == "/home/test/Documents" }
 	workstationDiscoverSourcesFunc = func(context.Context) ([]DiscoveredSource, error) { return nil, nil }
 
-	cfg := &ProfilesConfig{}
-	result, err := SetupWorkstation(context.Background(), WithWorkstationProfiles(cfg), WithWorkstationDryRun())
+	cfg := &profile.Config{}
+	result, err := Setup(context.Background(), WithProfiles(cfg), WithDryRun())
 	if err != nil {
-		t.Fatalf("SetupWorkstation: %v", err)
+		t.Fatalf("Setup: %v", err)
 	}
 	if result.Plan == nil || result.Applied != nil {
 		t.Fatalf("unexpected setup result: %#v", result)
@@ -204,23 +206,23 @@ func TestSetupWorkstation_DryRun(t *testing.T) {
 	}
 }
 
-func TestSetupWorkstation_Apply(t *testing.T) {
+func TestSetup_Apply(t *testing.T) {
 	reset := stubWorkstationSetupEnv(t)
 	defer reset()
 
-	workstationHostnameFunc = func() (string, error) { return "host", nil }
+	hostnameFunc = func() (string, error) { return "host", nil }
 	workstationUserHomeDirFunc = func() (string, error) { return "/home/test", nil }
 	workstationPathExistsFunc = func(path string) bool { return path == "/home/test/Documents" }
 	workstationDiscoverSourcesFunc = func(context.Context) ([]DiscoveredSource, error) { return nil, nil }
 
-	cfg := &ProfilesConfig{
-		Stores: map[string]ProfileStore{
+	cfg := &profile.Config{
+		Stores: map[string]profile.Store{
 			"primary": {URI: "local:/repo"},
 		},
 	}
-	result, err := SetupWorkstation(context.Background(), WithWorkstationProfiles(cfg), WithWorkstationStoreRef("primary"))
+	result, err := Setup(context.Background(), WithProfiles(cfg), WithStoreRef("primary"))
 	if err != nil {
-		t.Fatalf("SetupWorkstation: %v", err)
+		t.Fatalf("Setup: %v", err)
 	}
 	if result.Applied == nil || result.Applied.ProfilesCreated != 1 {
 		t.Fatalf("unexpected apply result: %#v", result)
@@ -234,13 +236,13 @@ func stubWorkstationSetupEnv(t *testing.T) func() {
 	t.Helper()
 	oldDiscover := workstationDiscoverSourcesFunc
 	oldHome := workstationUserHomeDirFunc
-	oldHost := workstationHostnameFunc
+	oldHost := hostnameFunc
 	oldExists := workstationPathExistsFunc
 	oldGOOS := workstationGOOS
 	return func() {
 		workstationDiscoverSourcesFunc = oldDiscover
 		workstationUserHomeDirFunc = oldHome
-		workstationHostnameFunc = oldHost
+		hostnameFunc = oldHost
 		workstationPathExistsFunc = oldExists
 		workstationGOOS = oldGOOS
 	}

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -1,4 +1,4 @@
-package engine
+package profile
 
 import (
 	"errors"
@@ -11,16 +11,16 @@ import (
 	"github.com/cloudstic/cli/pkg/secretref"
 )
 
-// ProfilesConfig is the top-level YAML document for backup profiles.
-type ProfilesConfig struct {
+// Config is the top-level YAML document for backup profiles.
+type Config struct {
 	Version  int                      `yaml:"version"`
-	Stores   map[string]ProfileStore  `yaml:"stores"`
-	Auth     map[string]ProfileAuth   `yaml:"auth"`
-	Profiles map[string]BackupProfile `yaml:"profiles"`
+	Stores   map[string]Store  `yaml:"stores"`
+	Auth     map[string]Auth   `yaml:"auth"`
+	Profiles map[string]Profile `yaml:"profiles"`
 }
 
-// ProfileStore defines reusable backend settings.
-type ProfileStore struct {
+// Store defines reusable backend settings.
+type Store struct {
 	URI               string `yaml:"uri"`
 	S3Endpoint        string `yaml:"s3_endpoint,omitempty"`
 	S3Region          string `yaml:"s3_region,omitempty"`
@@ -47,8 +47,8 @@ type ProfileStore struct {
 	KMSEndpoint             string `yaml:"kms_endpoint,omitempty"`
 }
 
-// BackupProfile defines one backup job preset.
-type BackupProfile struct {
+// Profile defines one backup job preset.
+type Profile struct {
 	Source            string   `yaml:"source"`
 	Store             string   `yaml:"store,omitempty"`
 	AuthRef           string   `yaml:"auth_ref,omitempty"`
@@ -69,8 +69,8 @@ type BackupProfile struct {
 	Enabled           *bool    `yaml:"enabled,omitempty"`
 }
 
-// ProfileAuth defines reusable OAuth settings for cloud providers.
-type ProfileAuth struct {
+// Auth defines reusable OAuth settings for cloud providers.
+type Auth struct {
 	Provider          string `yaml:"provider"` // google | onedrive
 	GoogleCreds       string `yaml:"google_credentials,omitempty"`
 	GoogleCredsRef    string `yaml:"google_credentials_ref,omitempty"`
@@ -83,33 +83,42 @@ type ProfileAuth struct {
 }
 
 // IsEnabled reports whether the profile should be included in -all-profiles.
-func (p BackupProfile) IsEnabled() bool {
+func (p Profile) IsEnabled() bool {
 	if p.Enabled == nil {
 		return true
 	}
 	return *p.Enabled
 }
 
-func normalizeProfilesConfig(cfg *ProfilesConfig) *ProfilesConfig {
+// Normalize returns a config that is safe to read and write into: a nil
+// config becomes an empty one, the version defaults to 1, and every map field
+// is non-nil.
+//
+// It is the nil-tolerant form of EnsureMaps, which mutates an existing config
+// in place and leaves the version alone. Prefer Normalize when the config may
+// be nil or may have come from an empty file.
+func Normalize(cfg *Config) *Config { return normalizeConfig(cfg) }
+
+func normalizeConfig(cfg *Config) *Config {
 	if cfg == nil {
-		cfg = &ProfilesConfig{}
+		cfg = &Config{}
 	}
 	if cfg.Version == 0 {
 		cfg.Version = 1
 	}
 	if cfg.Stores == nil {
-		cfg.Stores = map[string]ProfileStore{}
+		cfg.Stores = map[string]Store{}
 	}
 	if cfg.Auth == nil {
-		cfg.Auth = map[string]ProfileAuth{}
+		cfg.Auth = map[string]Auth{}
 	}
 	if cfg.Profiles == nil {
-		cfg.Profiles = map[string]BackupProfile{}
+		cfg.Profiles = map[string]Profile{}
 	}
 	return cfg
 }
 
-func validateProfilesConfig(cfg *ProfilesConfig) error {
+func validateConfig(cfg *Config) error {
 	for storeName, s := range cfg.Stores {
 		if err := validateSecretRef("store", storeName, "password_secret", s.PasswordSecret); err != nil {
 			return err
@@ -174,58 +183,58 @@ func validateSecretRef(entryType, entryName, fieldName, ref string) error {
 	return nil
 }
 
-// LoadProfilesFile reads and parses a profiles YAML file.
-func LoadProfilesFile(path string) (*ProfilesConfig, error) {
+// Load reads and parses a profiles YAML file.
+func Load(path string) (*Config, error) {
 	raw, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read profiles file %q: %w", path, err)
 	}
-	var cfg ProfilesConfig
+	var cfg Config
 	if err := yaml.Unmarshal(raw, &cfg); err != nil {
 		return nil, fmt.Errorf("parse profiles file %q: %w", path, err)
 	}
-	norm := normalizeProfilesConfig(&cfg)
-	if err := validateProfilesConfig(norm); err != nil {
+	norm := normalizeConfig(&cfg)
+	if err := validateConfig(norm); err != nil {
 		return nil, fmt.Errorf("validate profiles file %q: %w", path, err)
 	}
 	return norm, nil
 }
 
-// LoadProfilesFileOrEmpty loads profiles from path, treating a missing file
+// LoadOrEmpty loads profiles from path, treating a missing file
 // as an empty, version-1 config rather than an error. Callers that only read
 // or manage profiles (list, setup, the TUI) want this; callers running a
-// command against a named profile want LoadProfilesFile's hard error, since a
+// command against a named profile want Load's hard error, since a
 // silently-empty config there would misreport "unknown profile" instead of
 // "no profiles file".
-func LoadProfilesFileOrEmpty(path string) (*ProfilesConfig, error) {
-	cfg, err := LoadProfilesFile(path)
+func LoadOrEmpty(path string) (*Config, error) {
+	cfg, err := Load(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return &ProfilesConfig{Version: 1}, nil
+			return &Config{Version: 1}, nil
 		}
 		return nil, err
 	}
 	return cfg, nil
 }
 
-// EnsureProfilesMaps guarantees cfg's map fields are non-nil, so callers can
+// EnsureMaps guarantees cfg's map fields are non-nil, so callers can
 // write into them unconditionally.
-func EnsureProfilesMaps(cfg *ProfilesConfig) {
+func EnsureMaps(cfg *Config) {
 	if cfg.Stores == nil {
-		cfg.Stores = map[string]ProfileStore{}
+		cfg.Stores = map[string]Store{}
 	}
 	if cfg.Profiles == nil {
-		cfg.Profiles = map[string]BackupProfile{}
+		cfg.Profiles = map[string]Profile{}
 	}
 	if cfg.Auth == nil {
-		cfg.Auth = map[string]ProfileAuth{}
+		cfg.Auth = map[string]Auth{}
 	}
 }
 
-// SaveProfilesFile writes a profiles YAML file atomically.
-func SaveProfilesFile(path string, cfg *ProfilesConfig) error {
-	cfg = normalizeProfilesConfig(cfg)
-	if err := validateProfilesConfig(cfg); err != nil {
+// Save writes a profiles YAML file atomically.
+func Save(path string, cfg *Config) error {
+	cfg = normalizeConfig(cfg)
+	if err := validateConfig(cfg); err != nil {
 		return fmt.Errorf("validate profiles config: %w", err)
 	}
 

--- a/pkg/profile/profile_test.go
+++ b/pkg/profile/profile_test.go
@@ -1,4 +1,4 @@
-package engine
+package profile
 
 import (
 	"os"
@@ -7,16 +7,16 @@ import (
 	"testing"
 )
 
-func TestLoadProfilesFile_NormalizesMapsAndVersion(t *testing.T) {
+func TestLoad_NormalizesMapsAndVersion(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "profiles.yaml")
 	if err := os.WriteFile(path, []byte("profiles:\n  a:\n    source: local:/tmp\n"), 0600); err != nil {
 		t.Fatalf("write file: %v", err)
 	}
 
-	cfg, err := LoadProfilesFile(path)
+	cfg, err := Load(path)
 	if err != nil {
-		t.Fatalf("LoadProfilesFile: %v", err)
+		t.Fatalf("Load: %v", err)
 	}
 	if cfg.Version != 1 {
 		t.Fatalf("Version=%d want=1", cfg.Version)
@@ -32,12 +32,12 @@ func TestLoadProfilesFile_NormalizesMapsAndVersion(t *testing.T) {
 	}
 }
 
-func TestSaveProfilesFile_RoundTrip(t *testing.T) {
+func TestSave_RoundTrip(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "profiles.yaml")
 
-	err := SaveProfilesFile(path, &ProfilesConfig{
-		Stores: map[string]ProfileStore{
+	err := Save(path, &Config{
+		Stores: map[string]Store{
 			"s": {
 				URI:                     "local:./store",
 				PasswordSecret:          "env://CLOUDSTIC_PASSWORD",
@@ -51,17 +51,17 @@ func TestSaveProfilesFile_RoundTrip(t *testing.T) {
 				StoreSFTPKeySecret:      "env://STORE_SFTP_KEY",
 			},
 		},
-		Profiles: map[string]BackupProfile{
+		Profiles: map[string]Profile{
 			"p": {Source: "local:./docs", Store: "s"},
 		},
 	})
 	if err != nil {
-		t.Fatalf("SaveProfilesFile: %v", err)
+		t.Fatalf("Save: %v", err)
 	}
 
-	cfg, err := LoadProfilesFile(path)
+	cfg, err := Load(path)
 	if err != nil {
-		t.Fatalf("LoadProfilesFile: %v", err)
+		t.Fatalf("Load: %v", err)
 	}
 	if cfg.Profiles["p"].Source != "local:./docs" {
 		t.Fatalf("unexpected source: %q", cfg.Profiles["p"].Source)
@@ -83,7 +83,7 @@ func TestSaveProfilesFile_RoundTrip(t *testing.T) {
 	}
 }
 
-func TestLoadProfilesFile_InvalidSecretRef(t *testing.T) {
+func TestLoad_InvalidSecretRef(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "profiles.yaml")
 	content := `version: 1
@@ -96,9 +96,9 @@ stores:
 		t.Fatalf("write file: %v", err)
 	}
 
-	_, err := LoadProfilesFile(path)
+	_, err := Load(path)
 	if err == nil {
-		t.Fatal("LoadProfilesFile: expected validation error")
+		t.Fatal("Load: expected validation error")
 	}
 	msg := err.Error()
 	if !strings.Contains(msg, `store "prod" field "password_secret"`) {
@@ -109,11 +109,11 @@ stores:
 	}
 }
 
-func TestSaveProfilesFile_InvalidSecretRef(t *testing.T) {
+func TestSave_InvalidSecretRef(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "profiles.yaml")
-	err := SaveProfilesFile(path, &ProfilesConfig{
-		Stores: map[string]ProfileStore{
+	err := Save(path, &Config{
+		Stores: map[string]Store{
 			"prod": {
 				URI:                "local:./store",
 				StoreSFTPKeySecret: "env:/bad-format",
@@ -121,18 +121,18 @@ func TestSaveProfilesFile_InvalidSecretRef(t *testing.T) {
 		},
 	})
 	if err == nil {
-		t.Fatal("SaveProfilesFile: expected validation error")
+		t.Fatal("Save: expected validation error")
 	}
 	if !strings.Contains(err.Error(), `store "prod" field "store_sftp_key_secret"`) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
-func TestSaveProfilesFile_InvalidB2SecretRef(t *testing.T) {
+func TestSave_InvalidB2SecretRef(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "profiles.yaml")
-	err := SaveProfilesFile(path, &ProfilesConfig{
-		Stores: map[string]ProfileStore{
+	err := Save(path, &Config{
+		Stores: map[string]Store{
 			"b2store": {
 				URI:            "b2:bucket",
 				B2AppKeySecret: "env:/bad-format",
@@ -140,7 +140,7 @@ func TestSaveProfilesFile_InvalidB2SecretRef(t *testing.T) {
 		},
 	})
 	if err == nil {
-		t.Fatal("SaveProfilesFile: expected validation error")
+		t.Fatal("Save: expected validation error")
 	}
 	if !strings.Contains(err.Error(), `store "b2store" field "b2_app_key_secret"`) {
 		t.Fatalf("unexpected error: %v", err)

--- a/pkg/profile/safety_test.go
+++ b/pkg/profile/safety_test.go
@@ -1,4 +1,4 @@
-package engine
+package profile
 
 import (
 	"errors"
@@ -15,7 +15,7 @@ import (
 // IsEnabled treats a missing `enabled` key as true: a profile without the
 // field must still run under -all-profiles, or adding the field later would
 // silently change which profiles back up.
-func TestBackupProfile_IsEnabled(t *testing.T) {
+func TestProfile_IsEnabled(t *testing.T) {
 	enabled, disabled := true, false
 	for _, tc := range []struct {
 		name string
@@ -27,7 +27,7 @@ func TestBackupProfile_IsEnabled(t *testing.T) {
 		{"explicitly disabled", &disabled, false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := (BackupProfile{Enabled: tc.in}).IsEnabled(); got != tc.want {
+			if got := (Profile{Enabled: tc.in}).IsEnabled(); got != tc.want {
 				t.Errorf("IsEnabled() = %v, want %v", got, tc.want)
 			}
 		})
@@ -36,8 +36,8 @@ func TestBackupProfile_IsEnabled(t *testing.T) {
 
 // A missing file must read as an empty config, not an error: the caller
 // distinguishing "no profiles file" from "unknown profile" depends on it.
-func TestLoadProfilesFileOrEmpty_MissingFile(t *testing.T) {
-	cfg, err := LoadProfilesFileOrEmpty(filepath.Join(t.TempDir(), "absent.yaml"))
+func TestLoadOrEmpty_MissingFile(t *testing.T) {
+	cfg, err := LoadOrEmpty(filepath.Join(t.TempDir(), "absent.yaml"))
 	if err != nil {
 		t.Fatalf("a missing profiles file must not be an error: %v", err)
 	}
@@ -51,50 +51,50 @@ func TestLoadProfilesFileOrEmpty_MissingFile(t *testing.T) {
 
 // Any other read error must still surface — swallowing it would report a
 // broken file as "no profiles".
-func TestLoadProfilesFileOrEmpty_MalformedFileStillErrors(t *testing.T) {
+func TestLoadOrEmpty_MalformedFileStillErrors(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "profiles.yaml")
 	if err := os.WriteFile(path, []byte("this: is: not: valid: yaml:\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := LoadProfilesFileOrEmpty(path); err == nil {
+	if _, err := LoadOrEmpty(path); err == nil {
 		t.Fatal("expected a malformed profiles file to error")
 	} else if errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("a malformed file must not be reported as missing: %v", err)
 	}
 }
 
-func TestEnsureProfilesMaps(t *testing.T) {
-	cfg := &ProfilesConfig{}
-	EnsureProfilesMaps(cfg)
+func TestEnsureMaps(t *testing.T) {
+	cfg := &Config{}
+	EnsureMaps(cfg)
 	if cfg.Stores == nil || cfg.Profiles == nil || cfg.Auth == nil {
 		t.Fatalf("all map fields must be non-nil, got %+v", cfg)
 	}
 
 	// Existing content must survive a second call.
-	cfg.Profiles["keep"] = BackupProfile{}
-	EnsureProfilesMaps(cfg)
+	cfg.Profiles["keep"] = Profile{}
+	EnsureMaps(cfg)
 	if _, ok := cfg.Profiles["keep"]; !ok {
-		t.Error("EnsureProfilesMaps discarded existing entries")
+		t.Error("EnsureMaps discarded existing entries")
 	}
 }
 
 // Round-tripping is what the move must preserve end to end.
-func TestSaveThenLoadProfilesFile_RoundTrip(t *testing.T) {
+func TestSaveThenLoad_RoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "profiles.yaml")
-	want := &ProfilesConfig{
+	want := &Config{
 		Version: 1,
-		Stores:  map[string]ProfileStore{"s3": {URI: "local:///tmp/repo"}},
-		Profiles: map[string]BackupProfile{
+		Stores:  map[string]Store{"s3": {URI: "local:///tmp/repo"}},
+		Profiles: map[string]Profile{
 			"docs": {Source: "local:///home/me/docs", Store: "s3"},
 		},
 	}
-	if err := SaveProfilesFile(path, want); err != nil {
-		t.Fatalf("SaveProfilesFile: %v", err)
+	if err := Save(path, want); err != nil {
+		t.Fatalf("Save: %v", err)
 	}
 
-	got, err := LoadProfilesFile(path)
+	got, err := Load(path)
 	if err != nil {
-		t.Fatalf("LoadProfilesFile: %v", err)
+		t.Fatalf("Load: %v", err)
 	}
 	if got.Profiles["docs"].Source != want.Profiles["docs"].Source {
 		t.Errorf("Source = %q, want %q", got.Profiles["docs"].Source, want.Profiles["docs"].Source)

--- a/pkg/profile/secreterror_test.go
+++ b/pkg/profile/secreterror_test.go
@@ -1,0 +1,42 @@
+package profile
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/cloudstic/cli/pkg/secretref"
+)
+
+// A malformed secret reference in a profile is rejected during validation, and
+// the failure must stay inspectable rather than collapsing into an opaque
+// string: callers branch on Kind to tell "you typed the scheme wrong" from
+// "that backend is unavailable on this machine".
+//
+// This lived in the root package's tests, where the reasoning was that
+// secretref was internal and errors.As on the re-exported alias was a caller's
+// only handle on it. secretref is public now, so the alias is no longer what
+// makes this reachable — but the wrapping through Save still has to preserve
+// the typed error, which is what this pins.
+func TestSave_SecretRefErrorIsInspectable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "profiles.yaml")
+	cfg := &Config{
+		Version: 1,
+		Stores: map[string]Store{
+			"prod": {URI: "local:./store", PasswordSecret: "invalid"},
+		},
+	}
+
+	err := Save(path, cfg)
+	if err == nil {
+		t.Fatal("Save: expected a validation error for a malformed secret reference")
+	}
+
+	var refErr *secretref.Error
+	if !errors.As(err, &refErr) {
+		t.Fatalf("errors.As(err, *secretref.Error) failed on: %v", err)
+	}
+	if refErr.Kind != secretref.KindInvalidRef {
+		t.Errorf("Kind = %v, want %v", refErr.Kind, secretref.KindInvalidRef)
+	}
+}


### PR DESCRIPTION
Closes #382 — the last item under #378.

## Summary

`internal/engine` held three things that are not the backup engine: the profiles YAML format, the workstation onboarding planner, and local source discovery. None of them had a `Client` method behind it — `DiscoverSources` was a method that never touched its receiver, and `LoadProfilesFile` and friends were free functions over a path.

- **`pkg/profile`** — `Config`, `Profile`, `Store`, `Auth`, `Load`, `Save`, `LoadOrEmpty`, `EnsureMaps`, `Normalize`
- **`internal/workstation`** — `Plan`, `Apply`, `Setup`, `DiscoverSources`, and the platform-specific mount discovery

`profile` is public because the profiles file is a user-facing format that scripting should be able to read and write without pulling in the repository client. `workstation` is internal because it is a CLI onboarding wizard.

Names lose the prefixes that only existed to disambiguate inside one package: `ProfilesConfig` → `profile.Config`, `BackupProfile` → `profile.Profile`, `PlanWorkstationSetup` → `workstation.Plan`.

## Effect

| | before | after |
|---|---|---|
| root package exported symbols | 120 | **101** |
| lines moved out of `internal/engine` | — | ~1,100 |

The root package drops 11 type aliases, 3 option vars and 7 wrapper functions. `normalizeProfilesConfig` is exported as `profile.Normalize`, since `workstation` legitimately needs the nil-tolerant form and it is a real operation rather than an implementation detail.

## This is the largest breaking change of the effort

~326 call sites move from `cloudstic.ProfilesConfig` to `profile.Config` across `cmd/`, `internal/tui` and `internal/app`. The compiler verifies completeness, but it is a big diff to read, and it is deliberately **one commit** so it can be reverted cleanly if you would rather keep the root aliases.

## What the tests caught

I removed `DiscoverSources` from the `cloudsticClient` interface after grepping `cmd_source_test.go` for the method name and finding nothing. The test configures the stub through a *field* (`discoverResult`), so the grep missed it — and removing the seam made two tests assert against the **real machine mount table** instead of a stub. They failed with actual disk output.

Discovery now goes through a package-level seam in `cmd/cloudstic` rather than the client interface, which keeps `workstation` internal *and* keeps those tests hermetic.

Three tests moved rather than being deleted, each checked first for whether it was unique coverage:

- the secret-ref inspectability test moved to `pkg/profile` — and its comment corrected, since it asserted `secretref` was unimportable by consumers, which stopped being true when #387 promoted it
- the `DiscoverSources` and `Apply` smoke tests were genuinely redundant (`internal/workstation` covers `Apply` three ways), so they are gone

## Verification

```bash
env GOCACHE=/tmp/cloudstic-gocache go test -count=1 -race ./...
env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run --timeout=5m
```

Full `-race` suite green including `e2e`; lint reports 0 issues.