### PR TITLE
feat: make debug output reachable from outside the module (RFC 0022 §8)

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -84,7 +84,7 @@ func (c *Client) raiseRepoFormat(ctx context.Context) error {
 // unframed write corrupts permanently.
 func (c *Client) stampWriteFormat(ctx context.Context) {
 	if err := c.raiseRepoFormat(ctx); err != nil {
-		log.Debugf("could not stamp repository format: %v", err)
+		c.log.Debugf("could not stamp repository format: %v", err)
 	}
 }
 
@@ -108,7 +108,7 @@ func (c *Client) Backup(ctx context.Context, src source.Source, opts ...BackupOp
 	rawMeter := storelayer.NewMeteredStore(c.store)
 	c.storedMeter.Reset()
 
-	mgr := engine.NewBackupManager(src, rawMeter, c.reporter, c.hmacKey, opts...)
+	mgr := engine.NewBackupManager(src, rawMeter, c.reporter, c.hmacKey, c.logWriter, opts...)
 	result, err := mgr.Run(ctx)
 	if err != nil {
 		return nil, err

--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package cloudstic
 import (
 	"context"
 	"fmt"
+	"io"
 	"sync/atomic"
 
 	"github.com/cloudstic/cli/internal/core"
@@ -15,7 +16,7 @@ import (
 	"github.com/cloudstic/cli/pkg/store"
 )
 
-var log = logger.New("client", logger.ColorCyan)
+var defaultLog = logger.New("client", logger.ColorCyan)
 
 // ---------------------------------------------------------------------------
 // client
@@ -46,6 +47,21 @@ func WithKeychain(kc keychain.Chain) ClientOption {
 	return func(c *Client) { c.keychain = kc }
 }
 
+// WithLogger sends this client's debug output to w, along with that of the
+// engine and store layers it drives.
+//
+// Debug output was previously reachable only by setting a package-level
+// writer inside the module, so a library caller could not turn it on at all.
+// A sink given here belongs to this client alone: two clients in one process
+// can log to different places, or one can log while the other stays silent
+// (RFC 0022 §8).
+func WithLogger(w io.Writer) ClientOption {
+	return func(c *Client) {
+		c.logWriter = w
+		c.log = defaultLog.To(w)
+	}
+}
+
 // WithPackfile enables bundling small objects into 8MB packs to save API calls.
 func WithPackfile(enable bool) ClientOption {
 	return func(c *Client) { c.enablePackfile = enable }
@@ -73,11 +89,17 @@ type Client struct {
 	keychain       keychain.Chain
 	enablePackfile bool
 	reporter       ui.Reporter
+	// log is this client's debug sink, and logWriter the writer behind it,
+	// kept so the engine and store layers it constructs can be given the same
+	// one. An unbound logger falls back to the process-wide writer.
+	log       *logger.Logger
+	logWriter io.Writer
 }
 
 func NewClient(ctx context.Context, base store.ObjectStore, opts ...ClientOption) (*Client, error) {
 	c := &Client{
 		base:           base,
+		log:            defaultLog,
 		enablePackfile: true, // Packfile is enabled by default
 		reporter:       ui.NewNoOpReporter(),
 	}
@@ -108,12 +130,12 @@ func NewClient(ctx context.Context, base store.ObjectStore, opts ...ClientOption
 
 	inner := base
 
-	log.Debugf("packfile enabled: %v", c.enablePackfile)
+	c.log.Debugf("packfile enabled: %v", c.enablePackfile)
 	if c.enablePackfile {
 		// PackStore sits below the encryption layer, so the catalog and pack
 		// footers it writes never pass through EncryptedStore. Give it its own
 		// derived key so they are not left in plaintext.
-		var packOpts []storelayer.PackOption
+		packOpts := []storelayer.PackOption{storelayer.WithPackLogger(c.logWriter)}
 		if len(c.encryptionKey) > 0 {
 			indexKey, err := crypto.DeriveKey(c.encryptionKey, crypto.HKDFInfoPackIndexV1)
 			if err != nil {

--- a/client_logger_test.go
+++ b/client_logger_test.go
@@ -1,0 +1,97 @@
+package cloudstic_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	cloudstic "github.com/cloudstic/cli"
+	localsource "github.com/cloudstic/cli/pkg/source/local"
+	localstore "github.com/cloudstic/cli/pkg/store/local"
+)
+
+// TestWithLogger_ReachesTheStoreLayers is the acceptance test for RFC 0022 §8:
+// a caller outside cmd/cloudstic can turn debug output on, and gets the store
+// layers' output as well as the client's own.
+func TestWithLogger_ReachesTheStoreLayers(t *testing.T) {
+	ctx := context.Background()
+	base, err := localstore.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cloudstic.InitRepo(ctx, base); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := cloudstic.NewClient(ctx, base, cloudstic.WithLogger(&buf)); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if out == "" {
+		t.Fatal("WithLogger produced no output at all")
+	}
+	if !strings.Contains(out, "[client]") {
+		t.Errorf("no client output; got %q", out)
+	}
+	if !strings.Contains(out, "[store]") {
+		t.Errorf("no store-layer output; got %q", out)
+	}
+}
+
+// TestWithLogger_ReachesTheBackupEngine covers the layer furthest from the
+// client. It is here because the engine's logger is set in a struct literal
+// that a rename silently left unset: the nil logger swallowed every backup
+// debug line while every test still passed. An assertion on real output is
+// what catches that class of mistake.
+func TestWithLogger_ReachesTheBackupEngine(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	base, err := localstore.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cloudstic.InitRepo(ctx, base); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	c, err := cloudstic.NewClient(ctx, base, cloudstic.WithLogger(&buf))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Backup(ctx, localsource.New(dir)); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "[backup]") {
+		t.Errorf("no backup-engine output reached the sink; got %q", buf.String())
+	}
+}
+
+// TestWithLogger_IsPerClient is the property the global could never provide.
+func TestWithLogger_IsPerClient(t *testing.T) {
+	ctx := context.Background()
+	base, err := localstore.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cloudstic.InitRepo(ctx, base); err != nil {
+		t.Fatal(err)
+	}
+
+	var loud bytes.Buffer
+	if _, err := cloudstic.NewClient(ctx, base, cloudstic.WithLogger(&loud)); err != nil {
+		t.Fatal(err)
+	}
+	quiet, err := cloudstic.NewClient(ctx, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = quiet
+
+	if loud.Len() == 0 {
+		t.Error("the client given a sink logged nothing")
+	}
+}

--- a/cmd/cloudstic/clientbuild.go
+++ b/cmd/cloudstic/clientbuild.go
@@ -27,6 +27,9 @@ func openClient(ctx context.Context, cfg clientConfig, reporterOverride cloudsti
 		open.WithReporter(reporter),
 		open.WithPasswordPrompt(passwordPrompts()),
 	)
+	if debugLog != nil {
+		opts = append(opts, open.WithLogger(debugLog))
+	}
 	return open.Client(ctx, cfg, opts...)
 }
 

--- a/cmd/cloudstic/storebuild.go
+++ b/cmd/cloudstic/storebuild.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 
-	"github.com/cloudstic/cli/internal/logger"
 	"github.com/cloudstic/cli/internal/ui"
 	"github.com/cloudstic/cli/pkg/open"
 	"github.com/cloudstic/cli/pkg/store"
@@ -35,17 +34,16 @@ func openStoreWithDebugLog(ctx context.Context, cfg storeConfig) (store.ObjectSt
 // newDebugLog returns the shared debug writer when debug output is enabled,
 // and nil otherwise.
 //
-// Setting logger.Writer is a side effect of a function that otherwise reads as
-// pure, which is the global RFC 0022 §8 removes. It stays for now because the
-// engine and store layers still log through it; §8 replaces it with a sink
-// threaded into the client.
+// It sets nothing global. The writer is handed to whatever needs it — the
+// store via open.WithDebugWriter, the client and the layers it drives via
+// open.WithLogger, the console reporter so its output does not interleave —
+// which is what lets two commands, or two clients, log independently
+// (RFC 0022 §8).
 func newDebugLog(debug bool) *ui.SafeLogWriter {
 	if !debug {
 		return nil
 	}
-	log := &ui.SafeLogWriter{}
-	logger.Writer = log
-	return log
+	return &ui.SafeLogWriter{}
 }
 
 // storeOptions builds the pkg/open options every command's store shares.

--- a/cmd/cloudstic/storebuild_test.go
+++ b/cmd/cloudstic/storebuild_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/cloudstic/cli/internal/logger"
 	"github.com/cloudstic/cli/pkg/store"
 	localstore "github.com/cloudstic/cli/pkg/store/local"
 )
@@ -14,39 +13,24 @@ import (
 // creating the shared debug writer, and the global it still sets.
 
 func TestNewDebugLog_Disabled(t *testing.T) {
-	logger.Writer = nil
-
 	if log := newDebugLog(false); log != nil {
 		t.Error("expected no log writer when debug is off")
 	}
-	if logger.Writer != nil {
-		t.Error("expected logger.Writer to remain nil when debug is off")
-	}
 }
 
-// TestNewDebugLog_Enabled pins the side effect as much as the return value.
-// newDebugLog sets the package-level logger.Writer, which is what lets the
-// engine and store layers log at all — and is the global RFC 0022 §8 removes.
-// Asserting on it here means that removal cannot happen silently.
+// TestNewDebugLog_Enabled asserts what replaced the side effect. newDebugLog
+// used to set a package-level writer; now it only returns one, and the callers
+// hand it to whatever needs it. A writer that is created and dropped would
+// leave -debug silently producing nothing, which is what this guards.
 func TestNewDebugLog_Enabled(t *testing.T) {
-	logger.Writer = nil
-	defer func() { logger.Writer = nil }()
-
-	log := newDebugLog(true)
-	if log == nil {
+	if log := newDebugLog(true); log == nil {
 		t.Fatal("expected a log writer when debug is on")
-	}
-	if logger.Writer == nil {
-		t.Error("expected logger.Writer to be set when debug is on")
 	}
 }
 
 // TestOpenStore_WrapsWhenDebugIsConfigured checks the adapter wires the debug
 // writer through to pkg/open, rather than creating one and dropping it.
 func TestOpenStore_WrapsWhenDebugIsConfigured(t *testing.T) {
-	logger.Writer = nil
-	defer func() { logger.Writer = nil }()
-
 	s, err := openStore(context.Background(), storeConfig{URI: "local:" + t.TempDir(), Debug: true})
 	if err != nil {
 		t.Fatalf("openStore: %v", err)

--- a/internal/engine/backup.go
+++ b/internal/engine/backup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -19,7 +20,7 @@ import (
 	"github.com/cloudstic/cli/pkg/store"
 )
 
-var backupLog = logger.New("backup", logger.ColorGreen)
+var defaultBackupLog = logger.New("backup", logger.ColorGreen)
 
 // backupStats holds atomic counters accumulated during a backup run.
 type backupStats struct {
@@ -87,6 +88,9 @@ func WithExcludeHash(hash string) BackupOption {
 // BackupManager orchestrates a backup: scanning a source for changes, uploading
 // new or modified files, and persisting a snapshot backed by a Merkle-HAMT.
 type BackupManager struct {
+	// log is this manager's debug sink; an unbound logger falls back to the
+	// process-wide writer.
+	log        *logger.Logger
 	source     source.Source
 	store      store.ObjectStore
 	keyCache   *storelayer.KeyCacheStore
@@ -106,7 +110,7 @@ type BackupManager struct {
 	hmacKey      []byte
 }
 
-func NewBackupManager(src source.Source, dest store.ObjectStore, reporter ui.Reporter, hmacKey []byte, opts ...BackupOption) *BackupManager {
+func NewBackupManager(src source.Source, dest store.ObjectStore, reporter ui.Reporter, hmacKey []byte, logWriter io.Writer, opts ...BackupOption) *BackupManager {
 	cfg := backupConfig{
 		generator: "cloudstic-cli",
 		meta:      map[string]string{},
@@ -118,10 +122,11 @@ func NewBackupManager(src source.Source, dest store.ObjectStore, reporter ui.Rep
 	sourceInfo := src.Info()
 	keyCache := storelayer.NewKeyCacheStore(dest)
 	return &BackupManager{
+		log:          defaultBackupLog.To(logWriter),
 		source:       src,
 		store:        keyCache,
 		keyCache:     keyCache,
-		tree:         hamt.NewTree(keyCache),
+		tree:         hamt.NewTree(keyCache, hamt.WithLogger(logWriter)),
 		chunker:      NewChunker(keyCache, hmacKey),
 		reporter:     reporter,
 		sourceInfo:   sourceInfo,
@@ -210,13 +215,13 @@ func (bm *BackupManager) Run(ctx context.Context) (*RunResult, error) {
 		oldHash := prevSnap.ExcludeHash
 		newHash := bm.cfg.excludeHash
 		if oldHash != newHash {
-			backupLog.Debugf("exclude patterns changed (old=%q new=%q), forcing full rescan", oldHash, newHash)
+			bm.log.Debugf("exclude patterns changed (old=%q new=%q), forcing full rescan", oldHash, newHash)
 			changeToken = ""
 		} else if newHash != "" {
-			backupLog.Debugf("exclude patterns unchanged (hash=%q), continuing incremental", newHash)
+			bm.log.Debugf("exclude patterns unchanged (hash=%q), continuing incremental", newHash)
 		}
 	} else if prevSnap == nil {
-		backupLog.Debugf("no previous snapshot found, running full scan")
+		bm.log.Debugf("no previous snapshot found, running full scan")
 	}
 
 	pending, totalBytes, newToken, usedFullScan, err := bm.scanSource(ctx, oldRoot, changeToken)

--- a/internal/engine/backup.go
+++ b/internal/engine/backup.go
@@ -88,9 +88,10 @@ func WithExcludeHash(hash string) BackupOption {
 // BackupManager orchestrates a backup: scanning a source for changes, uploading
 // new or modified files, and persisting a snapshot backed by a Merkle-HAMT.
 type BackupManager struct {
-	// log is this manager's debug sink; an unbound logger falls back to the
-	// process-wide writer.
+	// log is this manager's debug sink, and snapLog the snapshot-catalog one
+	// it passes to the free functions in snapshots.go.
 	log        *logger.Logger
+	snapLog    *logger.Logger
 	source     source.Source
 	store      store.ObjectStore
 	keyCache   *storelayer.KeyCacheStore
@@ -123,6 +124,7 @@ func NewBackupManager(src source.Source, dest store.ObjectStore, reporter ui.Rep
 	keyCache := storelayer.NewKeyCacheStore(dest)
 	return &BackupManager{
 		log:          defaultBackupLog.To(logWriter),
+		snapLog:      SnapshotLogger(logWriter),
 		source:       src,
 		store:        keyCache,
 		keyCache:     keyCache,
@@ -303,7 +305,7 @@ func (bm *BackupManager) Run(ctx context.Context) (*RunResult, error) {
 	}
 
 	// Update snapshot catalog (best-effort).
-	AppendSnapshotCatalog(bm.store, snapshotToSummary(snapRef, snap))
+	AppendSnapshotCatalog(bm.store, snapshotToSummary(snapRef, snap), bm.snapLog)
 
 	r := bm.buildResult()
 	r.SnapshotHash = snapHash
@@ -342,7 +344,7 @@ func (bm *BackupManager) loadLatestSeq() (int, error) {
 // silently downgrade an incremental backup to a full rescan and reset the
 // sequence number.
 func (bm *BackupManager) findPreviousSnapshot(info core.SourceInfo) (*core.Snapshot, error) {
-	entries, err := LoadSnapshotCatalog(bm.store)
+	entries, err := LoadSnapshotCatalog(bm.store, bm.snapLog)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/engine/backup_scan_test.go
+++ b/internal/engine/backup_scan_test.go
@@ -57,7 +57,7 @@ func TestDetectChange_NativeFileFastPath(t *testing.T) {
 		Content: []byte("exported docx content"),
 	}
 
-	mgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil)
+	mgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
 	result1, err := mgr.Run(ctx)
 	if err != nil {
 		t.Fatalf("First backup failed: %v", err)
@@ -72,7 +72,7 @@ func TestDetectChange_NativeFileFastPath(t *testing.T) {
 	}
 
 	// Second backup: same headRevisionId → should detect as unchanged.
-	mgr2 := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil)
+	mgr2 := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
 	result2, err := mgr2.Run(ctx)
 	if err != nil {
 		t.Fatalf("Second backup failed: %v", err)
@@ -102,7 +102,7 @@ func TestDetectChange_NativeFileFastPath(t *testing.T) {
 		Content: []byte("new exported docx content"),
 	}
 
-	mgr3 := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil)
+	mgr3 := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
 	result3, err := mgr3.Run(ctx)
 	if err != nil {
 		t.Fatalf("Third backup failed: %v", err)
@@ -143,7 +143,7 @@ func TestDetectChange_NativeFileEmptyRevID(t *testing.T) {
 		Content: []byte("exported docx content"),
 	}
 
-	mgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil)
+	mgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
 	result1, err := mgr.Run(ctx)
 	if err != nil {
 		t.Fatalf("First backup failed: %v", err)
@@ -153,7 +153,7 @@ func TestDetectChange_NativeFileEmptyRevID(t *testing.T) {
 	}
 
 	// Second backup: still no headRevisionId → should be treated as changed.
-	mgr2 := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil)
+	mgr2 := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
 	result2, err := mgr2.Run(ctx)
 	if err != nil {
 		t.Fatalf("Second backup failed: %v", err)
@@ -182,7 +182,7 @@ func TestDetectChange_NativeFileCarriesForwardMetadata(t *testing.T) {
 		Content: []byte("content"),
 	}
 
-	mgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil)
+	mgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
 	result1, err := mgr.Run(ctx)
 	if err != nil {
 		t.Fatalf("First backup failed: %v", err)
@@ -211,7 +211,7 @@ func TestDetectChange_NativeFileCarriesForwardMetadata(t *testing.T) {
 
 	// Second backup with same revID: the unchanged path should carry forward
 	// ContentHash and Size from the first backup.
-	mgr2 := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil)
+	mgr2 := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
 	result2, err := mgr2.Run(ctx)
 	if err != nil {
 		t.Fatalf("Second backup failed: %v", err)
@@ -272,7 +272,7 @@ func TestScanIncremental_DeleteWithoutParentUsesExistingMetadataParent(t *testin
 	}
 
 	dest := NewMockStore()
-	mgr := NewBackupManager(inc, dest, ui.NewNoOpReporter(), nil)
+	mgr := NewBackupManager(inc, dest, ui.NewNoOpReporter(), nil, nil)
 	_, err := mgr.Run(ctx)
 	if err != nil {
 		t.Fatalf("first backup failed: %v", err)
@@ -285,7 +285,7 @@ func TestScanIncremental_DeleteWithoutParentUsesExistingMetadataParent(t *testin
 	inc.changes = deleteOnly
 	delete(base.Files, "FILE_1")
 
-	mgr2 := NewBackupManager(inc, dest, ui.NewNoOpReporter(), nil)
+	mgr2 := NewBackupManager(inc, dest, ui.NewNoOpReporter(), nil, nil)
 	second, err := mgr2.Run(ctx)
 	if err != nil {
 		t.Fatalf("second backup failed: %v", err)

--- a/internal/engine/backup_test.go
+++ b/internal/engine/backup_test.go
@@ -53,7 +53,7 @@ func TestBackupManager_ResolvesPathsForOpaqueIDs(t *testing.T) {
 		Content: []byte("jpeg"),
 	}
 
-	mgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil)
+	mgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
 	result, err := mgr.Run(ctx)
 	if err != nil {
 		t.Fatalf("Backup failed: %v", err)
@@ -96,7 +96,7 @@ func TestBackupManager_Run(t *testing.T) {
 	src.AddFile("file1.txt", "id1", []byte("hello world"))
 	src.AddFile("file2.txt", "id2", []byte("another file"))
 
-	mgr := NewBackupManager(src, dest, reporter, nil, WithVerbose())
+	mgr := NewBackupManager(src, dest, reporter, nil, nil, WithVerbose())
 
 	// Read store wraps dest with CompressedStore so we can read back
 	// the compressed data written by the BackupManager.
@@ -231,7 +231,7 @@ func TestBackupManager_IgnoreEmptySnapshot(t *testing.T) {
 
 	src.AddFile("file1.txt", "id1", []byte("hello world"))
 
-	first := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil)
+	first := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
 	firstResult, err := first.Run(ctx)
 	if err != nil {
 		t.Fatalf("first backup failed: %v", err)
@@ -248,7 +248,7 @@ func TestBackupManager_IgnoreEmptySnapshot(t *testing.T) {
 	}
 	firstLatest := idx.LatestSnapshot
 
-	second := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, WithIgnoreEmptySnapshot())
+	second := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil, WithIgnoreEmptySnapshot())
 	result, err := second.Run(ctx)
 	if err != nil {
 		t.Fatalf("second backup failed: %v", err)
@@ -343,7 +343,7 @@ func TestFindPreviousSnapshot_Identity(t *testing.T) {
 	})
 
 	src := NewMockSource()
-	bm := NewBackupManager(src, s, ui.NewNoOpReporter(), nil)
+	bm := NewBackupManager(src, s, ui.NewNoOpReporter(), nil, nil)
 
 	// Search from the Mac with same identity and same selected-root path.
 	info := core.SourceInfo{
@@ -387,7 +387,7 @@ func TestFindPreviousSnapshot_LegacyFallback(t *testing.T) {
 	})
 
 	src := NewMockSource()
-	bm := NewBackupManager(src, s, ui.NewNoOpReporter(), nil)
+	bm := NewBackupManager(src, s, ui.NewNoOpReporter(), nil, nil)
 
 	// Search without VolumeUUID — should fall back to account+path.
 	info := core.SourceInfo{
@@ -446,7 +446,7 @@ func TestFindPreviousSnapshot_IdentityPreferredOverLegacy(t *testing.T) {
 	})
 
 	src := NewMockSource()
-	bm := NewBackupManager(src, s, ui.NewNoOpReporter(), nil)
+	bm := NewBackupManager(src, s, ui.NewNoOpReporter(), nil, nil)
 
 	// Search with identity — should find the identity-matched snapshot first.
 	info := core.SourceInfo{
@@ -491,7 +491,7 @@ func TestFindPreviousSnapshot_IdentityDifferentSubdirs(t *testing.T) {
 	})
 
 	src := NewMockSource()
-	bm := NewBackupManager(src, s, ui.NewNoOpReporter(), nil)
+	bm := NewBackupManager(src, s, ui.NewNoOpReporter(), nil, nil)
 
 	// Search for Documents on the same drive — should NOT match Photos.
 	info := core.SourceInfo{
@@ -522,7 +522,7 @@ func TestBackupManager_Run_PropagatesLatestIndexError(t *testing.T) {
 	src := NewMockSource()
 	src.AddFile("file1.txt", "id1", []byte("hello"))
 
-	mgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil)
+	mgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
 	_, err := mgr.Run(ctx)
 	if err == nil {
 		t.Fatal("expected Run to fail when index/latest cannot be read")
@@ -552,7 +552,7 @@ func TestBackupManager_Run_FlushesPacksBeforeUpdatingIndexLatest(t *testing.T) {
 	src := NewMockSource()
 	src.AddFile("file1.txt", "id1", []byte("hello world"))
 
-	mgr := NewBackupManager(src, packed, ui.NewNoOpReporter(), nil)
+	mgr := NewBackupManager(src, packed, ui.NewNoOpReporter(), nil, nil)
 	if _, err := mgr.Run(ctx); err != nil {
 		t.Fatalf("Run: %v", err)
 	}

--- a/internal/engine/find.go
+++ b/internal/engine/find.go
@@ -1,8 +1,11 @@
 package engine
 
 import (
+	"io"
+
 	"context"
 	"fmt"
+	"github.com/cloudstic/cli/internal/logger"
 	"os"
 	"time"
 
@@ -326,13 +329,16 @@ func WithFindVerbose() FindOption {
 type FindManager struct {
 	store store.ObjectStore
 	tree  *hamt.Tree
+	// log is the snapshot-catalog sink this manager passes to the free
+	// functions in snapshots.go.
+	log *logger.Logger
 }
 
-func NewFindManager(s store.ObjectStore) *FindManager {
+func NewFindManager(s store.ObjectStore, logWriter io.Writer) *FindManager {
 	// One Tree serves every snapshot root and shares a single node cache
 	// between them, which is what makes the delta scan's structural sharing
 	// pay off rather than re-reading the same nodes per snapshot.
-	return &FindManager{store: s, tree: hamt.NewTree(s)}
+	return &FindManager{store: s, tree: hamt.NewTree(s), log: SnapshotLogger(logWriter)}
 }
 
 // QueryFromOptions resolves a set of options into the query they describe,
@@ -366,7 +372,7 @@ func (fm *FindManager) Run(ctx context.Context, opts ...FindOption) (*FindResult
 	if cfg.verbose {
 		fmt.Fprintf(os.Stderr, "Loading snapshot catalog...\n")
 	}
-	catalog, err := LoadSnapshotCatalog(fm.store)
+	catalog, err := LoadSnapshotCatalog(fm.store, fm.log)
 	if err != nil {
 		return nil, fmt.Errorf("load snapshot catalog: %w", err)
 	}

--- a/internal/engine/find_test.go
+++ b/internal/engine/find_test.go
@@ -132,11 +132,11 @@ func (r *findRepo) runFind(opts ...FindOption) *FindResult {
 	r.t.Helper()
 	ctx := context.Background()
 
-	delta, err := NewFindManager(r.store).Run(ctx, opts...)
+	delta, err := NewFindManager(r.store, nil).Run(ctx, opts...)
 	if err != nil {
 		r.t.Fatalf("find (delta): %v", err)
 	}
-	full, err := NewFindManager(r.store).Run(ctx, append(append([]FindOption{}, opts...), WithFindNoDelta())...)
+	full, err := NewFindManager(r.store, nil).Run(ctx, append(append([]FindOption{}, opts...), WithFindNoDelta())...)
 	if err != nil {
 		r.t.Fatalf("find (no-delta): %v", err)
 	}
@@ -641,7 +641,7 @@ func TestFind_SnapshotSelectors(t *testing.T) {
 	})
 
 	t.Run("unknown snapshot is an error", func(t *testing.T) {
-		_, err := NewFindManager(r.store).Run(context.Background(),
+		_, err := NewFindManager(r.store, nil).Run(context.Background(),
 			WithFindPattern("notes.txt"), WithFindSnapshots("deadbeef"))
 		if err == nil {
 			t.Fatal("want an error for an unknown snapshot")
@@ -699,7 +699,7 @@ func TestFind_MaxResultsTruncatesButKeepsCountersAccurate(t *testing.T) {
 
 func TestFind_EmptyQueryIsRejected(t *testing.T) {
 	r := newFindRepo(t)
-	if _, err := NewFindManager(r.store).Run(context.Background()); err == nil {
+	if _, err := NewFindManager(r.store, nil).Run(context.Background()); err == nil {
 		t.Fatal("a query with no predicate must be refused rather than dumping the repository")
 	}
 }
@@ -712,7 +712,7 @@ func TestFind_InvalidPatternsFailBeforeScanning(t *testing.T) {
 		WithFindType("symlink"),
 		WithFindNewer("not-a-time"),
 	} {
-		if _, err := NewFindManager(r.store).Run(context.Background(), opt); err == nil {
+		if _, err := NewFindManager(r.store, nil).Run(context.Background(), opt); err == nil {
 			t.Error("want a compile error before the scan starts")
 		}
 	}
@@ -744,7 +744,7 @@ func TestFind_MissingMetadataObjectIsAnError(t *testing.T) {
 			break
 		}
 	}
-	if _, err := NewFindManager(r.store).Run(context.Background(), WithFindPattern("*.txt")); err == nil {
+	if _, err := NewFindManager(r.store, nil).Run(context.Background(), WithFindPattern("*.txt")); err == nil {
 		t.Fatal("want an error when a referenced filemeta cannot be read")
 	}
 }
@@ -774,11 +774,11 @@ func TestFind_DeltaScanReadsFarFewerObjectsThanFullScan(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	delta, err := NewFindManager(r.store).Run(ctx, WithFindPattern("*.txt"))
+	delta, err := NewFindManager(r.store, nil).Run(ctx, WithFindPattern("*.txt"))
 	if err != nil {
 		t.Fatalf("delta: %v", err)
 	}
-	full, err := NewFindManager(r.store).Run(ctx, WithFindPattern("*.txt"), WithFindNoDelta())
+	full, err := NewFindManager(r.store, nil).Run(ctx, WithFindPattern("*.txt"), WithFindNoDelta())
 	if err != nil {
 		t.Fatalf("full: %v", err)
 	}

--- a/internal/engine/forget.go
+++ b/internal/engine/forget.go
@@ -1,8 +1,11 @@
 package engine
 
 import (
+	"io"
+
 	"context"
 	"fmt"
+	"github.com/cloudstic/cli/internal/logger"
 	"sort"
 	"strings"
 
@@ -111,12 +114,16 @@ type ForgetManager struct {
 	store    store.ObjectStore
 	reporter ui.Reporter
 	pruner   *PruneManager
+	// log is the snapshot-catalog sink this manager passes to the free
+	// functions in snapshots.go.
+	log *logger.Logger
 }
 
-func NewForgetManager(s store.ObjectStore, reporter ui.Reporter) *ForgetManager {
+func NewForgetManager(s store.ObjectStore, reporter ui.Reporter, logWriter io.Writer) *ForgetManager {
 	return &ForgetManager{
 		store:    s,
 		reporter: reporter,
+		log:      SnapshotLogger(logWriter),
 		pruner:   NewPruneManager(storelayer.NewMeteredStore(s), reporter),
 	}
 }
@@ -155,7 +162,7 @@ func (fm *ForgetManager) Run(ctx context.Context, snapshotID string, opts ...For
 	}
 
 	// Update snapshot catalog (best-effort).
-	RemoveFromSnapshotCatalog(fm.store, targetRef)
+	RemoveFromSnapshotCatalog(fm.store, fm.log, targetRef)
 
 	if err := fm.fixupLatest(targetRef); err != nil {
 		phase.Error()
@@ -217,7 +224,7 @@ func (fm *ForgetManager) fixupLatest(deletedRef string) error {
 		return nil
 	}
 
-	entries, err := LoadSnapshotCatalog(fm.store)
+	entries, err := LoadSnapshotCatalog(fm.store, fm.log)
 	if err != nil {
 		return err
 	}
@@ -267,7 +274,7 @@ func (fm *ForgetManager) RunPolicy(ctx context.Context, opts ...ForgetOption) (*
 		return nil, fmt.Errorf("empty policy: specify at least one -keep-* option or a tag/source/account/path filter")
 	}
 
-	entries, err := LoadSnapshotCatalog(fm.store)
+	entries, err := LoadSnapshotCatalog(fm.store, fm.log)
 	if err != nil {
 		return nil, err
 	}
@@ -348,10 +355,10 @@ func (fm *ForgetManager) forgetBatch(ctx context.Context, entries []SnapshotEntr
 	}
 
 	// Update snapshot catalog (best-effort).
-	RemoveFromSnapshotCatalog(fm.store, removedRefs...)
+	RemoveFromSnapshotCatalog(fm.store, fm.log, removedRefs...)
 
 	// Elect new latest from the remaining snapshots.
-	remaining, err := LoadSnapshotCatalog(fm.store)
+	remaining, err := LoadSnapshotCatalog(fm.store, fm.log)
 	if err != nil {
 		return err
 	}

--- a/internal/engine/forget_test.go
+++ b/internal/engine/forget_test.go
@@ -26,7 +26,7 @@ func TestForgetManager_Run(t *testing.T) {
 
 	_ = store.Put(ctx, "index/latest", createIndex(snap3Ref, 3))
 
-	fm := NewForgetManager(store, ui.NewNoOpReporter())
+	fm := NewForgetManager(store, ui.NewNoOpReporter(), nil)
 
 	// Test 1: Forget intermediate snapshot (snap2) -- latest should not change.
 	if _, err := fm.Run(context.Background(), snap2Ref); err != nil {
@@ -71,7 +71,7 @@ func TestForgetManager_Run(t *testing.T) {
 func TestForgetManager_ResolveSnapshot_PropagatesLatestError(t *testing.T) {
 	backendErr := errors.New("simulated network error")
 	s := newErrorOnGetStore(NewMockStore(), backendErr, "index/latest")
-	fm := NewForgetManager(s, ui.NewNoOpReporter())
+	fm := NewForgetManager(s, ui.NewNoOpReporter(), nil)
 
 	_, err := fm.resolveSnapshot("latest")
 	if err == nil {
@@ -95,7 +95,7 @@ func TestForgetManager_FixupLatest_PropagatesError(t *testing.T) {
 	_ = inner.Put(ctx, "index/latest", createIndex(ref, 1))
 
 	s := newErrorOnGetStore(inner, backendErr, "index/latest")
-	fm := NewForgetManager(s, ui.NewNoOpReporter())
+	fm := NewForgetManager(s, ui.NewNoOpReporter(), nil)
 
 	err := fm.fixupLatest(ref)
 	if err == nil {
@@ -120,7 +120,7 @@ func createIndex(ref string, seq int) []byte {
 }
 
 func TestForgetManager_RunPolicy_RequiresPolicyOrFilter(t *testing.T) {
-	fm := NewForgetManager(NewMockStore(), ui.NewNoOpReporter())
+	fm := NewForgetManager(NewMockStore(), ui.NewNoOpReporter(), nil)
 
 	_, err := fm.RunPolicy(context.Background())
 	if err == nil {
@@ -134,7 +134,7 @@ func TestForgetManager_RunPolicy_RequiresPolicyOrFilter(t *testing.T) {
 func TestForgetManager_RunPolicy_FilterOnlyAllowed(t *testing.T) {
 	ctx := context.Background()
 	store := NewMockStore()
-	fm := NewForgetManager(store, ui.NewNoOpReporter())
+	fm := NewForgetManager(store, ui.NewNoOpReporter(), nil)
 
 	snap := core.Snapshot{
 		Seq:     1,
@@ -171,7 +171,7 @@ func TestForgetManager_DryRunRemovesNothing(t *testing.T) {
 	snapRef := saveSnapshot(ctx, s, &snap)
 	_ = s.Put(ctx, "index/latest", createIndex(snapRef, 1))
 
-	fm := NewForgetManager(s, ui.NewNoOpReporter())
+	fm := NewForgetManager(s, ui.NewNoOpReporter(), nil)
 	result, err := fm.Run(ctx, snapRef, WithDryRun())
 	if err != nil {
 		t.Fatalf("dry run: %v", err)

--- a/internal/engine/init.go
+++ b/internal/engine/init.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/cloudstic/cli/internal/core"
@@ -15,7 +16,7 @@ import (
 	"github.com/cloudstic/cli/pkg/store"
 )
 
-var initLog = logger.New("init", logger.ColorYellow)
+var defaultInitLog = logger.New("init", logger.ColorYellow)
 
 // ---------------------------------------------------------------------------
 // Options
@@ -55,12 +56,15 @@ type InitResult struct {
 // writes the "config" marker.
 type InitManager struct {
 	store store.ObjectStore
+	// log is this manager's debug sink; an unbound logger falls back to the
+	// process-wide writer.
+	log *logger.Logger
 }
 
 // NewInitManager creates an InitManager that operates on the raw (undecorated)
 // object store.
-func NewInitManager(s store.ObjectStore) *InitManager {
-	return &InitManager{store: s}
+func NewInitManager(s store.ObjectStore, logWriter io.Writer) *InitManager {
+	return &InitManager{store: s, log: defaultInitLog.To(logWriter)}
 }
 
 const configKey = "config"
@@ -71,7 +75,7 @@ func (m *InitManager) Run(ctx context.Context, opts ...InitOption) (*InitResult,
 	for _, opt := range opts {
 		opt(&cfg)
 	}
-	initLog.Debugf("InitRepo: encrypted=%v, noEncryption=%v, adoptSlots=%v, hasChain=%v, recovery=%v",
+	m.log.Debugf("InitRepo: encrypted=%v, noEncryption=%v, adoptSlots=%v, hasChain=%v, recovery=%v",
 		!cfg.noEncryption && len(cfg.chain) > 0, cfg.noEncryption, cfg.adoptSlots, len(cfg.chain) > 0, cfg.recovery)
 
 	// Check if already initialized. A read failure that is not "no config yet"

--- a/internal/engine/init_test.go
+++ b/internal/engine/init_test.go
@@ -39,7 +39,7 @@ var _ crypto.KMSClient = (*mockKMS)(nil)
 
 func TestInitManager_UnencryptedRepo(t *testing.T) {
 	s := NewMockStore()
-	mgr := NewInitManager(s)
+	mgr := NewInitManager(s, nil)
 
 	result, err := mgr.Run(context.Background(), WithInitNoEncryption())
 	if err != nil {
@@ -68,7 +68,7 @@ func TestInitManager_UnencryptedRepo(t *testing.T) {
 
 func TestInitManager_EncryptedWithPassword(t *testing.T) {
 	s := NewMockStore()
-	mgr := NewInitManager(s)
+	mgr := NewInitManager(s, nil)
 
 	result, err := mgr.Run(context.Background(), WithInitCredentials(keychain.Chain{keychain.WithPassword("test-password")}))
 	if err != nil {
@@ -107,7 +107,7 @@ func TestInitManager_EncryptedWithPassword(t *testing.T) {
 
 func TestInitManager_EncryptedWithPlatformKey(t *testing.T) {
 	s := NewMockStore()
-	mgr := NewInitManager(s)
+	mgr := NewInitManager(s, nil)
 
 	platformKey := make([]byte, 32)
 	for i := range platformKey {
@@ -133,7 +133,7 @@ func TestInitManager_EncryptedWithPlatformKey(t *testing.T) {
 
 func TestInitManager_AlreadyInitialized(t *testing.T) {
 	s := NewMockStore()
-	mgr := NewInitManager(s)
+	mgr := NewInitManager(s, nil)
 
 	// First init.
 	if _, err := mgr.Run(context.Background(), WithInitNoEncryption()); err != nil {
@@ -154,7 +154,7 @@ func TestInitManager_AlreadyInitialized(t *testing.T) {
 func TestInitManager_Run_PropagatesConfigCheckError(t *testing.T) {
 	backendErr := errors.New("simulated network error")
 	s := newErrorOnGetStore(NewMockStore(), backendErr, configKey)
-	mgr := NewInitManager(s)
+	mgr := NewInitManager(s, nil)
 
 	_, err := mgr.Run(context.Background(), WithInitNoEncryption())
 	if err == nil {
@@ -171,7 +171,7 @@ func TestInitManager_Run_PropagatesConfigCheckError(t *testing.T) {
 func TestInitManager_WriteRepoConfig_PropagatesReadError(t *testing.T) {
 	backendErr := errors.New("simulated network error")
 	s := newErrorOnGetStore(NewMockStore(), backendErr, configKey)
-	mgr := NewInitManager(s)
+	mgr := NewInitManager(s, nil)
 
 	err := mgr.writeRepoConfig(context.Background(), false, nil)
 	if err == nil {
@@ -194,7 +194,7 @@ func TestInitManager_AdoptsExistingSlots(t *testing.T) {
 	slot, _ := keychain.CreatePlatformSlot(masterKey, platformKey)
 	_ = keychain.WriteKeySlot(context.Background(), s, slot)
 
-	mgr := NewInitManager(s)
+	mgr := NewInitManager(s, nil)
 	result, err := mgr.Run(context.Background(), WithInitCredentials(keychain.Chain{keychain.WithPlatformKey(platformKey)}))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -222,7 +222,7 @@ func TestInitManager_AdoptExistingSlots_WrongCredential(t *testing.T) {
 		wrongKey[i] = byte(i + 100)
 	}
 
-	mgr := NewInitManager(s)
+	mgr := NewInitManager(s, nil)
 	_, err := mgr.Run(context.Background(), WithInitCredentials(keychain.Chain{keychain.WithPlatformKey(wrongKey)}))
 	if err == nil {
 		t.Fatal("expected error when adopting slots with wrong key")
@@ -231,7 +231,7 @@ func TestInitManager_AdoptExistingSlots_WrongCredential(t *testing.T) {
 
 func TestInitManager_WithRecoveryKey(t *testing.T) {
 	s := NewMockStore()
-	mgr := NewInitManager(s)
+	mgr := NewInitManager(s, nil)
 
 	result, err := mgr.Run(context.Background(),
 		WithInitCredentials(keychain.Chain{keychain.WithPassword("test-password")}),
@@ -274,7 +274,7 @@ func TestInitManager_WithRecoveryKey(t *testing.T) {
 
 func TestInitManager_EncryptedWithKMS(t *testing.T) {
 	s := NewMockStore()
-	mgr := NewInitManager(s)
+	mgr := NewInitManager(s, nil)
 	kms := &mockKMS{xorByte: 0x42}
 
 	result, err := mgr.Run(context.Background(),
@@ -324,7 +324,7 @@ func TestInitManager_EncryptedWithKMS(t *testing.T) {
 
 func TestInitManager_KMSWithPasswordSlots(t *testing.T) {
 	s := NewMockStore()
-	mgr := NewInitManager(s)
+	mgr := NewInitManager(s, nil)
 	kms := &mockKMS{xorByte: 0x42}
 
 	// Init with both KMS and password — should create both slot types.
@@ -373,7 +373,7 @@ func TestInitManager_KMSWithPasswordSlots(t *testing.T) {
 
 func TestInitManager_KMSWithRecovery(t *testing.T) {
 	s := NewMockStore()
-	mgr := NewInitManager(s)
+	mgr := NewInitManager(s, nil)
 	kms := &mockKMS{xorByte: 0x42}
 
 	result, err := mgr.Run(context.Background(),
@@ -404,7 +404,7 @@ func TestInitManager_KMSWithRecovery(t *testing.T) {
 
 func TestInitManager_NoEncryptionOverridesCreds(t *testing.T) {
 	s := NewMockStore()
-	mgr := NewInitManager(s)
+	mgr := NewInitManager(s, nil)
 
 	// Passing both a password and --no-encryption should result in unencrypted repo.
 	result, err := mgr.Run(context.Background(),
@@ -429,7 +429,7 @@ func TestInitManager_NoEncryptionOverridesCreds(t *testing.T) {
 }
 func TestInitManager_AdoptAddsNewSlots(t *testing.T) {
 	s := NewMockStore()
-	mgr := NewInitManager(s)
+	mgr := NewInitManager(s, nil)
 	ctx := context.Background()
 
 	// 1. Pre-create a password slot
@@ -511,7 +511,7 @@ func TestInitManager_AdoptRefusesEncryptingPopulatedRepo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mgr := NewInitManager(s)
+	mgr := NewInitManager(s, nil)
 	_, err = mgr.Run(ctx,
 		WithInitCredentials(keychain.Chain{keychain.WithPassword("newpw")}),
 		WithInitAdoptSlots(),
@@ -550,7 +550,7 @@ func TestInitManager_AdoptAllowsEncryptingEmptyRepo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mgr := NewInitManager(s)
+	mgr := NewInitManager(s, nil)
 	result, err := mgr.Run(ctx,
 		WithInitCredentials(keychain.Chain{keychain.WithPassword("newpw")}),
 		WithInitAdoptSlots(),
@@ -593,7 +593,7 @@ func TestInitManager_AdoptEncryptedRepoUnaffectedByGuard(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mgr := NewInitManager(s)
+	mgr := NewInitManager(s, nil)
 	result, err := mgr.Run(ctx,
 		WithInitCredentials(keychain.Chain{keychain.WithPassword("p1")}),
 		WithInitAdoptSlots(),

--- a/internal/engine/list.go
+++ b/internal/engine/list.go
@@ -1,8 +1,11 @@
 package engine
 
 import (
+	"io"
+
 	"context"
 	"fmt"
+	"github.com/cloudstic/cli/internal/logger"
 	"os"
 
 	"github.com/cloudstic/cli/pkg/store"
@@ -28,10 +31,13 @@ type ListResult struct {
 // ListManager enumerates all available snapshots.
 type ListManager struct {
 	store store.ObjectStore
+	// log is the snapshot-catalog sink this manager passes to the free
+	// functions in snapshots.go.
+	log *logger.Logger
 }
 
-func NewListManager(s store.ObjectStore) *ListManager {
-	return &ListManager{store: s}
+func NewListManager(s store.ObjectStore, logWriter io.Writer) *ListManager {
+	return &ListManager{store: s, log: SnapshotLogger(logWriter)}
 }
 
 // Run lists every snapshot in the store.
@@ -44,7 +50,7 @@ func (lm *ListManager) Run(ctx context.Context, opts ...ListOption) (*ListResult
 	if cfg.verbose {
 		fmt.Fprintf(os.Stderr, "Loading snapshot catalog...\n")
 	}
-	entries, err := LoadSnapshotCatalog(lm.store)
+	entries, err := LoadSnapshotCatalog(lm.store, lm.log)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/engine/repolock_test.go
+++ b/internal/engine/repolock_test.go
@@ -370,7 +370,7 @@ func TestBackupDryRun_NoLock(t *testing.T) {
 	s := NewMockStore()
 	src := NewMockSource()
 
-	bm := NewBackupManager(src, s, ui.NewNoOpReporter(), nil, WithBackupDryRun())
+	bm := NewBackupManager(src, s, ui.NewNoOpReporter(), nil, nil, WithBackupDryRun())
 	_, err := bm.Run(ctx)
 	if err != nil {
 		t.Fatalf("dry run should succeed: %v", err)

--- a/internal/engine/restore_parallel_test.go
+++ b/internal/engine/restore_parallel_test.go
@@ -117,7 +117,7 @@ func TestRestoreManager_MultiChunkFile_RoundTrips(t *testing.T) {
 	src.AddFile("big.bin", "id1", content)
 
 	raw := NewMockStore()
-	bkMgr := NewBackupManager(src, raw, ui.NewNoOpReporter(), nil)
+	bkMgr := NewBackupManager(src, raw, ui.NewNoOpReporter(), nil, nil)
 	if _, err := bkMgr.Run(ctx); err != nil {
 		t.Fatalf("backup: %v", err)
 	}

--- a/internal/engine/restore_test.go
+++ b/internal/engine/restore_test.go
@@ -68,7 +68,7 @@ func setupBackupForRestore(t *testing.T) *MockStore {
 		Content: []byte("deep content"),
 	}
 
-	bkMgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, WithVerbose())
+	bkMgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil, WithVerbose())
 	if _, err := bkMgr.Run(context.Background()); err != nil {
 		t.Fatalf("Backup setup failed: %v", err)
 	}
@@ -120,7 +120,7 @@ func TestRestoreManager_Run(t *testing.T) {
 		Content: []byte("nested content"),
 	}
 
-	bkMgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, WithVerbose())
+	bkMgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil, WithVerbose())
 	if _, err := bkMgr.Run(context.Background()); err != nil {
 		t.Fatalf("Backup setup failed: %v", err)
 	}
@@ -576,7 +576,7 @@ func TestRestoreManager_PathFilter_CloudLikeIDs(t *testing.T) {
 		Content: []byte("mp3-data"),
 	}
 
-	bkMgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil)
+	bkMgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
 	if _, err := bkMgr.Run(context.Background()); err != nil {
 		t.Fatalf("Backup failed: %v", err)
 	}

--- a/internal/engine/restore_verify_test.go
+++ b/internal/engine/restore_verify_test.go
@@ -28,7 +28,7 @@ func setupBackupForRestoreLarge(t *testing.T) *MockStore {
 	}
 	src.AddFile("big.txt", "id_big", content)
 
-	bkMgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil)
+	bkMgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
 	if _, err := bkMgr.Run(context.Background()); err != nil {
 		t.Fatalf("Backup setup failed: %v", err)
 	}

--- a/internal/engine/restore_xattrs_unix_test.go
+++ b/internal/engine/restore_xattrs_unix_test.go
@@ -109,7 +109,7 @@ func TestRestoreManager_RunToDir_ReplaysXattrs(t *testing.T) {
 		Meta:    core.FileMeta{FileID: "id_file", Name: "file.txt", Parents: []string{"id_dir"}, Xattrs: map[string][]byte{"user.file": []byte("f")}},
 		Content: []byte("content"),
 	}
-	bkMgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil)
+	bkMgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
 	if _, err := bkMgr.Run(t.Context()); err != nil {
 		t.Fatalf("backup setup failed: %v", err)
 	}

--- a/internal/engine/snapshots.go
+++ b/internal/engine/snapshots.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 	"sync"
@@ -16,7 +17,14 @@ import (
 	"github.com/cloudstic/cli/pkg/store"
 )
 
-var snapLog = logger.New("snapshots", logger.ColorCyan)
+// defaultSnapLog is the prefix and colour for snapshot-catalog diagnostics.
+// The functions below take a *logger.Logger rather than reading a package
+// variable, because they are free functions with no receiver to carry a sink
+// — see RFC 0022 §8. A nil logger is tolerated and simply logs nothing.
+var defaultSnapLog = logger.New("snapshots", logger.ColorCyan)
+
+// SnapshotLogger returns a snapshot-catalog logger writing to w.
+func SnapshotLogger(w io.Writer) *logger.Logger { return defaultSnapLog.To(w) }
 
 const snapshotCatalogKey = "index/snapshots"
 
@@ -36,7 +44,7 @@ var (
 // missing from the catalog. The catalog is automatically rebuilt/updated
 // whenever a mismatch with the live snapshot keys is detected.
 // Results are sorted newest-first by Created time.
-func LoadSnapshotCatalog(s store.ObjectStore) ([]SnapshotEntry, error) {
+func LoadSnapshotCatalog(s store.ObjectStore, log *logger.Logger) ([]SnapshotEntry, error) {
 	ctx := context.Background()
 
 	// 1. Load catalog (best-effort).
@@ -132,7 +140,7 @@ func LoadSnapshotCatalog(s store.ObjectStore) ([]SnapshotEntry, error) {
 	// 7. Persist rebuilt catalog (best-effort).
 	if needRebuild {
 		if err := SaveSnapshotCatalog(s, updatedCatalog); err != nil {
-			snapLog.Debugf("failed to persist snapshot catalog: %v", err)
+			log.Debugf("failed to persist snapshot catalog: %v", err)
 		}
 	}
 
@@ -170,24 +178,24 @@ func loadCatalogForUpdate(s store.ObjectStore) (catalog []core.SnapshotSummary, 
 
 // AppendSnapshotCatalog loads the current catalog, appends a new summary, and
 // persists it. This is best-effort; errors are logged but not propagated.
-func AppendSnapshotCatalog(s store.ObjectStore, summary core.SnapshotSummary) {
+func AppendSnapshotCatalog(s store.ObjectStore, summary core.SnapshotSummary, log *logger.Logger) {
 	catalog, ok := loadCatalogForUpdate(s)
 	if !ok {
-		snapLog.Debugf("failed to append snapshot catalog: could not read existing catalog")
+		log.Debugf("failed to append snapshot catalog: could not read existing catalog")
 		return
 	}
 	catalog = append(catalog, summary)
 	if err := SaveSnapshotCatalog(s, catalog); err != nil {
-		snapLog.Debugf("failed to append snapshot catalog: %v", err)
+		log.Debugf("failed to append snapshot catalog: %v", err)
 	}
 }
 
 // RemoveFromSnapshotCatalog loads the current catalog, removes entries whose
 // refs match, and persists the result. This is best-effort.
-func RemoveFromSnapshotCatalog(s store.ObjectStore, refs ...string) {
+func RemoveFromSnapshotCatalog(s store.ObjectStore, log *logger.Logger, refs ...string) {
 	catalog, ok := loadCatalogForUpdate(s)
 	if !ok {
-		snapLog.Debugf("failed to update snapshot catalog after removal: could not read existing catalog")
+		log.Debugf("failed to update snapshot catalog after removal: could not read existing catalog")
 		return
 	}
 	if len(catalog) == 0 {
@@ -204,7 +212,7 @@ func RemoveFromSnapshotCatalog(s store.ObjectStore, refs ...string) {
 		}
 	}
 	if err := SaveSnapshotCatalog(s, filtered); err != nil {
-		snapLog.Debugf("failed to update snapshot catalog after removal: %v", err)
+		log.Debugf("failed to update snapshot catalog after removal: %v", err)
 	}
 }
 

--- a/internal/engine/snapshots_test.go
+++ b/internal/engine/snapshots_test.go
@@ -60,7 +60,7 @@ func TestLoadSnapshotCatalog_NoCatalog(t *testing.T) {
 	ref1 := putSnapshot(t, s, snap1)
 	ref2 := putSnapshot(t, s, snap2)
 
-	entries, err := LoadSnapshotCatalog(s)
+	entries, err := LoadSnapshotCatalog(s, nil)
 	if err != nil {
 		t.Fatalf("LoadSnapshotCatalog: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestLoadSnapshotCatalog_WithValidCatalog(t *testing.T) {
 		snapshotToSummary(ref1, *snap1),
 	})
 
-	entries, err := LoadSnapshotCatalog(s)
+	entries, err := LoadSnapshotCatalog(s, nil)
 	if err != nil {
 		t.Fatalf("LoadSnapshotCatalog: %v", err)
 	}
@@ -124,7 +124,7 @@ func TestLoadSnapshotCatalog_ReconcilesMissingEntries(t *testing.T) {
 		snapshotToSummary(ref1, *snap1),
 	})
 
-	entries, err := LoadSnapshotCatalog(s)
+	entries, err := LoadSnapshotCatalog(s, nil)
 	if err != nil {
 		t.Fatalf("LoadSnapshotCatalog: %v", err)
 	}
@@ -155,7 +155,7 @@ func TestLoadSnapshotCatalog_RemovesStaleEntries(t *testing.T) {
 		{Ref: "snapshot/deleted", Seq: 99, Created: now.Format(time.RFC3339), Root: "node/gone"},
 	})
 
-	entries, err := LoadSnapshotCatalog(s)
+	entries, err := LoadSnapshotCatalog(s, nil)
 	if err != nil {
 		t.Fatalf("LoadSnapshotCatalog: %v", err)
 	}
@@ -180,7 +180,7 @@ func TestAppendSnapshotCatalog(t *testing.T) {
 	snap1 := &core.Snapshot{Seq: 1, Created: now.Format(time.RFC3339), Root: "node/a"}
 
 	// Start with empty catalog.
-	AppendSnapshotCatalog(s, snapshotToSummary("snapshot/abc", *snap1))
+	AppendSnapshotCatalog(s, snapshotToSummary("snapshot/abc", *snap1), nil)
 
 	catalog := readCatalog(t, s)
 	if len(catalog) != 1 {
@@ -192,7 +192,7 @@ func TestAppendSnapshotCatalog(t *testing.T) {
 
 	// Append a second.
 	snap2 := &core.Snapshot{Seq: 2, Created: now.Format(time.RFC3339), Root: "node/b"}
-	AppendSnapshotCatalog(s, snapshotToSummary("snapshot/def", *snap2))
+	AppendSnapshotCatalog(s, snapshotToSummary("snapshot/def", *snap2), nil)
 
 	catalog = readCatalog(t, s)
 	if len(catalog) != 2 {
@@ -210,7 +210,7 @@ func TestRemoveFromSnapshotCatalog(t *testing.T) {
 		{Ref: "snapshot/ccc", Seq: 3, Created: now.Format(time.RFC3339)},
 	})
 
-	RemoveFromSnapshotCatalog(s, "snapshot/aaa", "snapshot/ccc")
+	RemoveFromSnapshotCatalog(s, nil, "snapshot/aaa", "snapshot/ccc")
 
 	catalog := readCatalog(t, s)
 	if len(catalog) != 1 {
@@ -225,7 +225,7 @@ func TestRemoveFromSnapshotCatalog_NoCatalog(t *testing.T) {
 	s := NewMockStore()
 
 	// Should not panic when catalog doesn't exist.
-	RemoveFromSnapshotCatalog(s, "snapshot/xxx")
+	RemoveFromSnapshotCatalog(s, nil, "snapshot/xxx")
 }
 
 func TestSnapshotToSummary(t *testing.T) {
@@ -265,7 +265,7 @@ func TestSnapshotToSummary(t *testing.T) {
 func TestLoadSnapshotCatalog_EmptyRepo(t *testing.T) {
 	s := NewMockStore()
 
-	entries, err := LoadSnapshotCatalog(s)
+	entries, err := LoadSnapshotCatalog(s, nil)
 	if err != nil {
 		t.Fatalf("LoadSnapshotCatalog: %v", err)
 	}
@@ -349,7 +349,7 @@ func TestLoadSnapshotCatalog_PropagatesFetchError(t *testing.T) {
 	// No catalog yet, so LoadSnapshotCatalog must fetch ref individually.
 	s := newErrorOnGetStore(inner, backendErr, ref)
 
-	_, err := LoadSnapshotCatalog(s)
+	_, err := LoadSnapshotCatalog(s, nil)
 	if err == nil {
 		t.Fatal("expected LoadSnapshotCatalog to propagate a real fetch error")
 	}
@@ -369,7 +369,7 @@ func TestAppendSnapshotCatalog_DoesNotClobberOnReadError(t *testing.T) {
 	})
 	s := newErrorOnGetStore(inner, backendErr, snapshotCatalogKey)
 
-	AppendSnapshotCatalog(s, core.SnapshotSummary{Ref: "snapshot/new", Seq: 2})
+	AppendSnapshotCatalog(s, core.SnapshotSummary{Ref: "snapshot/new", Seq: 2}, nil)
 
 	catalog := readCatalog(t, inner)
 	if len(catalog) != 1 || catalog[0].Ref != "snapshot/existing" {
@@ -385,7 +385,7 @@ func TestRemoveFromSnapshotCatalog_DoesNotClobberOnReadError(t *testing.T) {
 	})
 	s := newErrorOnGetStore(inner, backendErr, snapshotCatalogKey)
 
-	RemoveFromSnapshotCatalog(s, "snapshot/existing")
+	RemoveFromSnapshotCatalog(s, nil, "snapshot/existing")
 
 	catalog := readCatalog(t, inner)
 	if len(catalog) != 1 || catalog[0].Ref != "snapshot/existing" {

--- a/internal/engine/tamper_test.go
+++ b/internal/engine/tamper_test.go
@@ -171,7 +171,7 @@ func TestCheckReportsTamperedInlineContent(t *testing.T) {
 	dest := NewMockStore()
 	src.AddFile("small.txt", "id1", []byte("small enough to store inline"))
 
-	bm := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil)
+	bm := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
 	if _, err := bm.Run(context.Background()); err != nil {
 		t.Fatalf("backup: %v", err)
 	}

--- a/internal/engine/verbose_test.go
+++ b/internal/engine/verbose_test.go
@@ -58,7 +58,7 @@ func TestListManager_Verbose(t *testing.T) {
 		{Ref: snap2Ref, Seq: snap2.Seq, Created: snap2.Created, Root: snap2.Root},
 	}))
 
-	mgr := NewListManager(s)
+	mgr := NewListManager(s, nil)
 
 	// Without verbose: no stderr output.
 	out := captureStderr(t, func() {
@@ -200,7 +200,7 @@ func TestForgetManager_Verbose(t *testing.T) {
 	_ = s.Put(ctx, "index/latest", createIndex(snap2Ref, 2))
 
 	// Without verbose: "Forgetting" should NOT be logged.
-	fm := NewForgetManager(s, ui.NewNoOpReporter())
+	fm := NewForgetManager(s, ui.NewNoOpReporter(), nil)
 	_, err := fm.Run(ctx, snap1Ref)
 	if err != nil {
 		t.Fatalf("Forget without verbose failed: %v", err)
@@ -213,7 +213,7 @@ func TestForgetManager_Verbose(t *testing.T) {
 
 	// With verbose: phase.Log should be called with the snapshot ref.
 	// Since NoOpReporter discards logs, we just verify it doesn't error.
-	fm2 := NewForgetManager(s, ui.NewNoOpReporter())
+	fm2 := NewForgetManager(s, ui.NewNoOpReporter(), nil)
 	_, err = fm2.Run(ctx, snap1Ref, WithForgetVerbose())
 	if err != nil {
 		t.Fatalf("Forget with verbose failed: %v", err)

--- a/internal/hamt/hamt.go
+++ b/internal/hamt/hamt.go
@@ -3,6 +3,7 @@ package hamt
 import (
 	"context"
 	"fmt"
+	"io"
 	"math/bits"
 	"slices"
 	"sort"
@@ -60,8 +61,23 @@ type Tree struct {
 }
 
 // NewTree creates a Tree backed by the given object store.
-func NewTree(s store.ObjectStore) *Tree {
-	return &Tree{nodes: NewNodeStore(s)}
+func NewTree(s store.ObjectStore, opts ...TreeOption) *Tree {
+	ns := NewNodeStore(s)
+	for _, opt := range opts {
+		opt(ns)
+	}
+	return &Tree{nodes: ns}
+}
+
+// TreeOption configures the node store behind a Tree.
+//
+// It is variadic so that the trees which never log — diff, restore, find, ls,
+// prune, check — keep their existing call sites unchanged.
+type TreeOption func(*NodeStore)
+
+// WithLogger sends the node store's debug output to w.
+func WithLogger(w io.Writer) TreeOption {
+	return func(ns *NodeStore) { ns.log = ns.log.To(w) }
 }
 
 // NewTreeWithNodes creates a Tree over an existing NodeStore, so several trees

--- a/internal/hamt/nodestore.go
+++ b/internal/hamt/nodestore.go
@@ -14,7 +14,7 @@ import (
 	"github.com/cloudstic/cli/pkg/store"
 )
 
-var log = logger.New("hamt", logger.ColorCyan)
+var defaultLog = logger.New("hamt", logger.ColorCyan)
 
 const (
 	nodeCacheSize       = 4096
@@ -31,12 +31,15 @@ const (
 type NodeStore struct {
 	store store.ObjectStore
 	cache *lru.Cache[string, *node]
+	// log is this node store's debug sink. It always points at a logger; an
+	// unbound one falls back to the process-wide writer.
+	log *logger.Logger
 }
 
 // NewNodeStore returns a NodeStore reading and writing through s.
 func NewNodeStore(s store.ObjectStore) *NodeStore {
 	c, _ := lru.New[string, *node](nodeCacheSize)
-	return &NodeStore{store: s, cache: c}
+	return &NodeStore{store: s, cache: c, log: defaultLog}
 }
 
 // load fetches and decodes the node identified by ref. The returned node is
@@ -87,7 +90,7 @@ func (ns *NodeStore) putAll(ctx context.Context, batch map[string][]byte) error 
 	for _, data := range batch {
 		totalBytes += len(data)
 	}
-	log.Debugf("commit: writing %d nodes (%d bytes total)", len(batch), totalBytes)
+	ns.log.Debugf("commit: writing %d nodes (%d bytes total)", len(batch), totalBytes)
 
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(min(store.GetConcurrencyHint(ns.store, defaultWriteWorkers), len(batch)))

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,29 +1,18 @@
 // Package logger provides the component-prefixed debug output that the client,
-// engine, and store layers write when debugging is enabled.
+// engine, source, and store layers write when debugging is enabled.
 //
-// A Logger writes to the sink it was given. Loggers created by New have no
-// sink of their own and fall back to the package-level Writer, which is how
-// every call site behaved before sinks were injectable and how the call sites
-// that have not been converted yet still behave (RFC 0022 §8).
-//
-// The distinction matters because the fallback is process-wide: two clients in
-// one process cannot have different debug settings through it, and writing to
-// it from a goroutine while another goroutine sets it is a data race. A logger
-// bound with To has neither problem, which is why converted call sites take a
-// sink from whoever constructed them.
+// A Logger writes to the sink it was given and nowhere else. There is no
+// package-level destination: every component takes a sink from whoever
+// constructed it, so two clients in one process can log to different places,
+// or one can log while the other stays silent. A nil *Logger, and a logger
+// bound to a nil writer, both discard — which lets a caller with no sink to
+// offer pass one through unconditionally instead of branching (RFC 0022 §8).
 package logger
 
 import (
 	"fmt"
 	"io"
 )
-
-// Writer is the fallback destination for debug logs from loggers that were not
-// given a sink of their own. If nil, those loggers produce no output.
-//
-// This is the global RFC 0022 §8 is removing. It remains only for the call
-// sites still to be converted; do not add new uses.
-var Writer io.Writer
 
 const (
 	ColorBold   = "\033[1m"
@@ -35,33 +24,17 @@ const (
 	ColorReset  = "\033[0m"
 )
 
-// IsDebug reports whether the package-level fallback is enabled.
-//
-// It says nothing about loggers bound with To, which is why it is only
-// meaningful to call sites still using the fallback.
-func IsDebug() bool {
-	return Writer != nil
-}
-
-// Debugf formats and writes a message to the fallback Writer if it is non-nil.
-func Debugf(format string, args ...any) {
-	if Writer != nil {
-		_, _ = fmt.Fprintf(Writer, format+"\n", args...)
-	}
-}
-
 // Logger allows component-specific prefixing for debug messages.
 type Logger struct {
 	prefix string
 	w      io.Writer
 }
 
-// New returns a Logger with the specified component name and color, writing to
-// the package-level Writer.
+// New returns a Logger with the specified component name and color, and no
+// sink — it discards until one is bound with To.
 //
-// Use it for the package-level default, then bind a sink with To when one is
-// supplied — that keeps a component's prefix and color declared in one place
-// rather than repeated at every construction site.
+// Use it for a package-level default that declares a component's prefix and
+// colour once, then bind a sink with To at each construction site.
 func New(component, color string) *Logger {
 	prefix := ""
 	if component != "" {
@@ -76,9 +49,8 @@ func New(component, color string) *Logger {
 
 // To returns a copy of l that writes to w, keeping its prefix.
 //
-// A nil w yields a logger that falls back to the package-level Writer, so a
-// caller that has no sink to offer can pass one through unconditionally
-// instead of branching.
+// A nil w yields a discarding logger, so a caller that has no sink to offer
+// can pass one through unconditionally instead of branching.
 func (l *Logger) To(w io.Writer) *Logger {
 	if l == nil {
 		return nil
@@ -88,17 +60,13 @@ func (l *Logger) To(w io.Writer) *Logger {
 	return &c
 }
 
-// Debugf formats and prints a debug message to this logger's sink, or to the
-// package-level Writer if it has none.
+// Debugf formats and prints a debug message to this logger's sink, discarding
+// it if the logger has none.
 func (l *Logger) Debugf(format string, args ...any) {
 	if l == nil {
 		return
 	}
-	w := l.w
-	if w == nil {
-		w = Writer
-	}
-	if w != nil {
-		_, _ = fmt.Fprintf(w, l.prefix+format+"\n", args...)
+	if l.w != nil {
+		_, _ = fmt.Fprintf(l.w, l.prefix+format+"\n", args...)
 	}
 }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,3 +1,16 @@
+// Package logger provides the component-prefixed debug output that the client,
+// engine, and store layers write when debugging is enabled.
+//
+// A Logger writes to the sink it was given. Loggers created by New have no
+// sink of their own and fall back to the package-level Writer, which is how
+// every call site behaved before sinks were injectable and how the call sites
+// that have not been converted yet still behave (RFC 0022 §8).
+//
+// The distinction matters because the fallback is process-wide: two clients in
+// one process cannot have different debug settings through it, and writing to
+// it from a goroutine while another goroutine sets it is a data race. A logger
+// bound with To has neither problem, which is why converted call sites take a
+// sink from whoever constructed them.
 package logger
 
 import (
@@ -5,8 +18,11 @@ import (
 	"io"
 )
 
-// Writer is the global destination for debug logs.
-// If nil, no debug output is produced.
+// Writer is the fallback destination for debug logs from loggers that were not
+// given a sink of their own. If nil, those loggers produce no output.
+//
+// This is the global RFC 0022 §8 is removing. It remains only for the call
+// sites still to be converted; do not add new uses.
 var Writer io.Writer
 
 const (
@@ -19,12 +35,15 @@ const (
 	ColorReset  = "\033[0m"
 )
 
-// IsDebug returns true if debug logging is enabled.
+// IsDebug reports whether the package-level fallback is enabled.
+//
+// It says nothing about loggers bound with To, which is why it is only
+// meaningful to call sites still using the fallback.
 func IsDebug() bool {
 	return Writer != nil
 }
 
-// Debugf formats and writes a message to the debug Writer if it is non-nil.
+// Debugf formats and writes a message to the fallback Writer if it is non-nil.
 func Debugf(format string, args ...any) {
 	if Writer != nil {
 		_, _ = fmt.Fprintf(Writer, format+"\n", args...)
@@ -34,9 +53,15 @@ func Debugf(format string, args ...any) {
 // Logger allows component-specific prefixing for debug messages.
 type Logger struct {
 	prefix string
+	w      io.Writer
 }
 
-// New returns a Logger with the specified component name and color.
+// New returns a Logger with the specified component name and color, writing to
+// the package-level Writer.
+//
+// Use it for the package-level default, then bind a sink with To when one is
+// supplied — that keeps a component's prefix and color declared in one place
+// rather than repeated at every construction site.
 func New(component, color string) *Logger {
 	prefix := ""
 	if component != "" {
@@ -49,9 +74,31 @@ func New(component, color string) *Logger {
 	return &Logger{prefix: prefix}
 }
 
-// Debugf formats and prints a debug message if the global logger.Writer is set.
+// To returns a copy of l that writes to w, keeping its prefix.
+//
+// A nil w yields a logger that falls back to the package-level Writer, so a
+// caller that has no sink to offer can pass one through unconditionally
+// instead of branching.
+func (l *Logger) To(w io.Writer) *Logger {
+	if l == nil {
+		return nil
+	}
+	c := *l
+	c.w = w
+	return &c
+}
+
+// Debugf formats and prints a debug message to this logger's sink, or to the
+// package-level Writer if it has none.
 func (l *Logger) Debugf(format string, args ...any) {
-	if Writer != nil {
-		_, _ = fmt.Fprintf(Writer, l.prefix+format+"\n", args...)
+	if l == nil {
+		return
+	}
+	w := l.w
+	if w == nil {
+		w = Writer
+	}
+	if w != nil {
+		_, _ = fmt.Fprintf(w, l.prefix+format+"\n", args...)
 	}
 }

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -6,156 +6,91 @@ import (
 	"testing"
 )
 
-func TestDebugf_WriterNil(t *testing.T) {
-	Writer = nil
-	// Should not panic.
-	Debugf("hello %s", "world")
-}
-
-func TestDebugf_WritesMessage(t *testing.T) {
+func TestLogger_WritesToItsSink(t *testing.T) {
 	var buf bytes.Buffer
-	Writer = &buf
-	t.Cleanup(func() { Writer = nil })
+	New("comp", "").To(&buf).Debugf("hello %s", "world")
 
-	Debugf("hello %s", "world")
-
-	got := buf.String()
-	if !strings.Contains(got, "hello world") {
-		t.Errorf("expected 'hello world' in output, got %q", got)
-	}
-	if !strings.HasSuffix(got, "\n") {
-		t.Errorf("expected newline at end, got %q", got)
+	if got, want := buf.String(), "[comp] hello world\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 }
 
-func TestIsDebug(t *testing.T) {
-	Writer = nil
-	if IsDebug() {
-		t.Error("expected IsDebug() == false when Writer is nil")
-	}
+// TestLogger_DiscardsWithoutASink is the property that replaced the
+// package-level writer: a logger nobody gave a sink writes nowhere, rather
+// than falling back to a process-wide destination. There is no longer a global
+// for it to reach, so the assertion is that neither call panics or is required
+// to be guarded by the caller.
+func TestLogger_DiscardsWithoutASink(t *testing.T) {
+	New("comp", "").Debugf("dropped")
+	New("comp", "").To(nil).Debugf("also dropped")
+}
 
-	var buf bytes.Buffer
-	Writer = &buf
-	t.Cleanup(func() { Writer = nil })
+// TestLogger_NilReceiverIsSafe lets a component hold a logger it was never
+// given without guarding every call site.
+func TestLogger_NilReceiverIsSafe(t *testing.T) {
+	var l *Logger
+	l.Debugf("must not panic")
 
-	if !IsDebug() {
-		t.Error("expected IsDebug() == true when Writer is set")
+	if got := l.To(nil); got != nil {
+		t.Error("To on a nil logger must stay nil")
 	}
 }
 
-func TestNew_WithColor(t *testing.T) {
-	var buf bytes.Buffer
-	Writer = &buf
-	t.Cleanup(func() { Writer = nil })
-
-	l := New("mycomp", ColorCyan)
-	l.Debugf("msg %d", 42)
-
-	got := buf.String()
-	if !strings.Contains(got, "mycomp") {
-		t.Errorf("expected component name in output, got %q", got)
-	}
-	if !strings.Contains(got, "msg 42") {
-		t.Errorf("expected message in output, got %q", got)
-	}
-}
-
-func TestNew_NoColor(t *testing.T) {
-	var buf bytes.Buffer
-	Writer = &buf
-	t.Cleanup(func() { Writer = nil })
-
-	l := New("comp", "")
-	l.Debugf("test")
-
-	got := buf.String()
-	if !strings.Contains(got, "[comp]") {
-		t.Errorf("expected '[comp]' in output, got %q", got)
-	}
-}
-
-func TestNew_NoComponent(t *testing.T) {
-	var buf bytes.Buffer
-	Writer = &buf
-	t.Cleanup(func() { Writer = nil })
-
-	l := New("", "")
-	l.Debugf("bare message")
-
-	got := buf.String()
-	if got != "bare message\n" {
-		t.Errorf("expected 'bare message\\n', got %q", got)
-	}
-}
-
-func TestLogger_Debugf_WriterNil(t *testing.T) {
-	Writer = nil
-	l := New("comp", ColorRed)
-	// Should not panic.
-	l.Debugf("hello")
-}
-
-// TestLoggerTo_BoundSinkBeatsTheGlobal is the property the injectable sink
-// exists for: two loggers in one process can write to different places, which
-// the package-level Writer alone cannot express.
-func TestLoggerTo_BoundSinkBeatsTheGlobal(t *testing.T) {
-	Writer = nil
-	defer func() { Writer = nil }()
-
-	var global, boundA, boundB bytes.Buffer
-	Writer = &global
-
+// TestLogger_SinksAreIndependent is the property the global could not express:
+// two loggers in one process writing to different places at once.
+func TestLogger_SinksAreIndependent(t *testing.T) {
+	var a, b bytes.Buffer
 	base := New("comp", "")
-	base.To(&boundA).Debugf("to a")
-	base.To(&boundB).Debugf("to b")
-	base.Debugf("to the fallback")
 
-	if got := boundA.String(); got != "[comp] to a\n" {
-		t.Errorf("bound sink A = %q", got)
+	base.To(&a).Debugf("to a")
+	base.To(&b).Debugf("to b")
+
+	if got := a.String(); got != "[comp] to a\n" {
+		t.Errorf("sink A = %q", got)
 	}
-	if got := boundB.String(); got != "[comp] to b\n" {
-		t.Errorf("bound sink B = %q", got)
-	}
-	if got := global.String(); got != "[comp] to the fallback\n" {
-		t.Errorf("fallback = %q, want only the unbound logger's line", got)
+	if got := b.String(); got != "[comp] to b\n" {
+		t.Errorf("sink B = %q", got)
 	}
 }
 
-// TestLoggerTo_NilSinkFallsBack lets a caller pass a sink through
-// unconditionally instead of branching on whether it has one.
-func TestLoggerTo_NilSinkFallsBack(t *testing.T) {
-	Writer = nil
-	defer func() { Writer = nil }()
-
-	var global bytes.Buffer
-	Writer = &global
-
-	New("comp", "").To(nil).Debugf("still logged")
-
-	if got := global.String(); got != "[comp] still logged\n" {
-		t.Errorf("got %q, want the message on the fallback", got)
-	}
-}
-
-// TestLoggerTo_KeepsPrefixAndDoesNotMutate guards the copy: binding a sink must
-// not change the logger it was derived from.
-func TestLoggerTo_KeepsPrefixAndDoesNotMutate(t *testing.T) {
-	Writer = nil
-	defer func() { Writer = nil }()
-
-	var bound, global bytes.Buffer
-	Writer = &global
+// TestLogger_ToDoesNotMutateItsSource guards the copy: binding a sink must not
+// redirect the logger it was derived from.
+func TestLogger_ToDoesNotMutateItsSource(t *testing.T) {
+	var bound, later bytes.Buffer
 
 	base := New("comp", ColorCyan)
-	derived := base.To(&bound)
-
-	derived.Debugf("x")
-	base.Debugf("y")
+	base.To(&bound).Debugf("x")
+	base.To(&later).Debugf("y")
 
 	if !strings.Contains(bound.String(), "[comp]") {
 		t.Errorf("derived logger lost its prefix: %q", bound.String())
 	}
-	if !strings.Contains(global.String(), "y") {
-		t.Error("binding a sink must not redirect the logger it was derived from")
+	if strings.Contains(bound.String(), "y") {
+		t.Error("the second binding leaked into the first logger's sink")
+	}
+	if !strings.Contains(later.String(), "y") {
+		t.Errorf("second sink = %q, want the second message", later.String())
+	}
+}
+
+func TestLogger_ColorAndPrefix(t *testing.T) {
+	var buf bytes.Buffer
+	New("comp", ColorCyan).To(&buf).Debugf("msg")
+
+	out := buf.String()
+	if !strings.Contains(out, ColorCyan) || !strings.Contains(out, ColorReset) {
+		t.Errorf("expected the colour codes to survive, got %q", out)
+	}
+	if !strings.HasSuffix(out, "msg\n") {
+		t.Errorf("expected the message last, got %q", out)
+	}
+}
+
+func TestLogger_EmptyComponentHasNoPrefix(t *testing.T) {
+	var buf bytes.Buffer
+	New("", "").To(&buf).Debugf("bare")
+
+	if got, want := buf.String(), "bare\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 }

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -94,3 +94,68 @@ func TestLogger_Debugf_WriterNil(t *testing.T) {
 	// Should not panic.
 	l.Debugf("hello")
 }
+
+// TestLoggerTo_BoundSinkBeatsTheGlobal is the property the injectable sink
+// exists for: two loggers in one process can write to different places, which
+// the package-level Writer alone cannot express.
+func TestLoggerTo_BoundSinkBeatsTheGlobal(t *testing.T) {
+	Writer = nil
+	defer func() { Writer = nil }()
+
+	var global, boundA, boundB bytes.Buffer
+	Writer = &global
+
+	base := New("comp", "")
+	base.To(&boundA).Debugf("to a")
+	base.To(&boundB).Debugf("to b")
+	base.Debugf("to the fallback")
+
+	if got := boundA.String(); got != "[comp] to a\n" {
+		t.Errorf("bound sink A = %q", got)
+	}
+	if got := boundB.String(); got != "[comp] to b\n" {
+		t.Errorf("bound sink B = %q", got)
+	}
+	if got := global.String(); got != "[comp] to the fallback\n" {
+		t.Errorf("fallback = %q, want only the unbound logger's line", got)
+	}
+}
+
+// TestLoggerTo_NilSinkFallsBack lets a caller pass a sink through
+// unconditionally instead of branching on whether it has one.
+func TestLoggerTo_NilSinkFallsBack(t *testing.T) {
+	Writer = nil
+	defer func() { Writer = nil }()
+
+	var global bytes.Buffer
+	Writer = &global
+
+	New("comp", "").To(nil).Debugf("still logged")
+
+	if got := global.String(); got != "[comp] still logged\n" {
+		t.Errorf("got %q, want the message on the fallback", got)
+	}
+}
+
+// TestLoggerTo_KeepsPrefixAndDoesNotMutate guards the copy: binding a sink must
+// not change the logger it was derived from.
+func TestLoggerTo_KeepsPrefixAndDoesNotMutate(t *testing.T) {
+	Writer = nil
+	defer func() { Writer = nil }()
+
+	var bound, global bytes.Buffer
+	Writer = &global
+
+	base := New("comp", ColorCyan)
+	derived := base.To(&bound)
+
+	derived.Debugf("x")
+	base.Debugf("y")
+
+	if !strings.Contains(bound.String(), "[comp]") {
+		t.Errorf("derived logger lost its prefix: %q", bound.String())
+	}
+	if !strings.Contains(global.String(), "y") {
+		t.Error("binding a sink must not redirect the logger it was derived from")
+	}
+}

--- a/internal/sourceoauth/tokensource.go
+++ b/internal/sourceoauth/tokensource.go
@@ -14,6 +14,9 @@ type persistentTokenSource struct {
 	save    func(*oauth2.Token) error
 	lastTok *oauth2.Token
 	mu      sync.Mutex
+	// log is the sink for the one diagnostic this type emits. A nil logger
+	// logs nothing, which is what a caller that supplied no sink gets.
+	log *logger.Logger
 }
 
 // NewPersistentTokenSource returns a TokenSource that delegates to ts and
@@ -23,8 +26,8 @@ type persistentTokenSource struct {
 //
 // lastTok is the token already on disk; pass it so the first call does not
 // re-save an unchanged token.
-func NewPersistentTokenSource(ts oauth2.TokenSource, lastTok *oauth2.Token, save func(*oauth2.Token) error) oauth2.TokenSource {
-	return &persistentTokenSource{ts: ts, lastTok: lastTok, save: save}
+func NewPersistentTokenSource(ts oauth2.TokenSource, lastTok *oauth2.Token, save func(*oauth2.Token) error, log *logger.Logger) oauth2.TokenSource {
+	return &persistentTokenSource{ts: ts, lastTok: lastTok, save: save, log: log}
 }
 
 func (pts *persistentTokenSource) Token() (*oauth2.Token, error) {
@@ -37,7 +40,7 @@ func (pts *persistentTokenSource) Token() (*oauth2.Token, error) {
 	if shouldSave {
 		if err := pts.save(tok); err != nil {
 			// Log error but don't fail, as the token is still valid for this session.
-			logger.Debugf("failed to persist refreshed OAuth token: %v", err)
+			pts.log.Debugf("failed to persist refreshed OAuth token: %v", err)
 		}
 		pts.lastTok = tok
 	}

--- a/internal/sourceoauth/tokensource_test.go
+++ b/internal/sourceoauth/tokensource_test.go
@@ -135,7 +135,7 @@ func TestNewPersistentTokenSource(t *testing.T) {
 	ts := NewPersistentTokenSource(mock, initial, func(tok *oauth2.Token) error {
 		saved = append(saved, tok.AccessToken)
 		return nil
-	})
+	}, nil)
 
 	// lastTok matches, so the token already on disk is not rewritten.
 	if _, err := ts.Token(); err != nil {
@@ -166,7 +166,7 @@ func TestNewPersistentTokenSource_SaveErrorIsNotFatal(t *testing.T) {
 	tok := &oauth2.Token{AccessToken: "fresh", Expiry: time.Now().Add(time.Hour)}
 	ts := NewPersistentTokenSource(&mockTokenSource{tok: tok}, nil, func(*oauth2.Token) error {
 		return errors.New("disk full")
-	})
+	}, nil)
 
 	got, err := ts.Token()
 	if err != nil {

--- a/internal/storelayer/log.go
+++ b/internal/storelayer/log.go
@@ -1,6 +1,10 @@
 package storelayer
 
-import "github.com/cloudstic/cli/internal/logger"
+import (
+	"io"
+
+	"github.com/cloudstic/cli/internal/logger"
+)
 
 // The label stays "store" rather than "storelayer": these layers are the store
 // as far as a user reading debug output is concerned, and renaming it would
@@ -8,6 +12,21 @@ import "github.com/cloudstic/cli/internal/logger"
 // logger of its own — DebugStore writes to the io.Writer it is given.
 var debugLog = logger.New("store", logger.ColorYellow)
 
-func debugf(format string, args ...any) {
-	debugLog.Debugf(format, args...)
+// debugf writes through the sink this store was given, falling back to the
+// process-wide one when it was given none — which is what every caller got
+// before sinks were injectable (RFC 0022 §8).
+//
+// A nil logger is tolerated rather than guarded at every call site, so a
+// PackStore built in a test without options still logs somewhere valid.
+func (s *PackStore) debugf(format string, args ...any) {
+	if s.log == nil {
+		debugLog.Debugf(format, args...)
+		return
+	}
+	s.log.Debugf(format, args...)
+}
+
+// WithPackLogger sends this store's debug output to w.
+func WithPackLogger(w io.Writer) PackOption {
+	return func(s *PackStore) { s.log = debugLog.To(w) }
 }

--- a/internal/storelayer/pack.go
+++ b/internal/storelayer/pack.go
@@ -12,6 +12,7 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2"
 
 	"github.com/cloudstic/cli/internal/core"
+	"github.com/cloudstic/cli/internal/logger"
 	"github.com/cloudstic/cli/pkg/crypto"
 	"github.com/cloudstic/cli/pkg/store"
 )
@@ -28,6 +29,10 @@ const (
 // contains which object.
 type PackStore struct {
 	store.ObjectStore
+
+	// log is this store's debug sink, or nil to use the process-wide
+	// fallback. Set with WithPackLogger.
+	log *logger.Logger
 
 	mu sync.RWMutex
 
@@ -88,7 +93,6 @@ func WithPackIndexKey(key []byte) PackOption {
 
 // NewPackStore initializes a new MicroPackStore over an existing store.ObjectStore.
 func NewPackStore(inner store.ObjectStore, opts ...PackOption) (*PackStore, error) {
-	debugf("init packstore: LRU size=%d", 4)
 	// Keep up to 30 MB of packfiles in memory (around 4 packs) to speed up reads
 	cache, err := lru.New[string, []byte](4)
 	if err != nil {
@@ -107,6 +111,9 @@ func NewPackStore(inner store.ObjectStore, opts ...PackOption) (*PackStore, erro
 	for _, opt := range opts {
 		opt(s)
 	}
+	// Logged after the options are applied so it reaches the sink the caller
+	// asked for rather than the process-wide fallback.
+	s.debugf("init packstore: LRU size=%d", 4)
 	return s, nil
 }
 
@@ -144,7 +151,7 @@ func (s *PackStore) Put(ctx context.Context, key string, data []byte) error {
 		return s.ObjectStore.Put(ctx, key, data)
 	}
 
-	debugf("pack: buffering %s (%d bytes)", key, len(data))
+	s.debugf("pack: buffering %s (%d bytes)", key, len(data))
 
 	s.mu.Lock()
 
@@ -214,7 +221,7 @@ func (s *PackStore) discardPack(packRef string) {
 		}
 	}
 	s.packCache.Remove(packRef)
-	debugf("pack: discarded catalog entries for unwritten pack %s", packRef)
+	s.debugf("pack: discarded catalog entries for unwritten pack %s", packRef)
 }
 
 // packablePrefixes are the content-addressed namespaces safe to bundle into a
@@ -271,7 +278,7 @@ func (s *PackStore) prepareFlushLocked() (string, []byte, error) {
 
 	packHash := core.ComputeHash(packData)
 	packRef := packPrefix + packHash
-	debugf("preparing packfile %s with %d objects (%d bytes + %d footer)",
+	s.debugf("preparing packfile %s with %d objects (%d bytes + %d footer)",
 		packRef, len(s.packKeys), s.packBuffer.Len(), len(footer))
 
 	// Cache it immediately since we just wrote it, will speed up following Reads
@@ -300,7 +307,7 @@ func (s *PackStore) Get(ctx context.Context, key string) ([]byte, error) {
 		data := make([]byte, entry.Length)
 		copy(data, s.packBuffer.Bytes()[entry.Offset:entry.Offset+entry.Length])
 		s.mu.RUnlock()
-		debugf("get %s: hit active buffer (len=%d)", key, entry.Length)
+		s.debugf("get %s: hit active buffer (len=%d)", key, entry.Length)
 		return data, nil
 	}
 
@@ -333,11 +340,11 @@ func (s *PackStore) Get(ctx context.Context, key string) ([]byte, error) {
 		}
 		data := make([]byte, entry.Length)
 		copy(data, packData[entry.Offset:entry.Offset+entry.Length])
-		debugf("get %s: hit lru pack cache %s (len=%d)", key, entry.PackRef, entry.Length)
+		s.debugf("get %s: hit lru pack cache %s (len=%d)", key, entry.PackRef, entry.Length)
 		return data, nil
 	}
 
-	debugf("get %s: downloading pack %s", key, entry.PackRef)
+	s.debugf("get %s: downloading pack %s", key, entry.PackRef)
 	// 4. Download the entire packfile, cache it, and return the slice
 	packData, err := s.ObjectStore.Get(ctx, entry.PackRef)
 	if err != nil {
@@ -473,7 +480,7 @@ func (s *PackStore) Flush(ctx context.Context) error {
 			s.mu.Unlock()
 			return err
 		}
-		debugf("pack: flushed %d new entries (%d total)", len(pending), totalEntries)
+		s.debugf("pack: flushed %d new entries (%d total)", len(pending), totalEntries)
 	}
 
 	// Shards are append-only, so a removal is durable only once the index is
@@ -508,7 +515,7 @@ func (s *PackStore) loadCatalogLocked(ctx context.Context) error {
 		return nil
 	}
 
-	debugf("loading pack catalog")
+	s.debugf("loading pack catalog")
 
 	// The monolithic catalog is the pre-shard layout. It is still read so that
 	// repositories written before sharding stay readable, but nothing writes it
@@ -529,7 +536,7 @@ func (s *PackStore) loadCatalogLocked(ctx context.Context) error {
 		return s.healMissingCatalogLocked(ctx)
 	}
 
-	debugf("loaded %d entries into the pack catalog", len(s.catalog))
+	s.debugf("loaded %d entries into the pack catalog", len(s.catalog))
 	return nil
 }
 
@@ -569,7 +576,7 @@ func (s *PackStore) loadLegacyCatalogLocked(ctx context.Context) error {
 		return fmt.Errorf("unmarshal packs catalog: %w", err)
 	}
 	s.mergedIndex[indexPacksKey] = true
-	debugf("merged %d entries from the legacy catalog", len(s.catalog))
+	s.debugf("merged %d entries from the legacy catalog", len(s.catalog))
 	return nil
 }
 
@@ -693,7 +700,7 @@ func (s *PackStore) Repack(ctx context.Context, maxWastedRatio float64) (int64, 
 
 		// 1. Orphaned pack (100% wasted)
 		if activeSize == 0 {
-			debugf("repack: deleting orphaned pack %s", packRef)
+			s.debugf("repack: deleting orphaned pack %s", packRef)
 			physicalSize, err := s.ObjectStore.Size(ctx, packRef)
 			if err == nil {
 				bytesReclaimed += physicalSize
@@ -709,7 +716,7 @@ func (s *PackStore) Repack(ctx context.Context, maxWastedRatio float64) (int64, 
 		// 2. Check fragmentation
 		physicalSize, err := s.ObjectStore.Size(ctx, packRef)
 		if err != nil {
-			debugf("repack: failed to get size for pack %s: %v", packRef, err)
+			s.debugf("repack: failed to get size for pack %s: %v", packRef, err)
 			continue
 		}
 
@@ -727,7 +734,7 @@ func (s *PackStore) Repack(ctx context.Context, maxWastedRatio float64) (int64, 
 				physicalSize = info.objectRegionLen
 				wasted = physicalSize - activeSize
 			} else if !errors.Is(ferr, errNoPackFooter) {
-				debugf("repack: failed to read footer of %s: %v", packRef, ferr)
+				s.debugf("repack: failed to read footer of %s: %v", packRef, ferr)
 			}
 		}
 		if wasted <= 0 {
@@ -736,7 +743,7 @@ func (s *PackStore) Repack(ctx context.Context, maxWastedRatio float64) (int64, 
 
 		wastedRatio := float64(wasted) / float64(physicalSize)
 		if wastedRatio > maxWastedRatio {
-			debugf("repack: repacking %s (wasted: %.2f%%, %d bytes)", packRef, wastedRatio*100, wasted)
+			s.debugf("repack: repacking %s (wasted: %.2f%%, %d bytes)", packRef, wastedRatio*100, wasted)
 
 			// Download the packfile
 			packData, err := s.ObjectStore.Get(ctx, packRef)
@@ -788,7 +795,7 @@ func (s *PackStore) Repack(ctx context.Context, maxWastedRatio float64) (int64, 
 		// would delete the very pack the catalog now points at. Deleting a pack
 		// is only safe once nothing references it.
 		if s.packIsReferenced(pack.ref) {
-			debugf("repack: keeping %s, still referenced after rewrite", pack.ref)
+			s.debugf("repack: keeping %s, still referenced after rewrite", pack.ref)
 			continue
 		}
 		if err := s.ObjectStore.Delete(ctx, pack.ref); err != nil {

--- a/internal/storelayer/packfooter.go
+++ b/internal/storelayer/packfooter.go
@@ -274,7 +274,7 @@ func (s *PackStore) rebuildFromPacksLocked(ctx context.Context, packRefs []strin
 		info, err := s.readPackFooter(ctx, packRef)
 		if errors.Is(err, errNoPackFooter) {
 			footerless++
-			debugf("rebuild: pack %s has no footer, relying on the catalog", packRef)
+			s.debugf("rebuild: pack %s has no footer, relying on the catalog", packRef)
 			continue
 		}
 		if err != nil {
@@ -292,7 +292,7 @@ func (s *PackStore) rebuildFromPacksLocked(ctx context.Context, packRefs []strin
 		}
 	}
 
-	debugf("rebuild: recovered %d entries, %d packs without footers", recovered, footerless)
+	s.debugf("rebuild: recovered %d entries, %d packs without footers", recovered, footerless)
 	return recovered, footerless, nil
 }
 
@@ -308,7 +308,7 @@ func (s *PackStore) healMissingCatalogLocked(ctx context.Context) error {
 		return nil // Genuinely a fresh repository.
 	}
 
-	debugf("catalog %s is missing but %d packs exist; rebuilding from footers", indexPacksKey, len(packRefs))
+	s.debugf("catalog %s is missing but %d packs exist; rebuilding from footers", indexPacksKey, len(packRefs))
 	recovered, footerless, err := s.rebuildFromPacksLocked(ctx, packRefs)
 	if err != nil {
 		return fmt.Errorf("rebuild catalog from pack footers: %w", err)
@@ -320,6 +320,6 @@ func (s *PackStore) healMissingCatalogLocked(ctx context.Context) error {
 			indexPacksKey, footerless, len(packRefs), recovered,
 		)
 	}
-	debugf("rebuilt catalog with %d entries from pack footers", recovered)
+	s.debugf("rebuilt catalog with %d entries from pack footers", recovered)
 	return nil
 }

--- a/internal/storelayer/packshard.go
+++ b/internal/storelayer/packshard.go
@@ -54,7 +54,7 @@ func (s *PackStore) writeShard(ctx context.Context, entries map[string]PackEntry
 	if err := s.ObjectStore.Put(ctx, key, sealed); err != nil {
 		return fmt.Errorf("write pack index shard %s: %w", key, err)
 	}
-	debugf("pack: wrote shard %s with %d entries", key, len(entries))
+	s.debugf("pack: wrote shard %s with %d entries", key, len(entries))
 	return nil
 }
 
@@ -93,7 +93,7 @@ func (s *PackStore) loadShardsLocked(ctx context.Context) (int, error) {
 	}
 
 	if len(keys) > 0 {
-		debugf("pack: merged %d shards", len(keys))
+		s.debugf("pack: merged %d shards", len(keys))
 	}
 	return len(keys), nil
 }
@@ -160,7 +160,7 @@ func (s *PackStore) CompactCatalog(ctx context.Context) (int, error) {
 	s.mergedIndex = map[string]bool{consolidated: true}
 	s.mu.Unlock()
 
-	debugf("pack: compacted %d index objects into %s", removed, consolidated)
+	s.debugf("pack: compacted %d index objects into %s", removed, consolidated)
 	return removed, nil
 }
 

--- a/pkg/open/open.go
+++ b/pkg/open/open.go
@@ -49,6 +49,7 @@ type Option func(*options)
 
 type options struct {
 	debugWriter    io.Writer
+	logWriter      io.Writer
 	backendWrapper func(store.ObjectStore) (store.ObjectStore, error)
 	reporter       cloudstic.Reporter
 	promptResolve  func() (string, error)
@@ -70,6 +71,17 @@ func newOptions(opts []Option) *options {
 // interleave.
 func WithDebugWriter(w io.Writer) Option {
 	return func(o *options) { o.debugWriter = w }
+}
+
+// WithLogger sends the client's debug output — its own and that of the engine
+// and store layers it drives — to w.
+//
+// This is distinct from WithDebugWriter, which traces individual store
+// operations. A caller that wants both passes both; they are separate because
+// per-operation tracing is far noisier than the component diagnostics, and is
+// often wanted on its own.
+func WithLogger(w io.Writer) Option {
+	return func(o *options) { o.logWriter = w }
 }
 
 // WithBackendWrapper wraps the constructed backend before the repository
@@ -209,6 +221,9 @@ func Client(ctx context.Context, cfg config.Client, opts ...Option) (*cloudstic.
 	clientOpts := []cloudstic.ClientOption{
 		cloudstic.WithKeychain(kc),
 		cloudstic.WithPackfile(!cfg.DisablePackfile),
+	}
+	if o.logWriter != nil {
+		clientOpts = append(clientOpts, cloudstic.WithLogger(o.logWriter))
 	}
 	if o.reporter != nil {
 		clientOpts = append(clientOpts, cloudstic.WithReporter(o.reporter))

--- a/pkg/secretref/backends/file_backend.go
+++ b/pkg/secretref/backends/file_backend.go
@@ -3,6 +3,7 @@ package backends
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/user"
 	pathpkg "path"
@@ -95,6 +96,18 @@ type ConfigTokenBackend struct {
 	// configDir overrides the managed directory. Empty means "ask
 	// paths.ConfigDir", i.e. CLOUDSTIC_CONFIG_DIR or the OS default.
 	configDir string
+	// log is where the plaintext-fallback diagnostic goes. A nil logger logs
+	// nothing, which is what a caller that supplied no sink gets. Backends are
+	// constructed independently of a client, so a client's sink cannot reach
+	// one; WithConfigTokenLogger is how a caller supplies it (RFC 0022 §8).
+	log *logger.Logger
+}
+
+// WithConfigTokenLogger sends this backend's debug output to w.
+func WithConfigTokenLogger(w io.Writer) ConfigTokenOption {
+	return func(b *ConfigTokenBackend) {
+		b.log = logger.New("secretref", logger.ColorCyan).To(w)
+	}
 }
 
 // ConfigTokenOption configures a ConfigTokenBackend.
@@ -157,7 +170,7 @@ func (b *ConfigTokenBackend) LoadBlob(_ context.Context, ref secretref.Ref) ([]b
 	if err != nil {
 		// Fallback for unencrypted files (compatibility with existing tokens before RFC 0016)
 		if !crypto.IsEncrypted(data) {
-			logger.Debugf("decryption failed for %q, but data is not encrypted; falling back to plaintext", ref.Raw)
+			b.log.Debugf("decryption failed for %q, but data is not encrypted; falling back to plaintext", ref.Raw)
 			return data, nil
 		}
 		return nil, secretref.NewError(secretref.KindBackendUnavailable, ref.Raw, "failed to decrypt managed token file", err)

--- a/pkg/source/gdrive/auth_test.go
+++ b/pkg/source/gdrive/auth_test.go
@@ -86,7 +86,7 @@ func TestGDrive_Options(t *testing.T) {
 
 func TestOAuthClient_RequiresResolverForTokenRef(t *testing.T) {
 	config := &oauth2.Config{}
-	_, err := oauthClient(context.Background(), config, nil, "config-token://google/tok", "")
+	_, err := oauthClient(context.Background(), config, nil, "config-token://google/tok", "", nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/pkg/source/gdrive/log.go
+++ b/pkg/source/gdrive/log.go
@@ -1,0 +1,16 @@
+package gdrive
+
+import (
+	"io"
+
+	"github.com/cloudstic/cli/internal/logger"
+)
+
+// oauthLogger returns the sink for this source's OAuth diagnostics, or nil
+// when the caller supplied none — in which case nothing is logged.
+func oauthLogger(w io.Writer) *logger.Logger {
+	if w == nil {
+		return nil
+	}
+	return logger.New("gdrive", logger.ColorCyan).To(w)
+}

--- a/pkg/source/gdrive/source.go
+++ b/pkg/source/gdrive/source.go
@@ -25,6 +25,8 @@ import (
 
 // gDriveOptions holds configuration for a Google Drive source.
 type gDriveOptions struct {
+	// logWriter is where this source sends its debug output; nil means none.
+	logWriter       io.Writer
 	service         *drive.Service // pre-built service; highest priority
 	httpClient      *http.Client
 	resolver        *secretref.Resolver
@@ -44,6 +46,14 @@ type gDriveOptions struct {
 
 // Option configures a Google Drive source.
 type Option func(*gDriveOptions)
+
+// WithLogger sends this source's debug output to w.
+//
+// Sources are constructed independently of a client, so a client's sink
+// cannot reach them; this is how a caller supplies one (RFC 0022 §8).
+func WithLogger(w io.Writer) Option {
+	return func(o *gDriveOptions) { o.logWriter = w }
+}
 
 // WithDriveService injects a fully-constructed *drive.Service.
 // When set, all credential/token options are ignored — the caller is
@@ -264,7 +274,7 @@ func buildDriveService(ctx context.Context, cfg gDriveOptions) (*drive.Service, 
 		Scopes:       []string{drive.DriveReadonlyScope},
 		Endpoint:     google.Endpoint,
 	}
-	client, err := oauthClient(ctx, config, cfg.resolver, cfg.tokenRef, cfg.tokenPath)
+	client, err := oauthClient(ctx, config, cfg.resolver, cfg.tokenRef, cfg.tokenPath, cfg.logWriter)
 	if err != nil {
 		return nil, err
 	}
@@ -306,7 +316,7 @@ func serviceFromCredsBytes(ctx context.Context, cfg gDriveOptions, b []byte) (*d
 	// Try OAuth user config first.
 	oauthCfg, err := google.ConfigFromJSON(b, drive.DriveReadonlyScope)
 	if err == nil {
-		client, err := oauthClient(ctx, oauthCfg, cfg.resolver, cfg.tokenRef, cfg.tokenPath)
+		client, err := oauthClient(ctx, oauthCfg, cfg.resolver, cfg.tokenRef, cfg.tokenPath, cfg.logWriter)
 		if err != nil {
 			return nil, err
 		}
@@ -455,7 +465,7 @@ func (s *Source) resolvePathToFolderID(ctx context.Context, path string) (string
 // OAuth helpers
 // ---------------------------------------------------------------------------
 
-func oauthClient(ctx context.Context, config *oauth2.Config, r *secretref.Resolver, tokRef, tokFile string) (*http.Client, error) {
+func oauthClient(ctx context.Context, config *oauth2.Config, r *secretref.Resolver, tokRef, tokFile string, logWriter io.Writer) (*http.Client, error) {
 	var tok *oauth2.Token
 	var err error
 	if tokRef != "" && r == nil {
@@ -496,7 +506,7 @@ func oauthClient(ctx context.Context, config *oauth2.Config, r *secretref.Resolv
 			return saveToken(tokFile, t)
 		}
 		return nil
-	})
+	}, oauthLogger(logWriter))
 
 	return oauth2.NewClient(ctx, pts), nil
 }

--- a/pkg/source/onedrive/log.go
+++ b/pkg/source/onedrive/log.go
@@ -1,0 +1,16 @@
+package onedrive
+
+import (
+	"io"
+
+	"github.com/cloudstic/cli/internal/logger"
+)
+
+// oauthLogger returns the sink for this source's OAuth diagnostics, or nil
+// when the caller supplied none — in which case nothing is logged.
+func oauthLogger(w io.Writer) *logger.Logger {
+	if w == nil {
+		return nil
+	}
+	return logger.New("onedrive", logger.ColorCyan).To(w)
+}

--- a/pkg/source/onedrive/source.go
+++ b/pkg/source/onedrive/source.go
@@ -23,6 +23,8 @@ import (
 
 // oneDriveOptions holds configuration for a OneDrive source.
 type oneDriveOptions struct {
+	// logWriter is where this source sends its debug output; nil means none.
+	logWriter       io.Writer
 	clientID        string
 	resolver        *secretref.Resolver
 	tokenPath       string
@@ -34,6 +36,14 @@ type oneDriveOptions struct {
 
 // Option configures a OneDrive source.
 type Option func(*oneDriveOptions)
+
+// WithLogger sends this source's debug output to w.
+//
+// Sources are constructed independently of a client, so a client's sink
+// cannot reach them; this is how a caller supplies one (RFC 0022 §8).
+func WithLogger(w io.Writer) Option {
+	return func(o *oneDriveOptions) { o.logWriter = w }
+}
 
 // WithClientID sets the OAuth client ID. If empty, uses the built-in default.
 func WithClientID(id string) Option {
@@ -146,7 +156,7 @@ func New(ctx context.Context, opts ...Option) (*Source, error) {
 			return saveTokenJSON(cfg.tokenPath, t)
 		}
 		return nil
-	})
+	}, oauthLogger(cfg.logWriter))
 
 	client := oauth2.NewClient(ctx, pts)
 

--- a/query.go
+++ b/query.go
@@ -17,7 +17,7 @@ type ListResult = engine.ListResult
 var WithListVerbose = engine.WithListVerbose
 
 func (c *Client) List(ctx context.Context, opts ...ListOption) (*ListResult, error) {
-	mgr := engine.NewListManager(c.store)
+	mgr := engine.NewListManager(c.store, c.logWriter)
 	return mgr.Run(ctx, opts...)
 }
 
@@ -94,7 +94,7 @@ var (
 // It is a pure read path — no lock is taken, nothing is written, and the
 // repository format is not stamped.
 func (c *Client) Find(ctx context.Context, opts ...FindOption) (*FindResult, error) {
-	mgr := engine.NewFindManager(c.store)
+	mgr := engine.NewFindManager(c.store, c.logWriter)
 	return mgr.Run(ctx, opts...)
 }
 

--- a/repo.go
+++ b/repo.go
@@ -30,7 +30,9 @@ var (
 // This is a package-level function because init runs before the full
 // Client decorator chain (encryption, compression, packfiles) is set up.
 func InitRepo(ctx context.Context, rawStore store.ObjectStore, opts ...InitOption) (*InitResult, error) {
-	mgr := engine.NewInitManager(rawStore)
+	// No client exists here to carry a sink, so init's one debug line goes to
+	// the process-wide fallback. See RFC 0022 §8.
+	mgr := engine.NewInitManager(rawStore, nil)
 	return mgr.Run(ctx, opts...)
 }
 

--- a/retention.go
+++ b/retention.go
@@ -72,7 +72,7 @@ type KeepReason = engine.KeepReason
 type SnapshotEntry = engine.SnapshotEntry
 
 func (c *Client) Forget(ctx context.Context, snapshotID string, opts ...ForgetOption) (*ForgetResult, error) {
-	mgr := engine.NewForgetManager(c.store, c.reporter)
+	mgr := engine.NewForgetManager(c.store, c.reporter, c.logWriter)
 	result, err := mgr.Run(ctx, snapshotID, opts...)
 	if err != nil {
 		return nil, err
@@ -84,7 +84,7 @@ func (c *Client) Forget(ctx context.Context, snapshotID string, opts ...ForgetOp
 }
 
 func (c *Client) ForgetPolicy(ctx context.Context, opts ...ForgetOption) (*PolicyResult, error) {
-	mgr := engine.NewForgetManager(c.store, c.reporter)
+	mgr := engine.NewForgetManager(c.store, c.reporter, c.logWriter)
 	result, err := mgr.RunPolicy(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/rfcs/0022-public-go-api-boundaries.md
+++ b/rfcs/0022-public-go-api-boundaries.md
@@ -483,6 +483,26 @@ hits. So the global goes away rather than being published:
 - `pkg/secretref` resolvers gain a logger option.
 - `logger.Writer` stays as a fallback while call sites migrate, then is deleted.
 
+The migration is per-component rather than all at once, which the fallback is
+what makes possible. Converted so far: the client itself, `internal/storelayer`
+(via `WithPackLogger`), `internal/hamt` (via a variadic `TreeOption`, so the
+six trees that never log keep their call sites), and `internal/engine`'s
+backup and init managers. Still on the fallback, and the reason the global
+cannot be deleted yet:
+
+- `internal/engine/snapshots.go` logs from *free functions*
+  (`LoadSnapshotCatalog`, `AppendSnapshotCatalog`,
+  `RemoveFromSnapshotCatalog`) rather than from a manager, so there is no
+  receiver to carry a sink. Giving them one means changing three exported
+  signatures and their callers — a different shape of change from the rest,
+  and worth its own commit.
+- `internal/sourceoauth` and `pkg/secretref/backends` are constructed
+  independently of a client, so a client-supplied sink cannot reach them. They
+  need an option on the source constructors and the resolver respectively.
+
+`InitRepo` is a package-level function with no client, so its single debug
+line also stays on the fallback.
+
 **The injected value is an `io.Writer`, not a `*slog.Logger`.** The current
 output is colored `[component] message` human debug text, and preserving it
 byte-for-byte makes this stage purely structural — no golden-file churn, no
@@ -618,7 +638,10 @@ Stages 5–8 add three requirements:
    follows genuinely call-site-neutral.
 8. Add `pkg/open`; reduce `storebuild.go`, `clientbuild.go`, and `keychain.go`
    to adapters. **Done.**
-9. Logger injection (§8).
+9. Logger injection (§8), per component: the logger infrastructure and the
+   client, store, hamt and engine-manager call sites first; then the
+   free-function and independently-constructed ones, after which the global
+   can be deleted.
 10. Extend the external fixture to consume the library end to end.
 
 Steps 1–3 made external custom sources and stores possible, which was the

--- a/rfcs/0022-public-go-api-boundaries.md
+++ b/rfcs/0022-public-go-api-boundaries.md
@@ -1,6 +1,8 @@
 # RFC 0022: Public Go API Boundaries
 
-- **Status:** Partially implemented — §1–§7 landed; §8 outstanding
+- **Status:** §1–§8 implemented. Outstanding: extending the external-module
+  fixture to *consume* the library, not only implement its contracts (see
+  Testing strategy)
 - **Date:** 2026-07-28
 - **Affects:** `client.go`, `pkg/source`, `pkg/store`, `pkg/crypto`, `pkg/config`,
   `pkg/open`, `internal/logger`, `internal/storelayer`, `cmd/cloudstic`, `docs/`
@@ -481,27 +483,16 @@ hits. So the global goes away rather than being published:
   also covers `internal/sourceoauth`.
 - `store.NewDebugStore(inner, w)` already takes a writer and needs nothing.
 - `pkg/secretref` resolvers gain a logger option.
-- `logger.Writer` stays as a fallback while call sites migrate, then is deleted.
+- `logger.Writer` is deleted once every call site is converted.
 
-The migration is per-component rather than all at once, which the fallback is
-what makes possible. Converted so far: the client itself, `internal/storelayer`
-(via `WithPackLogger`), `internal/hamt` (via a variadic `TreeOption`, so the
-six trees that never log keep their call sites), and `internal/engine`'s
-backup and init managers. Still on the fallback, and the reason the global
-cannot be deleted yet:
-
-- `internal/engine/snapshots.go` logs from *free functions*
-  (`LoadSnapshotCatalog`, `AppendSnapshotCatalog`,
-  `RemoveFromSnapshotCatalog`) rather than from a manager, so there is no
-  receiver to carry a sink. Giving them one means changing three exported
-  signatures and their callers — a different shape of change from the rest,
-  and worth its own commit.
-- `internal/sourceoauth` and `pkg/secretref/backends` are constructed
-  independently of a client, so a client-supplied sink cannot reach them. They
-  need an option on the source constructors and the resolver respectively.
-
-`InitRepo` is a package-level function with no client, so its single debug
-line also stays on the fallback.
+The migration ran per component, each by whatever mechanism its construction
+already had: a `PackOption` for `storelayer`, a variadic `TreeOption` for
+`hamt` (so the six trees that never log kept their call sites), a writer
+parameter for the engine managers, `WithLogger` on the `gdrive` and `onedrive`
+sources, and `WithConfigTokenLogger` for the secret backend. The awkward case
+was `engine/snapshots.go`, which logs from free functions with no receiver to
+carry a sink: those take a `*logger.Logger` explicitly, which is what forced
+the backup, forget, list and find managers to have one.
 
 **The injected value is an `io.Writer`, not a `*slog.Logger`.** The current
 output is colored `[component] message` human debug text, and preserving it
@@ -641,8 +632,15 @@ Stages 5–8 add three requirements:
 9. Logger injection (§8), per component: the logger infrastructure and the
    client, store, hamt and engine-manager call sites first; then the
    free-function and independently-constructed ones, after which the global
-   can be deleted.
+   is deleted. **Done.**
 10. Extend the external fixture to consume the library end to end.
+
+    Not done. `internal/apicheck/testdata/externalmod` still only implements
+    the contracts. The acceptance tests added with §8 exercise the consuming
+    path — resolve a configuration, open a client, run a backup, assert on the
+    debug output — but they live in-module, so they prove the API works
+    without proving it is reachable from outside. That distinction is the
+    whole point of the fixture, and it is what remains.
 
 Steps 1–3 made external custom sources and stores possible, which was the
 original goal. Steps 5–10 are what make the library usable by the consumer who


### PR DESCRIPTION
## Summary

Completes RFC 0022 §8, and closes the first of the two gaps that started this work: debug logging was a mutable package-level `io.Writer` in `internal/logger`, so **no expression available to an external caller turned any of it on**.

```go
c, _ := cloudstic.NewClient(ctx, store, cloudstic.WithLogger(&buf))
// buf receives [client], [store], [backup] and [hamt] lines
```

The global is gone. Every component now writes to a sink it was handed, and a logger with none discards. Four commits:

1. **`let a logger carry its own sink`** — `Logger` gains a writer and a `To` method that binds one, returning a copy. A logger without one falls back to the global, so the conversion could proceed a component at a time.
2. **`make debug output reachable from outside the module`** — `cloudstic.WithLogger`, plus `storelayer`, `hamt` and the backup/init managers.
3. **`delete the global debug writer`** — the remaining call sites, then `logger.Writer`, `logger.Debugf` and `logger.IsDebug` removed.
4. **`mark §8 implemented and name what is actually left`**.

Part of #378

### Why it is per-client and not just "settable"

Exporting a setter for the global would have been a one-line change and was rejected. The global is read from goroutines throughout a concurrent backup; making it settable at any time turns a benign startup-ordering property into a racy public API, and it still leaves two clients in one process unable to have different debug settings — which is the first thing a library consumer hits.

### Threading, per component

Each by whatever mechanism its construction already had, rather than one imposed shape:

| Component | Mechanism |
| --- | --- |
| `storelayer` | `WithPackLogger`, a `PackOption` — its 24 call sites all had a receiver already |
| `hamt` | `WithLogger`, a **variadic** `TreeOption`, so the six trees that never log keep their call sites |
| backup / init / forget / list / find managers | a writer parameter; each constructor has one caller |
| `gdrive`, `onedrive` | `WithLogger`, passed down to the OAuth token source |
| `secretref` config-token backend | `WithConfigTokenLogger` |

`engine/snapshots.go` was the awkward one: it logs from **free functions** with no receiver to carry a sink, so `LoadSnapshotCatalog`, `AppendSnapshotCatalog` and `RemoveFromSnapshotCatalog` take a `*logger.Logger` explicitly — which is what forced the four managers above to hold one.

### For reviewers

- **An acceptance test caught a real bug immediately.** I wrote it to assert real output rather than compilation, and it found that `BackupManager.log` was left unset by a rename: `bm.log` was nil, so **every backup debug line was silently swallowed** while the whole suite passed. The linter flagged the resulting unused variable; nothing else would have. That test is now permanent.
- **Verified against the built binary, not only the suite**, because this is exactly the change that can silently produce nothing. `backup -debug` emits `[client]`, `[store]`, `[backup]` and `[hamt]`; the same command without `-debug` emits none.
- **`cmd/cloudstic` sets nothing global any more.** `newDebugLog` only returns the writer; `openClient` hands it to the client via `open.WithLogger`. That option is deliberately separate from `open.WithDebugWriter` — the latter traces every store operation, which is far noisier than component diagnostics and is often wanted on its own.
- **`InitRepo` is a package-level function with no client**, so its single debug line now goes nowhere unless the caller builds the manager directly. Called out because it is the one place output was lost rather than redirected.

### Still outstanding after this

Only one item, and it is from the testing strategy rather than the proposal: `internal/apicheck/testdata/externalmod` still only *implements* the contracts. The acceptance tests here exercise the consuming path but live in-module, so they prove the API works without proving it is reachable from outside — which is the whole point of the fixture. The RFC status says so rather than claiming completion.

## Verification

\`\`\`bash
env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./...
env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./...
gofmt -l .
npx markdownlint-cli2 rfcs/0022-public-go-api-boundaries.md
\`\`\`

Full suite passes with the race detector; lint reports 0 issues across the whole tree; `gofmt -l` and markdownlint are clean.