### PR TITLE
refactor: add pkg/open and reduce the CLI builders to adapters (RFC 0022)

### DIFF
--- a/cmd/cloudstic/clientbuild.go
+++ b/cmd/cloudstic/clientbuild.go
@@ -5,36 +5,29 @@ import (
 
 	cloudstic "github.com/cloudstic/cli"
 	"github.com/cloudstic/cli/internal/ui"
+	"github.com/cloudstic/cli/pkg/open"
 )
 
-// This file layers a store, keychain, and reporter into a repository client,
-// from resolved configuration. See storebuild.go for the store layer alone.
+// Client construction lives in pkg/open. What stays here is choosing the
+// progress reporter, which is presentation rather than configuration, and so
+// belongs to the program doing the presenting (RFC 0022 §7).
 
 // openClient constructs the object store described by cfg and opens a
 // repository client on top of it. Passing a nil reporter selects one from the
 // configured output mode.
 func openClient(ctx context.Context, cfg clientConfig, reporterOverride cloudstic.Reporter) (*cloudstic.Client, error) {
-	raw, err := newObjectStore(ctx, cfg.Store)
-	if err != nil {
-		return nil, err
-	}
-	raw, debugLog := withDebugStore(raw, cfg.Store.Debug)
+	debugLog := newDebugLog(cfg.Store.Debug)
 
 	reporter := reporterOverride
 	if reporter == nil {
 		reporter = newReporter(cfg, debugLog)
 	}
 
-	kc, err := buildKeychain(ctx, cfg.Unlock)
-	if err != nil {
-		return nil, err
-	}
-
-	return cloudstic.NewClient(ctx, raw,
-		cloudstic.WithKeychain(kc),
-		cloudstic.WithReporter(reporter),
-		cloudstic.WithPackfile(!cfg.DisablePackfile),
+	opts := append(storeOptions(debugLog),
+		open.WithReporter(reporter),
+		open.WithPasswordPrompt(passwordPrompts()),
 	)
+	return open.Client(ctx, cfg, opts...)
 }
 
 func newReporter(cfg clientConfig, debugLog *ui.SafeLogWriter) cloudstic.Reporter {

--- a/cmd/cloudstic/clientbuild_test.go
+++ b/cmd/cloudstic/clientbuild_test.go
@@ -149,18 +149,6 @@ func TestClientConfigZeroValueEnablesPackfiles(t *testing.T) {
 	}
 }
 
-// TestS3RegionDefault covers the other zero-value hazard: the region default
-// used to be pre-filled into one of the two config constructors, so a config
-// built any other way reached the S3 backend with an empty region.
-func TestS3RegionDefault(t *testing.T) {
-	if got := s3Region(""); got != defaultS3Region {
-		t.Errorf("s3Region(\"\") = %q, want %q", got, defaultS3Region)
-	}
-	if got := s3Region("eu-west-3"); got != "eu-west-3" {
-		t.Errorf("s3Region(%q) = %q, want it left alone", "eu-west-3", got)
-	}
-}
-
 // TestOpenClient_ReporterOverrideWins pins the parameter that lets the TUI and
 // tests supply their own reporter: when one is passed, the output mode does
 // not get to pick a different one.

--- a/cmd/cloudstic/cmd_store.go
+++ b/cmd/cloudstic/cmd_store.go
@@ -354,7 +354,7 @@ func checkOrInitStore(r *runner, ctx context.Context, cfg *profile.Config, store
 		return fmt.Errorf("could not resolve store credentials: %w", err)
 	}
 	resolved.Unlock.NoPrompt = r.noPrompt
-	raw, err := newObjectStore(ctx, resolved.Store)
+	raw, err := openStore(ctx, resolved.Store)
 	if err != nil {
 		return fmt.Errorf("could not connect to store: %w", err)
 	}

--- a/cmd/cloudstic/cmd_store_test.go
+++ b/cmd/cloudstic/cmd_store_test.go
@@ -310,9 +310,9 @@ func TestCheckOrInitStore_AlreadyInitialized(t *testing.T) {
 	if err != nil {
 		t.Fatalf("clientConfigFromProfileStore: %v", err)
 	}
-	raw, err := newObjectStore(context.Background(), sc.Store)
+	raw, err := openStore(context.Background(), sc.Store)
 	if err != nil {
-		t.Fatalf("newObjectStore: %v", err)
+		t.Fatalf("openStore: %v", err)
 	}
 	_, err = cloudstic.InitRepo(t.Context(), raw, cloudstic.WithInitNoEncryption())
 	if err != nil {
@@ -349,9 +349,9 @@ func TestCheckOrInitStore_InitializedEncrypted_ValidCredentials(t *testing.T) {
 	if err != nil {
 		t.Fatalf("clientConfigFromProfileStore: %v", err)
 	}
-	raw, err := newObjectStore(context.Background(), sc.Store)
+	raw, err := openStore(context.Background(), sc.Store)
 	if err != nil {
-		t.Fatalf("newObjectStore: %v", err)
+		t.Fatalf("openStore: %v", err)
 	}
 	_, err = cloudstic.InitRepo(t.Context(), raw, cloudstic.WithInitCredentials(keychain.Chain{keychain.WithPassword("correct-password")}))
 	if err != nil {
@@ -389,9 +389,9 @@ func TestCheckOrInitStore_InitializedEncrypted_InvalidCredentials(t *testing.T) 
 	if err != nil {
 		t.Fatalf("clientConfigFromProfileStore: %v", err)
 	}
-	raw, err := newObjectStore(context.Background(), sc.Store)
+	raw, err := openStore(context.Background(), sc.Store)
 	if err != nil {
-		t.Fatalf("newObjectStore: %v", err)
+		t.Fatalf("openStore: %v", err)
 	}
 	_, err = cloudstic.InitRepo(t.Context(), raw, cloudstic.WithInitCredentials(keychain.Chain{keychain.WithPassword("correct-password")}))
 	if err != nil {
@@ -1409,7 +1409,7 @@ func TestRunStoreNew_LocalStore(t *testing.T) {
 // profile store naming no region still reaches S3 on the default one.
 //
 // The default is no longer pre-filled into the config: it is applied once at
-// construction (s3Region, storebuild.go), so that a config built any other way
+// construction (pkg/open), so that a config built any other way
 // gets it too. The config therefore carries "" here, and the assertion is on
 // the value the backend actually receives.
 func TestClientConfigFromProfileStore_DefaultRegion(t *testing.T) {
@@ -1423,9 +1423,8 @@ func TestClientConfigFromProfileStore_DefaultRegion(t *testing.T) {
 	if sc.Store.S3.Region != "" {
 		t.Fatalf("expected the config to carry no region, got %q", sc.Store.S3.Region)
 	}
-	if got := s3Region(sc.Store.S3.Region); got != "us-east-1" {
-		t.Fatalf("expected default region us-east-1 at construction, got %q", got)
-	}
+	// The default itself is applied by pkg/open at construction; what this
+	// package is responsible for is not pre-filling it.
 }
 
 // TestClientConfigFromProfileStore_ExplicitRegionWins guards the other half:
@@ -1436,8 +1435,8 @@ func TestClientConfigFromProfileStore_ExplicitRegionWins(t *testing.T) {
 	if err != nil {
 		t.Fatalf("clientConfigFromProfileStore: %v", err)
 	}
-	if got := s3Region(sc.Store.S3.Region); got != "eu-west-3" {
-		t.Fatalf("expected the profile's region eu-west-3, got %q", got)
+	if sc.Store.S3.Region != "eu-west-3" {
+		t.Fatalf("expected the profile's region eu-west-3, got %q", sc.Store.S3.Region)
 	}
 }
 

--- a/cmd/cloudstic/keychain.go
+++ b/cmd/cloudstic/keychain.go
@@ -2,86 +2,36 @@ package main
 
 import (
 	"context"
-	"encoding/hex"
-	"fmt"
 	"os"
 
 	"github.com/moby/term"
 
 	"github.com/cloudstic/cli/internal/ui"
-	"github.com/cloudstic/cli/pkg/crypto"
-	"github.com/cloudstic/cli/pkg/crypto/kms"
 	"github.com/cloudstic/cli/pkg/keychain"
+	"github.com/cloudstic/cli/pkg/open"
 )
 
-// buildKeychain assembles the credential chain that unlocks a repository, in
-// the order the client should try them.
+// The credential chain is assembled by pkg/open. What stays here is whether an
+// interactive prompt is even possible, which pkg/open deliberately refuses to
+// guess: it is this process's stdin that decides, and only a terminal program
+// can answer that for itself (RFC 0022 §7).
+
+// buildKeychain assembles the credential chain that unlocks a repository.
 func buildKeychain(ctx context.Context, cfg unlockConfig) (keychain.Chain, error) {
-	platformKey, err := parsePlatformKey(cfg.EncryptionKey)
-	if err != nil {
-		return nil, err
-	}
-
-	kmsClient, err := buildKMSClient(ctx, cfg.KMS)
-	if err != nil {
-		return nil, err
-	}
-
-	var chain keychain.Chain
-
-	if kmsClient != nil {
-		chain = append(chain, keychain.WithKMSClient(kmsClient))
-	}
-	if len(platformKey) > 0 {
-		chain = append(chain, keychain.WithPlatformKey(platformKey))
-	}
-	if cfg.Password != "" {
-		chain = append(chain, keychain.WithPassword(cfg.Password))
-	}
-	if cfg.RecoveryKey != "" {
-		chain = append(chain, keychain.WithRecoveryKey(cfg.RecoveryKey))
-	}
-	if (len(chain) == 0 || cfg.Prompt) && !cfg.NoPrompt && term.IsTerminal(os.Stdin.Fd()) {
-		chain = append(chain, keychain.WithPrompt(
-			func() (string, error) { return ui.PromptPassword("Repository password") },
-			func() (string, error) { return ui.PromptPasswordConfirm("Enter new repository password") },
-		))
-	}
-
-	return chain, nil
+	return open.Keychain(ctx, cfg, open.WithPasswordPrompt(passwordPrompts()))
 }
 
-// buildKMSClient creates an AWS KMS client if a key ARN is configured,
-// otherwise returns nil.
-func buildKMSClient(ctx context.Context, cfg kmsConfig) (crypto.KMSClient, error) {
-	if cfg.KeyARN == "" {
+// passwordPrompts returns the interactive prompt functions, or nil when this
+// process has no terminal to prompt on.
+//
+// Returning nil is how "do not prompt" is expressed to pkg/open: without them
+// no prompt credential is appended, so a non-interactive run fails with a
+// missing-credential error instead of blocking on a read that will never be
+// answered.
+func passwordPrompts() (resolve, wrap func() (string, error)) {
+	if !term.IsTerminal(os.Stdin.Fd()) {
 		return nil, nil
 	}
-	var opts []kms.Option
-	if cfg.Region != "" {
-		opts = append(opts, kms.WithRegion(cfg.Region))
-	}
-	if cfg.Endpoint != "" {
-		opts = append(opts, kms.WithEndpoint(cfg.Endpoint))
-	}
-	client, err := kms.New(ctx, cfg.KeyARN, opts...)
-	if err != nil {
-		return nil, fmt.Errorf("init KMS client: %w", err)
-	}
-	return client, nil
-}
-
-// parsePlatformKey decodes the hex-encoded platform key, if one is configured.
-func parsePlatformKey(encKeyHex string) ([]byte, error) {
-	if encKeyHex == "" {
-		return nil, nil
-	}
-	platformKey, err := hex.DecodeString(encKeyHex)
-	if err != nil {
-		return nil, fmt.Errorf("invalid --encryption-key (must be hex-encoded): %w", err)
-	}
-	if len(platformKey) != crypto.KeySize {
-		return nil, fmt.Errorf("--encryption-key must be %d bytes (%d hex chars), got %d bytes", crypto.KeySize, crypto.KeySize*2, len(platformKey))
-	}
-	return platformKey, nil
+	return func() (string, error) { return ui.PromptPassword("Repository password") },
+		func() (string, error) { return ui.PromptPasswordConfirm("Enter new repository password") }
 }

--- a/cmd/cloudstic/keychain_test.go
+++ b/cmd/cloudstic/keychain_test.go
@@ -2,239 +2,69 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/moby/term"
-
-	"github.com/cloudstic/cli/pkg/keychain"
 )
 
-// These are characterization tests: they pin what buildKeychain and its
-// helpers do today, quirks included, so that RFC 0022 §7 can move them into a
-// public package and prove the move changed nothing. They were written before
-// the move, against code that had no direct unit tests at all.
+// Chain composition is tested in pkg/open, which owns it. What is left here is
+// the one decision that stayed behind: whether an interactive prompt is
+// possible at all.
 //
-// The credential order buildKeychain produces is the important part. It is the
-// order the client tries credentials in, so changing it silently changes which
-// key unlocks a repository when a caller supplies more than one.
+// pkg/open deliberately refuses to guess that — a library's answer to "can I
+// prompt?" is not a terminal program's — so it prompts only when given the
+// functions to prompt with. Supplying them, or not, is this package's job.
 
-// credKinds names the concrete type behind each credential in a chain.
-//
-// It deliberately asserts on unexported type names from pkg/keychain. That is
-// the coupling we want here: the property under test is *which* credential
-// constructor was called and in what order, and the concrete type is the only
-// thing that records it — keychain.Credential is a two-method interface that
-// every credential satisfies identically. If pkg/keychain renames one of these
-// types, this test should fail and be updated deliberately, rather than pass
-// while the chain composition drifts.
-func credKinds(t *testing.T, chain keychain.Chain) []string {
-	t.Helper()
-	kinds := make([]string, 0, len(chain))
-	for _, c := range chain {
-		kinds = append(kinds, strings.TrimPrefix(fmt.Sprintf("%T", c), "keychain."))
-	}
-	return kinds
-}
+// TestPasswordPrompts_RequiresATerminal is the successor to the
+// characterization test written before pkg/open existed. That one recorded a
+// branch that could not be reached under `go test` because it read
+// os.Stdin directly; this one asserts the decision that replaced it.
+func TestPasswordPrompts_RequiresATerminal(t *testing.T) {
+	resolve, wrap := passwordPrompts()
 
-// validHexKey is 32 bytes, the size crypto.KeySize requires.
-const validHexKey = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
-
-func TestBuildKeychain_ChainComposition(t *testing.T) {
-	// The prompt credential is appended only when stdin is a terminal, which it
-	// is not under `go test`. Every case below therefore reflects the
-	// non-interactive chain; TestBuildKeychain_PromptRequiresATerminal covers
-	// the branch that is unreachable here and says why.
 	if term.IsTerminal(os.Stdin.Fd()) {
-		t.Skip("stdin is a terminal; the non-interactive chains asserted here would gain a prompt credential")
+		if resolve == nil || wrap == nil {
+			t.Error("on a terminal, both prompt functions must be supplied")
+		}
+		return
 	}
 
-	tests := []struct {
-		name string
-		cfg  unlockConfig
-		want []string
-	}{
-		{
-			name: "empty config yields an empty chain",
-			cfg:  unlockConfig{},
-			want: []string{},
-		},
-		{
-			name: "password only",
-			cfg:  unlockConfig{Password: "hunter2"},
-			want: []string{"passwordCred"},
-		},
-		{
-			name: "encryption key only",
-			cfg:  unlockConfig{EncryptionKey: validHexKey},
-			want: []string{"platformKeyCred"},
-		},
-		{
-			name: "recovery key only",
-			cfg:  unlockConfig{RecoveryKey: "abandon abandon ability"},
-			want: []string{"recoveryCred"},
-		},
-		{
-			name: "kms only",
-			cfg:  unlockConfig{KMS: kmsConfig{KeyARN: "arn:aws:kms:us-east-1:1:key/x", Region: "us-east-1"}},
-			want: []string{"kmsClientCred"},
-		},
-		{
-			name: "every credential, in precedence order",
-			cfg: unlockConfig{
-				EncryptionKey: validHexKey,
-				Password:      "hunter2",
-				RecoveryKey:   "abandon abandon ability",
-				KMS:           kmsConfig{KeyARN: "arn:aws:kms:us-east-1:1:key/x", Region: "us-east-1"},
-			},
-			want: []string{"kmsClientCred", "platformKeyCred", "passwordCred", "recoveryCred"},
-		},
-		{
-			name: "prompt:true does not add a credential without a terminal",
-			cfg:  unlockConfig{Password: "hunter2", Prompt: true},
-			want: []string{"passwordCred"},
-		},
-		{
-			name: "noPrompt suppresses nothing else",
-			cfg:  unlockConfig{Password: "hunter2", NoPrompt: true},
-			want: []string{"passwordCred"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			chain, err := buildKeychain(context.Background(), tt.cfg)
-			if err != nil {
-				t.Fatalf("buildKeychain: %v", err)
-			}
-			got := credKinds(t, chain)
-			if len(got) != len(tt.want) {
-				t.Fatalf("chain = %v, want %v", got, tt.want)
-			}
-			for i := range got {
-				if got[i] != tt.want[i] {
-					t.Errorf("chain[%d] = %s, want %s (full chain %v, want %v)",
-						i, got[i], tt.want[i], got, tt.want)
-				}
-			}
-		})
+	if resolve != nil || wrap != nil {
+		t.Error("without a terminal there is nothing to prompt on, so no prompt " +
+			"functions may be supplied — otherwise a non-interactive run blocks " +
+			"on a read that will never be answered")
 	}
 }
 
-// TestBuildKeychain_PromptRequiresATerminal records a dependency the move in
-// §7 has to deal with: whether a prompt credential is appended is decided by
-// reading the process's own stdin, via term.IsTerminal(os.Stdin.Fd()).
-//
-// That is correct for a CLI and wrong for a library — a consumer's answer to
-// "can I prompt?" is not this process's stdin. The condition is
-// (chain is empty || prompt) && !noPrompt && stdin is a terminal, so under
-// `go test` the third term is false and the branch cannot be reached at all.
-// When buildKeychain becomes public, the terminal check must become an
-// injected decision rather than an ambient one; this test is here to fail
-// loudly if that lands without anyone noticing the behavior changed.
-func TestBuildKeychain_PromptRequiresATerminal(t *testing.T) {
+// TestBuildKeychain_NoPromptCredentialWithoutATerminal joins the two halves:
+// the decision made here, and the chain pkg/open builds from it. An empty
+// config would take a prompt if one were available, so this is the case where
+// the terminal check is the only thing deciding.
+func TestBuildKeychain_NoPromptCredentialWithoutATerminal(t *testing.T) {
 	if term.IsTerminal(os.Stdin.Fd()) {
-		t.Skip("stdin is a terminal; this test characterizes the non-terminal path")
+		t.Skip("stdin is a terminal; this characterizes the non-interactive path")
 	}
 
-	// An empty config satisfies both (len(chain) == 0) and !noPrompt, so the
-	// terminal check is the only thing preventing a prompt credential.
 	chain, err := buildKeychain(context.Background(), unlockConfig{})
 	if err != nil {
 		t.Fatalf("buildKeychain: %v", err)
 	}
 	if len(chain) != 0 {
-		t.Fatalf("chain = %v, want empty: without a terminal the prompt credential must not be added, "+
-			"which leaves nothing to unlock with", credKinds(t, chain))
+		t.Fatalf("chain has %d credential(s), want none: without a terminal the "+
+			"prompt credential must not be added, which leaves nothing to unlock with",
+			len(chain))
 	}
 }
 
-func TestBuildKeychain_PropagatesPlatformKeyError(t *testing.T) {
-	_, err := buildKeychain(context.Background(), unlockConfig{EncryptionKey: "not-hex"})
-	if err == nil {
-		t.Fatal("expected an error for a non-hex encryption key, got nil")
-	}
-	if !strings.Contains(err.Error(), "hex-encoded") {
-		t.Errorf("error = %q, want it to mention hex encoding so the user can act on it", err)
-	}
-}
-
-func TestParsePlatformKey(t *testing.T) {
-	tests := []struct {
-		name    string
-		in      string
-		wantLen int
-		wantErr string
-	}{
-		{name: "empty is not an error", in: "", wantLen: 0},
-		{name: "valid 32-byte key", in: validHexKey, wantLen: 32},
-		{name: "uppercase hex is accepted", in: strings.ToUpper(validHexKey), wantLen: 32},
-		{name: "non-hex", in: "zzzz", wantErr: "hex-encoded"},
-		{name: "odd length", in: "abc", wantErr: "hex-encoded"},
-		{name: "too short", in: "0011", wantErr: "must be 32 bytes"},
-		{name: "too long", in: validHexKey + "00", wantErr: "must be 32 bytes"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := parsePlatformKey(tt.in)
-			if tt.wantErr != "" {
-				if err == nil {
-					t.Fatalf("parsePlatformKey(%q) = %x, want error containing %q", tt.in, got, tt.wantErr)
-				}
-				if !strings.Contains(err.Error(), tt.wantErr) {
-					t.Errorf("error = %q, want it to contain %q", err, tt.wantErr)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("parsePlatformKey(%q): %v", tt.in, err)
-			}
-			if len(got) != tt.wantLen {
-				t.Errorf("len = %d, want %d", len(got), tt.wantLen)
-			}
-		})
-	}
-}
-
-// TestBuildKMSClient_NoARNIsNotAnError pins the branch that decides whether
-// KMS participates at all: an absent ARN yields (nil, nil), and buildKeychain
-// reads that nil to mean "no KMS credential". An implementation that returned
-// an error here instead would break every non-KMS unlock.
-func TestBuildKMSClient_NoARNIsNotAnError(t *testing.T) {
-	client, err := buildKMSClient(context.Background(), kmsConfig{})
+// TestBuildKeychain_StillCarriesConfiguredCredentials guards against the
+// adapter dropping the configuration on the way through to pkg/open.
+func TestBuildKeychain_StillCarriesConfiguredCredentials(t *testing.T) {
+	chain, err := buildKeychain(context.Background(), unlockConfig{Password: "hunter2"})
 	if err != nil {
-		t.Fatalf("buildKMSClient with no ARN: %v", err)
+		t.Fatalf("buildKeychain: %v", err)
 	}
-	if client != nil {
-		t.Errorf("client = %v, want nil so buildKeychain omits the KMS credential", client)
-	}
-
-	// A region or endpoint without an ARN still means "no KMS".
-	client, err = buildKMSClient(context.Background(), kmsConfig{Region: "us-east-1", Endpoint: "http://localhost:4566"})
-	if err != nil {
-		t.Fatalf("buildKMSClient with region but no ARN: %v", err)
-	}
-	if client != nil {
-		t.Errorf("client = %v, want nil: the ARN alone decides whether KMS is used", client)
-	}
-}
-
-// TestBuildKMSClient_ARNBuildsOffline records that constructing the client
-// contacts nothing — no credentials, no network, no IMDS probe. buildKeychain
-// calls it eagerly on every unlock that names an ARN, so if this ever started
-// reaching the network it would add latency to each one.
-func TestBuildKMSClient_ARNBuildsOffline(t *testing.T) {
-	client, err := buildKMSClient(context.Background(), kmsConfig{
-		KeyARN: "arn:aws:kms:us-east-1:123456789012:key/1234abcd",
-		Region: "us-east-1",
-	})
-	if err != nil {
-		t.Fatalf("buildKMSClient: %v", err)
-	}
-	if client == nil {
-		t.Fatal("client = nil, want a client: an ARN must produce one")
+	if len(chain) != 1 {
+		t.Fatalf("chain has %d credential(s), want exactly the configured password", len(chain))
 	}
 }

--- a/cmd/cloudstic/storebuild.go
+++ b/cmd/cloudstic/storebuild.go
@@ -2,121 +2,61 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"github.com/cloudstic/cli/pkg/config"
-
-	"golang.org/x/crypto/ssh"
 
 	"github.com/cloudstic/cli/internal/logger"
 	"github.com/cloudstic/cli/internal/ui"
+	"github.com/cloudstic/cli/pkg/open"
 	"github.com/cloudstic/cli/pkg/store"
-	b2store "github.com/cloudstic/cli/pkg/store/b2"
-	localstore "github.com/cloudstic/cli/pkg/store/local"
-	s3store "github.com/cloudstic/cli/pkg/store/s3"
-	sftpstore "github.com/cloudstic/cli/pkg/store/sftp"
 )
 
-// This file builds an object store from resolved configuration. It takes a
-// storeConfig value rather than parsed flags, so store construction is
-// testable without going through the flag package. Client construction (which
-// layers a store, keychain, and reporter together) lives in clientbuild.go.
+// Store construction lives in pkg/open. What stays here is what is specific to
+// being a terminal program: creating the debug writer that the console
+// reporter also draws through, and the build-tagged crash-injection hook the
+// e2e tests use (RFC 0022 §7).
 
 // openStore constructs the object store described by cfg, with debug wrapping
 // applied. Used by commands that operate on the store directly (init, key).
 func openStore(ctx context.Context, cfg storeConfig) (store.ObjectStore, error) {
-	raw, err := newObjectStore(ctx, cfg)
-	if err != nil {
-		return nil, err
-	}
-	s, _ := withDebugStore(raw, cfg.Debug)
-	return s, nil
+	s, _, err := openStoreWithDebugLog(ctx, cfg)
+	return s, err
 }
 
-// withDebugStore wraps a store with a DebugStore and enables the global debug
-// logger when debug is set. It returns the (possibly wrapped) store and the log
-// writer, which the console reporter shares so store logs and progress output
-// do not interleave.
-func withDebugStore(s store.ObjectStore, debug bool) (store.ObjectStore, *ui.SafeLogWriter) {
+// openStoreWithDebugLog also returns the debug log writer, which the console
+// reporter shares so that store logs and progress output do not interleave.
+func openStoreWithDebugLog(ctx context.Context, cfg storeConfig) (store.ObjectStore, *ui.SafeLogWriter, error) {
+	debugLog := newDebugLog(cfg.Debug)
+	s, err := open.Store(ctx, cfg, storeOptions(debugLog)...)
+	if err != nil {
+		return nil, nil, err
+	}
+	return s, debugLog, nil
+}
+
+// newDebugLog returns the shared debug writer when debug output is enabled,
+// and nil otherwise.
+//
+// Setting logger.Writer is a side effect of a function that otherwise reads as
+// pure, which is the global RFC 0022 §8 removes. It stays for now because the
+// engine and store layers still log through it; §8 replaces it with a sink
+// threaded into the client.
+func newDebugLog(debug bool) *ui.SafeLogWriter {
 	if !debug {
-		return s, nil
+		return nil
 	}
 	log := &ui.SafeLogWriter{}
 	logger.Writer = log
-	return store.NewDebugStore(s, log), log
+	return log
 }
 
-// newObjectStore constructs the backend store named by the configured URI,
-// without any decorator layers.
-func newObjectStore(ctx context.Context, cfg storeConfig) (store.ObjectStore, error) {
-	uri, err := config.ParseStoreURI(cfg.URI)
-	if err != nil {
-		return nil, err
-	}
-
-	var inner store.ObjectStore
-	switch uri.Scheme {
-	case "local":
-		inner, err = localstore.New(uri.Path)
-	case "b2":
-		if cfg.B2.KeyID == "" || cfg.B2.AppKey == "" {
-			return nil, fmt.Errorf("B2 credentials required: pass -b2-key-id/-b2-app-key (or set B2_KEY_ID/B2_APP_KEY)")
-		}
-		inner, err = b2store.New(uri.Bucket, b2store.WithCredentials(cfg.B2.KeyID, cfg.B2.AppKey), b2store.WithPrefix(uri.Prefix))
-	case "s3":
-		inner, err = s3store.New(
-			ctx,
-			uri.Bucket,
-			s3store.WithEndpoint(cfg.S3.Endpoint),
-			s3store.WithRegion(s3Region(cfg.S3.Region)),
-			s3store.WithProfile(cfg.S3.Profile),
-			s3store.WithCredentials(cfg.S3.AccessKey, cfg.S3.SecretKey),
-			s3store.WithPrefix(uri.Prefix),
-		)
-	case "sftp":
-		inner, err = sftpstore.New(uri.Host, sftpStoreOpts(cfg.SFTP, uri)...)
-	default:
-		return nil, fmt.Errorf("unsupported store type: %s", uri.Scheme)
-	}
-
-	if err != nil {
-		return nil, err
-	}
-	return withCrashInjection(inner)
-}
-
-// s3Region applies the built-in region default. It lives here, at the single
-// point of construction, rather than being pre-filled into every storeConfig
-// that might reach it: the flag path gets defaultS3Region from the -s3-region
-// flag's own default, but a config built from a profile store has no flag to
-// carry it, and prefilling that separately is how the two paths drift.
-func s3Region(region string) string {
-	if region == "" {
-		return defaultS3Region
-	}
-	return region
-}
-
-func sftpStoreOpts(cfg sftpConfig, uri *storeURIParts) []sftpstore.Option {
-	opts := []sftpstore.Option{
-		sftpstore.WithBasePath(uri.Path),
-	}
-	if uri.Port != "" {
-		opts = append(opts, sftpstore.WithPort(uri.Port))
-	}
-	if uri.User != "" {
-		opts = append(opts, sftpstore.WithUser(uri.User))
-	}
-	if cfg.Password != "" {
-		opts = append(opts, sftpstore.WithPassword(cfg.Password))
-	}
-	if cfg.Key != "" {
-		opts = append(opts, sftpstore.WithKey(cfg.Key))
-	}
-	if cfg.Insecure {
-		opts = append(opts, sftpstore.WithHostKeyCallback(ssh.InsecureIgnoreHostKey())) //nolint:gosec // explicitly requested by user
-	}
-	if cfg.KnownHosts != "" {
-		opts = append(opts, sftpstore.WithKnownHosts(cfg.KnownHosts))
+// storeOptions builds the pkg/open options every command's store shares.
+//
+// The crash-injection hook wraps the backend rather than the finished store,
+// which is the order it has always had: it counts writes reaching the backend,
+// not writes entering the decorator chain.
+func storeOptions(debugLog *ui.SafeLogWriter) []open.Option {
+	opts := []open.Option{open.WithBackendWrapper(withCrashInjection)}
+	if debugLog != nil {
+		opts = append(opts, open.WithDebugWriter(debugLog))
 	}
 	return opts
 }

--- a/cmd/cloudstic/storebuild_test.go
+++ b/cmd/cloudstic/storebuild_test.go
@@ -9,81 +9,62 @@ import (
 	localstore "github.com/cloudstic/cli/pkg/store/local"
 )
 
-func newTestLocalStore(t *testing.T) *localstore.Store {
-	t.Helper()
-	s, err := localstore.New(t.TempDir())
-	if err != nil {
-		t.Fatalf("NewLocalStore: %v", err)
-	}
-	return s
-}
+// Store construction itself is tested in pkg/open. What is left here is the
+// part that stayed behind because it is specific to being a terminal program:
+// creating the shared debug writer, and the global it still sets.
 
-func TestWithDebugStore_Disabled(t *testing.T) {
+func TestNewDebugLog_Disabled(t *testing.T) {
 	logger.Writer = nil
 
-	inner := newTestLocalStore(t)
-	result, log := withDebugStore(inner, false)
-
-	if result != inner {
-		t.Error("Expected withDebugStore to return the original store when debug is false")
-	}
-	if log != nil {
-		t.Error("Expected no log writer when debug is false")
+	if log := newDebugLog(false); log != nil {
+		t.Error("expected no log writer when debug is off")
 	}
 	if logger.Writer != nil {
-		t.Error("Expected logger.Writer to remain nil when debug is false")
+		t.Error("expected logger.Writer to remain nil when debug is off")
 	}
 }
 
-func TestWithDebugStore_Enabled(t *testing.T) {
+// TestNewDebugLog_Enabled pins the side effect as much as the return value.
+// newDebugLog sets the package-level logger.Writer, which is what lets the
+// engine and store layers log at all — and is the global RFC 0022 §8 removes.
+// Asserting on it here means that removal cannot happen silently.
+func TestNewDebugLog_Enabled(t *testing.T) {
 	logger.Writer = nil
 	defer func() { logger.Writer = nil }()
 
-	inner := newTestLocalStore(t)
-	result, log := withDebugStore(inner, true)
-
-	if _, ok := result.(*store.DebugStore); !ok {
-		t.Errorf("Expected result to be *store.DebugStore, got %T", result)
-	}
+	log := newDebugLog(true)
 	if log == nil {
-		t.Error("Expected a log writer when debug is true")
+		t.Fatal("expected a log writer when debug is on")
 	}
 	if logger.Writer == nil {
-		t.Error("Expected logger.Writer to be set when debug is true")
+		t.Error("expected logger.Writer to be set when debug is on")
 	}
 }
 
-// Store construction takes a config value, so it is exercised without going
-// through flag parsing at all.
-func TestNewObjectStore_FromConfigWithoutFlagParsing(t *testing.T) {
-	dir := t.TempDir()
-	s, err := newObjectStore(context.Background(), storeConfig{URI: "local:" + dir})
+// TestOpenStore_WrapsWhenDebugIsConfigured checks the adapter wires the debug
+// writer through to pkg/open, rather than creating one and dropping it.
+func TestOpenStore_WrapsWhenDebugIsConfigured(t *testing.T) {
+	logger.Writer = nil
+	defer func() { logger.Writer = nil }()
+
+	s, err := openStore(context.Background(), storeConfig{URI: "local:" + t.TempDir(), Debug: true})
 	if err != nil {
-		t.Fatalf("newObjectStore: %v", err)
+		t.Fatalf("openStore: %v", err)
+	}
+	if _, ok := s.(*store.DebugStore); !ok {
+		t.Errorf("expected a *store.DebugStore when Debug is set, got %T", s)
+	}
+}
+
+func TestOpenStore_UnwrappedByDefault(t *testing.T) {
+	s, err := openStore(context.Background(), storeConfig{URI: "local:" + t.TempDir()})
+	if err != nil {
+		t.Fatalf("openStore: %v", err)
+	}
+	if _, ok := s.(*store.DebugStore); ok {
+		t.Error("expected no debug wrapping when Debug is unset")
 	}
 	if _, ok := s.(*localstore.Store); !ok {
-		t.Fatalf("expected *localstore.Store, got %T", s)
-	}
-}
-
-func TestNewObjectStore_UnknownScheme(t *testing.T) {
-	if _, err := newObjectStore(context.Background(), storeConfig{URI: "nope:whatever"}); err == nil {
-		t.Fatal("expected error for unknown store scheme")
-	}
-}
-
-// B2 credentials come from the resolved b2Config, not from raw os.Getenv
-// calls, so a missing credential is caught before any network dial is
-// attempted.
-func TestNewObjectStore_B2_RequiresCredentials(t *testing.T) {
-	cases := []storeConfig{
-		{URI: "b2:my-bucket"},
-		{URI: "b2:my-bucket", B2: b2Config{KeyID: "id-only"}},
-		{URI: "b2:my-bucket", B2: b2Config{AppKey: "key-only"}},
-	}
-	for _, cfg := range cases {
-		if _, err := newObjectStore(context.Background(), cfg); err == nil {
-			t.Fatalf("expected error for incomplete B2 credentials: %+v", cfg.B2)
-		}
+		t.Errorf("expected the bare backend, got %T", s)
 	}
 }

--- a/cmd/cloudstic/storeuri.go
+++ b/cmd/cloudstic/storeuri.go
@@ -2,15 +2,9 @@ package main
 
 import "github.com/cloudstic/cli/pkg/config"
 
-// URI parsing lives in pkg/config: it is resolution, not construction, and it
-// is the half of the store contract a caller can use without linking a cloud
-// SDK. Seventeen call sites in this package parse a URI purely to validate one
-// — profile and store commands, the TUI forms, the config tables — and none of
-// them should have to pay for the AWS or Google client to do it (RFC 0022 §7).
+// URI parsing lives in pkg/config, and store construction in pkg/open, so the
+// store-side parsed type is no longer named in this package at all.
 //
-// The types stay spellable under their original names here so this package
-// reads as it did.
-type (
-	storeURIParts  = config.StoreURI
-	sourceURIParts = config.SourceURI
-)
+// The source-side one still is: building a source from a URI has not moved
+// yet, so cmd_backup.go's sftpSourceOpts continues to take one (RFC 0022 §7).
+type sourceURIParts = config.SourceURI

--- a/internal/apicheck/external_test.go
+++ b/internal/apicheck/external_test.go
@@ -73,15 +73,22 @@ var vendorSDKPrefixes = []string{
 }
 
 // sdkBearingPackages are the public packages allowed to depend on a provider
-// SDK, because carrying one is their entire purpose: each is a single
-// provider's implementation of a contract declared elsewhere.
+// SDK, because carrying one is their entire purpose.
 //
 // Membership is a deliberate API-design decision, not an exemption for
 // convenience. Adding an entry means "importing this package should cost a
 // cloud SDK", and every package NOT listed here is a promise that it does not.
+//
+// All but one are a single provider's implementation of a contract declared
+// elsewhere. pkg/open is the exception and is listed on different grounds: it
+// constructs stores and clients from any configuration, so it necessarily
+// links every provider it can build. That is precisely why the configuration
+// *types* live in pkg/config instead — resolving and validating a profile is
+// then free, and only actually connecting costs an SDK (RFC 0022 §7).
 var sdkBearingPackages = map[string]bool{
 	"github.com/cloudstic/cli/pkg/crypto/kms":      true,
 	"github.com/cloudstic/cli/pkg/keychain/kms":    true,
+	"github.com/cloudstic/cli/pkg/open":            true,
 	"github.com/cloudstic/cli/pkg/source/gdrive":   true,
 	"github.com/cloudstic/cli/pkg/source/onedrive": true,
 	"github.com/cloudstic/cli/pkg/store/s3":        true,

--- a/pkg/open/keychain.go
+++ b/pkg/open/keychain.go
@@ -1,0 +1,96 @@
+package open
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/cloudstic/cli/pkg/config"
+	"github.com/cloudstic/cli/pkg/crypto"
+	"github.com/cloudstic/cli/pkg/crypto/kms"
+	"github.com/cloudstic/cli/pkg/keychain"
+)
+
+// Keychain assembles the credential chain that unlocks a repository, in the
+// order the client should try them.
+//
+// The order is the contract: KMS, then a raw platform key, then a password,
+// then a recovery mnemonic, then an interactive prompt. Each is tried against
+// the repository's key slots and the first that opens one wins, so a caller
+// supplying several is not ambiguous — it is a preference list.
+//
+// A prompt is appended only when WithPasswordPrompt supplied one *and* the
+// configuration allows it: either nothing else is available, or a prompt was
+// asked for explicitly, and NoPrompt is not set. A caller that supplies no
+// prompt gets a chain that can fail but can never block waiting for input.
+func Keychain(ctx context.Context, cfg config.Unlock, opts ...Option) (keychain.Chain, error) {
+	return openKeychain(ctx, cfg, newOptions(opts))
+}
+
+func openKeychain(ctx context.Context, cfg config.Unlock, o *options) (keychain.Chain, error) {
+	platformKey, err := parsePlatformKey(cfg.EncryptionKey)
+	if err != nil {
+		return nil, err
+	}
+
+	kmsClient, err := newKMSClient(ctx, cfg.KMS)
+	if err != nil {
+		return nil, err
+	}
+
+	var chain keychain.Chain
+
+	if kmsClient != nil {
+		chain = append(chain, keychain.WithKMSClient(kmsClient))
+	}
+	if len(platformKey) > 0 {
+		chain = append(chain, keychain.WithPlatformKey(platformKey))
+	}
+	if cfg.Password != "" {
+		chain = append(chain, keychain.WithPassword(cfg.Password))
+	}
+	if cfg.RecoveryKey != "" {
+		chain = append(chain, keychain.WithRecoveryKey(cfg.RecoveryKey))
+	}
+	if (len(chain) == 0 || cfg.Prompt) && !cfg.NoPrompt && o.promptResolve != nil {
+		chain = append(chain, keychain.WithPrompt(o.promptResolve, o.promptWrap))
+	}
+
+	return chain, nil
+}
+
+// newKMSClient creates a KMS client if a key ARN is configured, and otherwise
+// returns nil — which the chain above reads as "KMS does not participate".
+// An absent ARN is not an error: it is how every non-KMS repository is opened.
+func newKMSClient(ctx context.Context, cfg config.KMS) (crypto.KMSClient, error) {
+	if cfg.KeyARN == "" {
+		return nil, nil
+	}
+	var opts []kms.Option
+	if cfg.Region != "" {
+		opts = append(opts, kms.WithRegion(cfg.Region))
+	}
+	if cfg.Endpoint != "" {
+		opts = append(opts, kms.WithEndpoint(cfg.Endpoint))
+	}
+	client, err := kms.New(ctx, cfg.KeyARN, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("init KMS client: %w", err)
+	}
+	return client, nil
+}
+
+// parsePlatformKey decodes the hex-encoded platform key, if one is configured.
+func parsePlatformKey(encKeyHex string) ([]byte, error) {
+	if encKeyHex == "" {
+		return nil, nil
+	}
+	platformKey, err := hex.DecodeString(encKeyHex)
+	if err != nil {
+		return nil, fmt.Errorf("invalid --encryption-key (must be hex-encoded): %w", err)
+	}
+	if len(platformKey) != crypto.KeySize {
+		return nil, fmt.Errorf("--encryption-key must be %d bytes (%d hex chars), got %d bytes", crypto.KeySize, crypto.KeySize*2, len(platformKey))
+	}
+	return platformKey, nil
+}

--- a/pkg/open/keychain_test.go
+++ b/pkg/open/keychain_test.go
@@ -1,0 +1,246 @@
+package open
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cloudstic/cli/pkg/config"
+	"github.com/cloudstic/cli/pkg/keychain"
+)
+
+// These began as characterization tests in cmd/cloudstic, written before this
+// package existed, and moved with the code they pin.
+//
+// The credential order is the important part: it is the order the client tries
+// credentials in, so changing it silently changes which key unlocks a
+// repository when a caller supplies more than one.
+//
+// One thing improved in the move. In cmd/cloudstic the prompt branch was gated
+// on term.IsTerminal(os.Stdin.Fd()), so it was unreachable under `go test` and
+// every case had to be written around that. Here prompting is decided by
+// whether the caller passed WithPasswordPrompt, which makes the branch
+// ordinary, deterministic, and testable in both directions.
+
+// credKinds names the concrete type behind each credential in a chain.
+//
+// It deliberately asserts on unexported type names from pkg/keychain. That is
+// the coupling we want: the property under test is *which* credential
+// constructor was called and in what order, and the concrete type is the only
+// thing that records it — keychain.Credential is a two-method interface that
+// every credential satisfies identically.
+func credKinds(chain keychain.Chain) []string {
+	kinds := make([]string, 0, len(chain))
+	for _, c := range chain {
+		kinds = append(kinds, strings.TrimPrefix(fmt.Sprintf("%T", c), "keychain."))
+	}
+	return kinds
+}
+
+// validHexKey is 32 bytes, the size crypto.KeySize requires.
+const validHexKey = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+
+func promptOption() Option {
+	return WithPasswordPrompt(
+		func() (string, error) { return "prompted", nil },
+		func() (string, error) { return "prompted", nil },
+	)
+}
+
+func TestKeychain_ChainComposition(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  config.Unlock
+		opts []Option
+		want []string
+	}{
+		{
+			name: "no credentials and no prompt yields an empty chain",
+			cfg:  config.Unlock{},
+			want: []string{},
+		},
+		{
+			name: "password only",
+			cfg:  config.Unlock{Password: "hunter2"},
+			want: []string{"passwordCred"},
+		},
+		{
+			name: "encryption key only",
+			cfg:  config.Unlock{EncryptionKey: validHexKey},
+			want: []string{"platformKeyCred"},
+		},
+		{
+			name: "recovery key only",
+			cfg:  config.Unlock{RecoveryKey: "abandon abandon ability"},
+			want: []string{"recoveryCred"},
+		},
+		{
+			name: "kms only",
+			cfg:  config.Unlock{KMS: config.KMS{KeyARN: "arn:aws:kms:us-east-1:1:key/x", Region: "us-east-1"}},
+			want: []string{"kmsClientCred"},
+		},
+		{
+			name: "every credential, in precedence order",
+			cfg: config.Unlock{
+				EncryptionKey: validHexKey,
+				Password:      "hunter2",
+				RecoveryKey:   "abandon abandon ability",
+				KMS:           config.KMS{KeyARN: "arn:aws:kms:us-east-1:1:key/x", Region: "us-east-1"},
+			},
+			want: []string{"kmsClientCred", "platformKeyCred", "passwordCred", "recoveryCred"},
+		},
+		{
+			name: "a prompt is the last resort when nothing else is available",
+			cfg:  config.Unlock{},
+			opts: []Option{promptOption()},
+			want: []string{"promptCred"},
+		},
+		{
+			name: "a prompt is not added when another credential exists",
+			cfg:  config.Unlock{Password: "hunter2"},
+			opts: []Option{promptOption()},
+			want: []string{"passwordCred"},
+		},
+		{
+			name: "Prompt asks for one even alongside another credential",
+			cfg:  config.Unlock{Password: "hunter2", Prompt: true},
+			opts: []Option{promptOption()},
+			want: []string{"passwordCred", "promptCred"},
+		},
+		{
+			name: "NoPrompt beats Prompt",
+			cfg:  config.Unlock{Password: "hunter2", Prompt: true, NoPrompt: true},
+			opts: []Option{promptOption()},
+			want: []string{"passwordCred"},
+		},
+		{
+			name: "NoPrompt leaves an empty chain rather than prompting",
+			cfg:  config.Unlock{NoPrompt: true},
+			opts: []Option{promptOption()},
+			want: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chain, err := Keychain(context.Background(), tt.cfg, tt.opts...)
+			if err != nil {
+				t.Fatalf("Keychain: %v", err)
+			}
+			got := credKinds(chain)
+			if len(got) != len(tt.want) {
+				t.Fatalf("chain = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("chain[%d] = %s, want %s (full chain %v, want %v)",
+						i, got[i], tt.want[i], got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+// TestKeychain_WithoutAPromptOptionNeverBlocks is the property a
+// non-interactive caller depends on: with no prompt supplied, the chain can
+// fail for want of a credential but can never block on a read that will not be
+// answered.
+func TestKeychain_WithoutAPromptOptionNeverBlocks(t *testing.T) {
+	chain, err := Keychain(context.Background(), config.Unlock{})
+	if err != nil {
+		t.Fatalf("Keychain: %v", err)
+	}
+	if len(chain) != 0 {
+		t.Fatalf("chain = %v, want empty: without WithPasswordPrompt there is nothing "+
+			"to prompt with, so no prompt credential may be added", credKinds(chain))
+	}
+}
+
+func TestKeychain_PropagatesPlatformKeyError(t *testing.T) {
+	_, err := Keychain(context.Background(), config.Unlock{EncryptionKey: "not-hex"})
+	if err == nil {
+		t.Fatal("expected an error for a non-hex encryption key, got nil")
+	}
+	if !strings.Contains(err.Error(), "hex-encoded") {
+		t.Errorf("error = %q, want it to mention hex encoding so the user can act on it", err)
+	}
+}
+
+func TestParsePlatformKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		wantLen int
+		wantErr string
+	}{
+		{name: "empty is not an error", in: "", wantLen: 0},
+		{name: "valid 32-byte key", in: validHexKey, wantLen: 32},
+		{name: "uppercase hex is accepted", in: strings.ToUpper(validHexKey), wantLen: 32},
+		{name: "non-hex", in: "zzzz", wantErr: "hex-encoded"},
+		{name: "odd length", in: "abc", wantErr: "hex-encoded"},
+		{name: "too short", in: "0011", wantErr: "must be 32 bytes"},
+		{name: "too long", in: validHexKey + "00", wantErr: "must be 32 bytes"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePlatformKey(tt.in)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("parsePlatformKey(%q) = %x, want error containing %q", tt.in, got, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("error = %q, want it to contain %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parsePlatformKey(%q): %v", tt.in, err)
+			}
+			if len(got) != tt.wantLen {
+				t.Errorf("len = %d, want %d", len(got), tt.wantLen)
+			}
+		})
+	}
+}
+
+// TestNewKMSClient_NoARNIsNotAnError pins the branch that decides whether KMS
+// participates at all: an absent ARN yields (nil, nil), and the chain reads
+// that nil as "no KMS credential". An implementation that returned an error
+// here instead would break every non-KMS unlock.
+func TestNewKMSClient_NoARNIsNotAnError(t *testing.T) {
+	client, err := newKMSClient(context.Background(), config.KMS{})
+	if err != nil {
+		t.Fatalf("newKMSClient with no ARN: %v", err)
+	}
+	if client != nil {
+		t.Errorf("client = %v, want nil so the chain omits the KMS credential", client)
+	}
+
+	// A region or endpoint without an ARN still means "no KMS".
+	client, err = newKMSClient(context.Background(), config.KMS{Region: "us-east-1", Endpoint: "http://localhost:4566"})
+	if err != nil {
+		t.Fatalf("newKMSClient with region but no ARN: %v", err)
+	}
+	if client != nil {
+		t.Errorf("client = %v, want nil: the ARN alone decides whether KMS is used", client)
+	}
+}
+
+// TestNewKMSClient_ARNBuildsOffline records that constructing the client
+// contacts nothing — no credentials, no network, no IMDS probe. It is called
+// eagerly on every unlock that names an ARN, so if this ever started reaching
+// the network it would add latency to each one.
+func TestNewKMSClient_ARNBuildsOffline(t *testing.T) {
+	client, err := newKMSClient(context.Background(), config.KMS{
+		KeyARN: "arn:aws:kms:us-east-1:123456789012:key/1234abcd",
+		Region: "us-east-1",
+	})
+	if err != nil {
+		t.Fatalf("newKMSClient: %v", err)
+	}
+	if client == nil {
+		t.Fatal("client = nil, want a client: an ARN must produce one")
+	}
+}

--- a/pkg/open/open.go
+++ b/pkg/open/open.go
@@ -1,0 +1,217 @@
+// Package open constructs live objects from resolved configuration: an object
+// store from a store URI and its credentials, a keychain from a set of unlock
+// credentials, and a repository client from both.
+//
+// It is the other half of pkg/config. That package answers "what did the user
+// configure"; this one answers "connect to it". The split is what decides
+// import cost: pkg/config depends on nothing heavier than YAML parsing, so
+// reading and validating a profiles file is cheap, while constructing an S3 or
+// KMS client necessarily links a cloud SDK and only a caller who does that
+// pays for it (RFC 0022 §7).
+//
+// Everything the constructors need from the outside world is passed in rather
+// than reached for. The debug sink is a writer the caller supplies, the
+// progress reporter is a value the caller chooses, and whether an interactive
+// password prompt is available at all is the caller's decision — this package
+// never inspects the process's own stdin, because a library's answer to "can I
+// prompt?" is not the same as a terminal program's.
+package open
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"golang.org/x/crypto/ssh"
+
+	cloudstic "github.com/cloudstic/cli"
+	"github.com/cloudstic/cli/pkg/config"
+	"github.com/cloudstic/cli/pkg/store"
+	b2store "github.com/cloudstic/cli/pkg/store/b2"
+	localstore "github.com/cloudstic/cli/pkg/store/local"
+	s3store "github.com/cloudstic/cli/pkg/store/s3"
+	sftpstore "github.com/cloudstic/cli/pkg/store/sftp"
+)
+
+// defaultS3Region is the region used when the configuration names none. It is
+// applied here, at the single point of construction, so that a configuration
+// built from a profile and one built from command-line flags cannot disagree
+// about it.
+const defaultS3Region = "us-east-1"
+
+// Option configures how a store, keychain, or client is opened.
+//
+// These are behaviour knobs supplied by the caller, deliberately separate from
+// the pkg/config value types: configuration describes a repository and can be
+// serialized, compared, and round-tripped, while these carry writers,
+// callbacks, and interfaces that cannot.
+type Option func(*options)
+
+type options struct {
+	debugWriter    io.Writer
+	backendWrapper func(store.ObjectStore) (store.ObjectStore, error)
+	reporter       cloudstic.Reporter
+	promptResolve  func() (string, error)
+	promptWrap     func() (string, error)
+}
+
+func newOptions(opts []Option) *options {
+	o := &options{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return o
+}
+
+// WithDebugWriter logs every store operation to w.
+//
+// The writer is supplied rather than created here because it is usually shared
+// with a progress reporter, so that operation logs and progress output do not
+// interleave.
+func WithDebugWriter(w io.Writer) Option {
+	return func(o *options) { o.debugWriter = w }
+}
+
+// WithBackendWrapper wraps the constructed backend before the repository
+// layers are applied on top of it, for a caller adding its own quota,
+// rate-limit, metrics, or fault-injection decorator.
+//
+// This is the supported place to intervene in the store chain. The repository
+// decorators themselves stay internal because their composition order is a
+// correctness and security invariant (RFC 0022 §4a); wrapping the backend
+// underneath them carries no such hazard.
+func WithBackendWrapper(fn func(store.ObjectStore) (store.ObjectStore, error)) Option {
+	return func(o *options) { o.backendWrapper = fn }
+}
+
+// WithReporter sets the progress reporter the client reports through. Without
+// one the client reports nothing.
+func WithReporter(r cloudstic.Reporter) Option {
+	return func(o *options) { o.reporter = r }
+}
+
+// WithPasswordPrompt makes an interactive password prompt available as a
+// last-resort credential, used only when the configuration leaves no other way
+// in (or asks for a prompt explicitly) and does not forbid prompting.
+//
+// resolve is called to unlock an existing repository; wrap is called to choose
+// a password for a new key slot, and should confirm it.
+//
+// Supplying these is what makes prompting possible at all. That is the
+// caller's decision to make: this package cannot tell whether a prompt would
+// reach a human, and guessing by inspecting os.Stdin would be wrong for every
+// caller that is not a terminal program.
+func WithPasswordPrompt(resolve, wrap func() (string, error)) Option {
+	return func(o *options) { o.promptResolve, o.promptWrap = resolve, wrap }
+}
+
+// Store constructs the object store described by cfg.
+//
+// The result is a raw backend, with no repository layers on it. Pass it to
+// cloudstic.NewClient — or to Client below, which does that — to get
+// compression, encryption, and packing.
+func Store(ctx context.Context, cfg config.Store, opts ...Option) (store.ObjectStore, error) {
+	return openStore(ctx, cfg, newOptions(opts))
+}
+
+func openStore(ctx context.Context, cfg config.Store, o *options) (store.ObjectStore, error) {
+	uri, err := config.ParseStoreURI(cfg.URI)
+	if err != nil {
+		return nil, err
+	}
+
+	var inner store.ObjectStore
+	switch uri.Scheme {
+	case "local":
+		inner, err = localstore.New(uri.Path)
+	case "b2":
+		if cfg.B2.KeyID == "" || cfg.B2.AppKey == "" {
+			return nil, fmt.Errorf("B2 credentials required: pass -b2-key-id/-b2-app-key (or set B2_KEY_ID/B2_APP_KEY)")
+		}
+		inner, err = b2store.New(uri.Bucket, b2store.WithCredentials(cfg.B2.KeyID, cfg.B2.AppKey), b2store.WithPrefix(uri.Prefix))
+	case "s3":
+		inner, err = s3store.New(
+			ctx,
+			uri.Bucket,
+			s3store.WithEndpoint(cfg.S3.Endpoint),
+			s3store.WithRegion(s3Region(cfg.S3.Region)),
+			s3store.WithProfile(cfg.S3.Profile),
+			s3store.WithCredentials(cfg.S3.AccessKey, cfg.S3.SecretKey),
+			s3store.WithPrefix(uri.Prefix),
+		)
+	case "sftp":
+		inner, err = sftpstore.New(uri.Host, sftpStoreOpts(cfg.SFTP, uri)...)
+	default:
+		return nil, fmt.Errorf("unsupported store type: %s", uri.Scheme)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if o.backendWrapper != nil {
+		if inner, err = o.backendWrapper(inner); err != nil {
+			return nil, err
+		}
+	}
+	if o.debugWriter != nil {
+		inner = store.NewDebugStore(inner, o.debugWriter)
+	}
+	return inner, nil
+}
+
+// s3Region applies the built-in region default.
+func s3Region(region string) string {
+	if region == "" {
+		return defaultS3Region
+	}
+	return region
+}
+
+func sftpStoreOpts(cfg config.SFTP, uri *config.StoreURI) []sftpstore.Option {
+	opts := []sftpstore.Option{
+		sftpstore.WithBasePath(uri.Path),
+	}
+	if uri.Port != "" {
+		opts = append(opts, sftpstore.WithPort(uri.Port))
+	}
+	if uri.User != "" {
+		opts = append(opts, sftpstore.WithUser(uri.User))
+	}
+	if cfg.Password != "" {
+		opts = append(opts, sftpstore.WithPassword(cfg.Password))
+	}
+	if cfg.Key != "" {
+		opts = append(opts, sftpstore.WithKey(cfg.Key))
+	}
+	if cfg.Insecure {
+		opts = append(opts, sftpstore.WithHostKeyCallback(ssh.InsecureIgnoreHostKey())) //nolint:gosec // explicitly requested by the caller
+	}
+	if cfg.KnownHosts != "" {
+		opts = append(opts, sftpstore.WithKnownHosts(cfg.KnownHosts))
+	}
+	return opts
+}
+
+// Client opens a repository client on the store described by cfg, unlocked
+// with the credentials cfg names.
+func Client(ctx context.Context, cfg config.Client, opts ...Option) (*cloudstic.Client, error) {
+	o := newOptions(opts)
+
+	raw, err := openStore(ctx, cfg.Store, o)
+	if err != nil {
+		return nil, err
+	}
+	kc, err := openKeychain(ctx, cfg.Unlock, o)
+	if err != nil {
+		return nil, err
+	}
+
+	clientOpts := []cloudstic.ClientOption{
+		cloudstic.WithKeychain(kc),
+		cloudstic.WithPackfile(!cfg.DisablePackfile),
+	}
+	if o.reporter != nil {
+		clientOpts = append(clientOpts, cloudstic.WithReporter(o.reporter))
+	}
+	return cloudstic.NewClient(ctx, raw, clientOpts...)
+}

--- a/pkg/open/open_test.go
+++ b/pkg/open/open_test.go
@@ -1,0 +1,163 @@
+package open
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cloudstic/cli/pkg/config"
+	"github.com/cloudstic/cli/pkg/store"
+	localstore "github.com/cloudstic/cli/pkg/store/local"
+)
+
+// Store construction takes a config value, so it is exercised without going
+// through any flag parsing at all — which is the point of the pkg/config and
+// pkg/open split.
+
+func TestStore_LocalRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	s, err := Store(ctx, config.Store{URI: "local:" + t.TempDir()})
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if _, ok := s.(*localstore.Store); !ok {
+		t.Fatalf("expected *localstore.Store, got %T", s)
+	}
+
+	if err := s.Put(ctx, "config", []byte("marker")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, err := s.Get(ctx, "config")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got) != "marker" {
+		t.Errorf("Get = %q, want %q", got, "marker")
+	}
+}
+
+func TestStore_UnknownScheme(t *testing.T) {
+	if _, err := Store(context.Background(), config.Store{URI: "nope:whatever"}); err == nil {
+		t.Fatal("expected an error for an unknown store scheme")
+	}
+}
+
+// TestStore_B2RequiresCredentials checks the credential guard that lives here
+// rather than in the B2 backend, so a missing credential is caught before any
+// network dial is attempted. Its message names both the flags and the
+// environment variables that satisfy it.
+func TestStore_B2RequiresCredentials(t *testing.T) {
+	cases := []config.Store{
+		{URI: "b2:my-bucket"},
+		{URI: "b2:my-bucket", B2: config.B2{KeyID: "id-only"}},
+		{URI: "b2:my-bucket", B2: config.B2{AppKey: "key-only"}},
+	}
+	for _, cfg := range cases {
+		_, err := Store(context.Background(), cfg)
+		if err == nil {
+			t.Fatalf("expected an error for incomplete B2 credentials: %+v", cfg.B2)
+			continue
+		}
+		for _, want := range []string{"-b2-key-id", "B2_KEY_ID"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error = %q, want it to mention %q", err, want)
+			}
+		}
+	}
+}
+
+func TestStore_WithDebugWriterWraps(t *testing.T) {
+	var buf bytes.Buffer
+
+	s, err := Store(context.Background(), config.Store{URI: "local:" + t.TempDir()},
+		WithDebugWriter(&buf))
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if _, ok := s.(*store.DebugStore); !ok {
+		t.Fatalf("expected the store to be wrapped in *store.DebugStore, got %T", s)
+	}
+
+	if err := s.Put(context.Background(), "config", []byte("x")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if buf.Len() == 0 {
+		t.Error("the debug writer received nothing; the wrapper is not logging through it")
+	}
+}
+
+func TestStore_WithoutDebugWriterIsUnwrapped(t *testing.T) {
+	s, err := Store(context.Background(), config.Store{URI: "local:" + t.TempDir()})
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if _, ok := s.(*store.DebugStore); ok {
+		t.Error("no debug writer was supplied, so the store must not be wrapped")
+	}
+}
+
+// countingStore records that it was interposed, so the test can tell where in
+// the chain a backend wrapper ended up.
+type countingStore struct {
+	store.ObjectStore
+	puts *int
+}
+
+func (c countingStore) Put(ctx context.Context, key string, data []byte) error {
+	*c.puts++
+	return c.ObjectStore.Put(ctx, key, data)
+}
+
+// TestStore_BackendWrapperSitsBelowDebug pins the order the two decorators are
+// applied in. A wrapper is meant to see what actually reaches the backend, so
+// it belongs underneath the debug layer rather than on top of it — which is
+// also the order the CLI's crash-injection hook has always had.
+func TestStore_BackendWrapperSitsBelowDebug(t *testing.T) {
+	var buf bytes.Buffer
+	puts := 0
+
+	s, err := Store(context.Background(), config.Store{URI: "local:" + t.TempDir()},
+		WithBackendWrapper(func(inner store.ObjectStore) (store.ObjectStore, error) {
+			return countingStore{ObjectStore: inner, puts: &puts}, nil
+		}),
+		WithDebugWriter(&buf),
+	)
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if _, ok := s.(*store.DebugStore); !ok {
+		t.Fatalf("the outermost layer must be the debug store, got %T", s)
+	}
+	if err := s.Put(context.Background(), "config", []byte("x")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if puts != 1 {
+		t.Errorf("wrapper saw %d puts, want 1: it must be interposed, not bypassed", puts)
+	}
+}
+
+func TestStore_BackendWrapperErrorPropagates(t *testing.T) {
+	_, err := Store(context.Background(), config.Store{URI: "local:" + t.TempDir()},
+		WithBackendWrapper(func(store.ObjectStore) (store.ObjectStore, error) {
+			return nil, errWrapper
+		}))
+	if err == nil {
+		t.Fatal("expected the wrapper's error to propagate")
+	}
+}
+
+type wrapperError struct{}
+
+func (wrapperError) Error() string { return "wrapper failed" }
+
+var errWrapper = wrapperError{}
+
+func TestS3Region(t *testing.T) {
+	if got := s3Region(""); got != defaultS3Region {
+		t.Errorf("s3Region(%q) = %q, want the built-in default %q", "", got, defaultS3Region)
+	}
+	if got := s3Region("eu-west-3"); got != "eu-west-3" {
+		t.Errorf("s3Region(%q) = %q, want it left alone", "eu-west-3", got)
+	}
+}

--- a/rfcs/0022-public-go-api-boundaries.md
+++ b/rfcs/0022-public-go-api-boundaries.md
@@ -1,7 +1,6 @@
 # RFC 0022: Public Go API Boundaries
 
-- **Status:** Partially implemented — §1–§6 landed; §7's `pkg/config` half
-  landed, its `pkg/open` half outstanding; §8 outstanding
+- **Status:** Partially implemented — §1–§7 landed; §8 outstanding
 - **Date:** 2026-07-28
 - **Affects:** `client.go`, `pkg/source`, `pkg/store`, `pkg/crypto`, `pkg/config`,
   `pkg/open`, `internal/logger`, `internal/storelayer`, `cmd/cloudstic`, `docs/`
@@ -606,8 +605,7 @@ Stages 5–8 add three requirements:
 7. Export the resolved config types' *fields* in place, still in
    `package main`; then move the types to `pkg/config` behind
    `type clientConfig = config.Client` aliases; then the URI parsers; then
-   profile resolution with the resolver injected. **Done** — this is §7's
-   `pkg/config` half; the `pkg/open` half is step 8.
+   profile resolution with the resolver injected. **Done.**
 
    The first of those was not in the original plan, which assumed the aliases
    made the move call-site-neutral on their own. They do not: an alias makes
@@ -619,7 +617,7 @@ Stages 5–8 add three requirements:
    with unrelated identifiers spelled the same way — makes the move that
    follows genuinely call-site-neutral.
 8. Add `pkg/open`; reduce `storebuild.go`, `clientbuild.go`, and `keychain.go`
-   to adapters.
+   to adapters. **Done.**
 9. Logger injection (§8).
 10. Extend the external fixture to consume the library end to end.
 


### PR DESCRIPTION
## Summary

Completes RFC 0022 §7. `pkg/config` said what the user configured; nothing public could act on it. `pkg/open` now constructs a store, a keychain, or a repository client from those values, so a caller outside this module reaches a repository the same way the CLI does rather than reassembling the wiring.

```go
open.Store(ctx, cfg config.Store, opts...)
open.Keychain(ctx, cfg config.Unlock, opts...)
open.Client(ctx, cfg config.Client, opts...)
```

`storebuild.go`, `clientbuild.go` and `keychain.go` go from 258 lines to 141, holding only what is genuinely CLI-specific.

Part of #378

### Three ambient dependencies became injected

This is what let the code move at all — each was an `internal/ui` type in a signature that could not be made public:

| Was | Now |
| --- | --- |
| `withDebugStore` created and returned a `*ui.SafeLogWriter` | `WithDebugWriter(io.Writer)` — the caller supplies it |
| `newReporter` constructed `ui.NewConsoleReporter` / `NewNoOpReporter` | `WithReporter(cloudstic.Reporter)` — the caller chooses |
| `buildKeychain` called `ui.PromptPassword` behind a terminal check | `WithPasswordPrompt(resolve, wrap)` — the caller decides if prompting is possible |

### The prompt one is worth a closer look

`buildKeychain` decided whether to prompt by reading `term.IsTerminal(os.Stdin.Fd())`. Correct for a terminal program, wrong for a library — a consumer's answer to "can I prompt?" is not this process's stdin — and it is why the characterization test added in #393 could not reach that branch at all.

`pkg/open` now prompts only when given functions to prompt with, and `cmd/cloudstic` supplies them only when it has a terminal. **Behaviour is unchanged.** But the branch stopped being ambient, so it became testable in both directions for the first time: prompt-as-last-resort, `Prompt` alongside another credential, `NoPrompt` beating `Prompt`, and none-supplied. `TestBuildKeychain_PromptRequiresATerminal` — which existed to fail loudly when exactly this landed — is replaced by a pair that assert the decision (`cmd`) and the chain built from it (`pkg/open`) separately.

### For reviewers

- **`WithBackendWrapper` is not speculative API.** The CLI's build-tagged crash-injection hook wrapped the backend *below* the debug layer, and that order is load-bearing: it counts writes reaching the backend, not writes entering the decorator chain. A test pins the ordering. It also happens to be the extension point §4a says callers should use for a quota, rate-limit, or metrics decorator, now that the repository decorators are internal.
- **`pkg/open` is in `sdkBearingPackages` on different grounds from every other entry, and says so.** The others are one provider's implementation of a contract; `pkg/open` links *every* provider it can build. That is precisely why the configuration types stayed in `pkg/config` — resolving and validating a profile is still 78 dependencies and no SDK, and only connecting costs one.
- **Three findings came from the tooling, not from me.** The SDK sweep failed on `pkg/open` (working as designed — it was added to the allowlist deliberately, not silenced). The linter then caught that `storeURIParts` and `newTestLocalStore` had become dead once `sftpStoreOpts` moved.
- **`cmd_store.go` swapped `newObjectStore` for `openStore`.** That path never sets `Debug`, so the added debug wrapping is unreachable and behaviour is identical; flagging it because the two used to differ.
- Tests moved with the code they cover. `storeuri.go` keeps only the source-side alias, since building a source from a URI has not moved yet.

### Still outstanding

§8, and only §8: replacing the global `internal/logger.Writer` with an injected `io.Writer` threaded through the client and the source constructors. `newDebugLog` still sets that global, and `TestNewDebugLog_Enabled` asserts it does — deliberately, so §8 cannot remove it silently.

## Verification

\`\`\`bash
env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./...
env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./cmd/cloudstic/... ./pkg/... ./internal/apicheck/...
gofmt -l .
npx markdownlint-cli2 rfcs/0022-public-go-api-boundaries.md
\`\`\`

Full suite passes with the race detector; lint reports 0 issues; `gofmt -l` and markdownlint are clean.