### PR TITLE
feat(secretref): let callers choose the managed-token directory

### DIFF
--- a/internal/apicheck/testdata/externalmod/secretbackend.go
+++ b/internal/apicheck/testdata/externalmod/secretbackend.go
@@ -22,6 +22,17 @@ func (v *VaultBackend) Resolve(_ context.Context, ref secretref.Ref) (string, er
 	return "secret-from-vault", nil
 }
 
+// NewResolverInOwnConfigDir is the other half of embedding: an external
+// program needs its users' managed tokens under its own directory, not
+// Cloudstic's. Without WithConfigDir the only lever is the CLOUDSTIC_CONFIG_DIR
+// environment variable, which is process-wide and not something a library
+// should be reaching for.
+func NewResolverInOwnConfigDir(dir string) *secretref.Resolver {
+	b := backends.Default()
+	b["config-token"] = backends.NewConfigTokenBackend(backends.WithConfigDir(dir))
+	return secretref.NewResolver(b)
+}
+
 // NewResolverWithVault shows the extending case — adding a scheme to the
 // built-in set rather than replacing it, which is why backends.Default exists.
 func NewResolverWithVault() *secretref.Resolver {

--- a/pkg/secretref/backends/configtoken_test.go
+++ b/pkg/secretref/backends/configtoken_test.go
@@ -1,0 +1,95 @@
+package backends
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cloudstic/cli/pkg/secretref"
+)
+
+func configTokenRef(t *testing.T) secretref.Ref {
+	t.Helper()
+	ref, err := secretref.Parse("config-token://google/default")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	return ref
+}
+
+// WithConfigDir is what makes this backend usable outside the CLI. Without it
+// the managed directory comes from paths.ConfigDir, so an embedding program
+// would write its users' tokens into Cloudstic's own config directory with no
+// way to say otherwise.
+func TestConfigTokenBackend_WithConfigDir_WritesThere(t *testing.T) {
+	dir := t.TempDir()
+	b := NewConfigTokenBackend(WithConfigDir(dir))
+	ref := configTokenRef(t)
+	ctx := context.Background()
+
+	if err := b.Store(ctx, ref, "a-token"); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+
+	got, err := b.Resolve(ctx, ref)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != "a-token" {
+		t.Errorf("Resolve = %q, want %q", got, "a-token")
+	}
+
+	// It must have landed under the directory we chose, not the ambient one.
+	var found []string
+	_ = filepath.Walk(dir, func(p string, info os.FileInfo, err error) error {
+		if err == nil && info != nil && !info.IsDir() {
+			found = append(found, strings.TrimPrefix(p, dir))
+		}
+		return nil
+	})
+	if len(found) == 0 {
+		t.Fatal("nothing was written under the configured directory")
+	}
+}
+
+// The at-rest key is derived from a salt stored in the managed directory, so
+// two backends pointed at different directories must not be able to read each
+// other's tokens. This is the property that makes WithConfigDir a real
+// isolation boundary rather than just a path preference.
+func TestConfigTokenBackend_DirectoriesAreIsolated(t *testing.T) {
+	ctx := context.Background()
+	ref := configTokenRef(t)
+
+	first := NewConfigTokenBackend(WithConfigDir(t.TempDir()))
+	if err := first.Store(ctx, ref, "secret-one"); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+
+	second := NewConfigTokenBackend(WithConfigDir(t.TempDir()))
+	if _, err := second.Resolve(ctx, ref); err == nil {
+		t.Error("a backend in a different directory must not resolve the other's token")
+	}
+}
+
+// An unconfigured backend keeps its previous behaviour: the managed directory
+// comes from the environment, which is what the CLI relies on.
+func TestConfigTokenBackend_DefaultsToAmbientConfigDir(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CLOUDSTIC_CONFIG_DIR", dir)
+	ctx := context.Background()
+	ref := configTokenRef(t)
+
+	b := NewConfigTokenBackend()
+	if err := b.Store(ctx, ref, "ambient"); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	got, err := b.Resolve(ctx, ref)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != "ambient" {
+		t.Errorf("Resolve = %q, want %q", got, "ambient")
+	}
+}

--- a/pkg/secretref/backends/default.go
+++ b/pkg/secretref/backends/default.go
@@ -16,6 +16,14 @@ import "github.com/cloudstic/cli/pkg/secretref"
 // Default returns a fresh map of the built-in backends, keyed by scheme. The
 // map is newly allocated on each call, so callers may add to or remove from it
 // without affecting anyone else.
