### PR TITLE
refactor: add -config-dir and collapse the profiles-path helpers (RFC 0022)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,9 +118,25 @@ All objects are addressed by `<type>/<sha256>`:
 
 ### Configuration & Profiles
 
-- **Config directory** — resolved by `internal/paths.ConfigDir()`: `CLOUDSTIC_CONFIG_DIR` if set, else `os.UserConfigDir()/cloudstic` (e.g. `~/.config/cloudstic`), created `0700`. Holds the profiles file, OAuth tokens, etc.
+- **Config directory** — resolved by `internal/paths.ConfigDir(override)`: the `-config-dir` flag if given, else `CLOUDSTIC_CONFIG_DIR`, else `os.UserConfigDir()/cloudstic` (e.g. `~/.config/cloudstic`). Holds the profiles file, OAuth tokens, and the `config-token` secret backend's managed store. Resolution does **no** filesystem access — the directory is created `0700` by whoever writes into it (`paths.SaveAtomic`, `profile.Save`), so help, completion and `setup -dry-run` can ask where configuration lives without creating it.
 - **Profiles** — a profile bundles a named source + store (+ secret refs) so users run `cloudstic backup -profile <name>` instead of re-specifying flags. Persisted via `profile.Load`/`profile.Save` (`pkg/profile`). Managed from the CLI (`cmd_profile.go`, `cmd_setup.go`) and the TUI. See RFC `rfcs/0010-backup-profiles.md`. The active profile / file come from `CLOUDSTIC_PROFILE` / `CLOUDSTIC_PROFILES_FILE`.
 - **Resolution precedence** — `resolveClientConfig` (`config.go`) resolves a command's store configuration as: explicit CLI flag > selected profile's store field > environment variable > built-in default. A profile is a named choice the user invoked with `-profile`, so once selected it overrides ambient environment variables the same way it overrides built-in defaults — only an explicit flag beats it. `applyProfileStore` decides this per field via `flagProvided`, which only recognizes `originFlag`; `originEnv` values are treated the same as `originDefault` and are eligible to be overridden. See `TestResolveClientConfig_ProfileOverridesEnvironment` (`config_test.go`).
+
+### Flag Defaults That Depend on Other Flags
+
+A flag whose default is computed from another flag declares it with
+`withLateDefault` (`flagspec.go`) instead of passing a value to `stringFlag`.
+Late defaults resolve in `applyLateDefaults`, a pass after `applyEnvDefaults`,
+and only for flags still at their built-in value — so an explicit flag and an
+environment value both still win, and the origin stays `originDefault` so a
+profile may still override it.
+
+`-profiles-file` is the case this exists for: its default is a path inside
+`-config-dir`, unknown until parsing finishes. Computing such a default at
+declaration time is wrong twice over — it reads a flag that has no value yet,
+and it runs on every path that merely *describes* a command, including `-h` and
+shell completion, which is how resolving the profiles path used to create the
+config directory as a side effect of asking for help.
 
 ### Secret References
 
