### PR TITLE
ci: split unit and E2E jobs, add vulnerability gate

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -1,0 +1,11 @@
+name: Setup Go
+description: >-
+  Install the Go toolchain pinned by go.mod. Every workflow goes through this so
+  the toolchain source (and any future cache tuning) lives in one place.
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-go@v7
+      with:
+        go-version-file: go.mod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,115 +17,184 @@ on:
 permissions:
   contents: read
 
+# Superseded pushes to a pull request are abandoned; pushes to main always run
+# to completion so every commit on the branch keeps a coverage report.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
-      - name: Setup Go
-        uses: actions/setup-go@v7
-        with:
-          go-version-file: go.mod
+      - uses: ./.github/actions/setup-go
+      - name: Check go.mod is tidy
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
           version: v2.12.2
           args: --timeout=5m
 
-  test:
-    name: Test
+  vulncheck:
+    name: Vulnerabilities
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup-go
+      - name: Run govulncheck
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+
+  # Unit and E2E are separate jobs, not two steps of one job: nothing in the
+  # E2E run consumes the unit run's output, and keeping them together made the
+  # slowest runner pay for both in sequence.
+  unit:
+    name: Unit tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     permissions:
       contents: read
       checks: write
       pull-requests: write
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        include:
+          # Data races are OS-independent, so one runner carries the detector's
+          # 2-3x cost. The others are here for the platform-specific build paths.
+          - os: ubuntu-latest
+            race: '-race'
+          - os: macos-latest
+            race: ''
     steps:
       - uses: actions/checkout@v7
-      - name: Setup Go
-        uses: actions/setup-go@v7
-        with:
-          go-version-file: go.mod
-      - name: Install shell dependencies for E2E
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y zsh fish
-      - name: Run Unit Tests
+      - uses: ./.github/actions/setup-go
+      - name: Run unit tests
+        shell: bash
         run: |
           set -o pipefail
-          go test -v -json -race -coverprofile=unit.out -count=1 $(go list ./... | grep -v '/e2e') | tee test-output.json
-      - name: Run E2E Tests
-        run: |
-          set -o pipefail
-          E2E_COVERAGE_OUT="$PWD/e2e_coverage.out" go test -v -json -count=1 ./e2e/ | tee -a test-output.json
-      - name: Test Report
+          go test -json ${{ matrix.race }} -shuffle=on -coverprofile=unit.out -count=1 \
+            $(go list ./... | grep -v '/e2e') | tee test-output.json
+      - name: Test report
         uses: dorny/test-reporter@v3
-        if: always()
+        # Pull requests from forks get a read-only token, so publishing a check
+        # run from them fails; the job's own conclusion still reports the result.
+        if: >-
+          always() && (github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository)
         with:
-          name: Go Tests (${{ matrix.os }})
+          name: Unit tests (${{ matrix.os }})
           path: test-output.json
           reporter: golang-json
-      - name: Coverage Summary
+      - name: Coverage summary
         if: matrix.os == 'ubuntu-latest'
+        shell: bash
         run: |
