### PR TITLE
refactor: move the resolved config types to pkg/config (RFC 0022)

### DIFF
--- a/cmd/cloudstic/clientbuild.go
+++ b/cmd/cloudstic/clientbuild.go
@@ -14,18 +14,18 @@ import (
 // repository client on top of it. Passing a nil reporter selects one from the
 // configured output mode.
 func openClient(ctx context.Context, cfg clientConfig, reporterOverride cloudstic.Reporter) (*cloudstic.Client, error) {
-	raw, err := newObjectStore(ctx, cfg.store)
+	raw, err := newObjectStore(ctx, cfg.Store)
 	if err != nil {
 		return nil, err
 	}
-	raw, debugLog := withDebugStore(raw, cfg.store.debug)
+	raw, debugLog := withDebugStore(raw, cfg.Store.Debug)
 
 	reporter := reporterOverride
 	if reporter == nil {
 		reporter = newReporter(cfg, debugLog)
 	}
 
-	kc, err := buildKeychain(ctx, cfg.unlock)
+	kc, err := buildKeychain(ctx, cfg.Unlock)
 	if err != nil {
 		return nil, err
 	}
@@ -33,12 +33,12 @@ func openClient(ctx context.Context, cfg clientConfig, reporterOverride cloudsti
 	return cloudstic.NewClient(ctx, raw,
 		cloudstic.WithKeychain(kc),
 		cloudstic.WithReporter(reporter),
-		cloudstic.WithPackfile(!cfg.disablePackfile),
+		cloudstic.WithPackfile(!cfg.DisablePackfile),
 	)
 }
 
 func newReporter(cfg clientConfig, debugLog *ui.SafeLogWriter) cloudstic.Reporter {
-	if cfg.quiet || cfg.json {
+	if cfg.Quiet || cfg.JSON {
 		return ui.NewNoOpReporter()
 	}
 	cr := ui.NewConsoleReporter()

--- a/cmd/cloudstic/clientbuild_test.go
+++ b/cmd/cloudstic/clientbuild_test.go
@@ -34,19 +34,19 @@ func TestNewReporter_OutputModeSelectsReporter(t *testing.T) {
 		},
 		{
 			name:       "quiet silences progress",
-			cfg:        clientConfig{quiet: true},
+			cfg:        clientConfig{Quiet: true},
 			wantNoOp:   true,
 			wantReason: "-quiet must produce no progress output",
 		},
 		{
 			name:       "json silences progress",
-			cfg:        clientConfig{json: true},
+			cfg:        clientConfig{JSON: true},
 			wantNoOp:   true,
 			wantReason: "progress output would corrupt the JSON document on stdout",
 		},
 		{
 			name:       "quiet and json together",
-			cfg:        clientConfig{quiet: true, json: true},
+			cfg:        clientConfig{Quiet: true, JSON: true},
 			wantNoOp:   true,
 			wantReason: "either flag alone is enough",
 		},
@@ -77,7 +77,7 @@ func TestNewReporter_DebugLogOnlyAffectsTheConsoleReporter(t *testing.T) {
 		t.Error("a debug log must not turn the console reporter into a no-op reporter")
 	}
 
-	got = newReporter(clientConfig{quiet: true}, debugLog)
+	got = newReporter(clientConfig{Quiet: true}, debugLog)
 	if _, isNoOp := got.(*ui.NoOpReporter); !isNoOp {
 		t.Errorf("got %T, want a no-op reporter: a debug log must not override -quiet", got)
 	}
@@ -91,11 +91,11 @@ func TestNewReporter_DebugLogOnlyAffectsTheConsoleReporter(t *testing.T) {
 func TestOpenClient_UnencryptedLocalRepo(t *testing.T) {
 	ctx := context.Background()
 	cfg := clientConfig{
-		store: storeConfig{uri: "local:" + t.TempDir()},
-		quiet: true,
+		Store: storeConfig{URI: "local:" + t.TempDir()},
+		Quiet: true,
 	}
 
-	raw, err := openStore(ctx, cfg.store)
+	raw, err := openStore(ctx, cfg.Store)
 	if err != nil {
 		t.Fatalf("openStore: %v", err)
 	}
@@ -123,14 +123,14 @@ func TestOpenClient_UnencryptedLocalRepo(t *testing.T) {
 // error from any layer.
 func TestClientConfigZeroValueEnablesPackfiles(t *testing.T) {
 	var cfg clientConfig
-	if cfg.disablePackfile {
+	if cfg.DisablePackfile {
 		t.Error("the zero value must leave packfiles enabled, matching NewClient's own default")
 	}
 
 	// The two constructors must agree with the zero value when nothing asks
 	// otherwise.
 	fromFlags := clientConfigFromFlags(&globalFlags{})
-	if fromFlags.disablePackfile {
+	if fromFlags.DisablePackfile {
 		t.Error("clientConfigFromFlags with no flags set must leave packfiles enabled")
 	}
 
@@ -138,13 +138,13 @@ func TestClientConfigZeroValueEnablesPackfiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("clientConfigFromProfileStore: %v", err)
 	}
-	if fromProfile.disablePackfile {
+	if fromProfile.DisablePackfile {
 		t.Error("a profile store that says nothing about packfiles must leave them enabled")
 	}
 
 	// And the flag still works.
 	disabled := clientConfigFromFlags(&globalFlags{disablePackfile: true})
-	if !disabled.disablePackfile {
+	if !disabled.DisablePackfile {
 		t.Error("-disable-packfile must still disable packfiles")
 	}
 }
@@ -167,10 +167,10 @@ func TestS3RegionDefault(t *testing.T) {
 func TestOpenClient_ReporterOverrideWins(t *testing.T) {
 	ctx := context.Background()
 	cfg := clientConfig{
-		store: storeConfig{uri: "local:" + t.TempDir()},
+		Store: storeConfig{URI: "local:" + t.TempDir()},
 	}
 
-	raw, err := openStore(ctx, cfg.store)
+	raw, err := openStore(ctx, cfg.Store)
 	if err != nil {
 		t.Fatalf("openStore: %v", err)
 	}

--- a/cmd/cloudstic/cmd_backup.go
+++ b/cmd/cloudstic/cmd_backup.go
@@ -669,17 +669,17 @@ func sftpSourceOpts(cfg sftpConfig, uri *sourceURIParts) []sftpsource.Option {
 	if uri.user != "" {
 		opts = append(opts, sftpsource.WithUser(uri.user))
 	}
-	if cfg.password != "" {
-		opts = append(opts, sftpsource.WithPassword(cfg.password))
+	if cfg.Password != "" {
+		opts = append(opts, sftpsource.WithPassword(cfg.Password))
 	}
-	if cfg.key != "" {
-		opts = append(opts, sftpsource.WithKey(cfg.key))
+	if cfg.Key != "" {
+		opts = append(opts, sftpsource.WithKey(cfg.Key))
 	}
-	if cfg.insecure {
+	if cfg.Insecure {
 		opts = append(opts, sftpsource.WithHostKeyCallback(ssh.InsecureIgnoreHostKey())) //nolint:gosec // explicitly requested by user
 	}
-	if cfg.knownHosts != "" {
-		opts = append(opts, sftpsource.WithKnownHosts(cfg.knownHosts))
+	if cfg.KnownHosts != "" {
+		opts = append(opts, sftpsource.WithKnownHosts(cfg.KnownHosts))
 	}
 	return opts
 }

--- a/cmd/cloudstic/cmd_backup_profile_test.go
+++ b/cmd/cloudstic/cmd_backup_profile_test.go
@@ -60,14 +60,14 @@ func TestMergeProfileBackupArgs_AppliesProfileAndStore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveClientConfig: %v", err)
 	}
-	if resolved.store.uri != "s3:bucket/prefix" {
-		t.Fatalf("store.uri=%q want s3:bucket/prefix", resolved.store.uri)
+	if resolved.Store.URI != "s3:bucket/prefix" {
+		t.Fatalf("store.uri=%q want s3:bucket/prefix", resolved.Store.URI)
 	}
-	if resolved.store.s3.region != "eu-west-1" {
-		t.Fatalf("s3.region=%q want eu-west-1", resolved.store.s3.region)
+	if resolved.Store.S3.Region != "eu-west-1" {
+		t.Fatalf("s3.region=%q want eu-west-1", resolved.Store.S3.Region)
 	}
-	if resolved.store.s3.accessKey != "AKIA" {
-		t.Fatalf("s3.accessKey=%q want AKIA", resolved.store.s3.accessKey)
+	if resolved.Store.S3.AccessKey != "AKIA" {
+		t.Fatalf("s3.accessKey=%q want AKIA", resolved.Store.S3.AccessKey)
 	}
 }
 
@@ -101,8 +101,8 @@ func TestMergeProfileBackupArgs_CLIFlagsWin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveClientConfig: %v", err)
 	}
-	if resolved.store.uri != "local:/cli-store" {
-		t.Fatalf("store.uri=%q want local:/cli-store", resolved.store.uri)
+	if resolved.Store.URI != "local:/cli-store" {
+		t.Fatalf("store.uri=%q want local:/cli-store", resolved.Store.URI)
 	}
 }
 
@@ -372,22 +372,22 @@ func TestApplyProfileStore_AllFields(t *testing.T) {
 		got  string
 		want string
 	}{
-		{"store.uri", cfg.store.uri, "s3:my-bucket/prefix"},
-		{"s3.region", cfg.store.s3.region, "us-east-1"},
-		{"s3.endpoint", cfg.store.s3.endpoint, "https://s3.example.com"},
-		{"s3.profile", cfg.store.s3.profile, "prod"},
-		{"s3.accessKey", cfg.store.s3.accessKey, "AKIATEST"},
-		{"s3.secretKey", cfg.store.s3.secretKey, "SECRETTEST"},
-		{"b2.keyID", cfg.store.b2.keyID, "b2-key-id"},
-		{"b2.appKey", cfg.store.b2.appKey, "b2-app-key"},
-		{"sftp.password", cfg.store.sftp.password, "sftp-pw"},
-		{"sftp.key", cfg.store.sftp.key, "/tmp/sftp.key"},
-		{"unlock.password", cfg.unlock.password, "secret-pw"},
-		{"unlock.encryptionKey", cfg.unlock.encryptionKey, "enc-key-val"},
-		{"unlock.recoveryKey", cfg.unlock.recoveryKey, "rec-key-val"},
-		{"kms.keyARN", cfg.unlock.kms.keyARN, "arn:aws:kms:us-east-1:123:key/abc"},
-		{"kms.region", cfg.unlock.kms.region, "us-east-1"},
-		{"kms.endpoint", cfg.unlock.kms.endpoint, "https://kms.example.com"},
+		{"store.uri", cfg.Store.URI, "s3:my-bucket/prefix"},
+		{"s3.region", cfg.Store.S3.Region, "us-east-1"},
+		{"s3.endpoint", cfg.Store.S3.Endpoint, "https://s3.example.com"},
+		{"s3.profile", cfg.Store.S3.Profile, "prod"},
+		{"s3.accessKey", cfg.Store.S3.AccessKey, "AKIATEST"},
+		{"s3.secretKey", cfg.Store.S3.SecretKey, "SECRETTEST"},
+		{"b2.keyID", cfg.Store.B2.KeyID, "b2-key-id"},
+		{"b2.appKey", cfg.Store.B2.AppKey, "b2-app-key"},
+		{"sftp.password", cfg.Store.SFTP.Password, "sftp-pw"},
+		{"sftp.key", cfg.Store.SFTP.Key, "/tmp/sftp.key"},
+		{"unlock.password", cfg.Unlock.Password, "secret-pw"},
+		{"unlock.encryptionKey", cfg.Unlock.EncryptionKey, "enc-key-val"},
+		{"unlock.recoveryKey", cfg.Unlock.RecoveryKey, "rec-key-val"},
+		{"kms.keyARN", cfg.Unlock.KMS.KeyARN, "arn:aws:kms:us-east-1:123:key/abc"},
+		{"kms.region", cfg.Unlock.KMS.Region, "us-east-1"},
+		{"kms.endpoint", cfg.Unlock.KMS.Endpoint, "https://kms.example.com"},
 	}
 	for _, c := range checks {
 		if c.got != c.want {
@@ -407,8 +407,8 @@ func TestApplyProfileStore_CLIFlagOverrides(t *testing.T) {
 	if err != nil {
 		t.Fatalf("applyProfileStore: %v", err)
 	}
-	if cfg.store.uri != "local:/cli-store" {
-		t.Fatalf("store.uri=%q want local:/cli-store", cfg.store.uri)
+	if cfg.Store.URI != "local:/cli-store" {
+		t.Fatalf("store.uri=%q want local:/cli-store", cfg.Store.URI)
 	}
 }
 
@@ -419,8 +419,8 @@ func TestApplyProfileStore_SecretRef(t *testing.T) {
 	if err != nil {
 		t.Fatalf("applyProfileStore: %v", err)
 	}
-	if cfg.unlock.password != "from-secret-ref" {
-		t.Fatalf("unlock.password=%q want from-secret-ref", cfg.unlock.password)
+	if cfg.Unlock.Password != "from-secret-ref" {
+		t.Fatalf("unlock.password=%q want from-secret-ref", cfg.Unlock.Password)
 	}
 }
 
@@ -435,11 +435,11 @@ func TestApplyProfileStore_B2SecretRef(t *testing.T) {
 	if err != nil {
 		t.Fatalf("applyProfileStore: %v", err)
 	}
-	if cfg.store.b2.keyID != "b2-id-from-env" {
-		t.Fatalf("b2.keyID=%q want b2-id-from-env", cfg.store.b2.keyID)
+	if cfg.Store.B2.KeyID != "b2-id-from-env" {
+		t.Fatalf("b2.keyID=%q want b2-id-from-env", cfg.Store.B2.KeyID)
 	}
-	if cfg.store.b2.appKey != "b2-key-from-env" {
-		t.Fatalf("b2.appKey=%q want b2-key-from-env", cfg.store.b2.appKey)
+	if cfg.Store.B2.AppKey != "b2-key-from-env" {
+		t.Fatalf("b2.appKey=%q want b2-key-from-env", cfg.Store.B2.AppKey)
 	}
 }
 

--- a/cmd/cloudstic/cmd_backup_test.go
+++ b/cmd/cloudstic/cmd_backup_test.go
@@ -99,10 +99,10 @@ func TestSFTPSourceOpts_TranslatesConfig(t *testing.T) {
 	}
 
 	full := sftpSourceOpts(sftpConfig{
-		password:   "s3cret",
-		key:        "/path/to/key",
-		insecure:   true,
-		knownHosts: "/path/to/known_hosts",
+		Password:   "s3cret",
+		Key:        "/path/to/key",
+		Insecure:   true,
+		KnownHosts: "/path/to/known_hosts",
 	}, uri)
 	if len(full) != 7 {
 		t.Fatalf("full config: got %d options, want 7", len(full))

--- a/cmd/cloudstic/cmd_init.go
+++ b/cmd/cloudstic/cmd_init.go
@@ -42,12 +42,12 @@ func runInit(r *runner, ctx context.Context, a *initArgs) int {
 // configuration rather than deriving it, so callers that address a store
 // directly (the TUI) can reuse it without going through flag parsing.
 func execInit(r *runner, ctx context.Context, a *initArgs, cfg clientConfig) int {
-	raw, err := openStore(ctx, cfg.store)
+	raw, err := openStore(ctx, cfg.Store)
 	if err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
 
-	kc, err := buildKeychain(ctx, cfg.unlock)
+	kc, err := buildKeychain(ctx, cfg.Unlock)
 	if err != nil {
 		return r.fail("Failed to build keychain: %v", err)
 	}
@@ -59,8 +59,8 @@ func execInit(r *runner, ctx context.Context, a *initArgs, cfg clientConfig) int
 			if err != nil {
 				return r.fail("Error: %v", err)
 			}
-			cfg.unlock.password = pw
-			kc, _ = buildKeychain(ctx, cfg.unlock)
+			cfg.Unlock.Password = pw
+			kc, _ = buildKeychain(ctx, cfg.Unlock)
 		} else {
 			return r.fail("Error: encryption is required by default.\nProvide --password or --encryption-key to encrypt your repository.\nTo create an unencrypted repository, pass --no-encryption (not recommended).")
 		}

--- a/cmd/cloudstic/cmd_key.go
+++ b/cmd/cloudstic/cmd_key.go
@@ -28,7 +28,7 @@ func runKeyList(r *runner, ctx context.Context, a *keyListArgs) int {
 	if err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
-	raw, err := openStore(ctx, cfg.store)
+	raw, err := openStore(ctx, cfg.Store)
 	if err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
@@ -82,12 +82,12 @@ func runKeyPasswd(r *runner, ctx context.Context, a *keyPasswdArgs) int {
 	if err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
-	raw, err := openStore(ctx, cfg.store)
+	raw, err := openStore(ctx, cfg.Store)
 	if err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
 
-	kc, err := buildKeychain(ctx, cfg.unlock)
+	kc, err := buildKeychain(ctx, cfg.Unlock)
 	if err != nil {
 		return r.fail("%v", err)
 	}
@@ -138,12 +138,12 @@ func runAddRecoveryKey(r *runner, ctx context.Context, a *addRecoveryKeyArgs) in
 	if err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
-	raw, err := openStore(ctx, cfg.store)
+	raw, err := openStore(ctx, cfg.Store)
 	if err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
 
-	kc, err := buildKeychain(ctx, cfg.unlock)
+	kc, err := buildKeychain(ctx, cfg.Unlock)
 	if err != nil {
 		return r.fail("%v", err)
 	}

--- a/cmd/cloudstic/cmd_store.go
+++ b/cmd/cloudstic/cmd_store.go
@@ -352,8 +352,8 @@ func checkOrInitStore(r *runner, ctx context.Context, cfg *profile.Config, store
 		}
 		return fmt.Errorf("could not resolve store credentials: %w", err)
 	}
-	resolved.unlock.noPrompt = r.noPrompt
-	raw, err := newObjectStore(ctx, resolved.store)
+	resolved.Unlock.NoPrompt = r.noPrompt
+	raw, err := newObjectStore(ctx, resolved.Store)
 	if err != nil {
 		return fmt.Errorf("could not connect to store: %w", err)
 	}
@@ -371,7 +371,7 @@ func checkOrInitStore(r *runner, ctx context.Context, cfg *profile.Config, store
 		}
 		if repoStatus.Encrypted {
 			_, _ = fmt.Fprintln(r.out, "Repository is encrypted; verifying configured credentials...")
-			if err := verifyStoreEncryptionCredentials(ctx, resolved.unlock, raw); err != nil {
+			if err := verifyStoreEncryptionCredentials(ctx, resolved.Unlock, raw); err != nil {
 				return fmt.Errorf("store is initialized, but configured encryption credentials are invalid: %w", err)
 			}
 			_, _ = fmt.Fprintln(r.out, "Encryption credentials are valid.")
@@ -406,7 +406,7 @@ func checkOrInitStore(r *runner, ctx context.Context, cfg *profile.Config, store
 	// Build keychain from the store's encryption settings.
 	// For password-based encryption, the env var must be set for init.
 	// If not set, prompt for the password interactively.
-	kc, err := buildKeychain(ctx, resolved.unlock)
+	kc, err := buildKeychain(ctx, resolved.Unlock)
 	if err != nil {
 		return fmt.Errorf("failed to build keychain: %w", err)
 	}

--- a/cmd/cloudstic/cmd_store_test.go
+++ b/cmd/cloudstic/cmd_store_test.go
@@ -310,7 +310,7 @@ func TestCheckOrInitStore_AlreadyInitialized(t *testing.T) {
 	if err != nil {
 		t.Fatalf("clientConfigFromProfileStore: %v", err)
 	}
-	raw, err := newObjectStore(context.Background(), sc.store)
+	raw, err := newObjectStore(context.Background(), sc.Store)
 	if err != nil {
 		t.Fatalf("newObjectStore: %v", err)
 	}
@@ -349,7 +349,7 @@ func TestCheckOrInitStore_InitializedEncrypted_ValidCredentials(t *testing.T) {
 	if err != nil {
 		t.Fatalf("clientConfigFromProfileStore: %v", err)
 	}
-	raw, err := newObjectStore(context.Background(), sc.store)
+	raw, err := newObjectStore(context.Background(), sc.Store)
 	if err != nil {
 		t.Fatalf("newObjectStore: %v", err)
 	}
@@ -389,7 +389,7 @@ func TestCheckOrInitStore_InitializedEncrypted_InvalidCredentials(t *testing.T) 
 	if err != nil {
 		t.Fatalf("clientConfigFromProfileStore: %v", err)
 	}
-	raw, err := newObjectStore(context.Background(), sc.store)
+	raw, err := newObjectStore(context.Background(), sc.Store)
 	if err != nil {
 		t.Fatalf("newObjectStore: %v", err)
 	}
@@ -434,23 +434,23 @@ func TestClientConfigFromProfileStore_ResolvesEnvVars(t *testing.T) {
 	if err != nil {
 		t.Fatalf("clientConfigFromProfileStore: %v", err)
 	}
-	if sc.store.uri != "s3:bucket/prefix" {
-		t.Fatalf("store=%q", sc.store.uri)
+	if sc.Store.URI != "s3:bucket/prefix" {
+		t.Fatalf("store=%q", sc.Store.URI)
 	}
-	if sc.store.s3.region != "eu-west-1" {
-		t.Fatalf("s3Region=%q", sc.store.s3.region)
+	if sc.Store.S3.Region != "eu-west-1" {
+		t.Fatalf("s3Region=%q", sc.Store.S3.Region)
 	}
-	if sc.store.s3.accessKey != "my-access-key" {
-		t.Fatalf("s3AccessKey=%q", sc.store.s3.accessKey)
+	if sc.Store.S3.AccessKey != "my-access-key" {
+		t.Fatalf("s3AccessKey=%q", sc.Store.S3.AccessKey)
 	}
-	if sc.store.s3.secretKey != "my-secret-key" {
-		t.Fatalf("s3SecretKey=%q", sc.store.s3.secretKey)
+	if sc.Store.S3.SecretKey != "my-secret-key" {
+		t.Fatalf("s3SecretKey=%q", sc.Store.S3.SecretKey)
 	}
-	if sc.unlock.password != "s3cret" {
-		t.Fatalf("password=%q", sc.unlock.password)
+	if sc.Unlock.Password != "s3cret" {
+		t.Fatalf("password=%q", sc.Unlock.Password)
 	}
-	if sc.unlock.kms.keyARN != "arn:aws:kms:us-east-1:123:key/abc" {
-		t.Fatalf("kmsKeyARN=%q", sc.unlock.kms.keyARN)
+	if sc.Unlock.KMS.KeyARN != "arn:aws:kms:us-east-1:123:key/abc" {
+		t.Fatalf("kmsKeyARN=%q", sc.Unlock.KMS.KeyARN)
 	}
 }
 
@@ -466,8 +466,8 @@ func TestClientConfigFromProfileStore_ResolvesSecretRef(t *testing.T) {
 	if err != nil {
 		t.Fatalf("clientConfigFromProfileStore: %v", err)
 	}
-	if sc.store.s3.accessKey != "secret-ak" {
-		t.Fatalf("s3AccessKey=%q want secret-ak", sc.store.s3.accessKey)
+	if sc.Store.S3.AccessKey != "secret-ak" {
+		t.Fatalf("s3AccessKey=%q want secret-ak", sc.Store.S3.AccessKey)
 	}
 }
 
@@ -1420,10 +1420,10 @@ func TestClientConfigFromProfileStore_DefaultRegion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("clientConfigFromProfileStore: %v", err)
 	}
-	if sc.store.s3.region != "" {
-		t.Fatalf("expected the config to carry no region, got %q", sc.store.s3.region)
+	if sc.Store.S3.Region != "" {
+		t.Fatalf("expected the config to carry no region, got %q", sc.Store.S3.Region)
 	}
-	if got := s3Region(sc.store.s3.region); got != "us-east-1" {
+	if got := s3Region(sc.Store.S3.Region); got != "us-east-1" {
 		t.Fatalf("expected default region us-east-1 at construction, got %q", got)
 	}
 }
@@ -1436,7 +1436,7 @@ func TestClientConfigFromProfileStore_ExplicitRegionWins(t *testing.T) {
 	if err != nil {
 		t.Fatalf("clientConfigFromProfileStore: %v", err)
 	}
-	if got := s3Region(sc.store.s3.region); got != "eu-west-3" {
+	if got := s3Region(sc.Store.S3.Region); got != "eu-west-3" {
 		t.Fatalf("expected the profile's region eu-west-3, got %q", got)
 	}
 }
@@ -1451,10 +1451,10 @@ func TestClientConfigFromProfileStore_SFTPFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("clientConfigFromProfileStore: %v", err)
 	}
-	if sc.store.sftp.password != "direct-pw" {
-		t.Fatalf("expected storeSFTPPassword=direct-pw, got %q", sc.store.sftp.password)
+	if sc.Store.SFTP.Password != "direct-pw" {
+		t.Fatalf("expected storeSFTPPassword=direct-pw, got %q", sc.Store.SFTP.Password)
 	}
-	if sc.store.sftp.key != "/path/to/key" {
-		t.Fatalf("expected storeSFTPKey=/path/to/key, got %q", sc.store.sftp.key)
+	if sc.Store.SFTP.Key != "/path/to/key" {
+		t.Fatalf("expected storeSFTPKey=/path/to/key, got %q", sc.Store.SFTP.Key)
 	}
 }

--- a/cmd/cloudstic/cmd_tui_activity.go
+++ b/cmd/cloudstic/cmd_tui_activity.go
@@ -208,8 +208,8 @@ func tuiClientConfig(storeCfg profile.Store) (clientConfig, error) {
 	if err != nil {
 		return clientConfig{}, err
 	}
-	cfg.quiet = true
-	cfg.store.debug = false
+	cfg.Quiet = true
+	cfg.Store.Debug = false
 	return cfg, nil
 }
 

--- a/cmd/cloudstic/cmd_tui_run.go
+++ b/cmd/cloudstic/cmd_tui_run.go
@@ -101,7 +101,7 @@ func (b tuiCLIBackend) InitProfile(ctx context.Context, profilesFile, profileNam
 	if err != nil {
 		return err
 	}
-	resolved.quiet = false
+	resolved.Quiet = false
 	if code := execInit(b.r, ctx, &initArgs{globalFlags: &globalFlags{}}, resolved); code != 0 {
 		return fmt.Errorf("init failed")
 	}

--- a/cmd/cloudstic/config.go
+++ b/cmd/cloudstic/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/cloudstic/cli/pkg/config"
 	"github.com/cloudstic/cli/pkg/profile"
 )
 
@@ -20,74 +21,20 @@ import (
 // and never sees globalFlags, which is what makes it unit-testable without
 // going through flag parsing.
 
-// s3Config holds the credentials and endpoint settings for an S3 store.
-type s3Config struct {
-	Endpoint  string
-	Region    string
-	Profile   string
-	AccessKey string
-	SecretKey string
-}
-
-// b2Config holds Backblaze B2 application key credentials.
-type b2Config struct {
-	KeyID  string
-	AppKey string
-}
-
-// sftpConfig holds SFTP authentication and host-key settings. The same shape
-// serves both a store and a backup source, which are configured independently.
-type sftpConfig struct {
-	Password   string
-	Key        string
-	KnownHosts string
-	Insecure   bool
-}
-
-// kmsConfig holds AWS KMS settings for kms-platform key slots.
-type kmsConfig struct {
-	KeyARN   string
-	Region   string
-	Endpoint string
-}
-
-// storeConfig is everything needed to construct an object store.
-type storeConfig struct {
-	URI   string
-	S3    s3Config
-	B2    b2Config
-	SFTP  sftpConfig
-	Debug bool
-}
-
-// unlockConfig is everything needed to build the keychain that unlocks a
-// repository.
-type unlockConfig struct {
-	Password      string
-	EncryptionKey string
-	RecoveryKey   string
-	KMS           kmsConfig
-	Prompt        bool
-	NoPrompt      bool
-}
-
-// clientConfig is the resolved configuration for opening a repository client.
-//
-// Fields are oriented so the zero value is the correct default, because
-// RFC 0022 §7 makes these types public and a consumer writing
-// clientConfig{Store: …} must get the same behaviour the CLI gets. That is why
-// packfiles are expressed as DisablePackfile rather than Packfile: NewClient
-// enables them by default, so a `Packfile bool` zero value would silently turn
-// them off and write a repository with a different physical layout, with no
-// error at any layer. The negative field also matches the -disable-packfile
-// flag it comes from.
-type clientConfig struct {
-	Store           storeConfig
-	Unlock          unlockConfig
-	DisablePackfile bool
-	Quiet           bool
-	JSON            bool
-}
+// The resolved configuration types now live in pkg/config, so that a caller
+// outside this module can build the same values the CLI does. They are aliased
+// rather than renamed at every use site: an alias is the same type, so these
+// spellings and pkg/config's stay interchangeable while the remaining
+// resolution logic in this file moves across (RFC 0022 §7).
+type (
+	s3Config     = config.S3
+	b2Config     = config.B2
+	sftpConfig   = config.SFTP
+	kmsConfig    = config.KMS
+	storeConfig  = config.Store
+	unlockConfig = config.Unlock
+	clientConfig = config.Client
+)
 
 // clientConfigFromFlags projects parsed flags into a resolved configuration,
 // without consulting any profile. It is a pure translation: no I/O, no

--- a/cmd/cloudstic/config.go
+++ b/cmd/cloudstic/config.go
@@ -22,71 +22,71 @@ import (
 
 // s3Config holds the credentials and endpoint settings for an S3 store.
 type s3Config struct {
-	endpoint  string
-	region    string
-	profile   string
-	accessKey string
-	secretKey string
+	Endpoint  string
+	Region    string
+	Profile   string
+	AccessKey string
+	SecretKey string
 }
 
 // b2Config holds Backblaze B2 application key credentials.
 type b2Config struct {
-	keyID  string
-	appKey string
+	KeyID  string
+	AppKey string
 }
 
 // sftpConfig holds SFTP authentication and host-key settings. The same shape
 // serves both a store and a backup source, which are configured independently.
 type sftpConfig struct {
-	password   string
-	key        string
-	knownHosts string
-	insecure   bool
+	Password   string
+	Key        string
+	KnownHosts string
+	Insecure   bool
 }
 
 // kmsConfig holds AWS KMS settings for kms-platform key slots.
 type kmsConfig struct {
-	keyARN   string
-	region   string
-	endpoint string
+	KeyARN   string
+	Region   string
+	Endpoint string
 }
 
 // storeConfig is everything needed to construct an object store.
 type storeConfig struct {
-	uri   string
-	s3    s3Config
-	b2    b2Config
-	sftp  sftpConfig
-	debug bool
+	URI   string
+	S3    s3Config
+	B2    b2Config
+	SFTP  sftpConfig
+	Debug bool
 }
 
 // unlockConfig is everything needed to build the keychain that unlocks a
 // repository.
 type unlockConfig struct {
-	password      string
-	encryptionKey string
-	recoveryKey   string
-	kms           kmsConfig
-	prompt        bool
-	noPrompt      bool
+	Password      string
+	EncryptionKey string
+	RecoveryKey   string
+	KMS           kmsConfig
+	Prompt        bool
+	NoPrompt      bool
 }
 
 // clientConfig is the resolved configuration for opening a repository client.
 //
 // Fields are oriented so the zero value is the correct default, because
 // RFC 0022 §7 makes these types public and a consumer writing
-// clientConfig{store: …} must get the same behaviour the CLI gets. That is why
-// packfiles are expressed as disablePackfile rather than packfile: NewClient
-// enables them by default, so a `packfile bool` zero value would silently turn
+// clientConfig{Store: …} must get the same behaviour the CLI gets. That is why
+// packfiles are expressed as DisablePackfile rather than Packfile: NewClient
+// enables them by default, so a `Packfile bool` zero value would silently turn
 // them off and write a repository with a different physical layout, with no
 // error at any layer. The negative field also matches the -disable-packfile
 // flag it comes from.
 type clientConfig struct {
-	store           storeConfig
-	unlock          unlockConfig
-	disablePackfile bool
-	quiet           bool
-	json            bool
+	Store           storeConfig
+	Unlock          unlockConfig
+	DisablePackfile bool
+	Quiet           bool
+	JSON            bool
 }
 
 // clientConfigFromFlags projects parsed flags into a resolved configuration,
@@ -94,42 +94,42 @@ type clientConfig struct {
 // mutation of g.
 func clientConfigFromFlags(g *globalFlags) clientConfig {
 	return clientConfig{
-		store: storeConfig{
-			uri: g.store,
-			s3: s3Config{
-				endpoint:  g.s3Endpoint,
-				region:    g.s3Region,
-				profile:   g.s3Profile,
-				accessKey: g.s3AccessKey,
-				secretKey: g.s3SecretKey,
+		Store: storeConfig{
+			URI: g.store,
+			S3: s3Config{
+				Endpoint:  g.s3Endpoint,
+				Region:    g.s3Region,
+				Profile:   g.s3Profile,
+				AccessKey: g.s3AccessKey,
+				SecretKey: g.s3SecretKey,
 			},
-			b2: b2Config{
-				keyID:  g.b2KeyID,
-				appKey: g.b2AppKey,
+			B2: b2Config{
+				KeyID:  g.b2KeyID,
+				AppKey: g.b2AppKey,
 			},
-			sftp: sftpConfig{
-				password:   g.storeSFTPPassword,
-				key:        g.storeSFTPKey,
-				knownHosts: g.storeSFTPKnownHosts,
-				insecure:   g.storeSFTPInsecure,
+			SFTP: sftpConfig{
+				Password:   g.storeSFTPPassword,
+				Key:        g.storeSFTPKey,
+				KnownHosts: g.storeSFTPKnownHosts,
+				Insecure:   g.storeSFTPInsecure,
 			},
-			debug: g.debug,
+			Debug: g.debug,
 		},
-		unlock: unlockConfig{
-			password:      g.password,
-			encryptionKey: g.encryptionKey,
-			recoveryKey:   g.recoveryKey,
-			kms: kmsConfig{
-				keyARN:   g.kmsKeyARN,
-				region:   g.kmsRegion,
-				endpoint: g.kmsEndpoint,
+		Unlock: unlockConfig{
+			Password:      g.password,
+			EncryptionKey: g.encryptionKey,
+			RecoveryKey:   g.recoveryKey,
+			KMS: kmsConfig{
+				KeyARN:   g.kmsKeyARN,
+				Region:   g.kmsRegion,
+				Endpoint: g.kmsEndpoint,
 			},
-			prompt:   g.prompt,
-			noPrompt: g.noPrompt,
+			Prompt:   g.prompt,
+			NoPrompt: g.noPrompt,
 		},
-		disablePackfile: g.disablePackfile,
-		quiet:           g.quiet,
-		json:            g.json,
+		DisablePackfile: g.disablePackfile,
+		Quiet:           g.quiet,
+		JSON:            g.json,
 	}
 }
 
@@ -138,10 +138,10 @@ func clientConfigFromFlags(g *globalFlags) clientConfig {
 // only backup reads one.
 func sourceSFTPConfigFromFlags(g *globalFlags) sftpConfig {
 	return sftpConfig{
-		password:   g.sourceSFTPPassword,
-		key:        g.sourceSFTPKey,
-		knownHosts: g.sourceSFTPKnownHosts,
-		insecure:   g.sourceSFTPInsecure,
+		Password:   g.sourceSFTPPassword,
+		Key:        g.sourceSFTPKey,
+		KnownHosts: g.sourceSFTPKnownHosts,
+		Insecure:   g.sourceSFTPInsecure,
 	}
 }
 
@@ -236,22 +236,22 @@ func clientConfigFromProfileStore(s profile.Store) (clientConfig, error) {
 // obscure more than it clarifies.
 func applyProfileStore(cfg *clientConfig, s profile.Store, provided func(string) bool) error {
 	if !provided("store") && s.URI != "" {
-		cfg.store.uri = s.URI
+		cfg.Store.URI = s.URI
 	}
 	if !provided("s3-endpoint") && s.S3Endpoint != "" {
-		cfg.store.s3.endpoint = s.S3Endpoint
+		cfg.Store.S3.Endpoint = s.S3Endpoint
 	}
 	if !provided("s3-region") && s.S3Region != "" {
-		cfg.store.s3.region = s.S3Region
+		cfg.Store.S3.Region = s.S3Region
 	}
 	if !provided("kms-key-arn") && s.KMSKeyARN != "" {
-		cfg.unlock.kms.keyARN = s.KMSKeyARN
+		cfg.Unlock.KMS.KeyARN = s.KMSKeyARN
 	}
 	if !provided("kms-region") && s.KMSRegion != "" {
-		cfg.unlock.kms.region = s.KMSRegion
+		cfg.Unlock.KMS.Region = s.KMSRegion
 	}
 	if !provided("kms-endpoint") && s.KMSEndpoint != "" {
-		cfg.unlock.kms.endpoint = s.KMSEndpoint
+		cfg.Unlock.KMS.Endpoint = s.KMSEndpoint
 	}
 
 	// Values that may be given inline or as a secret reference. Unlike the
@@ -264,16 +264,16 @@ func applyProfileStore(cfg *clientConfig, s profile.Store, provided func(string)
 		secret string
 		dest   *string
 	}{
-		{"s3-profile", "s3_profile", s.S3Profile, "", &cfg.store.s3.profile},
-		{"s3-access-key", "s3_access_key", s.S3AccessKey, s.S3AccessKeySecret, &cfg.store.s3.accessKey},
-		{"s3-secret-key", "s3_secret_key", s.S3SecretKey, s.S3SecretKeySecret, &cfg.store.s3.secretKey},
-		{"b2-key-id", "b2_key_id", s.B2KeyID, s.B2KeyIDSecret, &cfg.store.b2.keyID},
-		{"b2-app-key", "b2_app_key", s.B2AppKey, s.B2AppKeySecret, &cfg.store.b2.appKey},
-		{"store-sftp-password", "store_sftp_password", s.StoreSFTPPassword, s.StoreSFTPPasswordSecret, &cfg.store.sftp.password},
-		{"store-sftp-key", "store_sftp_key", s.StoreSFTPKey, s.StoreSFTPKeySecret, &cfg.store.sftp.key},
-		{"password", "password", "", s.PasswordSecret, &cfg.unlock.password},
-		{"encryption-key", "encryption_key", "", s.EncryptionKeySecret, &cfg.unlock.encryptionKey},
-		{"recovery-key", "recovery_key", "", s.RecoveryKeySecret, &cfg.unlock.recoveryKey},
+		{"s3-profile", "s3_profile", s.S3Profile, "", &cfg.Store.S3.Profile},
+		{"s3-access-key", "s3_access_key", s.S3AccessKey, s.S3AccessKeySecret, &cfg.Store.S3.AccessKey},
+		{"s3-secret-key", "s3_secret_key", s.S3SecretKey, s.S3SecretKeySecret, &cfg.Store.S3.SecretKey},
+		{"b2-key-id", "b2_key_id", s.B2KeyID, s.B2KeyIDSecret, &cfg.Store.B2.KeyID},
+		{"b2-app-key", "b2_app_key", s.B2AppKey, s.B2AppKeySecret, &cfg.Store.B2.AppKey},
+		{"store-sftp-password", "store_sftp_password", s.StoreSFTPPassword, s.StoreSFTPPasswordSecret, &cfg.Store.SFTP.Password},
+		{"store-sftp-key", "store_sftp_key", s.StoreSFTPKey, s.StoreSFTPKeySecret, &cfg.Store.SFTP.Key},
+		{"password", "password", "", s.PasswordSecret, &cfg.Unlock.Password},
+		{"encryption-key", "encryption_key", "", s.EncryptionKeySecret, &cfg.Unlock.EncryptionKey},
+		{"recovery-key", "recovery_key", "", s.RecoveryKeySecret, &cfg.Unlock.RecoveryKey},
 	}
 	for _, r := range refs {
 		if provided(r.flag) {

--- a/cmd/cloudstic/config_test.go
+++ b/cmd/cloudstic/config_test.go
@@ -46,8 +46,8 @@ func TestResolveClientConfig_ProfileOverridesEnvironment(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveClientConfig: %v", err)
 	}
-	if resolved.store.s3.region != "profile-region" {
-		t.Fatalf("store.s3.region=%q want profile-region (profile should win over environment)", resolved.store.s3.region)
+	if resolved.Store.S3.Region != "profile-region" {
+		t.Fatalf("store.s3.region=%q want profile-region (profile should win over environment)", resolved.Store.S3.Region)
 	}
 }
 
@@ -75,14 +75,14 @@ func TestResolveClientConfig_AppliesProfileStore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveClientConfig: %v", err)
 	}
-	if cfg.store.uri != "s3:bucket/prefix" {
-		t.Fatalf("store=%q want s3:bucket/prefix", cfg.store.uri)
+	if cfg.Store.URI != "s3:bucket/prefix" {
+		t.Fatalf("store=%q want s3:bucket/prefix", cfg.Store.URI)
 	}
-	if cfg.store.s3.region != "eu-west-1" {
-		t.Fatalf("s3Region=%q want eu-west-1", cfg.store.s3.region)
+	if cfg.Store.S3.Region != "eu-west-1" {
+		t.Fatalf("s3Region=%q want eu-west-1", cfg.Store.S3.Region)
 	}
-	if cfg.store.s3.profile != "prod" {
-		t.Fatalf("s3Profile=%q want prod", cfg.store.s3.profile)
+	if cfg.Store.S3.Profile != "prod" {
+		t.Fatalf("s3Profile=%q want prod", cfg.Store.S3.Profile)
 	}
 }
 
@@ -123,23 +123,23 @@ func TestResolveClientConfig_EncryptionFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveClientConfig: %v", err)
 	}
-	if cfg.unlock.password != "s3cret" {
-		t.Fatalf("password=%q want s3cret", cfg.unlock.password)
+	if cfg.Unlock.Password != "s3cret" {
+		t.Fatalf("password=%q want s3cret", cfg.Unlock.Password)
 	}
-	if cfg.unlock.encryptionKey != "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
-		t.Fatalf("encryptionKey=%q want aaa...", cfg.unlock.encryptionKey)
+	if cfg.Unlock.EncryptionKey != "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
+		t.Fatalf("encryptionKey=%q want aaa...", cfg.Unlock.EncryptionKey)
 	}
-	if cfg.unlock.recoveryKey == "" {
+	if cfg.Unlock.RecoveryKey == "" {
 		t.Fatal("expected recoveryKey to be set from env")
 	}
-	if cfg.unlock.kms.keyARN != "arn:aws:kms:us-east-1:123456:key/abcd" {
-		t.Fatalf("kmsKeyARN=%q want arn:...", cfg.unlock.kms.keyARN)
+	if cfg.Unlock.KMS.KeyARN != "arn:aws:kms:us-east-1:123456:key/abcd" {
+		t.Fatalf("kmsKeyARN=%q want arn:...", cfg.Unlock.KMS.KeyARN)
 	}
-	if cfg.unlock.kms.region != "us-east-1" {
-		t.Fatalf("kmsRegion=%q want us-east-1", cfg.unlock.kms.region)
+	if cfg.Unlock.KMS.Region != "us-east-1" {
+		t.Fatalf("kmsRegion=%q want us-east-1", cfg.Unlock.KMS.Region)
 	}
-	if cfg.unlock.kms.endpoint != "https://kms.example.com" {
-		t.Fatalf("kmsEndpoint=%q want https://kms.example.com", cfg.unlock.kms.endpoint)
+	if cfg.Unlock.KMS.Endpoint != "https://kms.example.com" {
+		t.Fatalf("kmsEndpoint=%q want https://kms.example.com", cfg.Unlock.KMS.Endpoint)
 	}
 }
 
@@ -168,8 +168,8 @@ func TestResolveClientConfig_DoesNotOverrideExplicitStoreFlag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveClientConfig: %v", err)
 	}
-	if cfg.store.uri != "local:/explicit" {
-		t.Fatalf("store=%q want local:/explicit", cfg.store.uri)
+	if cfg.Store.URI != "local:/explicit" {
+		t.Fatalf("store=%q want local:/explicit", cfg.Store.URI)
 	}
 	// Resolution must not write back into the parsed flags.
 	if g.store != "local:/explicit" {

--- a/cmd/cloudstic/keychain.go
+++ b/cmd/cloudstic/keychain.go
@@ -17,12 +17,12 @@ import (
 // buildKeychain assembles the credential chain that unlocks a repository, in
 // the order the client should try them.
 func buildKeychain(ctx context.Context, cfg unlockConfig) (keychain.Chain, error) {
-	platformKey, err := parsePlatformKey(cfg.encryptionKey)
+	platformKey, err := parsePlatformKey(cfg.EncryptionKey)
 	if err != nil {
 		return nil, err
 	}
 
-	kmsClient, err := buildKMSClient(ctx, cfg.kms)
+	kmsClient, err := buildKMSClient(ctx, cfg.KMS)
 	if err != nil {
 		return nil, err
 	}
@@ -35,13 +35,13 @@ func buildKeychain(ctx context.Context, cfg unlockConfig) (keychain.Chain, error
 	if len(platformKey) > 0 {
 		chain = append(chain, keychain.WithPlatformKey(platformKey))
 	}
-	if cfg.password != "" {
-		chain = append(chain, keychain.WithPassword(cfg.password))
+	if cfg.Password != "" {
+		chain = append(chain, keychain.WithPassword(cfg.Password))
 	}
-	if cfg.recoveryKey != "" {
-		chain = append(chain, keychain.WithRecoveryKey(cfg.recoveryKey))
+	if cfg.RecoveryKey != "" {
+		chain = append(chain, keychain.WithRecoveryKey(cfg.RecoveryKey))
 	}
-	if (len(chain) == 0 || cfg.prompt) && !cfg.noPrompt && term.IsTerminal(os.Stdin.Fd()) {
+	if (len(chain) == 0 || cfg.Prompt) && !cfg.NoPrompt && term.IsTerminal(os.Stdin.Fd()) {
 		chain = append(chain, keychain.WithPrompt(
 			func() (string, error) { return ui.PromptPassword("Repository password") },
 			func() (string, error) { return ui.PromptPasswordConfirm("Enter new repository password") },
@@ -54,17 +54,17 @@ func buildKeychain(ctx context.Context, cfg unlockConfig) (keychain.Chain, error
 // buildKMSClient creates an AWS KMS client if a key ARN is configured,
 // otherwise returns nil.
 func buildKMSClient(ctx context.Context, cfg kmsConfig) (crypto.KMSClient, error) {
-	if cfg.keyARN == "" {
+	if cfg.KeyARN == "" {
 		return nil, nil
 	}
 	var opts []kms.Option
-	if cfg.region != "" {
-		opts = append(opts, kms.WithRegion(cfg.region))
+	if cfg.Region != "" {
+		opts = append(opts, kms.WithRegion(cfg.Region))
 	}
-	if cfg.endpoint != "" {
-		opts = append(opts, kms.WithEndpoint(cfg.endpoint))
+	if cfg.Endpoint != "" {
+		opts = append(opts, kms.WithEndpoint(cfg.Endpoint))
 	}
-	client, err := kms.New(ctx, cfg.keyARN, opts...)
+	client, err := kms.New(ctx, cfg.KeyARN, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("init KMS client: %w", err)
 	}

--- a/cmd/cloudstic/keychain_test.go
+++ b/cmd/cloudstic/keychain_test.go
@@ -63,42 +63,42 @@ func TestBuildKeychain_ChainComposition(t *testing.T) {
 		},
 		{
 			name: "password only",
-			cfg:  unlockConfig{password: "hunter2"},
+			cfg:  unlockConfig{Password: "hunter2"},
 			want: []string{"passwordCred"},
 		},
 		{
 			name: "encryption key only",
-			cfg:  unlockConfig{encryptionKey: validHexKey},
+			cfg:  unlockConfig{EncryptionKey: validHexKey},
 			want: []string{"platformKeyCred"},
 		},
 		{
 			name: "recovery key only",
-			cfg:  unlockConfig{recoveryKey: "abandon abandon ability"},
+			cfg:  unlockConfig{RecoveryKey: "abandon abandon ability"},
 			want: []string{"recoveryCred"},
 		},
 		{
 			name: "kms only",
-			cfg:  unlockConfig{kms: kmsConfig{keyARN: "arn:aws:kms:us-east-1:1:key/x", region: "us-east-1"}},
+			cfg:  unlockConfig{KMS: kmsConfig{KeyARN: "arn:aws:kms:us-east-1:1:key/x", Region: "us-east-1"}},
 			want: []string{"kmsClientCred"},
 		},
 		{
 			name: "every credential, in precedence order",
 			cfg: unlockConfig{
-				encryptionKey: validHexKey,
-				password:      "hunter2",
-				recoveryKey:   "abandon abandon ability",
-				kms:           kmsConfig{keyARN: "arn:aws:kms:us-east-1:1:key/x", region: "us-east-1"},
+				EncryptionKey: validHexKey,
+				Password:      "hunter2",
+				RecoveryKey:   "abandon abandon ability",
+				KMS:           kmsConfig{KeyARN: "arn:aws:kms:us-east-1:1:key/x", Region: "us-east-1"},
 			},
 			want: []string{"kmsClientCred", "platformKeyCred", "passwordCred", "recoveryCred"},
 		},
 		{
 			name: "prompt:true does not add a credential without a terminal",
-			cfg:  unlockConfig{password: "hunter2", prompt: true},
+			cfg:  unlockConfig{Password: "hunter2", Prompt: true},
 			want: []string{"passwordCred"},
 		},
 		{
 			name: "noPrompt suppresses nothing else",
-			cfg:  unlockConfig{password: "hunter2", noPrompt: true},
+			cfg:  unlockConfig{Password: "hunter2", NoPrompt: true},
 			want: []string{"passwordCred"},
 		},
 	}
@@ -152,7 +152,7 @@ func TestBuildKeychain_PromptRequiresATerminal(t *testing.T) {
 }
 
 func TestBuildKeychain_PropagatesPlatformKeyError(t *testing.T) {
-	_, err := buildKeychain(context.Background(), unlockConfig{encryptionKey: "not-hex"})
+	_, err := buildKeychain(context.Background(), unlockConfig{EncryptionKey: "not-hex"})
 	if err == nil {
 		t.Fatal("expected an error for a non-hex encryption key, got nil")
 	}
@@ -213,7 +213,7 @@ func TestBuildKMSClient_NoARNIsNotAnError(t *testing.T) {
 	}
 
 	// A region or endpoint without an ARN still means "no KMS".
-	client, err = buildKMSClient(context.Background(), kmsConfig{region: "us-east-1", endpoint: "http://localhost:4566"})
+	client, err = buildKMSClient(context.Background(), kmsConfig{Region: "us-east-1", Endpoint: "http://localhost:4566"})
 	if err != nil {
 		t.Fatalf("buildKMSClient with region but no ARN: %v", err)
 	}
@@ -228,8 +228,8 @@ func TestBuildKMSClient_NoARNIsNotAnError(t *testing.T) {
 // reaching the network it would add latency to each one.
 func TestBuildKMSClient_ARNBuildsOffline(t *testing.T) {
 	client, err := buildKMSClient(context.Background(), kmsConfig{
-		keyARN: "arn:aws:kms:us-east-1:123456789012:key/1234abcd",
-		region: "us-east-1",
+		KeyARN: "arn:aws:kms:us-east-1:123456789012:key/1234abcd",
+		Region: "us-east-1",
 	})
 	if err != nil {
 		t.Fatalf("buildKMSClient: %v", err)

--- a/cmd/cloudstic/storebuild.go
+++ b/cmd/cloudstic/storebuild.go
@@ -27,7 +27,7 @@ func openStore(ctx context.Context, cfg storeConfig) (store.ObjectStore, error) 
 	if err != nil {
 		return nil, err
 	}
-	s, _ := withDebugStore(raw, cfg.debug)
+	s, _ := withDebugStore(raw, cfg.Debug)
 	return s, nil
 }
 
@@ -47,7 +47,7 @@ func withDebugStore(s store.ObjectStore, debug bool) (store.ObjectStore, *ui.Saf
 // newObjectStore constructs the backend store named by the configured URI,
 // without any decorator layers.
 func newObjectStore(ctx context.Context, cfg storeConfig) (store.ObjectStore, error) {
-	uri, err := parseStoreURI(cfg.uri)
+	uri, err := parseStoreURI(cfg.URI)
 	if err != nil {
 		return nil, err
 	}
@@ -57,22 +57,22 @@ func newObjectStore(ctx context.Context, cfg storeConfig) (store.ObjectStore, er
 	case "local":
 		inner, err = localstore.New(uri.path)
 	case "b2":
-		if cfg.b2.keyID == "" || cfg.b2.appKey == "" {
+		if cfg.B2.KeyID == "" || cfg.B2.AppKey == "" {
 			return nil, fmt.Errorf("B2 credentials required: pass -b2-key-id/-b2-app-key (or set B2_KEY_ID/B2_APP_KEY)")
 		}
-		inner, err = b2store.New(uri.bucket, b2store.WithCredentials(cfg.b2.keyID, cfg.b2.appKey), b2store.WithPrefix(uri.prefix))
+		inner, err = b2store.New(uri.bucket, b2store.WithCredentials(cfg.B2.KeyID, cfg.B2.AppKey), b2store.WithPrefix(uri.prefix))
 	case "s3":
 		inner, err = s3store.New(
 			ctx,
 			uri.bucket,
-			s3store.WithEndpoint(cfg.s3.endpoint),
-			s3store.WithRegion(s3Region(cfg.s3.region)),
-			s3store.WithProfile(cfg.s3.profile),
-			s3store.WithCredentials(cfg.s3.accessKey, cfg.s3.secretKey),
+			s3store.WithEndpoint(cfg.S3.Endpoint),
+			s3store.WithRegion(s3Region(cfg.S3.Region)),
+			s3store.WithProfile(cfg.S3.Profile),
+			s3store.WithCredentials(cfg.S3.AccessKey, cfg.S3.SecretKey),
 			s3store.WithPrefix(uri.prefix),
 		)
 	case "sftp":
-		inner, err = sftpstore.New(uri.host, sftpStoreOpts(cfg.sftp, uri)...)
+		inner, err = sftpstore.New(uri.host, sftpStoreOpts(cfg.SFTP, uri)...)
 	default:
 		return nil, fmt.Errorf("unsupported store type: %s", uri.scheme)
 	}
@@ -105,17 +105,17 @@ func sftpStoreOpts(cfg sftpConfig, uri *storeURIParts) []sftpstore.Option {
 	if uri.user != "" {
 		opts = append(opts, sftpstore.WithUser(uri.user))
 	}
-	if cfg.password != "" {
-		opts = append(opts, sftpstore.WithPassword(cfg.password))
+	if cfg.Password != "" {
+		opts = append(opts, sftpstore.WithPassword(cfg.Password))
 	}
-	if cfg.key != "" {
-		opts = append(opts, sftpstore.WithKey(cfg.key))
+	if cfg.Key != "" {
+		opts = append(opts, sftpstore.WithKey(cfg.Key))
 	}
-	if cfg.insecure {
+	if cfg.Insecure {
 		opts = append(opts, sftpstore.WithHostKeyCallback(ssh.InsecureIgnoreHostKey())) //nolint:gosec // explicitly requested by user
 	}
-	if cfg.knownHosts != "" {
-		opts = append(opts, sftpstore.WithKnownHosts(cfg.knownHosts))
+	if cfg.KnownHosts != "" {
+		opts = append(opts, sftpstore.WithKnownHosts(cfg.KnownHosts))
 	}
 	return opts
 }

--- a/cmd/cloudstic/storebuild_test.go
+++ b/cmd/cloudstic/storebuild_test.go
@@ -57,7 +57,7 @@ func TestWithDebugStore_Enabled(t *testing.T) {
 // through flag parsing at all.
 func TestNewObjectStore_FromConfigWithoutFlagParsing(t *testing.T) {
 	dir := t.TempDir()
-	s, err := newObjectStore(context.Background(), storeConfig{uri: "local:" + dir})
+	s, err := newObjectStore(context.Background(), storeConfig{URI: "local:" + dir})
 	if err != nil {
 		t.Fatalf("newObjectStore: %v", err)
 	}
@@ -67,7 +67,7 @@ func TestNewObjectStore_FromConfigWithoutFlagParsing(t *testing.T) {
 }
 
 func TestNewObjectStore_UnknownScheme(t *testing.T) {
-	if _, err := newObjectStore(context.Background(), storeConfig{uri: "nope:whatever"}); err == nil {
+	if _, err := newObjectStore(context.Background(), storeConfig{URI: "nope:whatever"}); err == nil {
 		t.Fatal("expected error for unknown store scheme")
 	}
 }
@@ -77,13 +77,13 @@ func TestNewObjectStore_UnknownScheme(t *testing.T) {
 // attempted.
 func TestNewObjectStore_B2_RequiresCredentials(t *testing.T) {
 	cases := []storeConfig{
-		{uri: "b2:my-bucket"},
-		{uri: "b2:my-bucket", b2: b2Config{keyID: "id-only"}},
-		{uri: "b2:my-bucket", b2: b2Config{appKey: "key-only"}},
+		{URI: "b2:my-bucket"},
+		{URI: "b2:my-bucket", B2: b2Config{KeyID: "id-only"}},
+		{URI: "b2:my-bucket", B2: b2Config{AppKey: "key-only"}},
 	}
 	for _, cfg := range cases {
 		if _, err := newObjectStore(context.Background(), cfg); err == nil {
-			t.Fatalf("expected error for incomplete B2 credentials: %+v", cfg.b2)
+			t.Fatalf("expected error for incomplete B2 credentials: %+v", cfg.B2)
 		}
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,91 @@
+// Package config holds the resolved configuration for opening a Cloudstic
+// repository: which store to talk to, which credentials unlock it, and how the
+// client should behave.
+//
+// It is the boundary between how configuration is *expressed* — command-line
+// flags, environment variables, a profiles YAML file — and how a repository is
+// *opened*. Values here are fully resolved: a store URI has been chosen, and
+// secret references have already been read into the credentials they name.
+// Nothing in this package performs I/O against a store or a cloud provider;
+// pkg/open does that, and takes these values as input.
+//
+// The split matters for what it costs to import. This package depends only on
+// pkg/profile and pkg/secretref, so reading a profiles file and resolving it
+// into a configuration — to validate it, display it, or hand it to something
+// else — pulls in no cloud SDK. Constructing a store from that configuration
+// necessarily does, which is why construction lives in pkg/open (RFC 0022 §7).
+//
+// Zero values are the correct defaults. A Client{Store: …} with nothing else
+// set behaves the way the cloudstic CLI behaves with no flags passed, which is
+// why packfiles are expressed as DisablePackfile rather than Packfile: the
+// client enables them by default, so a positive field would silently turn them
+// off for every caller who did not think to mention them.
+package config
+
+// S3 holds the credentials and endpoint settings for an S3 store.
+type S3 struct {
+	Endpoint  string
+	Region    string
+	Profile   string
+	AccessKey string
+	SecretKey string
+}
+
+// B2 holds Backblaze B2 application key credentials.
+type B2 struct {
+	KeyID  string
+	AppKey string
+}
+
+// SFTP holds SFTP authentication and host-key settings. The same shape serves
+// both a store and a backup source, which are configured independently.
+type SFTP struct {
+	Password   string
+	Key        string
+	KnownHosts string
+	Insecure   bool
+}
+
+// KMS holds AWS KMS settings for kms-platform key slots.
+type KMS struct {
+	KeyARN   string
+	Region   string
+	Endpoint string
+}
+
+// Store is everything needed to construct an object store.
+//
+// Not to be confused with profile.Store, which is the same configuration as
+// *declared* in a profiles file, secret references and all. Store is what that
+// resolves to. config.FromProfileStore converts one into the other.
+type Store struct {
+	URI   string
+	S3    S3
+	B2    B2
+	SFTP  SFTP
+	Debug bool
+}
+
+// Unlock is everything needed to build the keychain that unlocks a repository.
+//
+// The credentials are tried in a fixed order — KMS, then EncryptionKey, then
+// Password, then RecoveryKey — so supplying more than one is not ambiguous.
+// Prompt and NoPrompt govern the interactive fallback, which is only ever
+// reachable when the caller opts into it.
+type Unlock struct {
+	Password      string
+	EncryptionKey string
+	RecoveryKey   string
+	KMS           KMS
+	Prompt        bool
+	NoPrompt      bool
+}
+
+// Client is the resolved configuration for opening a repository client.
+type Client struct {
+	Store           Store
+	Unlock          Unlock
+	DisablePackfile bool
+	Quiet           bool
+	JSON            bool
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,58 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/cloudstic/cli/pkg/config"
+)
+
+// TestZeroValueIsTheCorrectDefault is the contract that makes these structs
+// safe to hand to a caller who fills in only the fields they care about.
+//
+// It is not a tautology about Go zero values: it is the reason DisablePackfile
+// is spelled negatively. The client enables packfiles by default, and pkg/open
+// passes this field on unconditionally, so a positive `Packfile bool` would
+// mean that every caller writing config.Client{Store: …} silently got a
+// repository with a different physical layout — with no error from any layer.
+// If someone later "tidies" the field into the positive form, this test is
+// what should stop them.
+func TestZeroValueIsTheCorrectDefault(t *testing.T) {
+	var c config.Client
+
+	if c.DisablePackfile {
+		t.Error("the zero value must leave packfiles enabled, matching the client's own default")
+	}
+	if c.Quiet || c.JSON {
+		t.Error("the zero value must select the default output mode, not a silent one")
+	}
+	if c.Unlock.NoPrompt {
+		t.Error("the zero value must not suppress the interactive fallback")
+	}
+	if c.Unlock.Prompt {
+		t.Error("the zero value must not force an interactive prompt either; both are opt-in")
+	}
+	if c.Store.Debug {
+		t.Error("the zero value must not enable debug output")
+	}
+	if c.Store.SFTP.Insecure {
+		t.Error("the zero value must not disable SFTP host-key verification")
+	}
+}
+
+// TestClientIsComparable records that these are plain value types: no maps,
+// slices, or pointers. Callers can compare two configurations with == and copy
+// one by assignment, which is what lets the CLI resolve a configuration per
+// profile without any aliasing between them.
+func TestClientIsComparable(t *testing.T) {
+	a := config.Client{Store: config.Store{URI: "local:/tmp/x"}}
+	b := a
+
+	if a != b {
+		t.Fatal("a copied configuration must equal its original")
+	}
+
+	b.Store.URI = "s3:bucket"
+	if a.Store.URI != "local:/tmp/x" {
+		t.Error("mutating a copy must not affect the original; a reference field has crept in")
+	}
+}

--- a/rfcs/0022-public-go-api-boundaries.md
+++ b/rfcs/0022-public-go-api-boundaries.md
@@ -588,9 +588,20 @@ Stages 5–8 add three requirements:
 6. Characterization tests over the §7 blast radius, in `package main`, before
    anything moves. Then fix the `packfile` and `s3.region` zero values as a
    separate, behavioral commit. **Done.**
-7. Move config types to `pkg/config` behind `type clientConfig = config.Client`
-   aliases in `cmd/cloudstic`, then the URI parsers, then profile resolution
-   with the resolver injected — three commits, no call-site churn.
+7. Export the resolved config types' *fields* in place, still in
+   `package main`; then move the types to `pkg/config` behind
+   `type clientConfig = config.Client` aliases; then the URI parsers; then
+   profile resolution with the resolver injected.
+
+   The first of those was not in the original plan, which assumed the aliases
+   made the move call-site-neutral on their own. They do not: an alias makes
+   the type *name* spellable from `package main` (93 mentions), but it cannot
+   make unexported fields reachable from another package, and field accesses
+   are 100 sites across 8 files. Exporting the fields first — a pure rename,
+   one package, verified by the compiler and applied with `gopls rename` so
+   that fields named `key`, `region`, `password` and `profile` cannot collide
+   with unrelated identifiers spelled the same way — makes the move that
+   follows genuinely call-site-neutral.
 8. Add `pkg/open`; reduce `storebuild.go`, `clientbuild.go`, and `keychain.go`
    to adapters.
 9. Logger injection (§8).
@@ -605,7 +616,8 @@ improvement per line changed — it should not wait on the rest. Steps 6–8 are
 strictly ordered: the tests gate the move, and per this repo's refactoring
 practice the behavioral zero-value fix must not share a commit with the
 structural move. Step 7's type aliases are what keep each commit small enough
-to review, since no call site changes until the alias is removed.
+to review — but only once its field-export commit has run first, since until
+then the aliases cover the type names and nothing else.
 
 ## Open questions
 


### PR DESCRIPTION
## Summary

First half of RFC 0022 §7. The types describing a resolved repository configuration — which store to talk to, which credentials unlock it, how the client should behave — were private to `cmd/cloudstic`, so a caller outside this module could not name the values the CLI runs on, let alone build one. They are now `pkg/config`.

Three commits, in the order they have to happen:

- **`export the fields of the resolved config types`** — a pure rename, still in `package main`, nothing moved. 255 insertions, 255 deletions, no net change.
- **`move the resolved config types to pkg/config`** — the move itself. Changes no call site, because the previous commit already made the names agree. `cmd/cloudstic` keeps its own spellings as type aliases.
- **`correct RFC 0022's claim that aliases make the §7 move free`** — see below.

Part of #378

### The RFC was wrong about this, and the correction is the interesting part

The rollout said moving the types behind `type clientConfig = config.Client` aliases would change no call site. That is half true, and the wrong half is the expensive one. An alias makes the type *name* spellable from `package main` — 93 mentions — but it cannot make unexported fields reachable from another package, and field accesses are **100 sites across 8 files**.

Hence the split: export the fields first, in place, then move. The field export is one package, compiler-verified, and mechanically checkable; the move is cross-package and call-site-neutral. Separating them gives each a verification story a reviewer can actually apply. The RFC now records this as a fourth step rather than quietly rewriting the plan.

### For reviewers

- **The rename used `gopls rename`, not sed, and that mattered.** The fields are named `key`, `region`, `password`, `profile` — all of which appear as unrelated identifiers throughout `cmd/cloudstic`. gopls renames the symbol rather than the text, so the collision failure mode a textual pass would have had was not available. Reviewing the first commit is checking that it is net-zero, which `--shortstat` shows directly.
- **`pkg/config` has exactly one dependency: itself.** That is the argument for splitting it from the construction half rather than a nicety. Resolving a profiles file into a configuration — to validate it, display it, hand it elsewhere — must not cost a cloud SDK; only building a store from it does, and that lands in `pkg/open`.
- **`TestPublicPackagesPullNoVendorSDK` covered the new package the moment it existed**, without being told about it. That is the payoff from replacing the hand-listed check with an enumerating sweep during the `pkg/crypto/kms` split (#391).
- **`config.Store` sits next to `profile.Store` deliberately.** They are the same configuration at two stages — declared and resolved — and the conversion between them is the next PR. The RFC flags this as the one naming call worth arguing; now is the time.
- **The added tests are not tautologies about Go zero values.** `TestZeroValueIsTheCorrectDefault` is the reason `DisablePackfile` is spelled negatively: the client enables packfiles by default and `pkg/open` will pass the field on unconditionally, so a positive `Packfile bool` would mean every caller writing `config.Client{Store: …}` silently got a repository with a different physical layout. If someone later tidies the field into the positive form, that test is what should stop them.

### Not in this PR

The rest of §7 — the URI parsers, and profile resolution with the secret resolver injected — is deliberately left out. Profile resolution is a design change rather than a move, and the URI parsers raise an unresolved API question (whether `storeURIParts` becomes a public `config.StoreURI` or stays an implementation detail) that deserves its own review rather than being tacked on here.

## Verification

\`\`\`bash
env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./...
env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./cmd/cloudstic/... ./pkg/config/...
gofmt -l .
npx markdownlint-cli2 rfcs/0022-public-go-api-boundaries.md
\`\`\`

Full suite passes with the race detector; lint reports 0 issues; `gofmt -l` and markdownlint are clean.