### PR TITLE
test: characterize the unlock path and fix its zero-value defects (RFC 0022)

### DIFF
--- a/cmd/cloudstic/clientbuild.go
+++ b/cmd/cloudstic/clientbuild.go
@@ -33,7 +33,7 @@ func openClient(ctx context.Context, cfg clientConfig, reporterOverride cloudsti
 	return cloudstic.NewClient(ctx, raw,
 		cloudstic.WithKeychain(kc),
 		cloudstic.WithReporter(reporter),
-		cloudstic.WithPackfile(cfg.packfile),
+		cloudstic.WithPackfile(!cfg.disablePackfile),
 	)
 }
 

--- a/cmd/cloudstic/clientbuild_test.go
+++ b/cmd/cloudstic/clientbuild_test.go
@@ -6,6 +6,7 @@ import (
 
 	cloudstic "github.com/cloudstic/cli"
 	"github.com/cloudstic/cli/internal/ui"
+	"github.com/cloudstic/cli/pkg/profile"
 )
 
 // Characterization tests for the client construction path, which RFC 0022 §7
@@ -90,9 +91,8 @@ func TestNewReporter_DebugLogOnlyAffectsTheConsoleReporter(t *testing.T) {
 func TestOpenClient_UnencryptedLocalRepo(t *testing.T) {
 	ctx := context.Background()
 	cfg := clientConfig{
-		store:    storeConfig{uri: "local:" + t.TempDir()},
-		packfile: true,
-		quiet:    true,
+		store: storeConfig{uri: "local:" + t.TempDir()},
+		quiet: true,
 	}
 
 	raw, err := openStore(ctx, cfg.store)
@@ -115,14 +115,59 @@ func TestOpenClient_UnencryptedLocalRepo(t *testing.T) {
 	}
 }
 
+// TestClientConfigZeroValueEnablesPackfiles is the regression test for the
+// defect that made the field negative. NewClient enables packfiles by default,
+// and openClient passes this field on unconditionally, so a zero-valued config
+// must not turn them off — a consumer who never mentions packfiles would
+// otherwise write a repository with a different physical layout and get no
+// error from any layer.
+func TestClientConfigZeroValueEnablesPackfiles(t *testing.T) {
+	var cfg clientConfig
+	if cfg.disablePackfile {
+		t.Error("the zero value must leave packfiles enabled, matching NewClient's own default")
+	}
+
+	// The two constructors must agree with the zero value when nothing asks
+	// otherwise.
+	fromFlags := clientConfigFromFlags(&globalFlags{})
+	if fromFlags.disablePackfile {
+		t.Error("clientConfigFromFlags with no flags set must leave packfiles enabled")
+	}
+
+	fromProfile, err := clientConfigFromProfileStore(profile.Store{URI: "local:/tmp/x"})
+	if err != nil {
+		t.Fatalf("clientConfigFromProfileStore: %v", err)
+	}
+	if fromProfile.disablePackfile {
+		t.Error("a profile store that says nothing about packfiles must leave them enabled")
+	}
+
+	// And the flag still works.
+	disabled := clientConfigFromFlags(&globalFlags{disablePackfile: true})
+	if !disabled.disablePackfile {
+		t.Error("-disable-packfile must still disable packfiles")
+	}
+}
+
+// TestS3RegionDefault covers the other zero-value hazard: the region default
+// used to be pre-filled into one of the two config constructors, so a config
+// built any other way reached the S3 backend with an empty region.
+func TestS3RegionDefault(t *testing.T) {
+	if got := s3Region(""); got != defaultS3Region {
+		t.Errorf("s3Region(\"\") = %q, want %q", got, defaultS3Region)
+	}
+	if got := s3Region("eu-west-3"); got != "eu-west-3" {
+		t.Errorf("s3Region(%q) = %q, want it left alone", "eu-west-3", got)
+	}
+}
+
 // TestOpenClient_ReporterOverrideWins pins the parameter that lets the TUI and
 // tests supply their own reporter: when one is passed, the output mode does
 // not get to pick a different one.
 func TestOpenClient_ReporterOverrideWins(t *testing.T) {
 	ctx := context.Background()
 	cfg := clientConfig{
-		store:    storeConfig{uri: "local:" + t.TempDir()},
-		packfile: true,
+		store: storeConfig{uri: "local:" + t.TempDir()},
 	}
 
 	raw, err := openStore(ctx, cfg.store)

--- a/cmd/cloudstic/clientbuild_test.go
+++ b/cmd/cloudstic/clientbuild_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	cloudstic "github.com/cloudstic/cli"
+	"github.com/cloudstic/cli/internal/ui"
+)
+
+// Characterization tests for the client construction path, which RFC 0022 §7
+// moves into pkg/open. Scoped to what storebuild_test.go and storeuri_test.go
+// do not already cover: those exercise newObjectStore, withDebugStore, and URI
+// parsing, so the gaps are newReporter and openClient, which had no direct
+// coverage at all.
+
+// TestNewReporter_OutputModeSelectsReporter pins which reporter each output
+// mode gets. Getting this wrong is not cosmetic: a console reporter under
+// -json interleaves progress bars with the JSON document on stdout and makes
+// the output unparseable.
+func TestNewReporter_OutputModeSelectsReporter(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        clientConfig
+		wantNoOp   bool
+		wantReason string
+	}{
+		{
+			name:       "default is the console reporter",
+			cfg:        clientConfig{},
+			wantNoOp:   false,
+			wantReason: "interactive runs show progress",
+		},
+		{
+			name:       "quiet silences progress",
+			cfg:        clientConfig{quiet: true},
+			wantNoOp:   true,
+			wantReason: "-quiet must produce no progress output",
+		},
+		{
+			name:       "json silences progress",
+			cfg:        clientConfig{json: true},
+			wantNoOp:   true,
+			wantReason: "progress output would corrupt the JSON document on stdout",
+		},
+		{
+			name:       "quiet and json together",
+			cfg:        clientConfig{quiet: true, json: true},
+			wantNoOp:   true,
+			wantReason: "either flag alone is enough",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newReporter(tt.cfg, nil)
+			_, isNoOp := got.(*ui.NoOpReporter)
+			if isNoOp != tt.wantNoOp {
+				t.Errorf("newReporter(%+v) = %T, wantNoOp=%v (%s)",
+					tt.cfg, got, tt.wantNoOp, tt.wantReason)
+			}
+		})
+	}
+}
+
+// TestNewReporter_DebugLogOnlyAffectsTheConsoleReporter records that a debug
+// log writer is attached to the console reporter but never changes which
+// reporter is chosen. The writer is shared so store debug lines and progress
+// bars do not interleave; in quiet/json mode there are no bars to interleave
+// with.
+func TestNewReporter_DebugLogOnlyAffectsTheConsoleReporter(t *testing.T) {
+	debugLog := &ui.SafeLogWriter{}
+
+	got := newReporter(clientConfig{}, debugLog)
+	if _, isNoOp := got.(*ui.NoOpReporter); isNoOp {
+		t.Error("a debug log must not turn the console reporter into a no-op reporter")
+	}
+
+	got = newReporter(clientConfig{quiet: true}, debugLog)
+	if _, isNoOp := got.(*ui.NoOpReporter); !isNoOp {
+		t.Errorf("got %T, want a no-op reporter: a debug log must not override -quiet", got)
+	}
+}
+
+// TestOpenClient_UnencryptedLocalRepo exercises the whole construction path —
+// store, keychain, reporter, client — against a repository that needs no
+// credentials. It is the test most likely to catch a wiring mistake when §7
+// moves openClient into pkg/open, because it is the only one that runs all
+// four builders together.
+func TestOpenClient_UnencryptedLocalRepo(t *testing.T) {
+	ctx := context.Background()
+	cfg := clientConfig{
+		store:    storeConfig{uri: "local:" + t.TempDir()},
+		packfile: true,
+		quiet:    true,
+	}
+
+	raw, err := openStore(ctx, cfg.store)
+	if err != nil {
+		t.Fatalf("openStore: %v", err)
+	}
+	if _, err := cloudstic.InitRepo(ctx, raw); err != nil {
+		t.Fatalf("init repository: %v", err)
+	}
+
+	client, err := openClient(ctx, cfg, nil)
+	if err != nil {
+		t.Fatalf("openClient: %v", err)
+	}
+	if client == nil {
+		t.Fatal("openClient returned a nil client")
+	}
+	if client.Store() == nil {
+		t.Error("client has no store")
+	}
+}
+
+// TestOpenClient_ReporterOverrideWins pins the parameter that lets the TUI and
+// tests supply their own reporter: when one is passed, the output mode does
+// not get to pick a different one.
+func TestOpenClient_ReporterOverrideWins(t *testing.T) {
+	ctx := context.Background()
+	cfg := clientConfig{
+		store:    storeConfig{uri: "local:" + t.TempDir()},
+		packfile: true,
+	}
+
+	raw, err := openStore(ctx, cfg.store)
+	if err != nil {
+		t.Fatalf("openStore: %v", err)
+	}
+	if _, err := cloudstic.InitRepo(ctx, raw); err != nil {
+		t.Fatalf("init repository: %v", err)
+	}
+
+	// cfg selects the console reporter; the override must be used instead.
+	override := ui.NewNoOpReporter()
+	if _, err := openClient(ctx, cfg, override); err != nil {
+		t.Fatalf("openClient with a reporter override: %v", err)
+	}
+}