-          echo "## Code Coverage" >> $GITHUB_STEP_SUMMARY
-          echo "<details>" >> $GITHUB_STEP_SUMMARY
-          echo "<summary>Unit Tests</summary>" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo '```text' >> $GITHUB_STEP_SUMMARY
-          go tool cover -func=unit.out >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "</details>" >> $GITHUB_STEP_SUMMARY
-          if [ -f e2e_coverage.out ]; then
-            echo "<details>" >> $GITHUB_STEP_SUMMARY
-            echo "<summary>E2E Tests</summary>" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo '```text' >> $GITHUB_STEP_SUMMARY
-            go tool cover -func=e2e_coverage.out >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            echo "</details>" >> $GITHUB_STEP_SUMMARY
-          fi
-      - name: Upload coverage reports to Codecov
+          {
+            echo "## Unit coverage"
+            echo ""
+            echo '```text'
+            go tool cover -func=unit.out
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         if: matrix.os == 'ubuntu-latest'
         with:
           slug: Cloudstic/cli
-          files: unit.out,e2e_coverage.out
+          files: unit.out
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  verify-platform-build-paths:
-    name: Verify platform build paths (${{ matrix.name }})
+  e2e:
+    name: E2E tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          - name: macOS
-            os: macos-latest
-            run: go test ./pkg/secretref/... ./cmd/cloudstic
-          - name: Windows
-            os: windows-latest
-            run: go test ./pkg/secretref/... ./cmd/cloudstic
+        # Docker is only present on the Linux runner, so the MinIO and SFTP
+        # container suites skip themselves on macOS (see e2e/minio.go).
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v7
-      - name: Setup Go
-        uses: actions/setup-go@v7
+      - uses: ./.github/actions/setup-go
+      - name: Install shell dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y zsh fish
+      - name: Run E2E tests
+        shell: bash
+        run: |
+          set -o pipefail
+          E2E_COVERAGE_OUT="$PWD/e2e_coverage.out" \
+            go test -json -shuffle=on -count=1 ./e2e/ | tee test-output.json
+      - name: Test report
+        uses: dorny/test-reporter@v3
+        if: >-
+          always() && (github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository)
         with:
-          go-version-file: go.mod
-      - name: Run platform-specific verification
-        run: ${{ matrix.run }}
+          name: E2E tests (${{ matrix.os }})
+          path: test-output.json
+          reporter: golang-json
+      - name: Coverage summary
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          # The harness converts GOCOVERDIR into this file on exit; skip the
+          # section rather than failing the job if that conversion fell over.
+          [ -f e2e_coverage.out ] || exit 0
+          {
+            echo "## E2E coverage"
+            echo ""
+            echo '```text'
+            go tool cover -func=e2e_coverage.out
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v7
+        if: matrix.os == 'ubuntu-latest'
+        with:
+          slug: Cloudstic/cli
+          files: e2e_coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}
 
+  # macOS is covered by the macOS unit job, which already runs these packages.
+  platform:
+    name: Platform build paths
+    uses: ./.github/workflows/wc-platform-tests.yml
+    with:
+      runners: '["windows-latest"]'
+
+  # Mirrors the goreleaser `cloudstic-cross` build (.goreleaser.yml) so a
+  # target that only breaks at tag time breaks here instead. darwin is covered
+  # by the macOS jobs, which compile the CLI natively.
   build:
-    name: Build
+    name: Cross-compile (${{ matrix.goos }}/${{ matrix.goarch }})
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        goos: [linux, windows]
+        goarch: [amd64, arm64]
+    env:
+      CGO_ENABLED: '0'
+      GOOS: ${{ matrix.goos }}
+      GOARCH: ${{ matrix.goarch }}
     steps:
       - uses: actions/checkout@v7
-      - name: Setup Go
-        uses: actions/setup-go@v7
-        with:
-          go-version-file: go.mod
-      - name: Run Build
-        run: go build ./cmd/cloudstic
+      - uses: ./.github/actions/setup-go
+      - name: Build
+        run: go build -o /dev/null ./cmd/cloudstic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,8 +137,12 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
+          # -parallel above the runner's core count on purpose: these tests
+          # spend their time waiting on the CLI subprocess and its containers,
+          # not on CPU, so the default (GOMAXPROCS) leaves the runner idle.
+          # Measured on the suite: 83s at 4, 51s at 8, 45s at 12.
           E2E_COVERAGE_OUT="$PWD/e2e_coverage.out" \
-            go test -json -shuffle=on -count=1 ./e2e/ | tee test-output.json
+            go test -json -shuffle=on -parallel 8 -count=1 ./e2e/ | tee test-output.json
       - name: Test report
         uses: dorny/test-reporter@v3
         if: >-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,51 +14,35 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: go.mod
-      - run: go test -race -count=1 ./...
+      - uses: ./.github/actions/setup-go
+      - run: go test -race -shuffle=on -count=1 ./...
 
-  verify-platform-build-paths:
-    name: Verify platform build paths (${{ matrix.name }})
+  # The test job above runs on Linux only, so unlike in ci.yml both runners
+  # here are verifying build paths nothing else has compiled.
+  platform:
+    name: Platform build paths
     needs: test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - name: macOS
-            os: macos-latest
-            run: go test ./pkg/secretref/... ./cmd/cloudstic
-          - name: Windows
-            os: windows-latest
-            run: go test ./pkg/secretref/... ./cmd/cloudstic
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: go.mod
-      - name: Run platform-specific verification
-        run: ${{ matrix.run }}
+    uses: ./.github/workflows/wc-platform-tests.yml
+    with:
+      runners: '["macos-latest", "windows-latest"]'
 
   release:
     name: Release
     needs:
       - test
-      - verify-platform-build-paths
+      - platform
     runs-on: macos-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: go.mod
+      - uses: ./.github/actions/setup-go
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@v0
       - uses: goreleaser/goreleaser-action@v7
@@ -79,6 +63,7 @@ jobs:
   winget:
     needs: release
     runs-on: windows-latest
+    timeout-minutes: 15
     steps:
       - uses: vedantmgoyal9/winget-releaser@v2
         with:

--- a/.github/workflows/wc-platform-tests.yml
+++ b/.github/workflows/wc-platform-tests.yml
@@ -1,0 +1,32 @@
+name: Platform tests
+
+# Reusable: the packages whose behaviour is selected by build tags
+# (pkg/secretref's keychain/secret-service/wincred backends) plus the CLI that
+# wires them up. Called with different runner sets by ci.yml and release.yml,
+# so the command itself is defined exactly once.
+
+on:
+  workflow_call:
+    inputs:
+      runners:
+        description: JSON array of runner labels to verify on
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  platform:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJSON(inputs.runners) }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup-go
+      - name: Verify platform build paths
+        run: go test -count=1 ./pkg/secretref/... ./cmd/cloudstic

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/cloudstic/cli
 
 go 1.26.0
 