@@ -144,7 +160,7 @@ Backends expose `Load`/`Save`/`Delete`; unsupported operations return a typed `s
 | `CLOUDSTIC_KMS_KEY_ARN` / `CLOUDSTIC_KMS_REGION` / `CLOUDSTIC_KMS_ENDPOINT` | AWS KMS envelope-encryption config for `kms-platform` slots. |
 | `CLOUDSTIC_STORE` / `CLOUDSTIC_SOURCE` | Default store / source URI when no flag is given. |
 | `CLOUDSTIC_PROFILE` / `CLOUDSTIC_PROFILES_FILE` | Active backup profile and override for the profiles file path. |
-| `CLOUDSTIC_CONFIG_DIR` | Override the config/state directory (default `~/.config/cloudstic`). |
+| `CLOUDSTIC_CONFIG_DIR` | Override the config/state directory (default `~/.config/cloudstic`); `-config-dir` beats it. |
 | `CLOUDSTIC_{STORE,SOURCE}_SFTP_{PASSWORD,KEY,KNOWN_HOSTS,INSECURE}` | SFTP auth/host-key config for the store and source backends. |
 | `CLOUDSTIC_DISABLE_PACKFILE` | Disable the `PackStore` small-object bundling layer. |
 | `CLOUDSTIC_VOLUME_UUID` | Override the volume UUID for a local source (cross-machine incremental backup for portable drives). |

--- a/cmd/cloudstic/clientbuild_test.go
+++ b/cmd/cloudstic/clientbuild_test.go
@@ -134,7 +134,7 @@ func TestClientConfigZeroValueEnablesPackfiles(t *testing.T) {
 		t.Error("clientConfigFromFlags with no flags set must leave packfiles enabled")
 	}
 
-	fromProfile, err := clientConfigFromProfileStore(profile.Store{URI: "local:/tmp/x"})
+	fromProfile, err := clientConfigFromProfileStore(profile.Store{URI: "local:/tmp/x"}, "")
 	if err != nil {
 		t.Fatalf("clientConfigFromProfileStore: %v", err)
 	}

--- a/cmd/cloudstic/cmd_auth.go
+++ b/cmd/cloudstic/cmd_auth.go
@@ -12,9 +12,9 @@ import (
 
 type authListArgs struct{ profilesFile string }
 
-func declareAuthListArgs(_ *globalFlags) (*authListArgs, commandInput) {
+func declareAuthListArgs(g *globalFlags) (*authListArgs, commandInput) {
 	a := &authListArgs{}
-	return a, commandInput{flags: []flagSpec{profilesFileFlag(&a.profilesFile)}}
+	return a, commandInput{flags: []flagSpec{profilesFileFlag(&a.profilesFile, g)}}
 }
 
 func runAuthList(r *runner, ctx context.Context, a *authListArgs) int {
@@ -35,10 +35,10 @@ type authShowArgs struct {
 	name         string
 }
 
-func declareAuthShowArgs(_ *globalFlags) (*authShowArgs, commandInput) {
+func declareAuthShowArgs(g *globalFlags) (*authShowArgs, commandInput) {
 	a := &authShowArgs{}
 	return a, commandInput{
-		flags:       []flagSpec{profilesFileFlag(&a.profilesFile)},
+		flags:       []flagSpec{profilesFileFlag(&a.profilesFile, g)},
 		positionals: []positionalSpec{optionalPositional(&a.name, "auth name", "", "_cloudstic_auth_names")},
 	}
 }
@@ -81,10 +81,10 @@ type authNewArgs struct {
 	onedriveTokenRef  string
 }
 
-func declareAuthNewArgs(_ *globalFlags) (*authNewArgs, commandInput) {
+func declareAuthNewArgs(g *globalFlags) (*authNewArgs, commandInput) {
 	a := &authNewArgs{}
 	return a, commandInput{flags: []flagSpec{
-		profilesFileFlag(&a.profilesFile),
+		profilesFileFlag(&a.profilesFile, g),
 		stringFlag(&a.name, "name", "", "Auth reference name", withPlaceholder("<name>")),
 		stringFlag(&a.provider, "provider", "", "Auth provider: google|onedrive", withPlaceholder("<google|onedrive>")),
 		stringFlag(&a.googleCreds, "google-credentials", "", "Path to Google service account credentials JSON file", withPlaceholder("<path>"), withCompleter("_files")),
@@ -193,15 +193,16 @@ func runAuthNew(r *runner, ctx context.Context, a *authNewArgs) int {
 }
 
 type authLoginArgs struct {
+	*globalFlags
 	profilesFile string
 	name         string
 }
 
-func declareAuthLoginArgs(_ *globalFlags) (*authLoginArgs, commandInput) {
-	a := &authLoginArgs{}
+func declareAuthLoginArgs(g *globalFlags) (*authLoginArgs, commandInput) {
+	a := &authLoginArgs{globalFlags: g}
 	return a, commandInput{
 		flags: []flagSpec{
-			profilesFileFlag(&a.profilesFile),
+			profilesFileFlag(&a.profilesFile, g),
 			stringFlag(&a.name, "name", "", "Auth reference name", withPlaceholder("<name>"), withCompleter("_cloudstic_auth_names")),
 		},
 		positionals: []positionalSpec{optionalPositional(&a.name, "auth name", "", "_cloudstic_auth_names")},
@@ -232,6 +233,7 @@ func runAuthLogin(r *runner, ctx context.Context, a *authLoginArgs) int {
 
 	src, err := initSource(ctx, initSourceOptions{
 		sourceURI:         auth.Provider + "://auth",
+		configDir:         a.configDir,
 		googleCreds:       auth.GoogleCreds,
 		googleCredsRef:    auth.GoogleCredsRef,
 		googleTokenFile:   auth.GoogleTokenFile,

--- a/cmd/cloudstic/cmd_backup.go
+++ b/cmd/cloudstic/cmd_backup.go
@@ -18,7 +18,6 @@ import (
 	cloudstic "github.com/cloudstic/cli"
 	"github.com/cloudstic/cli/internal/engine"
 	"github.com/cloudstic/cli/internal/paths"
-	secretrefbackends "github.com/cloudstic/cli/pkg/secretref/backends"
 	"github.com/cloudstic/cli/pkg/source"
 	"github.com/cloudstic/cli/pkg/source/gdrive"
 	"github.com/cloudstic/cli/pkg/source/local"
@@ -141,6 +140,7 @@ func runSingleBackup(r *runner, ctx context.Context, a *backupArgs) int {
 
 	src, err := initSource(ctx, initSourceOptions{
 		sourceURI:         a.sourceURI,
+		configDir:         a.configDir,
 		skipNativeFiles:   a.skipNativeFiles,
 		volumeUUID:        a.volumeUUID,
 		googleCreds:       a.googleCreds,
@@ -222,7 +222,7 @@ func ensureDefaultAuthRefForCloudBackup(a *backupArgs) error {
 
 		tokenPath := getToken()
 		if tokenPath == "" {
-			resolved, resolveErr := resolveTokenPath("", defaultTokenFilename)
+			resolved, resolveErr := resolveTokenPath(a.configDir, "", defaultTokenFilename)
 			if resolveErr != nil {
 				return resolveErr
 			}
@@ -535,6 +535,7 @@ func printBackupSummary(out io.Writer, res *engine.RunResult) {
 
 type initSourceOptions struct {
 	sourceURI         string
+	configDir         string
 	skipNativeFiles   bool
 	volumeUUID        string
 	googleCreds       string
@@ -559,7 +560,7 @@ func initSource(ctx context.Context, opts initSourceOptions) (source.Source, err
 		return nil, err
 	}
 
-	resolver := secretrefbackends.NewDefaultResolver()
+	resolver := newSecretResolver(opts.configDir)
 
 	switch uri.Scheme {
 	case "local":
@@ -588,7 +589,7 @@ func initSource(ctx context.Context, opts initSourceOptions) (source.Source, err
 		sftpOpts = append(sftpOpts, sftpsource.WithExcludePatterns(opts.excludePatterns))
 		return sftpsource.New(uri.Host, sftpOpts...)
 	case "gdrive":
-		tokenPath, err := resolveTokenPath(opts.googleTokenFile, "google_token.json")
+		tokenPath, err := resolveTokenPath(opts.configDir, opts.googleTokenFile, "google_token.json")
 		if err != nil {
 			return nil, err
 		}
@@ -608,7 +609,7 @@ func initSource(ctx context.Context, opts initSourceOptions) (source.Source, err
 		}
 		return gdrive.New(ctx, gdriveOpts...)
 	case "gdrive-changes":
-		tokenPath, err := resolveTokenPath(opts.googleTokenFile, "google_token.json")
+		tokenPath, err := resolveTokenPath(opts.configDir, opts.googleTokenFile, "google_token.json")
 		if err != nil {
 			return nil, err
 		}
@@ -628,7 +629,7 @@ func initSource(ctx context.Context, opts initSourceOptions) (source.Source, err
 		}
 		return gdrive.NewChangeSource(ctx, gdriveOpts...)
 	case "onedrive":
-		tokenPath, err := resolveTokenPath(opts.onedriveTokenFile, "onedrive_token.json")
+		tokenPath, err := resolveTokenPath(opts.configDir, opts.onedriveTokenFile, "onedrive_token.json")
 		if err != nil {
 			return nil, err
 		}
@@ -642,7 +643,7 @@ func initSource(ctx context.Context, opts initSourceOptions) (source.Source, err
 			onedrive.WithExcludePatterns(opts.excludePatterns),
 		)
 	case "onedrive-changes":
-		tokenPath, err := resolveTokenPath(opts.onedriveTokenFile, "onedrive_token.json")
+		tokenPath, err := resolveTokenPath(opts.configDir, opts.onedriveTokenFile, "onedrive_token.json")
 		if err != nil {
 			return nil, err
 		}
@@ -699,12 +700,13 @@ func parseXattrNamespacePrefixes(raw string) []string {
 }
 
 // resolveTokenPath returns the token file path to use. If explicit is non-empty
-// it is used as-is; otherwise the filename is placed in the cloudstic config dir.
-func resolveTokenPath(explicit, defaultFilename string) (string, error) {
+// it is used as-is; otherwise the filename is placed in the cloudstic config
+// dir, which configDir may override (see paths.ConfigDir).
+func resolveTokenPath(configDir, explicit, defaultFilename string) (string, error) {
 	if explicit != "" {
 		return explicit, nil
 	}
-	return paths.TokenPath(defaultFilename)
+	return paths.TokenPath(configDir, defaultFilename)
 }
 
 // backupCommand declares the `backup` command.

--- a/cmd/cloudstic/cmd_backup_profile_test.go
+++ b/cmd/cloudstic/cmd_backup_profile_test.go
@@ -336,7 +336,7 @@ func applyTestProfileStore(t *testing.T, s profile.Store, provided ...string) (c
 	for _, name := range provided {
 		set[name] = true
 	}
-	err := applyProfileStore(&cfg, s, func(name string) bool { return set[name] })
+	err := applyProfileStore(&cfg, s, "", func(name string) bool { return set[name] })
 	return cfg, err
 }
 
@@ -402,7 +402,7 @@ func TestApplyProfileStore_CLIFlagOverrides(t *testing.T) {
 		g.store = "local:/cli-store"
 		return g
 	}())
-	err := applyProfileStore(&cfg, profile.Store{URI: "s3:profile-bucket"},
+	err := applyProfileStore(&cfg, profile.Store{URI: "s3:profile-bucket"}, "",
 		func(name string) bool { return name == "store" })
 	if err != nil {
 		t.Fatalf("applyProfileStore: %v", err)

--- a/cmd/cloudstic/cmd_profile.go
+++ b/cmd/cloudstic/cmd_profile.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/cloudstic/cli/pkg/config"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -16,8 +17,20 @@ import (
 
 const defaultProfilesFilename = "profiles.yaml"
 
-func defaultProfilesPath() (string, error) {
-	return paths.ProfilesPath(defaultProfilesFilename, true)
+// defaultProfilesPath returns where the profiles file lives when the user
+// names no path: inside the config directory, which configDir may override
+// (see paths.ConfigDir).
+//
+// CLOUDSTIC_PROFILES_FILE is deliberately not consulted here. It is bound to
+// the -profiles-file flag as an ordinary environment default, so it is already
+// applied — by the time this runs, it did not apply, which is precisely what
+// makes a default needed.
+func defaultProfilesPath(configDir string) (string, error) {
+	dir, err := paths.ConfigDir(configDir)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, defaultProfilesFilename), nil
 }
 
 type profileShowArgs struct {
@@ -25,10 +38,10 @@ type profileShowArgs struct {
 	name         string
 }
 
-func declareProfileShowArgs(_ *globalFlags) (*profileShowArgs, commandInput) {
+func declareProfileShowArgs(g *globalFlags) (*profileShowArgs, commandInput) {
 	a := &profileShowArgs{}
 	return a, commandInput{
-		flags:       []flagSpec{profilesFileFlag(&a.profilesFile)},
+		flags:       []flagSpec{profilesFileFlag(&a.profilesFile, g)},
 		positionals: []positionalSpec{optionalPositional(&a.name, "profile name", "", "_cloudstic_profile_names")},
 	}
 }
@@ -77,9 +90,9 @@ type profileListArgs struct {
 	profilesFile string
 }
 
-func declareProfileListArgs(_ *globalFlags) (*profileListArgs, commandInput) {
+func declareProfileListArgs(g *globalFlags) (*profileListArgs, commandInput) {
 	a := &profileListArgs{}
-	return a, commandInput{flags: []flagSpec{profilesFileFlag(&a.profilesFile)}}
+	return a, commandInput{flags: []flagSpec{profilesFileFlag(&a.profilesFile, g)}}
 }
 
 func runProfileList(r *runner, ctx context.Context, a *profileListArgs) int {
@@ -127,7 +140,7 @@ type profileNewArgs struct {
 func declareProfileNewArgs(g *globalFlags) (*profileNewArgs, commandInput) {
 	a := &profileNewArgs{globalFlags: g}
 	return a, commandInput{flags: []flagSpec{
-		profilesFileFlag(&a.profilesFile),
+		profilesFileFlag(&a.profilesFile, g),
 		stringFlag(&a.name, "name", "", "Profile name", withPlaceholder("<name>")),
 		stringFlag(&a.source, "source", "", "Source URI", withPlaceholder("<uri>"), withCompleter("_cloudstic_source_prefixes")),
 		stringFlag(&a.storeRef, "store-ref", "", "Store reference name from top-level stores map", withPlaceholder("<name>")),
@@ -250,9 +263,10 @@ func runProfileNew(r *runner, ctx context.Context, a *profileNewArgs) int {
 	if createdStore && r.canPrompt() {
 		s := cfg.Stores[a.storeRef]
 		if !storeHasExplicitEncryption(s) {
-			r.promptEncryptionConfig(ctx, cfg, a.storeRef, a.profilesFile)
+			r.promptEncryptionConfig(ctx, cfg, a.storeRef, a.profilesFile, a.configDir)
 		}
 		if err := checkOrInitStoreWithRecovery(r, ctx, cfg, a.storeRef, a.profilesFile, checkOrInitOptions{
+			configDir:            a.configDir,
 			allowMissingSecrets:  true,
 			warnOnMissingSecrets: true,
 			offerInit:            true,

--- a/cmd/cloudstic/cmd_setup.go
+++ b/cmd/cloudstic/cmd_setup.go
@@ -11,21 +11,12 @@ import (
 	"github.com/cloudstic/cli/internal/workstation"
 
 	"github.com/jedib0t/go-pretty/v6/table"
-
-	"github.com/cloudstic/cli/internal/paths"
 )
 
 var planWorkstationSetup = workstation.Plan
 
-func defaultProfilesPathNoCreate() string {
-	path, err := paths.ProfilesPath(defaultProfilesFilename, false)
-	if err != nil {
-		return defaultProfilesFilename
-	}
-	return path
-}
-
 type setupWorkstationArgs struct {
+	*globalFlags
 	dryRun       bool
 	yes          bool
 	jsonOutput   bool
@@ -33,14 +24,13 @@ type setupWorkstationArgs struct {
 	storeRef     string
 }
 
-func declareSetupWorkstationArgs(_ *globalFlags) (*setupWorkstationArgs, commandInput) {
-	a := &setupWorkstationArgs{}
+func declareSetupWorkstationArgs(g *globalFlags) (*setupWorkstationArgs, commandInput) {
+	a := &setupWorkstationArgs{globalFlags: g}
 	return a, commandInput{flags: []flagSpec{
 		boolFlag(&a.dryRun, "dry-run", false, "Preview generated profiles without writing configuration"),
 		boolFlag(&a.yes, "yes", false, "Accept default selections without prompting"),
 		boolFlag(&a.jsonOutput, "json", false, "Write onboarding plan as JSON"),
-		stringFlag(&a.profilesFile, "profiles-file", defaultProfilesPathNoCreate(), "Path to profiles YAML file",
-			withEnv("CLOUDSTIC_PROFILES_FILE"), withPlaceholder("<path>"), withCompleter("_files")),
+		profilesFileFlag(&a.profilesFile, g),
 		stringFlag(&a.storeRef, "store-ref", "", "Existing store reference to attach to generated profiles",
 			withPlaceholder("<name>")),
 	}}
@@ -67,9 +57,10 @@ func runSetupWorkstation(r *runner, ctx context.Context, args *setupWorkstationA
 			if created {
 				s := cfg.Stores[args.storeRef]
 				if !storeHasExplicitEncryption(s) {
-					r.promptEncryptionConfig(ctx, cfg, args.storeRef, args.profilesFile)
+					r.promptEncryptionConfig(ctx, cfg, args.storeRef, args.profilesFile, args.configDir)
 				}
 				if err := checkOrInitStoreWithRecovery(r, ctx, cfg, args.storeRef, args.profilesFile, checkOrInitOptions{
+					configDir:            args.configDir,
 					allowMissingSecrets:  true,
 					warnOnMissingSecrets: true,
 					offerInit:            true,

--- a/cmd/cloudstic/cmd_setup_test.go
+++ b/cmd/cloudstic/cmd_setup_test.go
@@ -179,17 +179,35 @@ func TestReviewWorkstationPlan_RenameUpdate(t *testing.T) {
 	}
 }
 
-func TestDefaultProfilesPathNoCreate(t *testing.T) {
+func TestDefaultProfilesPath(t *testing.T) {
 	configRoot := filepath.Join(t.TempDir(), "config")
 	t.Setenv("CLOUDSTIC_CONFIG_DIR", configRoot)
 	t.Setenv("CLOUDSTIC_PROFILES_FILE", "")
 
-	got := defaultProfilesPathNoCreate()
+	got, err := defaultProfilesPath("")
+	if err != nil {
+		t.Fatalf("defaultProfilesPath: %v", err)
+	}
 	want := filepath.Join(configRoot, defaultProfilesFilename)
 	if got != want {
 		t.Fatalf("path = %q, want %q", got, want)
 	}
 	if _, err := os.Stat(configRoot); !os.IsNotExist(err) {
 		t.Fatalf("config dir should not be created, err=%v", err)
+	}
+}
+
+func TestDefaultProfilesPath_ConfigDirOverridesEnvironment(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("CLOUDSTIC_CONFIG_DIR", filepath.Join(tmp, "from-env"))
+	t.Setenv("CLOUDSTIC_PROFILES_FILE", "")
+
+	fromFlag := filepath.Join(tmp, "from-flag")
+	got, err := defaultProfilesPath(fromFlag)
+	if err != nil {
+		t.Fatalf("defaultProfilesPath: %v", err)
+	}
+	if want := filepath.Join(fromFlag, defaultProfilesFilename); got != want {
+		t.Fatalf("path = %q, want %q", got, want)
 	}
 }

--- a/cmd/cloudstic/cmd_store.go
+++ b/cmd/cloudstic/cmd_store.go
@@ -19,9 +19,9 @@ import (
 
 type storeListArgs struct{ profilesFile string }
 
-func declareStoreListArgs(_ *globalFlags) (*storeListArgs, commandInput) {
+func declareStoreListArgs(g *globalFlags) (*storeListArgs, commandInput) {
 	a := &storeListArgs{}
-	return a, commandInput{flags: []flagSpec{profilesFileFlag(&a.profilesFile)}}
+	return a, commandInput{flags: []flagSpec{profilesFileFlag(&a.profilesFile, g)}}
 }
 
 func runStoreList(r *runner, ctx context.Context, a *storeListArgs) int {
@@ -42,10 +42,10 @@ type storeShowArgs struct {
 	name         string
 }
 
-func declareStoreShowArgs(_ *globalFlags) (*storeShowArgs, commandInput) {
+func declareStoreShowArgs(g *globalFlags) (*storeShowArgs, commandInput) {
 	a := &storeShowArgs{}
 	return a, commandInput{
-		flags:       []flagSpec{profilesFileFlag(&a.profilesFile)},
+		flags:       []flagSpec{profilesFileFlag(&a.profilesFile, g)},
 		positionals: []positionalSpec{optionalPositional(&a.name, "store name", "")},
 	}
 }
@@ -93,7 +93,7 @@ type storeNewArgs struct {
 func declareStoreNewArgs(g *globalFlags) (*storeNewArgs, commandInput) {
 	a := &storeNewArgs{globalFlags: g}
 	return a, commandInput{flags: []flagSpec{
-		profilesFileFlag(&a.profilesFile),
+		profilesFileFlag(&a.profilesFile, g),
 		stringFlag(&a.name, "name", "", "Store reference name", withPlaceholder("<name>")),
 		stringFlag(&a.uri, "uri", "", "Store URI (e.g. s3:bucket/path, local:/path, sftp://host/path)", withPlaceholder("<uri>"), withCompleter("_cloudstic_store_prefixes")),
 		stringFlag(&a.s3Region, "s3-region", "", "S3 region", withPlaceholder("<region>")),
@@ -218,9 +218,10 @@ func runStoreNew(r *runner, ctx context.Context, a *storeNewArgs) int {
 			forcePromptEncryption = !keepCurrent
 		}
 		if forcePromptEncryption || !storeHasExplicitEncryption(s) {
-			r.promptEncryptionConfig(ctx, cfg, a.name, a.profilesFile)
+			r.promptEncryptionConfig(ctx, cfg, a.name, a.profilesFile, a.configDir)
 		}
 		if err := checkOrInitStoreWithRecovery(r, ctx, cfg, a.name, a.profilesFile, checkOrInitOptions{
+			configDir:            a.configDir,
 			allowMissingSecrets:  true,
 			warnOnMissingSecrets: !existedBefore,
 			offerInit:            true,
@@ -238,14 +239,15 @@ func runStoreNew(r *runner, ctx context.Context, a *storeNewArgs) int {
 // before calling this. Errors are printed but never cause a non-zero exit—
 // the store config has already been saved.
 type storeVerifyArgs struct {
+	*globalFlags
 	profilesFile string
 	name         string
 }
 
-func declareStoreVerifyArgs(_ *globalFlags) (*storeVerifyArgs, commandInput) {
-	a := &storeVerifyArgs{}
+func declareStoreVerifyArgs(g *globalFlags) (*storeVerifyArgs, commandInput) {
+	a := &storeVerifyArgs{globalFlags: g}
 	return a, commandInput{
-		flags:       []flagSpec{profilesFileFlag(&a.profilesFile)},
+		flags:       []flagSpec{profilesFileFlag(&a.profilesFile, g)},
 		positionals: []positionalSpec{optionalPositional(&a.name, "store name", "")},
 	}
 }
@@ -275,6 +277,7 @@ func runStoreVerify(r *runner, ctx context.Context, a *storeVerifyArgs) int {
 		return r.fail("Unknown store %q", a.name)
 	}
 	if err := checkOrInitStoreWithRecovery(r, ctx, cfg, a.name, a.profilesFile, checkOrInitOptions{
+		configDir:            a.configDir,
 		warnOnMissingSecrets: true,
 	}, false); err != nil {
 		return r.fail("%v", err)
@@ -283,16 +286,17 @@ func runStoreVerify(r *runner, ctx context.Context, a *storeVerifyArgs) int {
 }
 
 type storeInitArgs struct {
+	*globalFlags
 	profilesFile string
 	name         string
 	yes          bool
 }
 
-func declareStoreInitArgs(_ *globalFlags) (*storeInitArgs, commandInput) {
-	a := &storeInitArgs{}
+func declareStoreInitArgs(g *globalFlags) (*storeInitArgs, commandInput) {
+	a := &storeInitArgs{globalFlags: g}
 	return a, commandInput{
 		flags: []flagSpec{
-			profilesFileFlag(&a.profilesFile),
+			profilesFileFlag(&a.profilesFile, g),
 			boolFlag(&a.yes, "yes", false, "Initialize without confirmation prompt"),
 		},
 		positionals: []positionalSpec{optionalPositional(&a.name, "store name", "")},
@@ -324,6 +328,7 @@ func runStoreInit(r *runner, ctx context.Context, a *storeInitArgs) int {
 		return r.fail("Unknown store %q", a.name)
 	}
 	if err := checkOrInitStoreWithRecovery(r, ctx, cfg, a.name, a.profilesFile, checkOrInitOptions{
+		configDir:            a.configDir,
 		warnOnMissingSecrets: true,
 		offerInit:            true,
 		assumeYes:            a.yes,
@@ -334,6 +339,9 @@ func runStoreInit(r *runner, ctx context.Context, a *storeInitArgs) int {
 }
 
 type checkOrInitOptions struct {
+	// configDir is the resolved -config-dir, which the store's secret
+	// references are read relative to. See newSecretResolver.
+	configDir            string
 	allowMissingSecrets  bool
 	warnOnMissingSecrets bool
 	offerInit            bool
@@ -342,7 +350,7 @@ type checkOrInitOptions struct {
 
 func checkOrInitStore(r *runner, ctx context.Context, cfg *profile.Config, storeName, profilesFile string, opts checkOrInitOptions) error {
 	s := cfg.Stores[storeName]
-	resolved, err := clientConfigFromProfileStore(s)
+	resolved, err := clientConfigFromProfileStore(s, opts.configDir)
 	if err != nil {
 		if opts.allowMissingSecrets && isSecretNotFoundError(err) {
 			if opts.warnOnMissingSecrets {
@@ -467,7 +475,7 @@ func checkOrInitStoreWithRecovery(r *runner, ctx context.Context, cfg *profile.C
 // promptEncryptionConfig guides the user through encryption configuration
 // and saves the chosen settings to profiles.yaml. It does not build a keychain
 // or prompt for the actual password — that happens later during init.
-func (r *runner) promptEncryptionConfig(ctx context.Context, cfg *profile.Config, storeName, profilesFile string) {
+func (r *runner) promptEncryptionConfig(ctx context.Context, cfg *profile.Config, storeName, profilesFile, configDir string) {
 	_, _ = fmt.Fprintln(r.out)
 	_, _ = fmt.Fprintln(r.out, "No encryption is configured for this store.")
 
@@ -488,7 +496,9 @@ func (r *runner) promptEncryptionConfig(ctx context.Context, cfg *profile.Config
 		cfg.Stores[storeName],
 		storeName,
 		picked,
-		r.promptSecretReference,
+		func(ctx context.Context, storeName, secretLabel, defaultEnvName, defaultAccount string) (string, error) {
+			return r.promptSecretReference(ctx, configDir, storeName, secretLabel, defaultEnvName, defaultAccount)
+		},
 		r.promptLine,
 		r.out,
 	)
@@ -549,7 +559,7 @@ func configureStoreEncryptionSelection(
 	return s, nil
 }
 
-func (r *runner) promptSecretReference(ctx context.Context, storeName, secretLabel, defaultEnvName, defaultAccount string) (string, error) {
+func (r *runner) promptSecretReference(ctx context.Context, configDir, storeName, secretLabel, defaultEnvName, defaultAccount string) (string, error) {
 	return promptSecretReferenceWithFns(
 		ctx,
 		storeName,
@@ -560,7 +570,7 @@ func (r *runner) promptSecretReference(ctx context.Context, storeName, secretLab
 		func(ctx context.Context, l, d string) (string, error) { return r.promptLine(ctx, l, d) },
 		func(_ context.Context, s string) (string, error) { return r.promptSecret(ctx, s) },
 		os.LookupEnv,
-		profileSecretResolver,
+		newSecretResolver(configDir),
 	)
 }
 

--- a/cmd/cloudstic/cmd_store_test.go
+++ b/cmd/cloudstic/cmd_store_test.go
@@ -306,7 +306,7 @@ func TestCheckOrInitStore_AlreadyInitialized(t *testing.T) {
 
 	// Initialize the store first.
 	s := profile.Store{URI: "local:" + storePath}
-	sc, err := clientConfigFromProfileStore(s)
+	sc, err := clientConfigFromProfileStore(s, "")
 	if err != nil {
 		t.Fatalf("clientConfigFromProfileStore: %v", err)
 	}
@@ -345,7 +345,7 @@ func TestCheckOrInitStore_InitializedEncrypted_ValidCredentials(t *testing.T) {
 	storePath := filepath.Join(tmpDir, "store")
 
 	s := profile.Store{URI: "local:" + storePath}
-	sc, err := clientConfigFromProfileStore(s)
+	sc, err := clientConfigFromProfileStore(s, "")
 	if err != nil {
 		t.Fatalf("clientConfigFromProfileStore: %v", err)
 	}
@@ -385,7 +385,7 @@ func TestCheckOrInitStore_InitializedEncrypted_InvalidCredentials(t *testing.T) 
 	storePath := filepath.Join(tmpDir, "store")
 
 	s := profile.Store{URI: "local:" + storePath}
-	sc, err := clientConfigFromProfileStore(s)
+	sc, err := clientConfigFromProfileStore(s, "")
 	if err != nil {
 		t.Fatalf("clientConfigFromProfileStore: %v", err)
 	}
@@ -430,7 +430,7 @@ func TestClientConfigFromProfileStore_ResolvesEnvVars(t *testing.T) {
 		KMSKeyARN:         "arn:aws:kms:us-east-1:123:key/abc",
 	}
 
-	sc, err := clientConfigFromProfileStore(s)
+	sc, err := clientConfigFromProfileStore(s, "")
 	if err != nil {
 		t.Fatalf("clientConfigFromProfileStore: %v", err)
 	}
@@ -462,7 +462,7 @@ func TestClientConfigFromProfileStore_ResolvesSecretRef(t *testing.T) {
 		S3AccessKeySecret: "env://SECRET_AK",
 	}
 
-	sc, err := clientConfigFromProfileStore(s)
+	sc, err := clientConfigFromProfileStore(s, "")
 	if err != nil {
 		t.Fatalf("clientConfigFromProfileStore: %v", err)
 	}
@@ -477,7 +477,7 @@ func TestClientConfigFromProfileStore_InvalidSecretRefReturnsError(t *testing.T)
 		PasswordSecret: "env:/bad-format",
 	}
 
-	_, err := clientConfigFromProfileStore(s)
+	_, err := clientConfigFromProfileStore(s, "")
 	if err == nil {
 		t.Fatal("expected error for invalid secret ref")
 	}
@@ -1255,7 +1255,7 @@ func TestConfigureStoreEncryptionSelection_KMSError(t *testing.T) {
 
 func TestPromptSecretReference_EnvInteractive(t *testing.T) {
 	t.Setenv("MY_ENV", "set-for-test")
-	if len(profileSecretResolver.WritableBackends()) > 0 {
+	if len(newSecretResolver("").WritableBackends()) > 0 {
 		setInteractiveStdinLines(t, "1", "MY_ENV")
 	} else {
 		setInteractiveStdinLines(t, "MY_ENV")
@@ -1264,7 +1264,7 @@ func TestPromptSecretReference_EnvInteractive(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	got, err := r.promptSecretReference(context.Background(), "prod", "repository password", "CLOUDSTIC_PASSWORD", "password")
+	got, err := r.promptSecretReference(context.Background(), "", "prod", "repository password", "CLOUDSTIC_PASSWORD", "password")
 	if err != nil {
 		t.Fatalf("promptSecretReference: %v", err)
 	}
@@ -1284,7 +1284,7 @@ func TestPromptEncryptionConfig_PasswordViaEnvRef(t *testing.T) {
 		},
 	}
 
-	if len(profileSecretResolver.WritableBackends()) > 0 {
+	if len(newSecretResolver("").WritableBackends()) > 0 {
 		setInteractiveStdinLines(t, "1", "1", "MY_BACKUP_PASSWORD")
 	} else {
 		setInteractiveStdinLines(t, "1", "MY_BACKUP_PASSWORD")
@@ -1293,7 +1293,7 @@ func TestPromptEncryptionConfig_PasswordViaEnvRef(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	r.promptEncryptionConfig(context.Background(), cfg, "prod", profilesPath)
+	r.promptEncryptionConfig(context.Background(), cfg, "prod", profilesPath, "")
 
 	s := cfg.Stores["prod"]
 	if s.PasswordSecret != "env://MY_BACKUP_PASSWORD" {
@@ -1416,7 +1416,7 @@ func TestClientConfigFromProfileStore_DefaultRegion(t *testing.T) {
 	s := profile.Store{
 		URI: "s3:some-bucket",
 	}
-	sc, err := clientConfigFromProfileStore(s)
+	sc, err := clientConfigFromProfileStore(s, "")
 	if err != nil {
 		t.Fatalf("clientConfigFromProfileStore: %v", err)
 	}
@@ -1431,7 +1431,7 @@ func TestClientConfigFromProfileStore_DefaultRegion(t *testing.T) {
 // applying the default at construction must not override a region the profile
 // actually names.
 func TestClientConfigFromProfileStore_ExplicitRegionWins(t *testing.T) {
-	sc, err := clientConfigFromProfileStore(profile.Store{URI: "s3:some-bucket", S3Region: "eu-west-3"})
+	sc, err := clientConfigFromProfileStore(profile.Store{URI: "s3:some-bucket", S3Region: "eu-west-3"}, "")
 	if err != nil {
 		t.Fatalf("clientConfigFromProfileStore: %v", err)
 	}
@@ -1446,7 +1446,7 @@ func TestClientConfigFromProfileStore_SFTPFields(t *testing.T) {
 		StoreSFTPPassword: "direct-pw",
 		StoreSFTPKey:      "/path/to/key",
 	}
-	sc, err := clientConfigFromProfileStore(s)
+	sc, err := clientConfigFromProfileStore(s, "")
 	if err != nil {
 		t.Fatalf("clientConfigFromProfileStore: %v", err)
 	}

--- a/cmd/cloudstic/cmd_tui.go
+++ b/cmd/cloudstic/cmd_tui.go
@@ -5,15 +5,16 @@ import (
 )
 
 type tuiArgs struct {
+	*globalFlags
 	profilesFile string
 }
 
-func declareTUIArgs(_ *globalFlags) (*tuiArgs, commandInput) {
-	// tui opts into no global groups; it reads only its own -profiles-file.
-	a := &tuiArgs{}
+func declareTUIArgs(g *globalFlags) (*tuiArgs, commandInput) {
+	// tui opts into no global *groups*; it reads only its own -profiles-file
+	// and the base flags every command gets, which is where -config-dir lives.
+	a := &tuiArgs{globalFlags: g}
 	return a, commandInput{flags: []flagSpec{
-		stringFlag(&a.profilesFile, "profiles-file", defaultProfilesPathNoCreate(), "Path to profiles YAML file",
-			withEnv("CLOUDSTIC_PROFILES_FILE"), withPlaceholder("<path>"), withCompleter("_files")),
+		profilesFileFlag(&a.profilesFile, g),
 	}}
 }
 
@@ -21,7 +22,7 @@ func runTUI(r *runner, ctx context.Context, args *tuiArgs) int {
 	if !r.canPrompt() {
 		return r.fail("cloudstic tui requires an interactive terminal")
 	}
-	return runTUIProgram(r, ctx, args.profilesFile)
+	return runTUIProgram(r, ctx, args.profilesFile, args.configDir)
 }
 
 // tuiCommand declares the `tui` command.

--- a/cmd/cloudstic/cmd_tui_activity.go
+++ b/cmd/cloudstic/cmd_tui_activity.go
@@ -203,8 +203,8 @@ func (p tuiReporterPhase) Error() {
 
 // tuiStoreConfig resolves a store definition into a client configuration for
 // the TUI, which addresses stores by name and never parses command-line flags.
-func tuiClientConfig(storeCfg profile.Store) (clientConfig, error) {
-	cfg, err := clientConfigFromProfileStore(storeCfg)
+func tuiClientConfig(storeCfg profile.Store, configDir string) (clientConfig, error) {
+	cfg, err := clientConfigFromProfileStore(storeCfg, configDir)
 	if err != nil {
 		return clientConfig{}, err
 	}

--- a/cmd/cloudstic/cmd_tui_forms_backend.go
+++ b/cmd/cloudstic/cmd_tui_forms_backend.go
@@ -16,11 +16,12 @@ import (
 type tuiFormsBackend struct {
 	r            *runner
 	profilesFile string
+	configDir    string
 	cfg          *profile.Config
 }
 
-func newTUIFormsBackend(r *runner, profilesFile string, cfg *profile.Config) *tuiFormsBackend {
-	return &tuiFormsBackend{r: r, profilesFile: profilesFile, cfg: cfg}
+func newTUIFormsBackend(r *runner, profilesFile, configDir string, cfg *profile.Config) *tuiFormsBackend {
+	return &tuiFormsBackend{r: r, profilesFile: profilesFile, configDir: configDir, cfg: cfg}
 }
 
 var _ tui.FormsBackend = (*tuiFormsBackend)(nil)
@@ -93,11 +94,11 @@ func (b *tuiFormsBackend) SaveProfile(name, sourceURI, storeRef, authRef string,
 	profile.Source = sourceURI
 	profile.Store = storeRef
 	profile.AuthRef = authRef
-	return tuiServiceFactory(nil, b.profilesFile).SaveProfile(b.profilesFile, name, profile)
+	return tuiServiceFactory(nil, b.profilesFile, b.configDir).SaveProfile(b.profilesFile, name, profile)
 }
 
 func (b *tuiFormsBackend) DeleteProfile(name string) error {
-	return tuiServiceFactory(nil, b.profilesFile).DeleteProfile(b.profilesFile, name)
+	return tuiServiceFactory(nil, b.profilesFile, b.configDir).DeleteProfile(b.profilesFile, name)
 }
 
 func (b *tuiFormsBackend) Reload() (*profile.Config, error) {

--- a/cmd/cloudstic/cmd_tui_run.go
+++ b/cmd/cloudstic/cmd_tui_run.go
@@ -32,8 +32,8 @@ var tuiLoadConfig = func(profilesFile string) (*profile.Config, error) {
 
 var tuiServiceFactory = defaultTUIServiceFactory
 
-func defaultTUIServiceFactory(r *runner, profilesFile string) *app.TUIService {
-	return app.NewTUIService(tuiCLIBackend{r: r, profilesFile: profilesFile})
+func defaultTUIServiceFactory(r *runner, profilesFile, configDir string) *app.TUIService {
+	return app.NewTUIService(tuiCLIBackend{r: r, profilesFile: profilesFile, configDir: configDir})
 }
 
 // runTUIProgram launches the dashboard. It builds a probe-less dashboard
@@ -41,7 +41,7 @@ func defaultTUIServiceFactory(r *runner, profilesFile string) *app.TUIService {
 // serially before the first frame. Bubble Tea owns the terminal: raw mode, the
 // alternate screen, mouse tracking, and resize handling are all cross-platform
 // (issue #341).
-func runTUIProgram(r *runner, ctx context.Context, profilesFile string) int {
+func runTUIProgram(r *runner, ctx context.Context, profilesFile, configDir string) int {
 	cfg, err := tuiLoadConfig(profilesFile)
 	if err != nil {
 		return r.fail("Failed to load profiles: %v", err)
@@ -49,9 +49,9 @@ func runTUIProgram(r *runner, ctx context.Context, profilesFile string) int {
 
 	skeleton := tui.BuildDashboard(cfg, nil)
 	model := tui.NewModel(skeleton).
-		WithConfig(cfg, tuiStoreProber{r: r}).
-		WithRunner(tuiActionRunner{r: r, profilesFile: profilesFile}).
-		WithForms(newTUIFormsBackend(r, profilesFile, cfg))
+		WithConfig(cfg, tuiStoreProber{r: r, configDir: configDir}).
+		WithRunner(tuiActionRunner{r: r, profilesFile: profilesFile, configDir: configDir}).
+		WithForms(newTUIFormsBackend(r, profilesFile, configDir, cfg))
 
 	stdin := r.stdin
 	if stdin == nil {
@@ -74,10 +74,11 @@ func runTUIProgram(r *runner, ctx context.Context, profilesFile string) int {
 type tuiCLIBackend struct {
 	r            *runner
 	profilesFile string
+	configDir    string
 }
 
 func (b tuiCLIBackend) LoadStoreSnapshots(ctx context.Context, storeName string, storeCfg profile.Store) ([]engine.SnapshotEntry, error) {
-	cfg, err := tuiClientConfig(storeCfg)
+	cfg, err := tuiClientConfig(storeCfg, b.configDir)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", storeName, err)
 	}
@@ -97,7 +98,7 @@ func (b tuiCLIBackend) InitProfile(ctx context.Context, profilesFile, profileNam
 	if !ok {
 		return fmt.Errorf("profile %q references unknown store %q", profileName, profileCfg.Store)
 	}
-	resolved, err := tuiClientConfig(storeCfg)
+	resolved, err := tuiClientConfig(storeCfg, b.configDir)
 	if err != nil {
 		return err
 	}
@@ -109,7 +110,7 @@ func (b tuiCLIBackend) InitProfile(ctx context.Context, profilesFile, profileNam
 }
 
 func (b tuiCLIBackend) BackupProfile(ctx context.Context, profilesFile, profileName string, profileCfg profile.Profile, cfg *profile.Config, reporter cloudstic.Reporter) error {
-	g := &globalFlags{profile: profileName, profilesFile: profilesFile, quiet: true}
+	g := &globalFlags{profile: profileName, profilesFile: profilesFile, configDir: b.configDir, quiet: true}
 	base := &backupArgs{globalFlags: g}
 	effective, err := mergeProfileBackupArgs(base, profileName, profileCfg, cfg)
 	if err != nil {
@@ -136,7 +137,7 @@ func (b tuiCLIBackend) CheckProfile(ctx context.Context, profilesFile, profileNa
 	if !ok {
 		return fmt.Errorf("profile %q references unknown store %q", profileName, profileCfg.Store)
 	}
-	resolved, err := tuiClientConfig(storeCfg)
+	resolved, err := tuiClientConfig(storeCfg, b.configDir)
 	if err != nil {
 		return err
 	}
@@ -157,11 +158,12 @@ func (b tuiCLIBackend) CheckProfile(ctx context.Context, profilesFile, profileNa
 // tuiStoreProber probes a single store's health by listing its snapshots,
 // bounded by the per-store timeout the model applies.
 type tuiStoreProber struct {
-	r *runner
+	r         *runner
+	configDir string
 }
 
 func (p tuiStoreProber) Probe(ctx context.Context, name string, store profile.Store) tui.StoreProbe {
-	snapshots, err := (tuiCLIBackend{r: p.r}).LoadStoreSnapshots(ctx, name, store)
+	snapshots, err := (tuiCLIBackend{r: p.r, configDir: p.configDir}).LoadStoreSnapshots(ctx, name, store)
 	if err != nil {
 		return tui.StoreProbe{Status: "error", Error: err.Error()}
 	}
@@ -174,6 +176,7 @@ func (p tuiStoreProber) Probe(ctx context.Context, name string, store profile.St
 type tuiActionRunner struct {
 	r            *runner
 	profilesFile string
+	configDir    string
 }
 
 func (a tuiActionRunner) Start(ctx context.Context, profile tui.ProfileCard, kind tui.ActionKind) <-chan tui.ActionUpdate {
@@ -203,7 +206,7 @@ func (a tuiActionRunner) Start(ctx context.Context, profile tui.ProfileCard, kin
 			}
 		})
 
-		service := tuiServiceFactory(a.r, a.profilesFile)
+		service := tuiServiceFactory(a.r, a.profilesFile, a.configDir)
 		var err error
 		if kind == tui.ActionKindCheck {
 			err = service.RunProfileCheck(ctx, a.profilesFile, profile, log.Reporter())

--- a/cmd/cloudstic/cmd_tui_run_test.go
+++ b/cmd/cloudstic/cmd_tui_run_test.go
@@ -22,7 +22,7 @@ func TestRunTUIProgram_Success(t *testing.T) {
 	defer restoreCfg()
 
 	r := &runner{out: &strings.Builder{}, errOut: &strings.Builder{}}
-	if code := runTUIProgram(r, context.Background(), "profiles.yaml"); code != 0 {
+	if code := runTUIProgram(r, context.Background(), "profiles.yaml", ""); code != 0 {
 		t.Fatalf("exit code=%d want 0", code)
 	}
 }
@@ -39,7 +39,7 @@ func TestRunTUIProgram_ProgramError(t *testing.T) {
 
 	errOut := &strings.Builder{}
 	r := &runner{out: &strings.Builder{}, errOut: errOut}
-	if code := runTUIProgram(r, context.Background(), "profiles.yaml"); code == 0 {
+	if code := runTUIProgram(r, context.Background(), "profiles.yaml", ""); code == 0 {
 		t.Fatalf("exit code=0 want non-zero on error")
 	}
 	if !strings.Contains(errOut.String(), "boom") {
@@ -55,7 +55,7 @@ func TestRunTUIProgram_ConfigError(t *testing.T) {
 
 	errOut := &strings.Builder{}
 	r := &runner{out: &strings.Builder{}, errOut: errOut}
-	if code := runTUIProgram(r, context.Background(), "profiles.yaml"); code == 0 {
+	if code := runTUIProgram(r, context.Background(), "profiles.yaml", ""); code == 0 {
 		t.Fatalf("exit code=0 want non-zero on config error")
 	}
 	if !strings.Contains(errOut.String(), "bad config") {

--- a/cmd/cloudstic/cmd_tui_secret_backend.go
+++ b/cmd/cloudstic/cmd_tui_secret_backend.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/cloudstic/cli/pkg/secretref"
-	secretrefbackends "github.com/cloudstic/cli/pkg/secretref/backends"
 )
 
 // Secret-ref form backend (tui/forms.SecretBackend), implemented over the
@@ -15,7 +14,7 @@ func (b *tuiFormsBackend) secretResolver() *secretref.Resolver {
 	if tuiSecretResolver != nil {
 		return tuiSecretResolver
 	}
-	return secretrefbackends.NewDefaultResolver()
+	return newSecretResolver(b.configDir)
 }
 
 func (b *tuiFormsBackend) StorageOptions() []string {

--- a/cmd/cloudstic/cmd_tui_store_backend.go
+++ b/cmd/cloudstic/cmd_tui_store_backend.go
@@ -95,7 +95,7 @@ func (b *tuiFormsBackend) SaveStore(name string, values map[string]string, editi
 	applyStoreConnectionValues(&store, values)
 	applyStoreEncryptionValues(&store, values)
 
-	if err := tuiServiceFactory(nil, b.profilesFile).SaveStore(b.profilesFile, name, store); err != nil {
+	if err := tuiServiceFactory(nil, b.profilesFile, b.configDir).SaveStore(b.profilesFile, name, store); err != nil {
 		return err
 	}
 	// Refresh the cache so the profile form's store selector immediately sees

--- a/cmd/cloudstic/cmd_tui_store_form.go
+++ b/cmd/cloudstic/cmd_tui_store_form.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/cloudstic/cli/pkg/profile"
+	"github.com/cloudstic/cli/pkg/secretref"
 )
 
 // Store-form domain helpers shared by the dashboard's store and secret backends
@@ -27,7 +28,10 @@ const (
 	tuiStoreEncryptionKMS      tuiStoreEncryptionMode = "kms"
 )
 
-var tuiSecretResolver = profileSecretResolver
+// tuiSecretResolver overrides the resolver the TUI forms use. Nil — the
+// normal case — means "build one from the resolved -config-dir"; tests set it
+// to a fake so a form can be exercised without touching a real keychain.
+var tuiSecretResolver *secretref.Resolver
 
 func newTUIStoreConfig(raw string) tuiStoreConfig {
 	parts, err := config.ParseStoreURI(raw)

--- a/cmd/cloudstic/cmd_tui_test.go
+++ b/cmd/cloudstic/cmd_tui_test.go
@@ -72,7 +72,7 @@ func newTestFormsBackend(t *testing.T, cfg *profile.Config) (*tuiFormsBackend, s
 	if err != nil {
 		t.Fatalf("tuiLoadConfig: %v", err)
 	}
-	return newTUIFormsBackend(&runner{out: io.Discard, errOut: io.Discard}, path, loaded), path
+	return newTUIFormsBackend(&runner{out: io.Discard, errOut: io.Discard}, path, "", loaded), path
 }
 
 func TestInitialStoreValues_PopulatesExistingSecretFields(t *testing.T) {

--- a/cmd/cloudstic/completion_dynamic.go
+++ b/cmd/cloudstic/completion_dynamic.go
@@ -77,15 +77,40 @@ func completionLoadProfilesConfig(path string) (*profile.Config, error) {
 	return cfg, nil
 }
 
+// completionProfilesPath finds the profiles file a completion request should
+// read, from the partial command line the shell passed along.
+//
+// It mirrors the real resolution — explicit -profiles-file, then
+// CLOUDSTIC_PROFILES_FILE, then a path inside the config directory that
+// -config-dir or CLOUDSTIC_CONFIG_DIR may move — but reimplements it over a
+// throwaway flag set rather than reusing the dispatcher, because the arguments
+// here are an incomplete command line that would not parse.
+//
+// A path that cannot be resolved yields "", which loads no profiles and offers
+// no candidates. Completion never reports errors: the shell has nowhere to
+// show them.
 func completionProfilesPath(args []string) string {
 	fs := flag.NewFlagSet("__complete", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	defaultPath := envDefault("CLOUDSTIC_PROFILES_FILE", defaultProfilesPathFallback())
-	profilesFile := fs.String("profiles-file", defaultPath, "")
+	profilesFile := fs.String("profiles-file", "", "")
+	configDir := fs.String("config-dir", "", "")
 	_ = fs.Parse(filterCompletionFlags(args, map[string]bool{
 		"profiles-file": true,
+		"config-dir":    true,
 	}))
-	return *profilesFile
+	if *profilesFile != "" {
+		return *profilesFile
+	}
+	if fromEnv := lookupEnv("CLOUDSTIC_PROFILES_FILE"); fromEnv != "" {
+		return fromEnv
+	}
+	// An empty -config-dir falls through to CLOUDSTIC_CONFIG_DIR inside
+	// paths.ConfigDir, so the flag still wins where it was given.
+	path, err := defaultProfilesPath(*configDir)
+	if err != nil {
+		return ""
+	}
+	return path
 }
 
 func filterCompletionFlags(args []string, specs map[string]bool) []string {

--- a/cmd/cloudstic/config.go
+++ b/cmd/cloudstic/config.go
@@ -106,7 +106,7 @@ func resolveClientConfig(g *globalFlags) (clientConfig, error) {
 	if s == nil {
 		return cfg, nil
 	}
-	if err := applyProfileStore(&cfg, *s, g.flagProvided); err != nil {
+	if err := applyProfileStore(&cfg, *s, g.configDir, g.flagProvided); err != nil {
 		return clientConfig{}, err
 	}
 	return cfg, nil
@@ -160,8 +160,8 @@ func lookupProfileStore(cfg *profile.Config, profileName string, p profile.Profi
 // applyExistingStoreDefaults (store_builder_helpers.go), which prefills
 // `store new`'s flags from an existing store entry for editing — an unrelated
 // concept despite the similar name.
-func clientConfigFromProfileStore(s profile.Store) (clientConfig, error) {
-	return config.FromProfileStore(context.Background(), s, profileSecretResolver)
+func clientConfigFromProfileStore(s profile.Store, configDir string) (clientConfig, error) {
+	return config.FromProfileStore(context.Background(), s, newSecretResolver(configDir))
 }
 
 // applyProfileStore folds a profile's store definition into cfg, with any flag
@@ -180,6 +180,6 @@ func clientConfigFromProfileStore(s profile.Store) (clientConfig, error) {
 // field types differ enough (bools, string slices, multi-field auth
 // resolution vs. plain strings here) that forcing a shared table would
 // obscure more than it clarifies.
-func applyProfileStore(cfg *clientConfig, s profile.Store, provided func(string) bool) error {
-	return config.ApplyProfileStore(context.Background(), cfg, s, profileSecretResolver, provided)
+func applyProfileStore(cfg *clientConfig, s profile.Store, configDir string, provided func(string) bool) error {
+	return config.ApplyProfileStore(context.Background(), cfg, s, newSecretResolver(configDir), provided)
 }

--- a/cmd/cloudstic/flags.go
+++ b/cmd/cloudstic/flags.go
@@ -14,6 +14,7 @@ const defaultS3Region = "us-east-1"
 
 type globalFlags struct {
 	store                             string
+	configDir                         string
 	profile, profilesFile             string
 	s3Endpoint, s3Region, s3Profile   string
 	s3AccessKey, s3SecretKey          string
@@ -42,10 +43,6 @@ type globalFlags struct {
 
 // repoFlagSpecs covers locating and addressing the repository itself.
 func repoFlagSpecs(g *globalFlags) []flagSpec {
-	defaultProfilesPath, err := defaultProfilesPath()
-	if err != nil {
-		defaultProfilesPath = defaultProfilesFilename
-	}
 	return []flagSpec{
 		stringFlag(&g.store, "store", "local:./backup_store",
 			"Storage backend URI: local:<path>, s3:<bucket>[/<prefix>], b2:<bucket>[/<prefix>], sftp://[user@]host[:port]/<path>",
@@ -53,8 +50,7 @@ func repoFlagSpecs(g *globalFlags) []flagSpec {
 			withShortUsage("Storage backend URI")),
 		stringFlag(&g.profile, "profile", "", "Profile name from profiles.yaml",
 			withEnv("CLOUDSTIC_PROFILE"), withPlaceholder("<name>"), withCompleter("_cloudstic_profile_names")),
-		stringFlag(&g.profilesFile, "profiles-file", defaultProfilesPath, "Path to profiles YAML file",
-			withEnv("CLOUDSTIC_PROFILES_FILE"), withPlaceholder("<path>"), withCompleter("_files")),
+		profilesFileFlag(&g.profilesFile, g),
 		stringFlag(&g.s3Endpoint, "s3-endpoint", "", "S3 compatible endpoint URL (for MinIO, R2, etc.)",
 			withEnv("CLOUDSTIC_S3_ENDPOINT"), withPlaceholder("<url>"),
 			withShortUsage("S3 compatible endpoint URL")),
@@ -140,8 +136,14 @@ func outputFlagSpecs(g *globalFlags) []flagSpec {
 }
 
 // baseFlagSpecs are accepted by every runnable command.
+//
+// -config-dir belongs here rather than in a narrower group because every
+// command can reach the config directory: it holds the profiles file, cached
+// OAuth tokens, and the config-token secret backend's managed store.
 func baseFlagSpecs(g *globalFlags) []flagSpec {
 	return []flagSpec{
+		stringFlag(&g.configDir, "config-dir", "", "Directory for profiles, tokens, and other state",
+			withEnv("CLOUDSTIC_CONFIG_DIR"), withPlaceholder("<path>"), withCompleter("_files")),
 		boolFlag(&g.noPrompt, "no-prompt", false, "Disable interactive prompts (for scripts and CI)"),
 	}
 }
@@ -210,6 +212,11 @@ func (c commandFlags) parse(args []string) error {
 	// flags still win and help output never sees them.
 	origins, err := applyEnvDefaults(fs, c.specs())
 	if err != nil {
+		return err
+	}
+	// Defaults that depend on another flag resolve last, once every flag has
+	// its final value — see applyLateDefaults.
+	if err := applyLateDefaults(c.specs(), origins); err != nil {
 		return err
 	}
 	// Recording provenance lets later stages (profile overrides) distinguish an

--- a/cmd/cloudstic/flagspec.go
+++ b/cmd/cloudstic/flagspec.go
@@ -47,10 +47,16 @@ type flagSpec struct {
 	// Environment values are applied after parsing so that help output can
 	// never render a live environment value (see applyEnvDefaults).
 	bind func(fs *flag.FlagSet)
-	// applyEnv sets the flag's target from a raw environment value, returning
-	// an actionable error when the value cannot be parsed. Nil when the flag
-	// has no environment binding.
-	applyEnv func(raw string) error
+	// setValue sets the flag's target from a raw string, returning an
+	// actionable error when the value cannot be parsed. It serves both of the
+	// after-parsing resolution steps — environment values and late defaults —
+	// since both arrive as text and both need the same parse. Nil for a flag
+	// backed by a custom flag.Value, which owns its own parsing.
+	setValue func(raw string) error
+	// lateDefault computes the flag's default value after parsing, for a
+	// default that depends on another flag. Nil for the ordinary case of a
+	// constant default passed to bind. See withLateDefault.
+	lateDefault func() (string, error)
 }
 
 // flagOpt customises a flagSpec at construction time.
@@ -94,6 +100,21 @@ func withPlaceholder(name string) flagOpt {
 	return func(s *flagSpec) { s.placeholder = name }
 }
 
+// withLateDefault supplies a default computed after parsing, for a flag whose
+// default depends on another flag's resolved value — -profiles-file, which
+// lives inside whatever -config-dir names.
+//
+// It runs only when the flag was left at its built-in default: an explicit
+// flag and an environment value both still win, and neither pays for the
+// computation. Resolving late is also what keeps the computation off the paths
+// that merely *describe* the flag. Help and completion build a command's flag
+// set without parsing it, so a default computed at declaration time runs on
+// `-h` — which is how resolving the profiles path used to create the config
+// directory as a side effect of being asked for help.
+func withLateDefault(fn func() (string, error)) flagOpt {
+	return func(s *flagSpec) { s.lateDefault = fn }
+}
+
 func applyOpts(s *flagSpec, opts []flagOpt) *flagSpec {
 	for _, opt := range opts {
 		opt(s)
@@ -109,7 +130,7 @@ func stringFlag(target *string, name, def, usage string, opts ...flagOpt) flagSp
 	spec.bind = func(fs *flag.FlagSet) {
 		fs.StringVar(target, name, def, spec.bindUsage())
 	}
-	spec.applyEnv = func(raw string) error {
+	spec.setValue = func(raw string) error {
 		*target = raw
 		return nil
 	}
@@ -123,7 +144,7 @@ func boolFlag(target *bool, name string, def bool, usage string, opts ...flagOpt
 	spec.bind = func(fs *flag.FlagSet) {
 		fs.BoolVar(target, name, def, spec.bindUsage())
 	}
-	spec.applyEnv = func(raw string) error {
+	spec.setValue = func(raw string) error {
 		parsed, err := strconv.ParseBool(raw)
 		if err != nil {
 			return fmt.Errorf("invalid boolean value %q: use true or false", raw)
@@ -141,7 +162,7 @@ func intFlag(target *int, name string, def int, usage string, opts ...flagOpt) f
 	spec.bind = func(fs *flag.FlagSet) {
 		fs.IntVar(target, name, def, spec.bindUsage())
 	}
-	spec.applyEnv = func(raw string) error {
+	spec.setValue = func(raw string) error {
 		parsed, err := strconv.Atoi(raw)
 		if err != nil {
 			return fmt.Errorf("invalid integer value %q", raw)
@@ -222,13 +243,13 @@ func applyEnvDefaults(fs *flag.FlagSet, specs []flagSpec) (map[string]flagOrigin
 		switch {
 		case explicit[s.name]:
 			origins[s.name] = originFlag
-		case s.env != "" && s.applyEnv != nil:
+		case s.env != "" && s.setValue != nil:
 			raw := lookupEnv(s.env)
 			if raw == "" {
 				origins[s.name] = originDefault
 				continue
 			}
-			if err := s.applyEnv(raw); err != nil {
+			if err := s.setValue(raw); err != nil {
 				return nil, fmt.Errorf("environment variable %s: %w", s.env, err)
 			}
 			origins[s.name] = originEnv
@@ -237,6 +258,33 @@ func applyEnvDefaults(fs *flag.FlagSet, specs []flagSpec) (map[string]flagOrigin
 		}
 	}
 	return origins, nil
+}
+
+// applyLateDefaults computes the default of every flag that declares one and
+// is still sitting at its built-in value.
+//
+// It runs as a separate pass after applyEnvDefaults rather than inside it,
+// because a late default reads other flags: -profiles-file's default is a path
+// inside -config-dir, which is only correct once every flag has taken its
+// final value. Folding the two together would make the result depend on the
+// order specs happen to be declared in.
+//
+// The origin stays originDefault, which is what it is — the user chose
+// nothing, so a profile is still free to override the value.
+func applyLateDefaults(specs []flagSpec, origins map[string]flagOrigin) error {
+	for _, s := range specs {
+		if s.lateDefault == nil || s.setValue == nil || origins[s.name] != originDefault {
+			continue
+		}
+		value, err := s.lateDefault()
+		if err != nil {
+			return fmt.Errorf("resolve default for -%s: %w", s.name, err)
+		}
+		if err := s.setValue(value); err != nil {
+			return fmt.Errorf("resolve default for -%s: %w", s.name, err)
+		}
+	}
+	return nil
 }
 
 // bindFlags registers every spec on fs, in declaration order.

--- a/cmd/cloudstic/flagspec_test.go
+++ b/cmd/cloudstic/flagspec_test.go
@@ -67,6 +67,95 @@ func TestExplicitFlagBeatsEnv(t *testing.T) {
 	}
 }
 
+// A late default fills in only where the user chose nothing, so it sits below
+// both an explicit flag and an environment value in the same precedence order
+// every other default obeys.
+func TestLateDefaultRunsOnlyWhenNothingElseSuppliedAValue(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		env  map[string]string
+		args []string
+		want string
+	}{
+		{"nothing supplied", map[string]string{}, nil, "from-late-default"},
+		{"env wins", map[string]string{"CLOUDSTIC_TEST_VALUE": "from-env"}, nil, "from-env"},
+		{"flag wins", map[string]string{"CLOUDSTIC_TEST_VALUE": "from-env"}, []string{"-thing", "from-flag"}, "from-flag"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			withFakeEnv(t, tc.env)
+
+			var target string
+			called := 0
+			spec := stringFlag(&target, "thing", "", "usage",
+				withEnv("CLOUDSTIC_TEST_VALUE"),
+				withLateDefault(func() (string, error) {
+					called++
+					return "from-late-default", nil
+				}))
+			fs := flag.NewFlagSet("t", flag.ContinueOnError)
+			bindFlags(fs, []flagSpec{spec})
+			b := commandFlags{set: fs, own: []flagSpec{spec}}
+			if err := b.parse(tc.args); err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if target != tc.want {
+				t.Errorf("target=%q want %q", target, tc.want)
+			}
+			// Not merely overridden afterwards: a late default that is not
+			// needed must never run, since computing it can touch the
+			// filesystem or fail.
+			if wantCalls := map[bool]int{true: 1, false: 0}[tc.want == "from-late-default"]; called != wantCalls {
+				t.Errorf("lateDefault called %d times, want %d", called, wantCalls)
+			}
+		})
+	}
+}
+
+// A late default that cannot be computed fails the command rather than
+// silently leaving the flag empty — an empty profiles path would read as "no
+// profiles configured" instead of an error.
+func TestLateDefaultErrorFailsParse(t *testing.T) {
+	withFakeEnv(t, map[string]string{})
+
+	var target string
+	spec := stringFlag(&target, "thing", "", "usage",
+		withLateDefault(func() (string, error) { return "", os.ErrPermission }))
+	fs := flag.NewFlagSet("t", flag.ContinueOnError)
+	bindFlags(fs, []flagSpec{spec})
+	b := commandFlags{set: fs, own: []flagSpec{spec}}
+	err := b.parse(nil)
+	if err == nil {
+		t.Fatal("parse succeeded, want an error")
+	}
+	if !strings.Contains(err.Error(), "-thing") {
+		t.Errorf("error %q does not name the flag it came from", err)
+	}
+}
+
+// -profiles-file's default lives inside -config-dir, which is the whole reason
+// late defaults exist. Both orderings are exercised because the two flags are
+// declared in different groups.
+func TestProfilesFileDefaultFollowsConfigDirFlag(t *testing.T) {
+	for _, args := range [][]string{
+		{"-config-dir", "/tmp/cloudstic-late-default"},
+		{"-config-dir=/tmp/cloudstic-late-default"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			withFakeEnv(t, map[string]string{})
+
+			g := &globalFlags{}
+			cf := newCommandFlags("t", repoCommandGroups, g, commandInput{})
+			if err := cf.parse(args); err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			want := filepath.Join("/tmp/cloudstic-late-default", defaultProfilesFilename)
+			if g.profilesFile != want {
+				t.Errorf("profilesFile=%q want %q", g.profilesFile, want)
+			}
+		})
+	}
+}
+
 // TestBoolFlagAcceptsParseBoolSpellings documents that boolean environment
 // values go through strconv.ParseBool, so "TRUE"/"yes"-style values behave
 // predictably rather than silently reading as false.

--- a/cmd/cloudstic/profile_builder_helpers.go
+++ b/cmd/cloudstic/profile_builder_helpers.go
@@ -17,17 +17,19 @@ func validateRefName(kind, name string) error {
 	return nil
 }
 
-func defaultProfilesPathFallback() string {
-	defaultPath, err := defaultProfilesPath()
-	if err != nil {
-		return defaultProfilesFilename
-	}
-	return defaultPath
-}
-
-func profilesFileFlag(target *string) flagSpec {
-	return stringFlag(target, "profiles-file", defaultProfilesPathFallback(), "Path to profiles YAML file",
-		withEnv("CLOUDSTIC_PROFILES_FILE"), withPlaceholder("<path>"), withCompleter("_files"))
+// profilesFileFlag declares -profiles-file, wherever it appears: as a global
+// flag on repository commands, and as its own flag on the commands that manage
+// the profiles file without opening a repository.
+//
+// The default is a path inside the config directory, so it can only be
+// computed once -config-dir has taken its final value — hence withLateDefault
+// rather than a default passed in here. That is also why the declaration takes
+// g: the two flags are resolved together, and this is the one place that
+// relationship is written down.
+func profilesFileFlag(target *string, g *globalFlags) flagSpec {
+	return stringFlag(target, "profiles-file", "", "Path to profiles YAML file",
+		withEnv("CLOUDSTIC_PROFILES_FILE"), withPlaceholder("<path>"), withCompleter("_files"),
+		withLateDefault(func() (string, error) { return defaultProfilesPath(g.configDir) }))
 }
 
 func loadProfilesOrInit(path string) (*profile.Config, error) {

--- a/cmd/cloudstic/profile_secret.go
+++ b/cmd/cloudstic/profile_secret.go
@@ -1,12 +1,30 @@
 package main
 
-import secretrefbackends "github.com/cloudstic/cli/pkg/secretref/backends"
+import (
+	"github.com/cloudstic/cli/pkg/secretref"
+	secretrefbackends "github.com/cloudstic/cli/pkg/secretref/backends"
+)
 
-// profileSecretResolver is the set of secret-reference schemes this CLI
-// understands. pkg/config takes a resolver as a parameter rather than
-// defaulting to one, so choosing it is the composition root's job — which for
-// this binary means here.
+// newSecretResolver builds the set of secret-reference schemes this CLI
+// understands, with the config-token backend pointed at configDir.
 //
+// pkg/config takes a resolver as a parameter rather than defaulting to one, so
+// choosing it is the composition root's job — which for this binary means here.
 // Default() returns a fresh map, so a build that wanted an extra scheme would
 // add to it here rather than this being the only set anyone can have.
-var profileSecretResolver = secretrefbackends.NewDefaultResolver()
+//
+// It is a function rather than a package-level value because the answer
+// depends on -config-dir: config-token:// references name a token in the
+// config directory's managed store, so pointing the CLI at a different
+// directory has to point those references there too. A process-wide value
+// would have to be reassigned after flag parsing, which is the kind of
+// write-once-and-hope global RFC 0022 §8 argues against creating.
+//
+// configDir carries paths.ConfigDir's meaning: empty means "use
+// CLOUDSTIC_CONFIG_DIR or the platform default".
+func newSecretResolver(configDir string) *secretref.Resolver {
+	backends := secretrefbackends.Default()
+	backends["config-token"] = secretrefbackends.NewConfigTokenBackend(
+		secretrefbackends.WithConfigDir(configDir))
+	return secretref.NewResolver(backends)
+}

--- a/cmd/cloudstic/testdata/help_check.golden
+++ b/cmd/cloudstic/testdata/help_check.golden
@@ -11,6 +11,7 @@ OPTIONS
     -read-data                     Re-hash all chunk data for full byte-level verification
 
 GLOBAL OPTIONS (also settable via environment variables)
+    -config-dir <path>             Directory for profiles, tokens, and other state  [env: CLOUDSTIC_CONFIG_DIR]
     -no-prompt                     Disable interactive prompts (for scripts and CI)
     -store <uri>                   Storage backend URI: local:<path>, s3:<bucket>[/<prefix>], b2:<bucket>[/<prefix>], sftp://[user@]host[:port]/<path>  [env: CLOUDSTIC_STORE]
     -profile <name>                Profile name from profiles.yaml  [env: CLOUDSTIC_PROFILE]

--- a/cmd/cloudstic/testdata/help_find.golden
+++ b/cmd/cloudstic/testdata/help_find.golden
@@ -30,6 +30,7 @@ OPTIONS
     -no-delta                      Walk every snapshot in full instead of diffing consecutive ones
 
 GLOBAL OPTIONS (also settable via environment variables)
+    -config-dir <path>             Directory for profiles, tokens, and other state  [env: CLOUDSTIC_CONFIG_DIR]
     -no-prompt                     Disable interactive prompts (for scripts and CI)
     -store <uri>                   Storage backend URI: local:<path>, s3:<bucket>[/<prefix>], b2:<bucket>[/<prefix>], sftp://[user@]host[:port]/<path>  [env: CLOUDSTIC_STORE]
     -profile <name>                Profile name from profiles.yaml  [env: CLOUDSTIC_PROFILE]

--- a/cmd/cloudstic/testdata/help_list.golden
+++ b/cmd/cloudstic/testdata/help_list.golden
@@ -8,6 +8,7 @@ OPTIONS
     -group                         Group snapshots by source identity
 
 GLOBAL OPTIONS (also settable via environment variables)
+    -config-dir <path>             Directory for profiles, tokens, and other state  [env: CLOUDSTIC_CONFIG_DIR]
     -no-prompt                     Disable interactive prompts (for scripts and CI)
     -store <uri>                   Storage backend URI: local:<path>, s3:<bucket>[/<prefix>], b2:<bucket>[/<prefix>], sftp://[user@]host[:port]/<path>  [env: CLOUDSTIC_STORE]
     -profile <name>                Profile name from profiles.yaml  [env: CLOUDSTIC_PROFILE]

--- a/cmd/cloudstic/testdata/scripts/config_dir.txtar
+++ b/cmd/cloudstic/testdata/scripts/config_dir.txtar
@@ -1,0 +1,36 @@
+# -config-dir moves the config directory, and resolving where it would be
+# never creates it.
+#
+# The harness points CLOUDSTIC_CONFIG_DIR at $WORK/config, so this script also
+# covers the flag winning over the environment.
+
+# Asking where configuration lives must not create it. Help and shell
+# completion both build a command's flag set without running the command.
+exec cloudstic backup -h
+! exists $WORK/config
+exec cloudstic completion bash
+! exists $WORK/config
+exec cloudstic setup workstation -dry-run -no-prompt
+! exists $WORK/config
+
+# A command that writes puts the profiles file under -config-dir, not under the
+# directory the environment names.
+exec cloudstic store new -name s1 -uri local:$WORK/store -no-prompt -config-dir $WORK/flagdir
+stdout 'saved in '
+exists $WORK/flagdir/profiles.yaml
+! exists $WORK/config
+
+# Reads follow the same flag, so the store written above is visible.
+exec cloudstic store list -config-dir $WORK/flagdir
+stdout 's1'
+
+# Without the flag the environment applies, and the store written under the
+# flag's directory is not there.
+exec cloudstic store list
+! stdout 's1'
+
+# An explicit -profiles-file still beats the config directory.
+exec cloudstic store new -name s2 -uri local:$WORK/store -no-prompt -config-dir $WORK/flagdir -profiles-file $WORK/explicit.yaml
+exists $WORK/explicit.yaml
+exec cloudstic store list -config-dir $WORK/flagdir
+! stdout 's2'

--- a/cmd/cloudstic/testdata/usage_root.golden
+++ b/cmd/cloudstic/testdata/usage_root.golden
@@ -60,6 +60,7 @@ GLOBAL OPTIONS (also settable via environment variables)
     -quiet                          Suppress progress bars (keeps final summary)
     -json                           Write command result as JSON to stdout
     -debug                          Log every store request (network calls, timing, sizes)
+    -config-dir <path>              Directory for profiles, tokens, and other state  [env: CLOUDSTIC_CONFIG_DIR]
     -no-prompt                      Disable interactive prompts (for scripts and CI)
 
   Store URI formats:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -193,7 +193,13 @@ Cloudstic stores OAuth tokens and other state files in a platform-specific confi
 | macOS    | `~/Library/Application Support/cloudstic/` |
 | Windows  | `%AppData%\cloudstic\` |
 
-Override with the `CLOUDSTIC_CONFIG_DIR` environment variable.
+Override with the `-config-dir` flag, which every command accepts, or the
+`CLOUDSTIC_CONFIG_DIR` environment variable. The flag wins where both are
+given.
+
+The directory is created when something is first written into it, so asking
+where it *would* be — `cloudstic <command> -h`, shell completion, or
+`cloudstic setup workstation -dry-run` — never creates it.
 
 ### Setting defaults with environment variables
 
@@ -321,6 +327,7 @@ cloudstic backup -source local:~/Documents -dry-run
 | `-all-profiles` | `false` | Run backup for all enabled profiles from `profiles.yaml` |
 | `-auth-ref` | | Use one named auth entry from `profiles.yaml` for cloud source credentials |
 | `-profiles-file` | `<config-dir>/profiles.yaml` | Override profile YAML location (also `CLOUDSTIC_PROFILES_FILE`) |
+| `-config-dir` | platform default | Directory holding profiles, tokens, and other state (also `CLOUDSTIC_CONFIG_DIR`) |
 | `-tag` | | Tag to apply to the snapshot (repeatable) |
 | `-exclude` | | Exclude pattern using gitignore syntax (repeatable) |
 | `-exclude-file` | | Path to file containing exclude patterns, one per line |
@@ -1997,7 +2004,7 @@ cloudstic forget -keep-daily 7 -keep-monthly 12 -dry-run
 | `CLOUDSTIC_KMS_REGION` | `-kms-region` | AWS KMS region |
 | `CLOUDSTIC_KMS_ENDPOINT` | `-kms-endpoint` | Custom AWS KMS endpoint URL |
 | `CLOUDSTIC_PROFILES_FILE` | `-profiles-file` | Path to profiles YAML file |
-| `CLOUDSTIC_CONFIG_DIR` | — | Override config directory path |
+| `CLOUDSTIC_CONFIG_DIR` | `-config-dir` | Override config directory path |
 | `GOOGLE_APPLICATION_CREDENTIALS` | `-google-credentials` | Path to your own Google OAuth credentials file (optional, overrides built-in) |
 | `GOOGLE_CREDENTIALS_JSON` | `-google-credentials-json` | Inline Google credentials JSON (OAuth client or service account) |
 | `GOOGLE_TOKEN_FILE` | `-google-token-file` | Override Google OAuth token path |

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -12,55 +12,35 @@ const appName = "cloudstic"
 
 // ConfigDir returns the directory for cloudstic configuration and state files.
 // Resolution order:
-//  1. CLOUDSTIC_CONFIG_DIR environment variable (if set)
-//  2. os.UserConfigDir()/cloudstic  (platform default)
+//  1. override, when non-empty (the -config-dir flag)
+//  2. CLOUDSTIC_CONFIG_DIR environment variable
+//  3. os.UserConfigDir()/cloudstic  (platform default)
 //
-// The directory is created with 0700 permissions if it does not exist.
-func ConfigDir() (string, error) {
-	if dir := os.Getenv("CLOUDSTIC_CONFIG_DIR"); dir != "" {
-		return ensureDir(dir)
+// Resolution performs no filesystem access. The directory is created, with
+// 0700 permissions, by whoever writes into it — SaveAtomic and profile.Save
+// both do — so asking where configuration *would* live never creates it. That
+// matters because the answer is needed on paths that must not have side
+// effects: rendering help, generating completions, and previewing a setup with
+// -dry-run all resolve this path without any intent to write.
+func ConfigDir(override string) (string, error) {
+	if override != "" {
+		return override, nil
 	}
-
+	if dir := os.Getenv("CLOUDSTIC_CONFIG_DIR"); dir != "" {
+		return dir, nil
+	}
 	base, err := os.UserConfigDir()
 	if err != nil {
 		return "", fmt.Errorf("determine config directory: %w", err)
 	}
-	return ensureDir(filepath.Join(base, appName))
-}
-
-// ProfilesPath resolves the path to a profiles file named filename inside the
-// config directory. Resolution follows ConfigDir's CLOUDSTIC_CONFIG_DIR then
-// os.UserConfigDir() precedence; CLOUDSTIC_PROFILES_FILE is deliberately not
-// consulted here, since callers that expose this as a flag default apply it
-// themselves via their own env-bound flag (so a live env value is never
-// baked into what -h displays).
-//
-// If create is true, the config directory is created as ConfigDir does. If
-// false, no filesystem access occurs — for callers that need a default value
-// before deciding whether the directory should exist (e.g. a dry-run preview
-// that must not create configuration as a side effect of being asked what it
-// would do).
-func ProfilesPath(filename string, create bool) (string, error) {
-	if create {
-		dir, err := ConfigDir()
-		if err != nil {
-			return "", err
-		}
-		return filepath.Join(dir, filename), nil
-	}
-	if dir := os.Getenv("CLOUDSTIC_CONFIG_DIR"); dir != "" {
-		return filepath.Join(dir, filename), nil
-	}
-	if dir, err := os.UserConfigDir(); err == nil {
-		return filepath.Join(dir, appName, filename), nil
-	}
-	return filename, nil
+	return filepath.Join(base, appName), nil
 }
 
 // TokenPath returns the full path for a token file stored inside the config
 // directory (e.g. "google_token.json" → "~/.config/cloudstic/google_token.json").
-func TokenPath(filename string) (string, error) {
-	dir, err := ConfigDir()
+// override has ConfigDir's meaning.
+func TokenPath(override, filename string) (string, error) {
+	dir, err := ConfigDir(override)
 	if err != nil {
 		return "", err
 	}
@@ -81,13 +61,6 @@ func MachineID() string {
 	// 2. Fallback to hostname if nothing else works
 	host, _ := os.Hostname()
 	return strings.TrimSpace(host)
-}
-
-func ensureDir(dir string) (string, error) {
-	if err := os.MkdirAll(dir, 0700); err != nil {
-		return "", fmt.Errorf("create config directory %s: %w", dir, err)
-	}
-	return dir, nil
 }
 
 // SaveAtomic writes data to a temporary file in the target directory and

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -7,59 +7,71 @@ import (
 	"testing"
 )
 
-func TestConfigDir_EnvVar(t *testing.T) {
+func TestConfigDir_OverrideBeatsEnvVar(t *testing.T) {
 	tmp := t.TempDir()
-	target := filepath.Join(tmp, "custom-config")
-	t.Setenv("CLOUDSTIC_CONFIG_DIR", target)
+	target := filepath.Join(tmp, "from-flag")
+	t.Setenv("CLOUDSTIC_CONFIG_DIR", filepath.Join(tmp, "from-env"))
 
-	dir, err := ConfigDir()
+	dir, err := ConfigDir(target)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if dir != target {
 		t.Errorf("got %q, want %q", dir, target)
 	}
-	// Dir should have been created.
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		t.Errorf("directory was not created")
+}
+
+func TestConfigDir_EnvVar(t *testing.T) {
+	tmp := t.TempDir()
+	target := filepath.Join(tmp, "custom-config")
+	t.Setenv("CLOUDSTIC_CONFIG_DIR", target)
+
+	dir, err := ConfigDir("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dir != target {
+		t.Errorf("got %q, want %q", dir, target)
 	}
 }
 
 func TestConfigDir_Default(t *testing.T) {
 	t.Setenv("CLOUDSTIC_CONFIG_DIR", "")
 
-	dir, err := ConfigDir()
+	dir, err := ConfigDir("")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if dir == "" {
-		t.Error("expected non-empty directory")
+	base, err := os.UserConfigDir()
+	if err != nil {
+		t.Skipf("no user config dir on this platform: %v", err)
 	}
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		t.Errorf("directory %q does not exist", dir)
+	if want := filepath.Join(base, appName); dir != want {
+		t.Errorf("got %q, want %q", dir, want)
 	}
 }
 
-func TestConfigDir_CreatesWithCorrectPermissions(t *testing.T) {
-	tmp := t.TempDir()
-	target := filepath.Join(tmp, "new-dir")
-	t.Setenv("CLOUDSTIC_CONFIG_DIR", target)
+// Resolving a path must not create anything. Help output, shell completion and
+// `setup -dry-run` all ask where configuration lives without intending to write
+// there, and creating the directory to answer would be a side effect of asking.
+func TestConfigDir_CreatesNothing(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "absent")
 
-	dir, err := ConfigDir()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	info, err := os.Stat(dir)
-	if err != nil {
-		t.Fatalf("stat failed: %v", err)
-	}
-	if !info.IsDir() {
-		t.Errorf("expected directory")
-	}
-	// On Unix, permissions should be 0700.
-	if perm := info.Mode().Perm(); perm != 0700 {
-		t.Errorf("expected 0700 permissions, got %o", perm)
+	for _, tc := range []struct {
+		name string
+		call func() (string, error)
+	}{
+		{"override", func() (string, error) { return ConfigDir(target) }},
+		{"token path", func() (string, error) { return TokenPath(target, "google_token.json") }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := tc.call(); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if _, err := os.Stat(target); !os.IsNotExist(err) {
+				t.Errorf("directory %q was created, want untouched (stat err: %v)", target, err)
+			}
+		})
 	}
 }
 
@@ -67,7 +79,7 @@ func TestTokenPath(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("CLOUDSTIC_CONFIG_DIR", tmp)
 
-	path, err := TokenPath("google_token.json")
+	path, err := TokenPath("", "google_token.json")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -77,19 +89,27 @@ func TestTokenPath(t *testing.T) {
 	}
 }
 
-func TestTokenPath_ReturnsError(t *testing.T) {
-	// Force an error by providing an invalid path that cannot be created.
-	// We make the parent a file, not a directory.
-	tmp := t.TempDir()
-	file := filepath.Join(tmp, "notadir")
-	if err := os.WriteFile(file, []byte("x"), 0600); err != nil {
-		t.Fatal(err)
+// The config directory is created by whoever writes into it, at 0700, rather
+// than by resolving its path. This is the guarantee that moved out of
+// ConfigDir when resolution stopped touching the filesystem.
+func TestSaveAtomic_CreatesConfigDirWithCorrectPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are not meaningful on Windows")
 	}
-	t.Setenv("CLOUDSTIC_CONFIG_DIR", filepath.Join(file, "subdir"))
+	dir := filepath.Join(t.TempDir(), "new-dir")
+	if err := SaveAtomic(filepath.Join(dir, "token.json"), []byte("x")); err != nil {
+		t.Fatalf("SaveAtomic failed: %v", err)
+	}
 
-	_, err := TokenPath("token.json")
-	if err == nil {
-		t.Error("expected error when config dir cannot be created")
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat failed: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("expected directory")
+	}
+	if perm := info.Mode().Perm(); perm != 0700 {
+		t.Errorf("expected 0700 permissions, got %o", perm)
 	}
 }
 

--- a/pkg/secretref/backends/file_backend.go
+++ b/pkg/secretref/backends/file_backend.go
@@ -121,10 +121,7 @@ func NewConfigTokenBackend(opts ...ConfigTokenOption) *ConfigTokenBackend {
 // dir returns the managed directory, falling back to the process-wide default
 // when the caller did not choose one.
 func (b *ConfigTokenBackend) dir() (string, error) {
-	if b.configDir != "" {
-		return b.configDir, nil
-	}
-	return paths.ConfigDir()
+	return paths.ConfigDir(b.configDir)
 }
 
 func (b *ConfigTokenBackend) Resolve(ctx context.Context, ref secretref.Ref) (string, error) {


### PR DESCRIPTION
## Summary

- Add a `-config-dir` global flag (`baseFlagSpecs`, so every command accepts it) bound to `CLOUDSTIC_CONFIG_DIR`. It was the only user-facing setting with no flag, read straight from the environment inside `internal/paths`.
- `paths.ConfigDir(override)` resolves flag > env > platform default and performs **no filesystem access**. The directory is created by whoever writes into it — `paths.SaveAtomic` and `profile.Save` both already `MkdirAll(…, 0700)`.
- Delete `paths.ProfilesPath` and its `create bool`, whose two branches were the same resolution written twice, along with the four `cmd` wrappers over it (`defaultProfilesPath`, `defaultProfilesPathFallback`, `defaultProfilesPathNoCreate`, and an inlined copy in `repoFlagSpecs`) — three different error behaviours over one `filepath.Join`.
- Add `withLateDefault` to `flagSpec`: a default computed after parsing, resolved in a pass after `applyEnvDefaults` and only for flags still at their built-in value. `-profiles-file` uses it, since its default is a path inside `-config-dir` and so is unknown until parsing finishes. `flagSpec.applyEnv` becomes `setValue`, now serving both resolution steps.
- `profileSecretResolver` becomes `newSecretResolver(configDir)`, threaded through `applyProfileStore`, `clientConfigFromProfileStore`, `initSource`, `promptSecretReference` and the TUI backends. `config-token://` references name a token in the config directory's managed store, so the flag has to reach them; threading beats reassigning a package-level var after parsing (RFC 0022 §8).

