### PR TITLE
test(e2e): run the E2E suite in parallel

### DIFF
--- a/e2e/compatibility_smoke_test.go
+++ b/e2e/compatibility_smoke_test.go
@@ -3,6 +3,7 @@ package e2e
 import "testing"
 
 func TestCLI_CompatibilitySmokeMatrix(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name: "compatibility_smoke",
 		test: func(t *testing.T, h *harness, entry matrixEntry) {

--- a/e2e/feature_backup_restore_test.go
+++ b/e2e/feature_backup_restore_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestCLI_Feature_BackupRestoreLatest(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name: "backup_restore_latest",
 		test: func(t *testing.T, h *harness, entry matrixEntry) {

--- a/e2e/feature_break_lock_test.go
+++ b/e2e/feature_break_lock_test.go
@@ -6,6 +6,7 @@ import "testing"
 // that has no active lock. After a clean backup completes, there should be no stale
 // lock file, so break-lock should report that no lock was found (or exit cleanly).
 func TestCLI_Feature_BreakLock(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name:         "break_lock_no_stale_lock",
 		sourceFilter: localOnlySource,

--- a/e2e/feature_cat_test.go
+++ b/e2e/feature_cat_test.go
@@ -13,6 +13,7 @@ type catJSONItem struct {
 // TestCLI_Feature_CatConfig verifies that `cloudstic cat config -json`
 // returns a structured JSON array containing the config object.
 func TestCLI_Feature_CatConfig(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name:         "cat_config",
 		sourceFilter: localOnlySource,
@@ -44,6 +45,7 @@ func TestCLI_Feature_CatConfig(t *testing.T) {
 // `cloudstic cat index/latest -json` returns a structured JSON array
 // containing an object with a latest snapshot reference.
 func TestCLI_Feature_CatIndexLatest(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name:         "cat_index_latest",
 		sourceFilter: localOnlySource,

--- a/e2e/feature_completion_runtime_test.go
+++ b/e2e/feature_completion_runtime_test.go
@@ -21,6 +21,7 @@ type completionScenario struct {
 }
 
 func TestCLI_Feature_CompletionRuntime_RootCommands(t *testing.T) {
+	t.Parallel()
 	runCompletionShellMatrix(t, completionScenario{
 		name:  "root_commands",
 		words: []string{"cloudstic", ""},
@@ -31,6 +32,7 @@ func TestCLI_Feature_CompletionRuntime_RootCommands(t *testing.T) {
 }
 
 func TestCLI_Feature_CompletionRuntime_BackupFlags(t *testing.T) {
+	t.Parallel()
 	runCompletionShellMatrix(t, completionScenario{
 		name:  "backup_flags",
 		words: []string{"cloudstic", "backup", "-"},
@@ -41,6 +43,7 @@ func TestCLI_Feature_CompletionRuntime_BackupFlags(t *testing.T) {
 }
 
 func TestCLI_Feature_CompletionRuntime_GroupedSubcommandFlags(t *testing.T) {
+	t.Parallel()
 	runCompletionShellMatrix(t, completionScenario{
 		name:  "grouped_subcommand_flags",
 		words: []string{"cloudstic", "key", "passwd", "-"},
@@ -51,6 +54,7 @@ func TestCLI_Feature_CompletionRuntime_GroupedSubcommandFlags(t *testing.T) {
 }
 
 func TestCLI_Feature_CompletionRuntime_ProfileValues(t *testing.T) {
+	t.Parallel()
 	runCompletionShellMatrix(t, completionScenario{
 		name:  "profile_values",
 		words: []string{"cloudstic", "backup", "-profile", ""},
@@ -61,6 +65,7 @@ func TestCLI_Feature_CompletionRuntime_ProfileValues(t *testing.T) {
 }
 
 func TestCLI_Feature_CompletionRuntime_StorePrefixes(t *testing.T) {
+	t.Parallel()
 	runCompletionShellMatrix(t, completionScenario{
 		name:  "store_prefixes",
 		words: []string{"cloudstic", "-store", ""},

--- a/e2e/feature_completion_test.go
+++ b/e2e/feature_completion_test.go
@@ -12,6 +12,7 @@ func TestCLI_Feature_Completion(t *testing.T) {
 	if !shouldRun(Hermetic) {
 		t.Skip("skipping hermetic test")
 	}
+	t.Parallel()
 
 	bin := buildBinary(t)
 

--- a/e2e/feature_compressed_roundtrip_test.go
+++ b/e2e/feature_compressed_roundtrip_test.go
@@ -109,6 +109,7 @@ func compressedFixtures(t *testing.T) map[string]string {
 }
 
 func TestCLI_Feature_CompressedFilesRoundTrip(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		name      string
 		encrypted bool

--- a/e2e/feature_crash_consistency_test.go
+++ b/e2e/feature_crash_consistency_test.go
@@ -27,6 +27,7 @@ func TestCLI_Feature_BackupCrashConsistency(t *testing.T) {
 	if !shouldRun(Hermetic) {
 		t.Skip("skipping hermetic test")
 	}
+	t.Parallel()
 	bin := buildBinary(t)
 
 	// Files well over the 512KiB chunk-size floor so each one's content

--- a/e2e/feature_diff_test.go
+++ b/e2e/feature_diff_test.go
@@ -6,6 +6,7 @@ import "testing"
 // added and modified files between two snapshots.
 // Diff is a metadata-only operation; local store is sufficient.
 func TestCLI_Feature_Diff(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name:         "diff_snapshots",
 		sourceFilter: localOnlySource,
@@ -39,6 +40,7 @@ func TestCLI_Feature_Diff(t *testing.T) {
 // TestCLI_Feature_DiffSameSnapshot verifies that diffing a snapshot against
 // itself produces no output (no changes).
 func TestCLI_Feature_DiffSameSnapshot(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name:         "diff_same_snapshot",
 		sourceFilter: localOnlySource,

--- a/e2e/feature_dry_run_test.go
+++ b/e2e/feature_dry_run_test.go
@@ -5,6 +5,7 @@ import "testing"
 // TestCLI_Feature_BackupDryRun verifies that `backup -dry-run` reports what
 // would be uploaded without actually writing any data to the store.
 func TestCLI_Feature_BackupDryRun(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name:         "backup_dry_run",
 		sourceFilter: localOnlySource,
@@ -25,6 +26,7 @@ func TestCLI_Feature_BackupDryRun(t *testing.T) {
 // This test complements the policy test in feature_retention_test.go by focusing
 // specifically on dry-run output semantics.
 func TestCLI_Feature_ForgetDryRun(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name:         "forget_dry_run",
 		sourceFilter: localOnlySource,

--- a/e2e/feature_encryption_test.go
+++ b/e2e/feature_encryption_test.go
@@ -9,6 +9,7 @@ import (
 // TestCLI_Feature_EncryptedRepoErrors verifies that accessing an encrypted
 // repository with no credentials or the wrong password produces clear errors.
 func TestCLI_Feature_EncryptedRepoErrors(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name:         "encrypted_repo_errors",
 		sourceFilter: localOnlySource,
@@ -31,6 +32,7 @@ func TestCLI_Feature_EncryptedRepoErrors(t *testing.T) {
 // TestCLI_Feature_InitRequiresEncryption verifies that `init` without any
 // encryption option fails with an actionable error message.
 func TestCLI_Feature_InitRequiresEncryption(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name:         "init_requires_encryption",
 		sourceFilter: localOnlySource,
@@ -45,6 +47,7 @@ func TestCLI_Feature_InitRequiresEncryption(t *testing.T) {
 // TestCLI_Feature_RecoveryKeyRoundTrip verifies the full recovery-key flow:
 // init with a BIP39 recovery key → backup → restore using only the mnemonic.
 func TestCLI_Feature_RecoveryKeyRoundTrip(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name:         "recovery_key_round_trip",
 		sourceFilter: localOnlySource,
@@ -80,6 +83,7 @@ func TestCLI_Feature_RecoveryKeyRoundTrip(t *testing.T) {
 // so all subsequent harness calls (backup, list, check, forget) work without
 // a password — no separate *Unencrypted methods needed.
 func TestCLI_Feature_UnencryptedLifecycle(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name:         "unencrypted_lifecycle",
 		sourceFilter: localOnlySource,

--- a/e2e/feature_exclude_test.go
+++ b/e2e/feature_exclude_test.go
@@ -10,6 +10,7 @@ import (
 // and -exclude-file patterns correctly suppress files from the backup.
 // This is a source-level feature; running on every store backend adds no value.
 func TestCLI_Feature_BackupExcludePatterns(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name:         "backup_exclude_patterns",
 		sourceFilter: localOnlySource,

--- a/e2e/feature_find_test.go
+++ b/e2e/feature_find_test.go
@@ -15,6 +15,7 @@ import (
 // Find is metadata-only, so a local store is sufficient here; the layered store
 // path gets its own test below.
 func TestCLI_Feature_Find(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name:         "find_across_snapshots",
 		sourceFilter: localOnlySource,
@@ -60,6 +61,7 @@ func TestCLI_Feature_Find(t *testing.T) {
 // be edited before it works is worse than no hint, and only an end-to-end run
 // can catch a flag name that does not exist.
 func TestCLI_Feature_FindLocatesDeletedFileAndPrintsAWorkingRestore(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name:         "find_deleted_file",
 		sourceFilter: localOnlySource,
@@ -136,6 +138,7 @@ func restoreArgsFromHint(t *testing.T, output, outDir string) []string {
 // tests use. A delta scan that is correct over a plain map but wrong once reads
 // are batched into packs would pass those and fail here.
 func TestCLI_Feature_FindDeltaScanMatchesFullScan(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name:         "find_delta_equivalence",
 		sourceFilter: localOnlySource,
@@ -194,6 +197,7 @@ func renderFindMatches(r *findResult) string {
 // TestCLI_Feature_FindByContent covers the axis the default grouping
 // deliberately does not collapse: two distinct files holding identical bytes.
 func TestCLI_Feature_FindByContent(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name:         "find_by_content",
 		sourceFilter: localOnlySource,
@@ -230,6 +234,7 @@ func TestCLI_Feature_FindByContent(t *testing.T) {
 // directory tree, where paths are reconstructed from the parent chain rather
 // than handed to the matcher.
 func TestCLI_Feature_FindPredicates(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name:         "find_predicates",
 		sourceFilter: localOnlySource,
@@ -284,6 +289,7 @@ func TestCLI_Feature_FindPredicates(t *testing.T) {
 // TestCLI_Feature_FindSnapshotSelectors checks that scoping narrows the search
 // rather than merely filtering its output.
 func TestCLI_Feature_FindSnapshotSelectors(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name:         "find_snapshot_selectors",
 		sourceFilter: localOnlySource,
@@ -324,6 +330,7 @@ func TestCLI_Feature_FindSnapshotSelectors(t *testing.T) {
 // empty result is a successful search, and a query with no predicate is refused
 // rather than dumping the whole repository.
 func TestCLI_Feature_FindExitStatus(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name:         "find_exit_status",
 		sourceFilter: localOnlySource,
@@ -350,6 +357,7 @@ func TestCLI_Feature_FindExitStatus(t *testing.T) {
 // depends on: stdout under -json is the result and nothing else, even when the
 // search has something to say about how it ran.
 func TestCLI_Feature_FindKeepsJSONClean(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name:         "find_json_is_clean",
 		sourceFilter: localOnlySource,

--- a/e2e/feature_integrity_test.go
+++ b/e2e/feature_integrity_test.go
@@ -3,6 +3,7 @@ package e2e
 import "testing"
 
 func TestCLI_Feature_IntegrityCheck(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name: "integrity_check",
 		test: func(t *testing.T, h *harness, entry matrixEntry) {

--- a/e2e/feature_legacy_repo_test.go
+++ b/e2e/feature_legacy_repo_test.go
@@ -118,6 +118,7 @@ func materialiseFixture(t *testing.T, dir string) string {
 // Every committed baseline must remain fully usable by the current build:
 // listable, checkable, restorable, and writable.
 func TestCLI_Feature_ReadsLegacyRepositories(t *testing.T) {
+	t.Parallel()
 	bin := buildBinary(t)
 
 	for _, dir := range legacyFixtures(t) {
@@ -260,6 +261,7 @@ func assertFixtureFiles(t *testing.T, dir string, want map[string]string) {
 // is not documented, or a documented baseline with no fixture, means the
 // written guarantee and the enforced one have drifted apart.
 func TestCompatibilityDocListsEveryFixture(t *testing.T) {
+	t.Parallel()
 	table := guaranteedBaselinesTable(t)
 
 	documented := documentedBaselines(table)

--- a/e2e/feature_ls_test.go
+++ b/e2e/feature_ls_test.go
@@ -5,6 +5,7 @@ import "testing"
 // TestCLI_Feature_Ls verifies that `cloudstic ls` lists all files in the
 // latest snapshot with the expected paths. Ls is metadata-only; local store is sufficient.
 func TestCLI_Feature_Ls(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name:         "ls_latest",
 		sourceFilter: localOnlySource,
@@ -27,6 +28,7 @@ func TestCLI_Feature_Ls(t *testing.T) {
 // TestCLI_Feature_LsBySnapshotID verifies that `cloudstic ls <id>` resolves
 // a specific snapshot by its prefix.
 func TestCLI_Feature_LsBySnapshotID(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name:         "ls_by_snapshot_id",
 		sourceFilter: localOnlySource,

--- a/e2e/feature_pack_index_test.go
+++ b/e2e/feature_pack_index_test.go
@@ -69,6 +69,7 @@ func fileExists(path string) bool {
 // A real backup through the CLI must leave no object keys readable in the pack
 // catalog or in any packfile footer, and must still restore byte for byte.
 func TestCLI_Feature_PackIndexIsSealedOnDisk(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name:         "pack_index_sealed_on_disk",
 		sourceFilter: localOnlySource,
@@ -116,6 +117,7 @@ func TestCLI_Feature_PackIndexIsSealedOnDisk(t *testing.T) {
 // An unencrypted repository has no key to seal with; it must keep working and
 // keep its indexes readable, rather than failing or half-sealing.
 func TestCLI_Feature_PackIndexUnsealedWithoutEncryption(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name:         "pack_index_unsealed_without_encryption",
 		sourceFilter: localOnlySource,

--- a/e2e/feature_partial_restore_test.go
+++ b/e2e/feature_partial_restore_test.go
@@ -3,6 +3,7 @@ package e2e
 import "testing"
 
 func TestCLI_Feature_PartialRestore(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name: "partial_restore",
 		test: func(t *testing.T, h *harness, entry matrixEntry) {

--- a/e2e/feature_profiles_test.go
+++ b/e2e/feature_profiles_test.go
@@ -18,6 +18,7 @@ func TestCLI_Feature_ProfilesLocalStore(t *testing.T) {
 	if !shouldRun(Hermetic) {
 		t.Skip("skipping hermetic test")
 	}
+	t.Parallel()
 
 	bin := buildBinary(t)
 	src1 := t.TempDir()
@@ -108,6 +109,7 @@ func TestCLI_Feature_ProfilesAllProfilesJSON(t *testing.T) {
 	if !shouldRun(Hermetic) {
 		t.Skip("skipping hermetic test")
 	}
+	t.Parallel()
 
 	bin := buildBinary(t)
 	src1 := t.TempDir()

--- a/e2e/feature_retention_test.go
+++ b/e2e/feature_retention_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestCLI_Feature_RetentionAndPrune(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name:         "retention_prune",
 		sourceFilter: localOnlySource,
@@ -27,6 +28,7 @@ func TestCLI_Feature_RetentionAndPrune(t *testing.T) {
 }
 
 func TestCLI_Feature_ForgetDryRunPolicy(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name:         "forget_policy_dry_run",
 		sourceFilter: localOnlySource,

--- a/e2e/feature_tags_test.go
+++ b/e2e/feature_tags_test.go
@@ -9,6 +9,7 @@ import "testing"
 // Note: `list` does not support filtering by tag — tags are shown inline in
 // the snapshot summary. `forget` is the command that supports --tag filtering.
 func TestCLI_Feature_BackupTags(t *testing.T) {
+	t.Parallel()
 	runFeatureMatrix(t, featureSpec{
 		name:         "backup_tags",
 		sourceFilter: localOnlySource,

--- a/e2e/feature_tui_test.go
+++ b/e2e/feature_tui_test.go
@@ -9,6 +9,7 @@ func TestCLI_Feature_TUI_Help(t *testing.T) {
 	if !shouldRun(Hermetic) {
 		t.Skip("skipping hermetic test")
 	}
+	t.Parallel()
 
 	bin := buildBinary(t)
 	out := run(t, bin, "tui", "--help")
@@ -25,6 +26,7 @@ func TestCLI_Feature_TUI_NonInteractiveGuardrail(t *testing.T) {
 	if !shouldRun(Hermetic) {
 		t.Skip("skipping hermetic test")
 	}
+	t.Parallel()
 
 	bin := buildBinary(t)
 	out := runExpectFail(t, bin, "tui")

--- a/e2e/matrix_test.go
+++ b/e2e/matrix_test.go
@@ -104,6 +104,10 @@ func dockerAvailable() bool {
 	return cmd.Run() == nil
 }
 
+// runFeatureMatrix deliberately does not mark the calling test parallel: a test
+// may call it more than once (see TestCLI_Feature_CompressedFilesRoundTrip),
+// and a second t.Parallel on the same T panics. Each top-level test declares
+// t.Parallel() itself, which is also where a reader expects to find it.
 func runFeatureMatrix(t *testing.T, spec featureSpec) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

- Declare `t.Parallel()` on each of the 45 top-level E2E tests. `runFeatureMatrix` already marked its *matrix entries* parallel, but the top-level tests were not — and Go runs a non-parallel test to completion before starting the next, so the suite serialised on one feature at a time and the matrix parallelism only ever applied within a single feature.
- Locally the suite goes from **144s to 47s**.

The harness needed no changes, which is what makes this safe:

- No test calls `t.Setenv` or `t.Chdir` — the two things that make a test ineligible for `t.Parallel`.
- Every subprocess gets an explicit `cmd.Env` from `cleanEnv()`, so no test depends on process-global environment.
- Sources, stores and restore roots are per-test `t.TempDir()`; the MinIO and SFTP stores each get their own container and a unique bucket, torn down via `t.Cleanup`.
- `buildBinary` is a `sync.Once` around a read-only binary.

`t.Parallel()` is declared in each test rather than inside `runFeatureMatrix`. Putting it in the helper is a one-line change covering 32 tests, but a test may legitimately call the helper more than once — `TestCLI_Feature_CompressedFilesRoundTrip` calls it for the encrypted and unencrypted cases — and the second call panics with `t.Parallel called multiple times`, pointing at the helper rather than the cause. A comment on `runFeatureMatrix` records why it stays out.

Part of #402's follow-up: E2E is the critical path of the CI run.

## Verification

- \`go test -shuffle=on -count=1 ./e2e/\` — four runs, all passing: 47.7s, 48.3s, 54.0s, 47.1s (no flakes under shuffled ordering)
- \`go vet ./e2e/\` passes; \`gofmt -l e2e/\` reports nothing

Throughput keeps scaling past the core count because these tests are subprocess-bound rather than CPU-bound:

| `-parallel` | wall clock |
| --- | --- |
| serial (before) | 144s |
| 4 | 83s |
| 8 | 51s |
| 12 | 45s |

A 2-core-multiple `-parallel` setting for the CI runners is a one-line follow-up in `ci.yml`, kept out of this PR since #402 is rewriting that file.