--- a/cmd/cloudstic/cmd_store_test.go
+++ b/cmd/cloudstic/cmd_store_test.go
@@ -1405,6 +1405,13 @@ func TestRunStoreNew_LocalStore(t *testing.T) {
 	}
 }
 
+// TestClientConfigFromProfileStore_DefaultRegion asserts the guarantee that a
+// profile store naming no region still reaches S3 on the default one.
+//
+// The default is no longer pre-filled into the config: it is applied once at
+// construction (s3Region, storebuild.go), so that a config built any other way
+// gets it too. The config therefore carries "" here, and the assertion is on
+// the value the backend actually receives.
 func TestClientConfigFromProfileStore_DefaultRegion(t *testing.T) {
 	s := profile.Store{
 		URI: "s3:some-bucket",
@@ -1413,8 +1420,24 @@ func TestClientConfigFromProfileStore_DefaultRegion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("clientConfigFromProfileStore: %v", err)
 	}
-	if sc.store.s3.region != "us-east-1" {
-		t.Fatalf("expected default region us-east-1, got %q", sc.store.s3.region)
+	if sc.store.s3.region != "" {
+		t.Fatalf("expected the config to carry no region, got %q", sc.store.s3.region)
+	}
+	if got := s3Region(sc.store.s3.region); got != "us-east-1" {
+		t.Fatalf("expected default region us-east-1 at construction, got %q", got)
+	}
+}
+
+// TestClientConfigFromProfileStore_ExplicitRegionWins guards the other half:
+// applying the default at construction must not override a region the profile
+// actually names.
+func TestClientConfigFromProfileStore_ExplicitRegionWins(t *testing.T) {
+	sc, err := clientConfigFromProfileStore(profile.Store{URI: "s3:some-bucket", S3Region: "eu-west-3"})
+	if err != nil {
+		t.Fatalf("clientConfigFromProfileStore: %v", err)
+	}
+	if got := s3Region(sc.store.s3.region); got != "eu-west-3" {
+		t.Fatalf("expected the profile's region eu-west-3, got %q", got)
 	}
 }
 

--- a/cmd/cloudstic/config.go
+++ b/cmd/cloudstic/config.go
@@ -72,12 +72,21 @@ type unlockConfig struct {
 }
 
 // clientConfig is the resolved configuration for opening a repository client.
+//
+// Fields are oriented so the zero value is the correct default, because
+// RFC 0022 §7 makes these types public and a consumer writing
+// clientConfig{store: …} must get the same behaviour the CLI gets. That is why
+// packfiles are expressed as disablePackfile rather than packfile: NewClient
+// enables them by default, so a `packfile bool` zero value would silently turn
+// them off and write a repository with a different physical layout, with no
+// error at any layer. The negative field also matches the -disable-packfile
+// flag it comes from.
 type clientConfig struct {
-	store    storeConfig
-	unlock   unlockConfig
-	packfile bool
-	quiet    bool
-	json     bool
+	store           storeConfig
+	unlock          unlockConfig
+	disablePackfile bool
+	quiet           bool
+	json            bool
 }
 
 // clientConfigFromFlags projects parsed flags into a resolved configuration,
@@ -118,9 +127,9 @@ func clientConfigFromFlags(g *globalFlags) clientConfig {
 			prompt:   g.prompt,
 			noPrompt: g.noPrompt,
 		},
-		packfile: !g.disablePackfile,
-		quiet:    g.quiet,
-		json:     g.json,
+		disablePackfile: g.disablePackfile,
+		quiet:           g.quiet,
+		json:            g.json,
 	}
 }
 
