### PR TITLE
refactor: enable errorlint, bodyclose, copyloopvar and usetesting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,25 @@ concurrency:
 
 jobs:
   lint:
-    name: Lint
+    # golangci-lint only analyses the files that build for one GOOS, so a
+    # Linux-only run never opens *_darwin.go or *_windows.go — which is most of
+    # pkg/secretref's backends. Linting all three target platforms found real
+    # issues in every one of them; the runner stays ubuntu since GOOS only
+    # selects which files are analysed, not where the analysis runs.
+    name: Lint (${{ matrix.goos }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        goos: [linux, darwin, windows]
+    env:
+      GOOS: ${{ matrix.goos }}
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-go
       - name: Check go.mod is tidy
+        if: matrix.goos == 'linux'
         run: |
           go mod tidy
           git diff --exit-code -- go.mod go.sum

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,19 @@
 version: "2"
 
+linters:
+  # The v2 defaults (errcheck, govet, ineffassign, staticcheck, unused) plus:
+  enable:
+    # Error comparisons that break the moment an error is wrapped with %w,
+    # which this codebase does throughout.
+    - errorlint
+    # Leaked HTTP response bodies. The gdrive and onedrive sources are the
+    # only HTTP clients here, and a leak there holds a connection per file.
+    - bodyclose
+    # Pre-1.22 loop-variable copies, now dead weight.
+    - copyloopvar
+    # os.MkdirTemp and friends in tests, where t.TempDir cleans up on failure.
+    - usetesting
+
 formatters:
   enable:
     - gofmt

--- a/cmd/cloudstic/cmd_tui_forms_backend.go
+++ b/cmd/cloudstic/cmd_tui_forms_backend.go
@@ -67,7 +67,7 @@ func (b *tuiFormsBackend) ComposeSource(sourceType, value string) (string, error
 		return "", nil
 	}
 	if _, err := config.ParseSourceURI(source); err != nil {
-		return "", fmt.Errorf("invalid source: %v", err)
+		return "", fmt.Errorf("invalid source: %w", err)
 	}
 	return source, nil
 }

--- a/cmd/cloudstic/cmd_tui_store_backend.go
+++ b/cmd/cloudstic/cmd_tui_store_backend.go
@@ -28,7 +28,7 @@ func (b *tuiFormsBackend) ComposeStore(storeType, value string) (string, error) 
 		return "", nil
 	}
 	if _, err := config.ParseStoreURI(uri); err != nil {
-		return "", fmt.Errorf("invalid store: %v", err)
+		return "", fmt.Errorf("invalid store: %w", err)
 	}
 	return uri, nil
 }