+//
+// Replacing an entry is also how you reconfigure a built-in. The config-token
+// backend writes into Cloudstic's own config directory by default, which a
+// program embedding this package usually does not want:
+//
+//	b := backends.Default()
+//	b["config-token"] = backends.NewConfigTokenBackend(backends.WithConfigDir(myDir))
+//	resolver := secretref.NewResolver(b)
 func Default() map[string]secretref.Backend {
 	return map[string]secretref.Backend{
 		"env":            NewEnvBackend(nil),

--- a/pkg/secretref/backends/file_backend.go
+++ b/pkg/secretref/backends/file_backend.go
@@ -85,11 +85,46 @@ func (b *FileBackend) Store(ctx context.Context, ref secretref.Ref, value string
 }
 
 // ConfigTokenBackend handles config-token://<provider>/<name> references.
-// It stores tokens in the app's managed config directory.
-type ConfigTokenBackend struct{}
+// It stores tokens in a managed config directory, encrypted at rest.
+//
+// Unlike file://, whose reference carries its own path, this backend chooses
+// where to write. That choice defaults to Cloudstic's own config directory,
+// which is right for the CLI but not for a program embedding this package —
+// hence WithConfigDir.
+type ConfigTokenBackend struct {
+	// configDir overrides the managed directory. Empty means "ask
+	// paths.ConfigDir", i.e. CLOUDSTIC_CONFIG_DIR or the OS default.
+	configDir string
+}
 
-func NewConfigTokenBackend() *ConfigTokenBackend {
-	return &ConfigTokenBackend{}
+// ConfigTokenOption configures a ConfigTokenBackend.
+type ConfigTokenOption func(*ConfigTokenBackend)
+
+// WithConfigDir places managed tokens under dir instead of Cloudstic's own
+// config directory.
+//
+// The salt that derives the at-rest encryption key lives in this directory
+// too, so pointing two backends at different directories gives them different
+// keys: tokens written under one are not readable under the other.
+func WithConfigDir(dir string) ConfigTokenOption {
+	return func(b *ConfigTokenBackend) { b.configDir = dir }
+}
+
+func NewConfigTokenBackend(opts ...ConfigTokenOption) *ConfigTokenBackend {
+	b := &ConfigTokenBackend{}
+	for _, opt := range opts {
+		opt(b)
+	}
+	return b
+}
+
+// dir returns the managed directory, falling back to the process-wide default
+// when the caller did not choose one.
+func (b *ConfigTokenBackend) dir() (string, error) {
+	if b.configDir != "" {
+		return b.configDir, nil
+	}
+	return paths.ConfigDir()
 }
 
 func (b *ConfigTokenBackend) Resolve(ctx context.Context, ref secretref.Ref) (string, error) {
@@ -197,7 +232,7 @@ func (b *ConfigTokenBackend) Store(ctx context.Context, ref secretref.Ref, value
 }
 
 func (b *ConfigTokenBackend) getEncryptionKey() ([]byte, error) {
-	configDir, err := paths.ConfigDir()
+	configDir, err := b.dir()
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +281,7 @@ func (b *ConfigTokenBackend) resolvePath(ref secretref.Ref) (string, error) {
 		}
 	}
 
-	configDir, err := paths.ConfigDir()
+	configDir, err := b.dir()
 	if err != nil {
 		return "", secretref.NewError(secretref.KindBackendUnavailable, ref.Raw, "failed to determine config directory", err)
 	}


### PR DESCRIPTION
Follows #389. Closes the last gap found by auditing `pkg/` → `internal/` imports.

Part of #378

## The problem

`ConfigTokenBackend` writes into Cloudstic's own config directory, resolved from `CLOUDSTIC_CONFIG_DIR` or the OS default. That is correct for the CLI and wrong for a program embedding `pkg/secretref`: its users' managed tokens land in *Cloudstic's* directory, and the only lever is a **process-wide environment variable** — not something a library should be reaching for.

It is the same shape as everything else RFC 0022 turned up: a public package with behaviour you cannot reach. Just milder, since there was at least an env-var escape hatch.

```go
b := backends.Default()
b["config-token"] = backends.NewConfigTokenBackend(backends.WithConfigDir(myDir))
resolver := secretref.NewResolver(b)
```

An unconfigured backend behaves exactly as before, so the CLI is untouched.

## Scope, and a correction

I initially described this as affecting "the `file://` and `config-token://` backends". That was wrong — **`file://` carries its own path in the reference** and imposes nothing. Only `ConfigTokenBackend` chooses a location, so only it gets the option.

`paths.MachineID` stays ambient on purpose: it is machine identity feeding key derivation, not a location, and making it injectable would weaken a security property rather than fix a coupling.

The other `pkg/` → `internal/` edges were audited and left alone — `pkg/store` uses `internal/logger` only for ANSI colour constants, `SaveAtomic` is a generic utility, and `internal/sftp` is implementation shared between two public packages. None of them appears in a signature or imposes policy.

## The isolation property

The salt deriving the at-rest encryption key lives in the managed directory too, so two backends pointed at different directories **cannot read each other's tokens**. That makes `WithConfigDir` a real isolation boundary rather than a path preference, and it is asserted rather than assumed.

Both new tests were verified by neutering `WithConfigDir` into a no-op:

```
--- FAIL: TestConfigTokenBackend_WithConfigDir_WritesThere
    nothing was written under the configured directory
--- FAIL: TestConfigTokenBackend_DirectoriesAreIsolated
    a backend in a different directory must not resolve the other's token
```

A third test pins that an unconfigured backend still follows `CLOUDSTIC_CONFIG_DIR`, which is what the CLI depends on.

## Verification

```bash
env GOCACHE=/tmp/cloudstic-gocache go test -count=1 -race ./...
env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run --timeout=5m
```

Green, 0 lint issues. The external-module fixture gained `NewResolverInOwnConfigDir`, so this is covered by a compile-and-run test rather than described.