### PR TITLE
ci: enforce gofmt in lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,5 @@
+version: "2"
+
+formatters:
+  enable:
+    - gofmt

--- a/internal/hamt/hamt_test.go
+++ b/internal/hamt/hamt_test.go
@@ -734,7 +734,6 @@ func TestNodeCacheLRUEviction(t *testing.T) {
 	}
 }
 
-
 func TestInternalNodeType(t *testing.T) {
 	store := newInMemoryStore()
 	tree := NewTree(store)

--- a/internal/storelayer/pack.go
+++ b/internal/storelayer/pack.go
@@ -96,13 +96,13 @@ func NewPackStore(inner store.ObjectStore, opts ...PackOption) (*PackStore, erro
 	}
 
 	s := &PackStore{
-		ObjectStore: inner,
-		packBuffer:        new(bytes.Buffer),
-		packKeys:          make(map[string]PackEntry),
-		catalog:           make(map[string]PackEntry),
-		pendingShard:      make(map[string]PackEntry),
-		mergedIndex:       make(map[string]bool),
-		packCache:         cache,
+		ObjectStore:  inner,
+		packBuffer:   new(bytes.Buffer),
+		packKeys:     make(map[string]PackEntry),
+		catalog:      make(map[string]PackEntry),
+		pendingShard: make(map[string]PackEntry),
+		mergedIndex:  make(map[string]bool),
+		packCache:    cache,
 	}
 	for _, opt := range opts {
 		opt(s)

--- a/internal/tui/forms/profile_test.go
+++ b/internal/tui/forms/profile_test.go
@@ -79,7 +79,7 @@ func (b *stubProfileBackend) SaveProfile(name, source, store, auth string, editi
 func TestProfileForm_CreateSaves(t *testing.T) {
 	b := newStubBackend()
 	f := NewProfileForm(b, "", "", "", "", false)
-	f = typeInto(f, "alpha")               // name
+	f = typeInto(f, "alpha")                      // name
 	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyTab}) // -> source_type
 	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyTab}) // -> source_value
 	f = typeInto(f, "/data")

--- a/internal/tui/forms/store.go
+++ b/internal/tui/forms/store.go
@@ -68,9 +68,9 @@ var StoreTypes = []string{"local", "s3", "b2", "sftp"}
 var EncryptionModes = []string{EncNone, EncPassword, EncPlatform, EncKMS}
 
 var (
-	storeS3Fields   = []string{FieldS3Region, FieldS3Profile, FieldS3Endpoint, FieldS3AccessKey, FieldS3SecretKey}
-	storeSFTPFields = []string{FieldSFTPPassword, FieldSFTPKey}
-	storeEncFields  = []string{FieldPasswordSecret, FieldPlatformSecret, FieldKMSKeyARN, FieldKMSRegion, FieldKMSEndpoint}
+	storeS3Fields        = []string{FieldS3Region, FieldS3Profile, FieldS3Endpoint, FieldS3AccessKey, FieldS3SecretKey}
+	storeSFTPFields      = []string{FieldSFTPPassword, FieldSFTPKey}
+	storeEncFields       = []string{FieldPasswordSecret, FieldPlatformSecret, FieldKMSKeyARN, FieldKMSRegion, FieldKMSEndpoint}
 	storeSecretRefFields = []string{
 		FieldS3AccessKey, FieldS3SecretKey, FieldSFTPPassword, FieldSFTPKey,
 		FieldPasswordSecret, FieldPlatformSecret,

--- a/internal/tui/forms/store_test.go
+++ b/internal/tui/forms/store_test.go
@@ -8,13 +8,13 @@ import (
 )
 
 type stubStoreBackend struct {
-	saved       map[string]string
-	savedName   string
-	savedEdit   bool
-	exists      map[string]bool
-	saveErr     error
-	secretErr   error
-	composeErr  error
+	saved      map[string]string
+	savedName  string
+	savedEdit  bool
+	exists     map[string]bool
+	saveErr    error
+	secretErr  error
+	composeErr error
 }
 
 func newStubStoreBackend() *stubStoreBackend {
@@ -63,7 +63,7 @@ func focusKey(f *Form, key string) *Form {
 func TestStoreForm_CreateLocalSaves(t *testing.T) {
 	b := newStubStoreBackend()
 	f := NewStoreForm(b, "", nil, false)
-	f = typeInto(f, "mystore")           // name
+	f = typeInto(f, "mystore") // name
 	f = focusKey(f, FieldStoreValue)
 	f = typeInto(f, "/backups")
 	f, _ = f.Update(tea.KeyMsg{Type: tea.KeyEnter})

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -13,9 +13,9 @@ import (
 
 // Config is the top-level YAML document for backup profiles.
 type Config struct {
-	Version  int                      `yaml:"version"`
-	Stores   map[string]Store  `yaml:"stores"`
-	Auth     map[string]Auth   `yaml:"auth"`
+	Version  int                `yaml:"version"`
+	Stores   map[string]Store   `yaml:"stores"`
+	Auth     map[string]Auth    `yaml:"auth"`
 	Profiles map[string]Profile `yaml:"profiles"`
 }
 


### PR DESCRIPTION
## Summary

- add a golangci-lint v2 configuration that enables the `gofmt` formatter
- format the existing Go files identified by the new check
- make the existing CI lint job reject unformatted Go code

## Validation

- `golangci-lint run ./... --timeout=5m` — 0 issues
- `go test -v -count=1 ./...` — all runnable tests passed; the sandbox blocked the B2 test's temporary localhost listener
- `go test -v -count=1 ./pkg/store/b2` with localhost access — passed
