### PR TITLE
ci: collapse the coverage report in the job summary

### DIFF
--- a/.github/actions/coverage-summary/action.yml
+++ b/.github/actions/coverage-summary/action.yml
@@ -1,0 +1,47 @@
+name: Coverage summary
+description: >-
+  Append a Go coverage profile to the job summary as a collapsed section. The
+  per-function report is long enough to bury everything below it, so it stays
+  folded and the total is promoted onto the row you can see without expanding.
+
+inputs:
+  file:
+    description: Path to a Go coverage profile.
+    required: true
+  label:
+    description: Name shown on the collapsed row.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      # Values reach the script through the environment rather than through
+      # ${{ }} interpolation, which would splice them into the source text.
+      env:
+        COVERAGE_FILE: ${{ inputs.file }}
+        COVERAGE_LABEL: ${{ inputs.label }}
+      run: |
+        set -euo pipefail
+
+        # E2E builds its profile from GOCOVERDIR as the harness exits. Skip the
+        # section rather than failing the job if that conversion fell over.
+        if [ ! -f "$COVERAGE_FILE" ]; then
+          echo "coverage summary: $COVERAGE_FILE not found, skipping" >&2
+          exit 0
+        fi
+
+        report=$(go tool cover -func="$COVERAGE_FILE")
+        total=$(printf '%s\n' "$report" | tail -n 1 | awk '{print $NF}')
+
+        {
+          echo "<details>"
+          echo "<summary><strong>$COVERAGE_LABEL</strong> — total $total</summary>"
+          # A blank line is required here: without it GitHub keeps parsing as
+          # HTML and the fenced block below renders as literal backticks.
+          echo ""
+          echo '```text'
+          printf '%s\n' "$report"
+          echo '```'
+          echo "</details>"
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,15 +94,10 @@ jobs:
           reporter: golang-json
       - name: Coverage summary
         if: matrix.os == 'ubuntu-latest'
-        shell: bash
-        run: |
-          {
-            echo "## Unit coverage"
-            echo ""
-            echo '```text'
-            go tool cover -func=unit.out
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+        uses: ./.github/actions/coverage-summary
+        with:
+          file: unit.out
+          label: Unit coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         if: matrix.os == 'ubuntu-latest'
@@ -154,18 +149,10 @@ jobs:
           reporter: golang-json
       - name: Coverage summary
         if: matrix.os == 'ubuntu-latest'
-        shell: bash
-        run: |
-          # The harness converts GOCOVERDIR into this file on exit; skip the
-          # section rather than failing the job if that conversion fell over.
-          [ -f e2e_coverage.out ] || exit 0
-          {
-            echo "## E2E coverage"
-            echo ""
-            echo '```text'
-            go tool cover -func=e2e_coverage.out
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+        uses: ./.github/actions/coverage-summary
+        with:
+          file: e2e_coverage.out
+          label: E2E coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
## Summary

- Wrap the coverage report in `<details>` so it starts folded. `go tool cover -func` prints one row per function, which is long enough to push everything else in the job summary off the screen.
- Lift the total onto the visible row, so the number you usually want needs no expanding:

  > ▸ **Unit coverage** — total 81.8%

- Move the rendering into a composite action next to `setup-go`. The unit and E2E steps had grown into near-identical copies of the same shell block; each call site is now just the file and the label.
- Inputs reach the script through the environment rather than `${{ }}` interpolation, which would splice them into the source text.

A missing profile still skips the section instead of failing the job — the E2E profile is built from `GOCOVERDIR` as the harness exits, and that guard existed inline before.

## Verification

- \`go run github.com/rhysd/actionlint/cmd/actionlint@latest\` passes
- Ran the action's script against a real profile and confirmed the rendered markdown: `<details>`, a blank line before the fence (without it GitHub keeps parsing as HTML and the block renders as literal backticks), and the total parsed onto the summary row
- Ran it against a missing file and confirmed it exits 0 with a note on stderr