### The side effect this fixes

`repoFlagSpecs` resolved the profiles-file default while *building* the flag set, and that path called `MkdirAll`. So describe-only invocations created the config directory:

```
CLOUDSTIC_CONFIG_DIR=/tmp/probe cloudstic backup -h        → /tmp/probe created
CLOUDSTIC_CONFIG_DIR=/tmp/probe cloudstic completion bash  → created
CLOUDSTIC_CONFIG_DIR=/tmp/probe cloudstic help             → created
```

All three now leave it untouched. `ProfilesPath`'s `create` flag existed only to dodge this for `setup -dry-run`, and goes away with it.

The eager resolution was never displayed either: `flagRows` (`usage.go`) renders usage and `[env: …]` only, never a flag's default — only *positionals* print defaults. So all four wrappers computed a value nobody saw, that was first actually read after parsing.

Part of #395

## Verification

- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./...` — full suite including e2e, exit 0
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./cmd/cloudstic/... ./internal/paths/... ./pkg/secretref/...` — 0 issues
- `npx markdownlint-cli2 AGENTS.md docs/user-guide.md` — 0 issues
- Golden files regenerated with `go test ./cmd/cloudstic -run 'TestRootUsageGolden|TestCommandHelpGolden' -update`; diff is one `-config-dir` row per affected file.

New tests:

- `cmd/cloudstic/testdata/scripts/config_dir.txtar` — help/completion/`-dry-run` create nothing; `-config-dir` routes reads and writes and beats `CLOUDSTIC_CONFIG_DIR`; `-profiles-file` still beats both.
- `TestLateDefaultRunsOnlyWhenNothingElseSuppliedAValue` / `TestLateDefaultErrorFailsParse` / `TestProfilesFileDefaultFollowsConfigDirFlag` (`flagspec_test.go`).
- `TestConfigDir_OverrideBeatsEnvVar`, `TestConfigDir_CreatesNothing`, `TestSaveAtomic_CreatesConfigDirWithCorrectPermissions` (`internal/paths`) — the 0700 guarantee moved to the write path it now belongs to.