### PR TITLE
fix: auth login built a source URI that named a drive, or did not parse

### DIFF
--- a/cmd/cloudstic/cmd_auth.go
+++ b/cmd/cloudstic/cmd_auth.go
@@ -120,23 +120,23 @@ func runAuthNew(r *runner, ctx context.Context, a *authNewArgs) int {
 	if err := validateRefName("auth", a.name); err != nil {
 		return r.fail("%v", err)
 	}
-	if a.provider != "google" && a.provider != "onedrive" {
+	if a.provider != config.ProviderGoogle && a.provider != config.ProviderOneDrive {
 		if r.canPrompt() {
-			picked, err := r.promptSelect(ctx, "Select auth provider", []string{"google", "onedrive"})
+			picked, err := r.promptSelect(ctx, "Select auth provider", []string{config.ProviderGoogle, config.ProviderOneDrive})
 			if err != nil {
 				return r.fail("Failed to read auth provider: %v", err)
 			}
 			a.provider = picked
 		}
-		if a.provider != "google" && a.provider != "onedrive" {
+		if a.provider != config.ProviderGoogle && a.provider != config.ProviderOneDrive {
 			return r.fail("-provider must be 'google' or 'onedrive'")
 		}
 	}
 
 	auth := profile.Auth{Provider: a.provider}
-	if a.provider == "google" {
+	if a.provider == config.ProviderGoogle {
 		if a.googleTokenFile == "" && a.googleTokenRef == "" {
-			def := defaultAuthTokenRef("google", a.name)
+			def := defaultAuthTokenRef(config.ProviderGoogle, a.name)
 			if r.canPrompt() {
 				v, err := r.promptLine(ctx, "Google token storage (file path or secret ref)", def)
 				if err != nil {
@@ -157,9 +157,9 @@ func runAuthNew(r *runner, ctx context.Context, a *authNewArgs) int {
 		auth.GoogleTokenFile = a.googleTokenFile
 		auth.GoogleTokenRef = a.googleTokenRef
 	}
-	if a.provider == "onedrive" {
+	if a.provider == config.ProviderOneDrive {
 		if a.onedriveTokenFile == "" && a.onedriveTokenRef == "" {
-			def := defaultAuthTokenRef("onedrive", a.name)
+			def := defaultAuthTokenRef(config.ProviderOneDrive, a.name)
 			if r.canPrompt() {
 				v, err := r.promptLine(ctx, "OneDrive token storage (file path or secret ref)", def)
 				if err != nil {
@@ -233,21 +233,13 @@ func runAuthLogin(r *runner, ctx context.Context, a *authLoginArgs) int {
 		return r.fail("Unknown auth %q", a.name)
 	}
 
-	src, err := open.Source(ctx, config.Source{
-		URI:       auth.Provider + "://auth",
-		ConfigDir: a.configDir,
-		Google: config.Google{
-			CredsPath: auth.GoogleCreds,
-			CredsRef:  auth.GoogleCredsRef,
-			TokenPath: auth.GoogleTokenFile,
-			TokenRef:  auth.GoogleTokenRef,
-		},
-		OneDrive: config.OneDrive{
-			ClientID:  auth.OneDriveClientID,
-			TokenPath: auth.OneDriveTokenFile,
-			TokenRef:  auth.OneDriveTokenRef,
-		},
-	}, open.WithSecretResolver(newSecretResolver(a.configDir)))
+	srcCfg, err := config.SourceForAuth(auth)
+	if err != nil {
+		return r.fail("Auth %q: %v", a.name, err)
+	}
+	srcCfg.ConfigDir = a.configDir
+
+	src, err := open.Source(ctx, srcCfg, open.WithSecretResolver(newSecretResolver(a.configDir)))
 	if err != nil {
 		return r.fail("Failed to initialize auth source: %v", err)
 	}
@@ -258,11 +250,11 @@ func runAuthLogin(r *runner, ctx context.Context, a *authLoginArgs) int {
 	return 0
 }
 
+// defaultAuthTokenRef is config.DefaultAuthTokenRef under the name this package
+// has always used for it. The convention itself lives in pkg/config so that
+// anything writing an auth entry produces the same reference the CLI reads.
 func defaultAuthTokenRef(provider, name string) string {
-	if name == "" {
-		name = "default"
-	}
-	return "config-token://" + provider + "/" + name
+	return config.DefaultAuthTokenRef(provider, name)
 }
 
 // authCommand declares the `auth` command group.

--- a/cmd/cloudstic/cmd_profile.go
+++ b/cmd/cloudstic/cmd_profile.go
@@ -415,7 +415,7 @@ func (r *runner) promptAuthSelection(ctx context.Context, cfg *profile.Config, p
 		return "", r.fail("Failed to read auth reference name: %v", err)
 	}
 
-	defTokenRef := "config-token://" + provider + "/" + refName
+	defTokenRef := config.DefaultAuthTokenRef(provider, refName)
 	tokenStorage, err := r.promptLine(ctx, "Token storage (file path or secret ref)", defTokenRef)
 	if err != nil {
 		return "", r.fail("Failed to read token storage: %v", err)

--- a/pkg/config/auth.go
+++ b/pkg/config/auth.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/cloudstic/cli/pkg/profile"
+)
+
+// Auth providers, as written in a profiles file's `provider:` field.
+const (
+	ProviderGoogle   = "google"
+	ProviderOneDrive = "onedrive"
+)
+
+// SourceURIForProvider returns the source URI that authenticates a provider
+// without addressing any particular content.
+//
+// The provider name and the source scheme are not the same word — Google's
+// provider is "google" but its scheme is "gdrive" — and the URI deliberately
+// carries no drive name or path. Both cloud sources resolve a drive name
+// eagerly during construction, so naming one here would make authenticating
+// depend on a drive existing, which is backwards: you authenticate in order to
+// find out which drives there are.
+func SourceURIForProvider(provider string) (string, error) {
+	switch provider {
+	case ProviderGoogle:
+		return "gdrive", nil
+	case ProviderOneDrive:
+		return "onedrive", nil
+	case "":
+		return "", fmt.Errorf("auth entry names no provider: want %q or %q", ProviderGoogle, ProviderOneDrive)
+	default:
+		return "", fmt.Errorf("unknown auth provider %q: want %q or %q", provider, ProviderGoogle, ProviderOneDrive)
+	}
+}
+
+// SourceForAuth returns the source configuration that authenticates auth's
+// provider with auth's credentials.
+//
+// Use it to act on a profiles file's auth entry — signing in, or checking which
+// account an entry belongs to — without addressing any content: pass the result
+// to open.Source and read the resulting source's Info.
+//
+// Only the credentials belonging to auth's provider are carried over. An entry
+// holding both providers' fields (which a hand-edited file may) does not produce
+// a source that would try both.
+func SourceForAuth(auth profile.Auth) (Source, error) {
+	uri, err := SourceURIForProvider(auth.Provider)
+	if err != nil {
+		return Source{}, err
+	}
+
+	cfg := Source{URI: uri}
+	switch auth.Provider {
+	case ProviderGoogle:
+		cfg.Google = Google{
+			CredsPath: auth.GoogleCreds,
+			CredsRef:  auth.GoogleCredsRef,
+			CredsJSON: auth.GoogleCredsJSON,
+			TokenPath: auth.GoogleTokenFile,
+			TokenRef:  auth.GoogleTokenRef,
+		}
+	case ProviderOneDrive:
+		cfg.OneDrive = OneDrive{
+			ClientID:  auth.OneDriveClientID,
+			TokenPath: auth.OneDriveTokenFile,
+			TokenRef:  auth.OneDriveTokenRef,
+		}
+	}
+	return cfg, nil
+}
+
+// DefaultAuthTokenRef returns the secret reference an auth entry's OAuth token
+// is stored under when the user names no location: a token in the config
+// directory's managed store, keyed by provider and entry name.
+//
+// An empty name yields the "default" entry, which is what an auth entry created
+// implicitly by `cloudstic backup gdrive` uses.
+func DefaultAuthTokenRef(provider, name string) string {
+	if name == "" {
+		name = "default"
+	}
+	return "config-token://" + provider + "/" + name
+}

--- a/pkg/config/auth_test.go
+++ b/pkg/config/auth_test.go
@@ -1,0 +1,160 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cloudstic/cli/pkg/config"
+	"github.com/cloudstic/cli/pkg/profile"
+)
+
+// TestSourceURIForProvider_ParsesAndNamesNoDrive is the regression test for a bug
+// that survived because the mapping lived in package main, where nothing typed it
+// and no test could reach it.
+//
+// `auth login` built its URI as provider + "://auth", which was wrong for both
+// providers in different ways: "google" is not a source scheme at all (Google's
+// is "gdrive"), so it failed to parse; and "onedrive://auth" parsed but put
+// "auth" in the host, which both cloud sources read as a *drive name* and
+// resolve eagerly during construction — so authenticating depended on a drive
+// called "auth" existing.
+//
+// Both halves are asserted here: the URI must parse, and it must carry no drive
+// name.
+func TestSourceURIForProvider_ParsesAndNamesNoDrive(t *testing.T) {
+	cases := []struct {
+		provider   string
+		wantScheme string
+	}{
+		{config.ProviderGoogle, "gdrive"},
+		{config.ProviderOneDrive, "onedrive"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.provider, func(t *testing.T) {
+			raw, err := config.SourceURIForProvider(tc.provider)
+			if err != nil {
+				t.Fatalf("SourceURIForProvider: %v", err)
+			}
+
+			uri, err := config.ParseSourceURI(raw)
+			if err != nil {
+				t.Fatalf("the URI for provider %q does not parse: %v", tc.provider, err)
+			}
+			if uri.Scheme != tc.wantScheme {
+				t.Errorf("scheme = %q, want %q", uri.Scheme, tc.wantScheme)
+			}
+			if uri.Host != "" {
+				t.Errorf("host = %q, want empty: a drive name here makes signing in "+
+					"depend on that drive existing", uri.Host)
+			}
+		})
+	}
+}
+
+func TestSourceURIForProvider_Rejects(t *testing.T) {
+	cases := []struct{ provider, want string }{
+		{"", "names no provider"},
+		{"gdrive", `unknown auth provider "gdrive"`}, // the scheme, not the provider
+		{"dropbox", `unknown auth provider "dropbox"`},
+		{"Google", `unknown auth provider "Google"`}, // matching is exact
+	}
+	for _, tc := range cases {
+		t.Run(tc.provider, func(t *testing.T) {
+			_, err := config.SourceURIForProvider(tc.provider)
+			if err == nil {
+				t.Fatalf("expected an error for provider %q", tc.provider)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not contain %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestSourceForAuth(t *testing.T) {
+	t.Run("google", func(t *testing.T) {
+		got, err := config.SourceForAuth(profile.Auth{
+			Provider:        config.ProviderGoogle,
+			GoogleCreds:     "/creds.json",
+			GoogleCredsRef:  "keychain://creds",
+			GoogleCredsJSON: `{"x":1}`,
+			GoogleTokenFile: "/token.json",
+			GoogleTokenRef:  "config-token://google/work",
+		})
+		if err != nil {
+			t.Fatalf("SourceForAuth: %v", err)
+		}
+		if got.URI != "gdrive" {
+			t.Errorf("URI = %q, want gdrive", got.URI)
+		}
+		want := config.Google{
+			CredsPath: "/creds.json",
+			CredsRef:  "keychain://creds",
+			CredsJSON: `{"x":1}`,
+			TokenPath: "/token.json",
+			TokenRef:  "config-token://google/work",
+		}
+		if got.Google != want {
+			t.Errorf("Google = %+v, want %+v", got.Google, want)
+		}
+	})
+
+	t.Run("onedrive", func(t *testing.T) {
+		got, err := config.SourceForAuth(profile.Auth{
+			Provider:          config.ProviderOneDrive,
+			OneDriveClientID:  "client-1",
+			OneDriveTokenFile: "/ms.json",
+			OneDriveTokenRef:  "config-token://onedrive/work",
+		})
+		if err != nil {
+			t.Fatalf("SourceForAuth: %v", err)
+		}
+		if got.URI != "onedrive" {
+			t.Errorf("URI = %q, want onedrive", got.URI)
+		}
+		want := config.OneDrive{
+			ClientID:  "client-1",
+			TokenPath: "/ms.json",
+			TokenRef:  "config-token://onedrive/work",
+		}
+		if got.OneDrive != want {
+			t.Errorf("OneDrive = %+v, want %+v", got.OneDrive, want)
+		}
+	})
+
+	// A hand-edited file may hold both providers' fields on one entry. Only the
+	// named provider's credentials travel, so the source cannot try both.
+	t.Run("carries only the named provider's credentials", func(t *testing.T) {
+		got, err := config.SourceForAuth(profile.Auth{
+			Provider:          config.ProviderGoogle,
+			GoogleTokenFile:   "/token.json",
+			OneDriveClientID:  "should-not-travel",
+			OneDriveTokenFile: "/should-not-travel.json",
+		})
+		if err != nil {
+			t.Fatalf("SourceForAuth: %v", err)
+		}
+		if got.OneDrive != (config.OneDrive{}) {
+			t.Errorf("OneDrive = %+v, want zero for a google entry", got.OneDrive)
+		}
+	})
+
+	t.Run("unknown provider", func(t *testing.T) {
+		if _, err := config.SourceForAuth(profile.Auth{Provider: "dropbox"}); err == nil {
+			t.Fatal("expected an error for an unknown provider")
+		}
+	})
+}
+
+func TestDefaultAuthTokenRef(t *testing.T) {
+	cases := []struct{ provider, name, want string }{
+		{"google", "work", "config-token://google/work"},
+		{"onedrive", "personal", "config-token://onedrive/personal"},
+		{"google", "", "config-token://google/default"},
+	}
+	for _, tc := range cases {
+		if got := config.DefaultAuthTokenRef(tc.provider, tc.name); got != tc.want {
+			t.Errorf("DefaultAuthTokenRef(%q, %q) = %q, want %q", tc.provider, tc.name, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`cloudstic auth login` constructed its source URI as `auth.Provider + "://auth"` ([cmd_auth.go:237](https://github.com/Cloudstic/cli/blob/main/cmd/cloudstic/cmd_auth.go#L237)). An auth entry's provider is `google` or `onedrive`, but those are not source schemes — Google's is `gdrive` — and the line was wrong for **both** providers, in different ways:

| provider | URI built | result |
|---|---|---|
| `google` | `google://auth` | **did not parse.** Every Google auth entry was unusable. |
| `onedrive` | `onedrive://auth` | parsed, but put `auth` in the host — which both cloud sources read as a shared-drive name and resolve eagerly during construction |

Reproduced against a build of `main`:

```
$ cloudstic auth login -profiles-file ./profiles.yaml google-work
Failed to initialize auth source: unknown source scheme "google" in "google://auth":
supported URI formats are local:<path> and sftp://[user@]host[:port]/<path>
```

The OneDrive half is the subtler one: `gdrive.New` resolves a drive name at [source.go:202](https://github.com/Cloudstic/cli/blob/main/pkg/source/gdrive/source.go#L202) and `onedrive.New` at [source.go:171](https://github.com/Cloudstic/cli/blob/main/pkg/source/onedrive/source.go#L171), so signing in depended on a drive literally named `auth` existing. That is backwards — you authenticate in order to discover which drives there are. It also means a naive `google` → `gdrive` swap would not have fixed this: it would have traded `unknown source scheme` for `shared drive "auth" not found`.

### Changes

- Add `config.SourceForAuth(profile.Auth) (config.Source, error)` — the provider→source mapping, next to the auth-ref provider rules it belongs with. The URI it produces is the bare scheme keyword, with no drive name and no path.
- Add `config.SourceURIForProvider`, `config.ProviderGoogle`, `config.ProviderOneDrive`, replacing the provider string literals in `cmd_auth.go`.
- Add `config.DefaultAuthTokenRef`, replacing the two in-tree copies of the `config-token://<provider>/<name>` convention (`cmd_auth.go` and `cmd_profile.go`).
- An unknown or missing provider now fails with a message naming the valid values, instead of a URI-parsing error that mentions neither.

Fixing this in `pkg/config` rather than in place is what makes it testable, and it closes a library gap in passing: a Go caller wanting "sign in with this auth entry" previously had to hand-write the mapping, including the part that was wrong.

## Verification

Both bugs are pinned by `TestSourceURIForProvider_ParsesAndNamesNoDrive`, which asserts the two properties that were violated — the URI parses, **and** it carries no drive name. Either bug alone fails it.

Reproduced and confirmed fixed with a real binary:

```
# before: unknown source scheme "google"
# after:
$ cloudstic auth login -profiles-file ./profiles.yaml -no-prompt google-work
Failed to initialize auth source: read credentials file: open /nonexistent/creds.json: no such file or directory
```

That is now the *correct* error — construction succeeds and the flow reaches real credential loading.

```
$ cloudstic auth login -profiles-file ./profiles.yaml -no-prompt broken   # provider: dropbox
Auth "broken": unknown auth provider "dropbox": want "google" or "onedrive"
```

- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./...` passes
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./...` reports `0 issues`

No documentation PR accompanies this: `commands/auth-login.mdx` already describes the intended behaviour, and the code now matches it.