@@ -47,7 +47,7 @@ func (b *tuiFormsBackend) StoreExists(name string) bool {
 
 func (b *tuiFormsBackend) ValidateSecretRef(ref string) error {
 	if _, err := secretref.Parse(ref); err != nil {
-		return fmt.Errorf("invalid secret reference: %v", err)
+		return fmt.Errorf("invalid secret reference: %w", err)
 	}
 	return nil
 }

--- a/e2e/feature_completion_runtime_test.go
+++ b/e2e/feature_completion_runtime_test.go
@@ -83,7 +83,6 @@ func runCompletionShellMatrix(t *testing.T, scenario completionScenario) {
 
 	rt := newCompletionRuntime(t)
 	for _, shell := range []string{"bash", "zsh", "fish"} {
-		shell := shell
 		t.Run(shell, func(t *testing.T) {
 			if _, err := exec.LookPath(shell); err != nil {
 				t.Skipf("%s not installed", shell)

--- a/e2e/harness_test.go
+++ b/e2e/harness_test.go
@@ -61,6 +61,12 @@ var (
 func buildBinary(t *testing.T) string {
 	t.Helper()
 	buildOnce.Do(func() {
+		// Deliberately not t.TempDir(): this runs once and the binary is shared
+		// by every test in the package, but t.TempDir() is scoped to whichever
+		// test happened to win the race into buildOnce — it would delete the
+		// binary the moment that test finished, and every test scheduled after
+		// it would exec a path that no longer exists.
+		//nolint:usetesting // see above; lifetime must outlive the calling test
 		dir, err := os.MkdirTemp("", "cloudstic-e2e-bin-*")
 		if err != nil {
 			buildErr = err

--- a/internal/engine/chunker.go
+++ b/internal/engine/chunker.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"io"
 	"sync"
 
@@ -115,7 +116,7 @@ func (c *Chunker) ProcessStream(ctx context.Context, r io.Reader, onProgress fun
 		defer close(jobs)
 		for {
 			chunk, err := cdc.Next()
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			if err != nil {

--- a/internal/engine/restore.go
+++ b/internal/engine/restore.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -201,7 +202,7 @@ func (rm *RestoreManager) runWithWriter(ctx context.Context, plan restorePlan, w
 			})
 			defer phase.Increment(1)
 			switch {
-			case err == errRestoreSkipped:
+			case errors.Is(err, errRestoreSkipped):
 				return nil
 			case err != nil:
 				phase.Log(fmt.Sprintf("Failed: %s: %v", rel, err))
@@ -221,7 +222,7 @@ func (rm *RestoreManager) runWithWriter(ctx context.Context, plan restorePlan, w
 
 		if meta.Type == core.FileTypeFolder {
 			if err := writer.MkdirAll(rel, meta); err != nil {
-				if err != errRestoreSkipped {
+				if !errors.Is(err, errRestoreSkipped) {
 					phase.Log(fmt.Sprintf("Failed: %s: %v", rel, err))
 					result.Errors++
 				}

--- a/internal/engine/restore_xattrs_stub.go
+++ b/internal/engine/restore_xattrs_stub.go
@@ -1,9 +1,0 @@
-//go:build !linux && !darwin
-
-package engine
-
-import "github.com/cloudstic/cli/internal/core"
-
-func applyRestoreXattrs(_ string, _ core.FileMeta, _ func(string, ...interface{})) error {
-	return nil
-}

--- a/internal/hamt/hamt.go
+++ b/internal/hamt/hamt.go
@@ -2,6 +2,7 @@ package hamt
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math/bits"
@@ -552,7 +553,7 @@ func lookupByKey(ctx context.Context, ns *NodeStore, root child, key string) (st
 		}
 		return nil
 	})
-	if err == errFoundSentinel {
+	if errors.Is(err, errFoundSentinel) {
 		return found, nil
 	}
 	return "", err

--- a/internal/storelayer/compressed_test.go
+++ b/internal/storelayer/compressed_test.go
@@ -2,7 +2,6 @@ package storelayer
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/cloudstic/cli/pkg/store/local"
@@ -12,11 +11,7 @@ func TestCompressedStore(t *testing.T) {
 	ctx := context.Background()
 
 	// 1. Setup local Datastore
-	tmpDir, err := os.MkdirTemp("", "cloudstic-compressed-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
+	tmpDir := t.TempDir()
 
 	localStore, err := local.New(tmpDir)
 	if err != nil {

--- a/internal/storelayer/metered_test.go
+++ b/internal/storelayer/metered_test.go
@@ -2,7 +2,6 @@ package storelayer
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/cloudstic/cli/pkg/store/local"
@@ -12,11 +11,7 @@ func TestMeteredStore(t *testing.T) {
 	ctx := context.Background()
 
 	// 1. Setup local Datastore
-	tmpDir, err := os.MkdirTemp("", "cloudstic-metered-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
+	tmpDir := t.TempDir()
 
 	localStore, err := local.New(tmpDir)
 	if err != nil {

--- a/internal/storelayer/pack_catalog_test.go
+++ b/internal/storelayer/pack_catalog_test.go
@@ -61,10 +61,7 @@ func (f *faultyCatalogStore) List(ctx context.Context, prefix string) ([]string,
 func newCatalogTestStore(t *testing.T) (*faultyCatalogStore, store.ObjectStore) {
 	t.Helper()
 
-	tmpDir, err := os.MkdirTemp("", "cloudstic-pack-catalog-*")
-	if err != nil {
-		t.Fatalf("create temp dir: %v", err)
-	}
+	tmpDir := t.TempDir()
 	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
 
 	localStore, err := local.New(tmpDir)

--- a/internal/storelayer/pack_durability_test.go
+++ b/internal/storelayer/pack_durability_test.go
@@ -87,10 +87,7 @@ func (d *deleteBlockingStore) Delete(ctx context.Context, key string) error {
 func TestPackStore_RepackInterruptedBeforeDeleteLosesNothing(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir, err := os.MkdirTemp("", "cloudstic-repack-durability-*")
-	if err != nil {
-		t.Fatalf("temp dir: %v", err)
-	}
+	tmpDir := t.TempDir()
 	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
 
 	localStore, err := local.New(tmpDir)

--- a/internal/storelayer/pack_test.go
+++ b/internal/storelayer/pack_test.go
@@ -2,7 +2,6 @@ package storelayer
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/cloudstic/cli/pkg/store/local"
@@ -11,11 +10,7 @@ import (
 func TestPackStore_RepackOrphan(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir, err := os.MkdirTemp("", "cloudstic-pack-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
+	tmpDir := t.TempDir()
 
 	localStore, err := local.New(tmpDir)
 	if err != nil {
@@ -80,11 +75,7 @@ func TestPackStore_RepackOrphan(t *testing.T) {
 func TestPackStore_RepackFragmented(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir, err := os.MkdirTemp("", "cloudstic-pack-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
+	tmpDir := t.TempDir()
 
 	localStore, err := local.New(tmpDir)
 	if err != nil {
@@ -164,11 +155,7 @@ func TestPackStore_RepackFragmented(t *testing.T) {
 func TestPackStore_RepackNoFragment(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir, err := os.MkdirTemp("", "cloudstic-pack-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
+	tmpDir := t.TempDir()
 
 	localStore, err := local.New(tmpDir)
 	if err != nil {

--- a/internal/storelayer/packfooter_test.go
+++ b/internal/storelayer/packfooter_test.go
@@ -389,10 +389,7 @@ func TestPackStore_FooterIsInertToOffsetBasedReaders(t *testing.T) {
 // GetRange must agree with a full Get, since footer recovery depends on it.
 func TestLocalStore_GetRangeMatchesFullGet(t *testing.T) {
 	ctx := context.Background()
-	tmp, err := os.MkdirTemp("", "cloudstic-range-*")
-	if err != nil {
-		t.Fatal(err)
-	}
+	tmp := t.TempDir()
 	t.Cleanup(func() { _ = os.RemoveAll(tmp) })
 
 	ls, err := local.New(tmp)

--- a/internal/tui/forms/form.go
+++ b/internal/tui/forms/form.go
@@ -7,6 +7,7 @@
 package forms
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -355,10 +356,7 @@ func (f *Form) submit() tea.Cmd {
 	result, err := f.Submit(f)
 	if err != nil {
 		var fieldErr *FieldError
-		if fe, ok := err.(*FieldError); ok {
-			fieldErr = fe
-		}
-		if fieldErr != nil {
+		if errors.As(err, &fieldErr) {
 			f.errField = fieldErr.Field
 			f.errMsg = fieldErr.Message
 			if field := f.field(fieldErr.Field); field != nil {

--- a/pkg/keychain/keychain.go
+++ b/pkg/keychain/keychain.go
@@ -128,7 +128,7 @@ func (c Chain) WrapAll(ctx context.Context, masterKey []byte) ([]KeySlot, error)
 	var results []KeySlot
 	for _, cred := range c {
 		slot, err := cred.Wrap(ctx, masterKey)
-		if err == ErrCannotWrap {
+		if errors.Is(err, ErrCannotWrap) {
 			continue
 		}
 		if err != nil {

--- a/pkg/secretref/backends/keychain_backend_darwin.go
+++ b/pkg/secretref/backends/keychain_backend_darwin.go
@@ -22,10 +22,12 @@ func defaultKeychainLookupBlob(ctx context.Context, service, account string) ([]
 
 	out, err := keychainGetGenericPasswordDarwin(service, account, "", "")
 	if err != nil {
-		switch err {
-		case keychain.ErrorItemNotFound:
+		switch {
+		case errors.Is(err, keychain.ErrorItemNotFound):
 			return nil, errKeychainNotFound
-		case keychain.ErrorInteractionNotAllowed, keychain.ErrorNotAvailable, keychain.ErrorNoSuchKeychain:
+		case errors.Is(err, keychain.ErrorInteractionNotAllowed),
+			errors.Is(err, keychain.ErrorNotAvailable),
+			errors.Is(err, keychain.ErrorNoSuchKeychain):
 			return nil, fmt.Errorf("%w: keychain locked or unavailable in this session", errKeychainUnavailable)
 		default:
 			return nil, fmt.Errorf("keychain lookup failed: %w", err)
@@ -59,7 +61,7 @@ func defaultKeychainStoreBlob(_ context.Context, service, account string, value 
 	item.SetData(value)
 
 	if err := keychainAddItemDarwin(item); err != nil {
-		if err == keychain.ErrorDuplicateItem {
+		if errors.Is(err, keychain.ErrorDuplicateItem) {
 			query := keychain.NewItem()
 			query.SetSecClass(keychain.SecClassGenericPassword)
 			query.SetService(service)
@@ -85,7 +87,7 @@ func defaultKeychainDelete(_ context.Context, service, account string) error {
 	query.SetAccount(account)
 
 	if err := keychainDeleteItemDarwin(query); err != nil {
-		if err == keychain.ErrorItemNotFound {
+		if errors.Is(err, keychain.ErrorItemNotFound) {
 			return nil
 		}
 		return mapKeychainStoreError(err)
@@ -94,8 +96,10 @@ func defaultKeychainDelete(_ context.Context, service, account string) error {
 }
 
 func mapKeychainStoreError(err error) error {
-	switch err {
-	case keychain.ErrorInteractionNotAllowed, keychain.ErrorNotAvailable, keychain.ErrorNoSuchKeychain:
+	switch {
+	case errors.Is(err, keychain.ErrorInteractionNotAllowed),
+		errors.Is(err, keychain.ErrorNotAvailable),
+		errors.Is(err, keychain.ErrorNoSuchKeychain):
 		return fmt.Errorf("%w: keychain locked or unavailable in this session", errKeychainUnavailable)
 	default:
 		return fmt.Errorf("keychain write failed: %w", err)

--- a/pkg/secretref/backends/keychain_backend_integration_darwin_test.go
+++ b/pkg/secretref/backends/keychain_backend_integration_darwin_test.go
@@ -27,10 +27,10 @@ func TestKeychainBackend_Integration(t *testing.T) {
 	item := keychain.NewGenericPassword(service, account, "", []byte(secret), "")
 	item.SetAccessible(keychain.AccessibleWhenUnlockedThisDeviceOnly)
 	if err := keychain.AddItem(item); err != nil {
-		if err == keychain.ErrorInteractionNotAllowed || err == keychain.ErrorNotAvailable || err == keychain.ErrorNoSuchKeychain {
+		if errors.Is(err, keychain.ErrorInteractionNotAllowed) || errors.Is(err, keychain.ErrorNotAvailable) || errors.Is(err, keychain.ErrorNoSuchKeychain) {
 			t.Skipf("keychain unavailable in this session: %v", err)
 		}
-		if err == keychain.ErrorDuplicateItem {
+		if errors.Is(err, keychain.ErrorDuplicateItem) {
 			query := keychain.NewItem()
 			query.SetSecClass(keychain.SecClassGenericPassword)
 			query.SetService(service)

--- a/pkg/secretref/backends/secret_service_backend_linux.go
+++ b/pkg/secretref/backends/secret_service_backend_linux.go
@@ -4,6 +4,7 @@ package backends
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -69,12 +70,10 @@ func defaultSecretServiceLookup(_ context.Context, collection, item string) (str
 func defaultSecretServiceExists(ctx context.Context, collection, item string) (bool, error) {
 	_, err := defaultSecretServiceLookup(ctx, collection, item)
 	if err != nil {
-		switch err {
-		case errSecretServiceNotFound:
+		if errors.Is(err, errSecretServiceNotFound) {
 			return false, nil
-		default:
-			return false, err
 		}
+		return false, err
 	}
 	return true, nil
 }
@@ -201,15 +200,17 @@ func mapSecretServiceCallError(err error, action string) error {
 	if err == nil {
 		return nil
 	}
-	switch e := err.(type) {
-	case dbus.Error:
-		return mapSecretServiceDBusErrorName(e.Name, action, err)
-	case *dbus.Error:
-		return mapSecretServiceDBusErrorName(e.Name, action, err)
+	var dbusErrPtr *dbus.Error
+	if errors.As(err, &dbusErrPtr) {
+		return mapSecretServiceDBusErrorName(dbusErrPtr.Name, action, err)
+	}
+	var dbusErr dbus.Error
+	if errors.As(err, &dbusErr) {
+		return mapSecretServiceDBusErrorName(dbusErr.Name, action, err)
 	}
 	lower := strings.ToLower(err.Error())
 	if strings.Contains(lower, "dbus") || strings.Contains(lower, "secret service") {
-		return fmt.Errorf("%w: %s failed (%v); use env://... as a fallback", errSecretServiceUnavailable, action, err)
+		return fmt.Errorf("%w: %s failed (%w); use env://... as a fallback", errSecretServiceUnavailable, action, err)
 	}
 	return fmt.Errorf("%s: %w", action, err)
 }

--- a/pkg/secretref/backends/wincred_backend_windows.go
+++ b/pkg/secretref/backends/wincred_backend_windows.go
@@ -4,6 +4,7 @@ package backends
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"unsafe"
 
@@ -42,10 +43,10 @@ func defaultWincredWriteSupported() bool { return true }
 func defaultWincredLookup(_ context.Context, target string) (string, error) {
 	value, err := wincredReadGenericCredential(target)
 	if err != nil {
-		switch err {
-		case windows.ERROR_NOT_FOUND:
+		switch {
+		case errors.Is(err, windows.ERROR_NOT_FOUND):
 			return "", errWincredNotFound
-		case windows.ERROR_NO_SUCH_LOGON_SESSION:
+		case errors.Is(err, windows.ERROR_NO_SUCH_LOGON_SESSION):
 			return "", fmt.Errorf("%w: Credential Manager unavailable in this logon session; this is common in service or scheduled-task contexts without a loaded user profile", errWincredUnavailable)
 		default:
 			return "", fmt.Errorf("windows credential lookup failed: %w", err)
@@ -57,24 +58,20 @@ func defaultWincredLookup(_ context.Context, target string) (string, error) {
 func defaultWincredExists(ctx context.Context, target string) (bool, error) {
 	_, err := defaultWincredLookup(ctx, target)
 	if err != nil {
-		switch err {
-		case errWincredNotFound:
+		if errors.Is(err, errWincredNotFound) {
 			return false, nil
-		default:
-			return false, err
 		}
+		return false, err
 	}
 	return true, nil
 }
 
 func defaultWincredStore(_ context.Context, target, value string) error {
 	if err := wincredWriteGenericCredential(target, value); err != nil {
-		switch err {
-		case windows.ERROR_NO_SUCH_LOGON_SESSION:
+		if errors.Is(err, windows.ERROR_NO_SUCH_LOGON_SESSION) {
 			return fmt.Errorf("%w: Credential Manager unavailable in this logon session; this is common in service or scheduled-task contexts without a loaded user profile", errWincredUnavailable)
-		default:
-			return fmt.Errorf("windows credential write failed: %w", err)
 		}
+		return fmt.Errorf("windows credential write failed: %w", err)
 	}
 	return nil
 }
@@ -93,12 +90,13 @@ func readGenericCredential(target string) (string, error) {
 		uintptr(unsafe.Pointer(&cred)),
 	)
 	if r1 == 0 {
-		if callErr != nil && callErr != windows.ERROR_SUCCESS {
+		if callErr != nil && !errors.Is(callErr, windows.ERROR_SUCCESS) {
 			return "", callErr
 		}
 		return "", windows.ERROR_GEN_FAILURE
 	}
-	defer procCredFree.Call(uintptr(unsafe.Pointer(cred)))
+	// CredFree returns void; the syscall wrapper's error is not meaningful here.
+	defer func() { _, _, _ = procCredFree.Call(uintptr(unsafe.Pointer(cred))) }()
 
 	if cred == nil {
 		return "", windows.ERROR_NOT_FOUND
@@ -128,7 +126,7 @@ func writeGenericCredential(target, value string) error {
 	}
 	r1, _, callErr := procCredWriteW.Call(uintptr(unsafe.Pointer(&cred)), 0)
 	if r1 == 0 {
-		if callErr != nil && callErr != windows.ERROR_SUCCESS {
+		if callErr != nil && !errors.Is(callErr, windows.ERROR_SUCCESS) {
 			return callErr
 		}
 		return windows.ERROR_GEN_FAILURE

--- a/pkg/source/gdrive/changes.go
+++ b/pkg/source/gdrive/changes.go
@@ -2,6 +2,7 @@ package gdrive
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/cloudstic/cli/pkg/source"
@@ -212,7 +213,7 @@ func (s *ChangeSource) resolveChangePath(ctx context.Context, meta source.FileMe
 	}
 	parentPath, err := s.resolveDrivePath(ctx, meta.Parents[0], pathMap)
 	if err != nil {
-		if err == errNotDescendant {
+		if errors.Is(err, errNotDescendant) {
 			return "", nil
 		}
 		return "", err

--- a/pkg/source/gdrive/source.go
+++ b/pkg/source/gdrive/source.go
@@ -3,6 +3,7 @@ package gdrive
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -571,8 +572,14 @@ func driveCallWithRetry[T any](ctx context.Context, fn func() (T, error)) (T, er
 	return result, err
 }
 
+// isRetryableGoogleErr reports whether err is a rate-limit or server-side
+// failure worth retrying. It unwraps rather than asserting directly: the API
+// client returns *googleapi.Error inside a *url.Error for transport-level
+// failures, and a bare assertion classified those as permanent — so a 429 or a
+// 503 reached on that path was surfaced immediately instead of being retried.
 func isRetryableGoogleErr(err error) bool {
-	if apiErr, ok := err.(*googleapi.Error); ok {
+	var apiErr *googleapi.Error
+	if errors.As(err, &apiErr) {
 		return apiErr.Code == 429 || apiErr.Code >= 500
 	}
 	return false
@@ -901,6 +908,8 @@ func (s *Source) GetFileStream(fileID string) (io.ReadCloser, error) {
 	err := retry.Do(context.Background(), retry.DefaultPolicy(), func() error {
 		call := s.service.Files.Get(fileID).SupportsAllDrives(true)
 		var err error
+		//nolint:bodyclose // resp.Body is returned to the caller as the
+		// io.ReadCloser it asked for; closing it here would close the stream.
 		resp, err = call.Download()
 		if err != nil {
 			if isRetryableGoogleErr(err) {
@@ -920,6 +929,8 @@ func (s *Source) exportFile(fileID, exportMimeType string) (io.ReadCloser, error
 	var resp *http.Response
 	err := retry.Do(context.Background(), retry.DefaultPolicy(), func() error {
 		var err error
+		//nolint:bodyclose // resp.Body is returned to the caller as the
+		// io.ReadCloser it asked for; closing it here would close the stream.
 		resp, err = s.service.Files.Export(fileID, exportMimeType).Download()
 		if err != nil {
 			if isRetryableGoogleErr(err) {

--- a/pkg/source/local/source_test.go
+++ b/pkg/source/local/source_test.go
@@ -12,11 +12,7 @@ import (
 
 func TestSource_WithExcludes(t *testing.T) {
 	ctx := context.Background()
-	tmpDir, err := os.MkdirTemp("", "cloudstic-exclude-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
+	tmpDir := t.TempDir()
 
 	// Create filesystem structure.
 	for _, dir := range []string{"src", ".git/objects", "node_modules/pkg", "build"} {
@@ -43,7 +39,7 @@ func TestSource_WithExcludes(t *testing.T) {
 
 	// Test Walk() — excluded files/dirs should not appear.
 	var walked []string
-	err = s.Walk(ctx, func(fm source.FileMeta) error {
+	err := s.Walk(ctx, func(fm source.FileMeta) error {
 		walked = append(walked, fm.FileID)
 		return nil
 	})
@@ -99,11 +95,7 @@ func TestSource_WithExcludes(t *testing.T) {
 
 func TestSource(t *testing.T) {
 	ctx := context.Background()
-	tmpDir, err := os.MkdirTemp("", "cloudstic-source-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
+	tmpDir := t.TempDir()
 
 	// Create a nested filesystem structure
 	nestedDir := filepath.Join(tmpDir, "folder")

--- a/pkg/source/local/source_volume_test.go
+++ b/pkg/source/local/source_volume_test.go
@@ -11,11 +11,7 @@ import (
 )
 
 func TestDetectVolumeIdentity_TempDir(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "cloudstic-volume-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
+	tmpDir := t.TempDir()
 
 	uuid, label, mountPoint := detectVolumeIdentity(tmpDir)
 
@@ -54,11 +50,7 @@ func TestNormalizeVolumeUUID(t *testing.T) {
 }
 
 func TestSource_WithVolumeUUID_Override(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "cloudstic-uuid-override-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
+	tmpDir := t.TempDir()
 
 	explicitUUID := "CUSTOM-UUID-1234-5678-ABCD-EF0123456789"
 	src := New(tmpDir, WithVolumeUUID(explicitUUID))
@@ -70,11 +62,7 @@ func TestSource_WithVolumeUUID_Override(t *testing.T) {
 }
 
 func TestSource_Info_PopulatesVolumeFields(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "cloudstic-info-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
+	tmpDir := t.TempDir()
 
 	src := New(tmpDir)
 	info := src.Info()
@@ -114,18 +102,14 @@ func TestSource_Info_PopulatesVolumeFields(t *testing.T) {
 }
 
 func TestSource_Walk_NormalizesPathSeparators(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "cloudstic-walk-sep-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
+	tmpDir := t.TempDir()
 
 	// Create nested structure.
 	writeTestFile(t, tmpDir, "docs/notes/file.txt", "hello")
 
 	src := New(tmpDir)
 	var metas []struct{ id, parent, path string }
-	err = src.Walk(t.Context(), func(fm source.FileMeta) error {
+	err := src.Walk(t.Context(), func(fm source.FileMeta) error {
 		var parent string
 		if len(fm.Parents) > 0 {
 			parent = fm.Parents[0]

--- a/pkg/source/local/source_windows.go
+++ b/pkg/source/local/source_windows.go
@@ -104,7 +104,7 @@ func getPartitionUUID(mountPoint string) string {
 	if err != nil {
 		return ""
 	}
-	defer windows.CloseHandle(handle)
+	defer func() { _ = windows.CloseHandle(handle) }()
 
 	var info partitionInformationEx
 	var bytesReturned uint32

--- a/pkg/store/debug_test.go
+++ b/pkg/store/debug_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"os"
 	"strings"
 	"testing"
 
@@ -15,11 +14,7 @@ import (
 func TestDebugStore_Operations(t *testing.T) {
 	ctx := context.Background()
 
-	tmp, err := os.MkdirTemp("", "cloudstic-debug-test-*")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = os.RemoveAll(tmp) }()
+	tmp := t.TempDir()
 
 	inner, err := local.New(tmp)
 	if err != nil {
@@ -125,11 +120,7 @@ func TestDebugStore_Operations(t *testing.T) {
 func TestDebugStore_LogsErrors(t *testing.T) {
 	ctx := context.Background()
 
-	tmp, err := os.MkdirTemp("", "cloudstic-debug-err-test-*")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = os.RemoveAll(tmp) }()
+	tmp := t.TempDir()
 
 	inner, err := local.New(tmp)
 	if err != nil {

--- a/pkg/store/local/store_test.go
+++ b/pkg/store/local/store_test.go
@@ -13,11 +13,7 @@ import (
 func TestStore(t *testing.T) {
 	ctx := context.Background()
 	// Setup temp dir
-	tmpDir, err := os.MkdirTemp("", "cloudstic-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
+	tmpDir := t.TempDir()
 
 	s, err := New(tmpDir)
 	if err != nil {

--- a/pkg/store/quota_test.go
+++ b/pkg/store/quota_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -41,7 +42,7 @@ func TestQuotaStore_ExceedsBudget(t *testing.T) {
 	if ctx.Err() == nil {
 		t.Fatal("context should be cancelled after exceeding budget")
 	}
-	if cause := context.Cause(ctx); cause != ErrQuotaExceeded {
+	if cause := context.Cause(ctx); !errors.Is(cause, ErrQuotaExceeded) {
 		t.Fatalf("expected ErrQuotaExceeded, got %v", cause)
 	}
 }

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -16,8 +16,13 @@ git diff --exit-code -- go.mod go.sum
 # Formatting is checked, not applied: .golangci.yml enables the gofmt formatter,
 # so `golangci-lint run` reports a misformatted file the same way CI does.
 # Run `golangci-lint fmt ./...` to fix what it reports.
-echo "==> Running golangci-lint..."
-golangci-lint run ./...
+# Once per target platform: golangci-lint only analyses the files that build
+# for one GOOS, so a single run never opens the *_darwin.go / *_windows.go
+# backends under pkg/secretref. CI runs the same three.
+for goos in linux darwin windows; do
+  echo "==> Running golangci-lint (GOOS=$goos)..."
+  GOOS=$goos golangci-lint run ./...
+done
 
 echo "==> Running markdownlint..."
 npx markdownlint-cli2 "**/*.md"


### PR DESCRIPTION
## Summary

`.golangci.yml` enabled only the v2 defaults. This adds four linters and fixes what they found.

**Enabling `errorlint` surfaced a blind spot first.** `golangci-lint` only analyses the files that build for one `GOOS`, so the Linux-only lint job never opened `*_darwin.go` or `*_windows.go` — which is most of `pkg/secretref`'s backends. Findings per platform: Linux 3, darwin 2, Windows 8. The lint job is now a `GOOS` matrix (linux/darwin/windows) and `scripts/check.sh` loops over the same three. Without that, half the fixes below live in files CI cannot see and would regress silently.

Findings worth calling out, as opposed to the mechanical ones:

- **`pkg/source/gdrive`** — `isRetryableGoogleErr` asserted `err.(*googleapi.Error)` directly. The API client returns that inside a `*url.Error` on transport failures, so a 429 or a 5xx reached on that path was classified **permanent and never retried** — on a source that fetches thousands of files.
- **`internal/engine/restore.go`** — the `errRestoreSkipped` sentinel was compared with `==`, so a wrapped skip from a writer implementation would be counted and logged as a restore *failure*.
- **`pkg/keychain`** — `WrapAll` compared `err == ErrCannotWrap` to decide which credentials to skip; a wrapped sentinel aborted the whole chain.
- **`internal/hamt`** — the `errFoundSentinel` walk terminator had the same problem, turning a successful lookup into an error.

Two `bodyclose` reports are **false positives**: `GetFileStream` and `exportFile` hand `resp.Body` to the caller as the `io.ReadCloser` it asked for, which the linter cannot see across the return. Both carry `//nolint` with that reason.

`usetesting` replaced `os.MkdirTemp` with `t.TempDir` in 17 tests. The eighteenth — `buildBinary` in `e2e` — keeps `os.MkdirTemp`: it runs once under `sync.Once` and the binary is shared by every test in the package, so a `t.TempDir` scoped to whichever test won the race into `buildOnce` would delete the binary the moment that test finished.

`internal/engine/restore_xattrs_stub.go` is deleted rather than annotated: its build tags (`!linux && !darwin`) are disjoint from its only callers' (`linux || darwin`), so the function was unreachable on every platform that compiled it.

## Verification

- \`GOOS=linux golangci-lint run ./...\` — 0 issues
- \`GOOS=darwin golangci-lint run ./...\` — 0 issues
- \`GOOS=windows golangci-lint run ./...\` — 0 issues
- \`GOOS=windows go build ./... && GOOS=windows go vet ./...\` passes (covers the deleted stub)
- \`go test -race -shuffle=on -count=1 \$(go list ./... | grep -v '/e2e')\` passes
- \`go test -shuffle=on -parallel 8 -count=1 ./e2e/\` passes
- \`go run github.com/rhysd/actionlint/cmd/actionlint@latest\` passes