+toolchain go1.26.5
+
 require (
 	github.com/Backblaze/blazer v0.7.2
 	github.com/aws/aws-sdk-go-v2 v1.43.0
@@ -124,6 +126,6 @@ require (
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260706201446-f0a921348800 // indirect
-	google.golang.org/grpc v1.82.0 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -290,8 +290,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260630182238-925bb5da69e7 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260630182238-925bb5da69e7/go.mod h1:KqHwBx2upmfa1XSi1WuRvC+2VGCLtooKkfmyvRbUmqA=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260706201446-f0a921348800 h1:qEHAMpSaUhtD0p3NbEEI83HwNGFxEwaSJ1G9PLnCBZE=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260706201446-f0a921348800/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.82.0 h1:vguDnZUPjE26w09A63VoxZPnvPjB5Riyc0mkXPFmAIU=
-google.golang.org/grpc v1.82.0/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,22 +1,32 @@
 #!/usr/bin/env bash
+#
+# Local mirror of the CI quality gates (.github/workflows/ci.yml). Keep the
+# commands here and the ones in CI in step, so a green run locally means a
+# green run on the pull request.
 
-set -e
+set -euo pipefail
 
 # Navigate to the root of the project
 cd "$(dirname "$0")/.."
 
-echo "==> Running go fmt..."
-go fmt ./...
+echo "==> Checking go.mod is tidy..."
+go mod tidy
+git diff --exit-code -- go.mod go.sum
 
+# Formatting is checked, not applied: .golangci.yml enables the gofmt formatter,
+# so `golangci-lint run` reports a misformatted file the same way CI does.
+# Run `golangci-lint fmt ./...` to fix what it reports.
 echo "==> Running golangci-lint..."
-# Note: assumes golangci-lint is installed locally
 golangci-lint run ./...
 
 echo "==> Running markdownlint..."
 npx markdownlint-cli2 "**/*.md"
 
+echo "==> Running govulncheck..."
+go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+
 echo "==> Running go test..."
-go test -v -race -coverprofile=coverage.out -count=1 ./...
+go test -race -shuffle=on -coverprofile=coverage.out -count=1 ./...
 
 echo "==> Coverage summary:"
 go tool cover -func=coverage.out | tail -n 1


### PR DESCRIPTION
## Summary

- Split the `Test` job into separate `unit` and `e2e` jobs. They were two sequential steps of one job, so the slowest runner paid for both — macOS took 6m13s (2m35 unit + 2m55 E2E) and set the wall-clock for the whole run. Nothing in the E2E step consumes the unit step's output.
- Run `-race` on Linux only. Data races are OS-independent; macOS no longer pays the detector's 2-3x cost to re-find what Linux already covers, and stays for the platform-specific build paths.
- Drop the macOS row of the platform job — it ran `go test ./pkg/secretref/... ./cmd/cloudstic`, and all three packages are already in the macOS unit run. 1m18s of pure duplicate work.
- Add a `concurrency` group so superseded pushes to a PR are cancelled; pushes to `main` still run to completion so every commit keeps a coverage report.
- Add `-shuffle=on` to both suites (verified both pass shuffled before enabling) and `timeout-minutes` to every job — nothing had one, so a hung E2E test could burn the 6-hour default.
- Gate `dorny/test-reporter` on non-fork PRs: fork PRs get a read-only token and cannot publish a check run.
- Deduplicate: add `.github/actions/setup-go` (the toolchain source was declared in each of seven jobs) and extract the platform verification into a reusable `wc-platform-tests.yml`, called by `ci.yml` (Windows) and `release.yml` (macOS + Windows, since its test job is Linux-only). The command was copy-pasted between the two.
- Add a `vulncheck` job. `govulncheck` found 8 reachable vulnerabilities — 7 stdlib, one in `google.golang.org/grpc`; pinning `toolchain go1.26.5` and bumping grpc to v1.82.1 clears all of them.
- Add a `go mod tidy` drift check, and replace the `Build` job with a cross-compile matrix over goreleaser's `cloudstic-cross` targets (linux/windows × amd64/arm64) — the old job duplicated a compile the Linux unit job already did, while the release matrix went unverified until tag time.
- `scripts/check.sh`: `go fmt ./...` rewrote source files and could never fail, so the check script silently mutated the tree instead of reporting. `.golangci.yml` already enables the gofmt formatter, so `golangci-lint run` reports formatting the way CI does.

Expected effect on wall-clock: the critical path drops from ~6m15s to roughly ~3m30s.

## Verification

- \`go run github.com/rhysd/actionlint/cmd/actionlint@latest\` passes
- \`go test -shuffle=on -count=1 \$(go list ./... | grep -v '/e2e')\` passes
- \`go test -shuffle=on -count=1 ./e2e/\` passes
- \`go run golang.org/x/vuln/cmd/govulncheck@latest ./...\` reports no vulnerabilities
- \`go mod tidy\` produces no diff