@@ -204,8 +213,7 @@ func lookupProfileStore(cfg *profile.Config, profileName string, p profile.Profi
 // `store new`'s flags from an existing store entry for editing — an unrelated
 // concept despite the similar name.
 func clientConfigFromProfileStore(s profile.Store) (clientConfig, error) {
-	cfg := clientConfig{packfile: true}
-	cfg.store.s3.region = defaultS3Region
+	var cfg clientConfig
 	if err := applyProfileStore(&cfg, s, func(string) bool { return false }); err != nil {
 		return clientConfig{}, err
 	}

--- a/cmd/cloudstic/keychain_test.go
+++ b/cmd/cloudstic/keychain_test.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/moby/term"
+
+	"github.com/cloudstic/cli/pkg/keychain"
+)
+
+// These are characterization tests: they pin what buildKeychain and its
+// helpers do today, quirks included, so that RFC 0022 §7 can move them into a
+// public package and prove the move changed nothing. They were written before
+// the move, against code that had no direct unit tests at all.
+//
+// The credential order buildKeychain produces is the important part. It is the
+// order the client tries credentials in, so changing it silently changes which
+// key unlocks a repository when a caller supplies more than one.
+
+// credKinds names the concrete type behind each credential in a chain.
+//
+// It deliberately asserts on unexported type names from pkg/keychain. That is
+// the coupling we want here: the property under test is *which* credential
+// constructor was called and in what order, and the concrete type is the only
+// thing that records it — keychain.Credential is a two-method interface that
+// every credential satisfies identically. If pkg/keychain renames one of these
+// types, this test should fail and be updated deliberately, rather than pass
+// while the chain composition drifts.
+func credKinds(t *testing.T, chain keychain.Chain) []string {
+	t.Helper()
+	kinds := make([]string, 0, len(chain))
+	for _, c := range chain {
+		kinds = append(kinds, strings.TrimPrefix(fmt.Sprintf("%T", c), "keychain."))
+	}
+	return kinds
+}
+
+// validHexKey is 32 bytes, the size crypto.KeySize requires.
+const validHexKey = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+
+func TestBuildKeychain_ChainComposition(t *testing.T) {
+	// The prompt credential is appended only when stdin is a terminal, which it
+	// is not under `go test`. Every case below therefore reflects the
+	// non-interactive chain; TestBuildKeychain_PromptRequiresATerminal covers
+	// the branch that is unreachable here and says why.
+	if term.IsTerminal(os.Stdin.Fd()) {
+		t.Skip("stdin is a terminal; the non-interactive chains asserted here would gain a prompt credential")
+	}
+
+	tests := []struct {
+		name string
+		cfg  unlockConfig
+		want []string
+	}{
+		{
+			name: "empty config yields an empty chain",
+			cfg:  unlockConfig{},
+			want: []string{},
+		},
+		{
+			name: "password only",
+			cfg:  unlockConfig{password: "hunter2"},
+			want: []string{"passwordCred"},
+		},
+		{
+			name: "encryption key only",
+			cfg:  unlockConfig{encryptionKey: validHexKey},
+			want: []string{"platformKeyCred"},
+		},
+		{
+			name: "recovery key only",
+			cfg:  unlockConfig{recoveryKey: "abandon abandon ability"},
+			want: []string{"recoveryCred"},
+		},
+		{
+			name: "kms only",
+			cfg:  unlockConfig{kms: kmsConfig{keyARN: "arn:aws:kms:us-east-1:1:key/x", region: "us-east-1"}},
+			want: []string{"kmsClientCred"},
+		},
+		{
+			name: "every credential, in precedence order",
+			cfg: unlockConfig{
+				encryptionKey: validHexKey,
+				password:      "hunter2",
+				recoveryKey:   "abandon abandon ability",
+				kms:           kmsConfig{keyARN: "arn:aws:kms:us-east-1:1:key/x", region: "us-east-1"},
+			},
+			want: []string{"kmsClientCred", "platformKeyCred", "passwordCred", "recoveryCred"},
+		},
+		{
+			name: "prompt:true does not add a credential without a terminal",
+			cfg:  unlockConfig{password: "hunter2", prompt: true},
+			want: []string{"passwordCred"},
+		},
+		{
+			name: "noPrompt suppresses nothing else",
+			cfg:  unlockConfig{password: "hunter2", noPrompt: true},
+			want: []string{"passwordCred"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chain, err := buildKeychain(context.Background(), tt.cfg)
+			if err != nil {
+				t.Fatalf("buildKeychain: %v", err)
+			}
+			got := credKinds(t, chain)
+			if len(got) != len(tt.want) {
+				t.Fatalf("chain = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("chain[%d] = %s, want %s (full chain %v, want %v)",
+						i, got[i], tt.want[i], got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+// TestBuildKeychain_PromptRequiresATerminal records a dependency the move in
+// §7 has to deal with: whether a prompt credential is appended is decided by
+// reading the process's own stdin, via term.IsTerminal(os.Stdin.Fd()).
+//
+// That is correct for a CLI and wrong for a library — a consumer's answer to
+// "can I prompt?" is not this process's stdin. The condition is
+// (chain is empty || prompt) && !noPrompt && stdin is a terminal, so under
+// `go test` the third term is false and the branch cannot be reached at all.
+// When buildKeychain becomes public, the terminal check must become an
+// injected decision rather than an ambient one; this test is here to fail
+// loudly if that lands without anyone noticing the behavior changed.
+func TestBuildKeychain_PromptRequiresATerminal(t *testing.T) {
+	if term.IsTerminal(os.Stdin.Fd()) {
+		t.Skip("stdin is a terminal; this test characterizes the non-terminal path")
+	}
+
+	// An empty config satisfies both (len(chain) == 0) and !noPrompt, so the
+	// terminal check is the only thing preventing a prompt credential.
+	chain, err := buildKeychain(context.Background(), unlockConfig{})
+	if err != nil {
+		t.Fatalf("buildKeychain: %v", err)
+	}
+	if len(chain) != 0 {
+		t.Fatalf("chain = %v, want empty: without a terminal the prompt credential must not be added, "+
+			"which leaves nothing to unlock with", credKinds(t, chain))
+	}
+}
+
+func TestBuildKeychain_PropagatesPlatformKeyError(t *testing.T) {
+	_, err := buildKeychain(context.Background(), unlockConfig{encryptionKey: "not-hex"})
+	if err == nil {
+		t.Fatal("expected an error for a non-hex encryption key, got nil")
+	}
+	if !strings.Contains(err.Error(), "hex-encoded") {
+		t.Errorf("error = %q, want it to mention hex encoding so the user can act on it", err)
+	}
+}
+
+func TestParsePlatformKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		wantLen int
+		wantErr string
+	}{
+		{name: "empty is not an error", in: "", wantLen: 0},
+		{name: "valid 32-byte key", in: validHexKey, wantLen: 32},
+		{name: "uppercase hex is accepted", in: strings.ToUpper(validHexKey), wantLen: 32},
+		{name: "non-hex", in: "zzzz", wantErr: "hex-encoded"},
+		{name: "odd length", in: "abc", wantErr: "hex-encoded"},
+		{name: "too short", in: "0011", wantErr: "must be 32 bytes"},
+		{name: "too long", in: validHexKey + "00", wantErr: "must be 32 bytes"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePlatformKey(tt.in)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("parsePlatformKey(%q) = %x, want error containing %q", tt.in, got, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("error = %q, want it to contain %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parsePlatformKey(%q): %v", tt.in, err)
+			}
+			if len(got) != tt.wantLen {
+				t.Errorf("len = %d, want %d", len(got), tt.wantLen)
+			}
+		})
+	}
+}
+
+// TestBuildKMSClient_NoARNIsNotAnError pins the branch that decides whether
+// KMS participates at all: an absent ARN yields (nil, nil), and buildKeychain
+// reads that nil to mean "no KMS credential". An implementation that returned
+// an error here instead would break every non-KMS unlock.
+func TestBuildKMSClient_NoARNIsNotAnError(t *testing.T) {
+	client, err := buildKMSClient(context.Background(), kmsConfig{})
+	if err != nil {
+		t.Fatalf("buildKMSClient with no ARN: %v", err)
+	}
+	if client != nil {
+		t.Errorf("client = %v, want nil so buildKeychain omits the KMS credential", client)
+	}
+
+	// A region or endpoint without an ARN still means "no KMS".
+	client, err = buildKMSClient(context.Background(), kmsConfig{region: "us-east-1", endpoint: "http://localhost:4566"})
+	if err != nil {
+		t.Fatalf("buildKMSClient with region but no ARN: %v", err)
+	}
+	if client != nil {
+		t.Errorf("client = %v, want nil: the ARN alone decides whether KMS is used", client)
+	}
+}
+
+// TestBuildKMSClient_ARNBuildsOffline records that constructing the client
+// contacts nothing — no credentials, no network, no IMDS probe. buildKeychain
+// calls it eagerly on every unlock that names an ARN, so if this ever started
+// reaching the network it would add latency to each one.
+func TestBuildKMSClient_ARNBuildsOffline(t *testing.T) {
+	client, err := buildKMSClient(context.Background(), kmsConfig{
+		keyARN: "arn:aws:kms:us-east-1:123456789012:key/1234abcd",
+		region: "us-east-1",
+	})
+	if err != nil {
+		t.Fatalf("buildKMSClient: %v", err)
+	}
+	if client == nil {
+		t.Fatal("client = nil, want a client: an ARN must produce one")
+	}
+}

--- a/cmd/cloudstic/profile_secret_test.go
+++ b/cmd/cloudstic/profile_secret_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// Characterization tests for the inline-vs-secret-reference precedence that
+// every credential field in a profile store goes through. RFC 0022 §7 moves
+// this into pkg/config, where the precedence becomes a documented public
+// contract rather than an implementation detail of applyProfileStore.
+//
+// env:// is used throughout because it is the one secret backend available on
+// every platform and needs no keychain, so these stay hermetic.
+
+func TestResolveProfileStoreValue_InlineWinsOverSecretRef(t *testing.T) {
+	t.Setenv("CLOUDSTIC_TEST_SECRET", "from-secret-ref")
+
+	got, err := resolveProfileStoreValue("s3_access_key", "inline-value", "env://CLOUDSTIC_TEST_SECRET")
+	if err != nil {
+		t.Fatalf("resolveProfileStoreValue: %v", err)
+	}
+	if got != "inline-value" {
+		t.Errorf("got %q, want %q: an inline value must win over a secret reference, "+
+			"and must do so without resolving the reference at all", got, "inline-value")
+	}
+}
+
+func TestResolveProfileStoreValue_FallsBackToSecretRef(t *testing.T) {
+	t.Setenv("CLOUDSTIC_TEST_SECRET", "from-secret-ref")
+
+	got, err := resolveProfileStoreValue("s3_access_key", "", "env://CLOUDSTIC_TEST_SECRET")
+	if err != nil {
+		t.Fatalf("resolveProfileStoreValue: %v", err)
+	}
+	if got != "from-secret-ref" {
+		t.Errorf("got %q, want %q", got, "from-secret-ref")
+	}
+}
+
+func TestResolveProfileStoreValue_NeitherIsEmptyNotAnError(t *testing.T) {
+	got, err := resolveProfileStoreValue("s3_access_key", "", "")
+	if err != nil {
+		t.Fatalf("resolveProfileStoreValue: %v", err)
+	}
+	if got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}
+
+// TestResolveProfileStoreValue_ErrorNamesTheField pins the diagnostic, which is
+// the whole reason resolution happens here rather than at connect time: a
+// missing secret must say which profile field asked for it and what reference
+// failed, not surface later as an empty credential and an auth error from a
+// cloud provider.
+func TestResolveProfileStoreValue_ErrorNamesTheField(t *testing.T) {
+	_, err := resolveProfileStoreValue("b2_app_key", "", "env://CLOUDSTIC_TEST_DEFINITELY_UNSET")
+	if err == nil {
+		t.Fatal("expected an error for an unresolvable secret reference, got nil")
+	}
+	for _, want := range []string{"b2_app_key", "env://CLOUDSTIC_TEST_DEFINITELY_UNSET"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %q, want it to mention %q", err, want)
+		}
+	}
+}
+
+func TestResolveProfileStoreValue_RejectsUnknownScheme(t *testing.T) {
+	_, err := resolveProfileStoreValue("password", "", "not-a-ref")
+	if err == nil {
+		t.Fatal("expected an error for a malformed secret reference, got nil")
+	}
+	if !strings.Contains(err.Error(), "password") {
+		t.Errorf("error = %q, want it to name the field", err)
+	}
+}

--- a/cmd/cloudstic/storebuild.go
+++ b/cmd/cloudstic/storebuild.go
@@ -66,7 +66,7 @@ func newObjectStore(ctx context.Context, cfg storeConfig) (store.ObjectStore, er
 			ctx,
 			uri.bucket,
 			s3store.WithEndpoint(cfg.s3.endpoint),
-			s3store.WithRegion(cfg.s3.region),
+			s3store.WithRegion(s3Region(cfg.s3.region)),
 			s3store.WithProfile(cfg.s3.profile),
 			s3store.WithCredentials(cfg.s3.accessKey, cfg.s3.secretKey),
 			s3store.WithPrefix(uri.prefix),
@@ -81,6 +81,18 @@ func newObjectStore(ctx context.Context, cfg storeConfig) (store.ObjectStore, er
 		return nil, err
 	}
 	return withCrashInjection(inner)
+}
+
+// s3Region applies the built-in region default. It lives here, at the single
+// point of construction, rather than being pre-filled into every storeConfig
+// that might reach it: the flag path gets defaultS3Region from the -s3-region
+// flag's own default, but a config built from a profile store has no flag to
+// carry it, and prefilling that separately is how the two paths drift.
+func s3Region(region string) string {
+	if region == "" {
+		return defaultS3Region
+	}
+	return region
 }
 
 func sftpStoreOpts(cfg sftpConfig, uri *storeURIParts) []sftpstore.Option {

--- a/rfcs/0022-public-go-api-boundaries.md
+++ b/rfcs/0022-public-go-api-boundaries.md
@@ -429,6 +429,13 @@ value is the safe default (matching the `-disable-packfile` flag it comes from),
 and the region default resolves inside `open.Store` rather than at one of two
 call sites.
 
+Both landed ahead of the move, as `disablePackfile` and `s3Region`
+(`storebuild.go`) while the types were still unexported — so the behavioral
+change was reviewable on its own, before any code changed packages. Moving the
+region default was caught by an existing test asserting the pre-filled value,
+which is the correct outcome: the config now carries `""` and the guarantee is
+asserted where the backend receives it.
+
 **`open.Client` is a convenience over public parts, not a funnel.** A composition
 root in a library is a fair thing to object to. The answer is that
 `open.Store`, `open.Source`, and `open.Keychain` are independently useful and
@@ -580,7 +587,7 @@ Stages 5–8 add three requirements:
    dependency-weight sweep that would have caught it. **Done.**
 6. Characterization tests over the §7 blast radius, in `package main`, before
    anything moves. Then fix the `packfile` and `s3.region` zero values as a
-   separate, behavioral commit.
+   separate, behavioral commit. **Done.**
 7. Move config types to `pkg/config` behind `type clientConfig = config.Client`
    aliases in `cmd/cloudstic`, then the URI parsers, then profile resolution
    with the resolver injected — three commits, no call-site churn.


### PR DESCRIPTION
## Summary

Two commits, deliberately not squashed together: the first adds tests and changes no production code, the second changes behaviour. They need different review postures.

**`test: characterize the unlock and client-construction path`** — RFC 0022 §7 moves configuration resolution and construction out of `package main` into `pkg/config` and `pkg/open`. Grepping the blast radius first showed the unlock path had no direct unit tests at all: `buildKeychain`, `buildKMSClient`, `parsePlatformKey`, `openClient`, `newReporter` and `resolveProfileStoreValue` were referenced by zero test files.

`buildKeychain` is the one that matters. It fixes the order credentials are tried in — KMS, platform key, password, recovery key, then an interactive prompt — and that order decides which key unlocks a repository when a caller supplies more than one. Today it is recorded only in the code; after the move it is a public promise. Coverage of those six functions goes from 0% to 80–100%.

**`fix: make the zero value of the resolved client config correct`** — `clientConfig.packfile` meant "enabled" but its zero value was `false`, and `openClient` passed it to `WithPackfile` unconditionally, overriding `NewClient`'s own `enablePackfile: true` default. The codebase compensated twice, in opposite directions (`!g.disablePackfile` in one constructor, a hardcoded `clientConfig{packfile: true}` in the other). The S3 region had the same shape, pre-filled in one constructor only.

Contained today, because both constructors compensate. Not contained once §7 makes these types public: a consumer writing `config.Client{Store: …}` would get packfiles silently disabled and no region, and write a repository with a different physical layout with no error from any layer. The field becomes `disablePackfile` so the zero value is the safe default, and the region default moves into `s3Region` (`storebuild.go`), applied once at the point of construction.

Part of #378

### For reviewers

- **Why the tests assert on unexported types from `pkg/keychain`.** `keychain.Credential` is a two-method interface that every credential satisfies identically, so the concrete type is the only thing recording which constructor ran — which is exactly the property under test. If `pkg/keychain` renames one, this test should fail and be updated deliberately.
- **A finding for §7, encoded as a test.** The one branch left uncovered in `buildKeychain` is the prompt credential, gated on `term.IsTerminal(os.Stdin.Fd())` and therefore unreachable under `go test`. That is a hidden global: correct for a CLI, wrong for a library, since a consumer's answer to "can I prompt?" is not this process's stdin. `TestBuildKeychain_PromptRequiresATerminal` exists to fail loudly when §7 turns it into an injected decision.
- **One existing test failed, correctly.** `TestClientConfigFromProfileStore_DefaultRegion` asserted the pre-filled intermediate region value. `cfg.store.s3.region` is read only by `newObjectStore`, so applying the default at construction is behaviour-preserving at the boundary that matters; the test now asserts the guarantee where the backend receives it, and gained a companion that an explicitly named region still wins.
- **Tests that would have duplicated `storebuild_test.go` / `storeuri_test.go`** (`withDebugStore`, URI rejection, B2 credential checks) were written, found redundant, and dropped rather than added alongside.
- Rebased onto `main` after #391 merged, so this carries only its own two commits.

## Verification

\`\`\`bash
env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./...
env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./cmd/cloudstic/...
gofmt -l .
\`\`\`

Full suite passes with the race detector; lint reports 0 issues; `gofmt -l` is clean (the four offenders flagged on #391 were fixed by #392).