### PR TITLE
fix: make an in-progress OAuth authorization interruptible

### DIFF
--- a/internal/sourceoauth/callback.go
+++ b/internal/sourceoauth/callback.go
@@ -21,7 +21,14 @@ import (
 //
 // If the browser cannot be opened, the auth URL is printed so the user can
 // navigate to it manually; the local server still captures the redirect.
-func ExchangeWithLocalServer(config *oauth2.Config, authCodeOpts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
+//
+// ctx governs the wait. This is the whole reason it is a parameter: the flow
+// blocks until a human finishes authorizing in a browser, which they may never
+// do, and the cloudstic CLI installs a SIGINT handler that cancels a context
+// rather than killing the process — so a wait that ignored ctx could not be
+// interrupted with Ctrl+C at all, and pressing it again would not help either.
+// Cancellation returns ctx.Err() promptly and shuts the local server down.
+func ExchangeWithLocalServer(ctx context.Context, config *oauth2.Config, authCodeOpts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
 	state, err := randomState()
 	if err != nil {
 		return nil, fmt.Errorf("generate state: %w", err)
@@ -66,23 +73,36 @@ func ExchangeWithLocalServer(config *oauth2.Config, authCodeOpts ...oauth2.AuthC
 
 	srv := &http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}
 	go func() { _ = srv.Serve(listener) }()
-	defer func() { _ = srv.Shutdown(context.Background()) }()
+	defer func() {
+		// Not ctx: on cancellation ctx is already done, and passing it here
+		// would skip the graceful shutdown entirely. A short bounded deadline
+		// lets an in-flight callback response finish without letting a wedged
+		// connection hold the process open.
+		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	}()
 
 	// PKCE: send code_challenge with the auth request
 	opts := append([]oauth2.AuthCodeOption{oauth2.S256ChallengeOption(verifier)}, authCodeOpts...)
 	authURL := config.AuthCodeURL(state, opts...)
 
 	fmt.Printf("Opening browser for authorization...\n")
-	if err := openBrowser(authURL); err != nil {
+	if err := openBrowserFn(authURL); err != nil {
 		fmt.Printf("Could not open browser automatically.\nPlease visit this URL:\n%s\n", authURL)
 	}
 
-	res := <-ch
+	var res result
+	select {
+	case res = <-ch:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 	if res.err != nil {
 		return nil, res.err
 	}
 
-	tok, err := config.Exchange(context.Background(), res.code, oauth2.VerifierOption(verifier))
+	tok, err := config.Exchange(ctx, res.code, oauth2.VerifierOption(verifier))
 	if err != nil {
 		return nil, fmt.Errorf("exchange token: %w", err)
 	}
@@ -96,6 +116,11 @@ func randomState() (string, error) {
 	}
 	return hex.EncodeToString(b), nil
 }
+
+// openBrowserFn is the browser launcher, indirected so tests can exercise the
+// flow without opening a real browser on the machine running them. Production
+// code never reassigns it.
+var openBrowserFn = openBrowser
 
 func openBrowser(url string) error {
 	var cmd *exec.Cmd

--- a/internal/sourceoauth/interrupt_test.go
+++ b/internal/sourceoauth/interrupt_test.go
@@ -1,0 +1,152 @@
+package sourceoauth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// stubBrowser replaces the real browser launcher for the duration of a test.
+// Without it these tests would open a browser window on the machine running
+// them, which is why the launcher is indirected at all.
+func stubBrowser(t *testing.T, fn func(string) error) {
+	t.Helper()
+	prev := openBrowserFn
+	openBrowserFn = fn
+	t.Cleanup(func() { openBrowserFn = prev })
+}
+
+func testOAuthConfig() *oauth2.Config {
+	return &oauth2.Config{
+		ClientID: "test-client",
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  "https://example.invalid/auth",
+			TokenURL: "https://example.invalid/token",
+		},
+	}
+}
+
+// TestExchangeWithLocalServer_CancelledContextReturns is the regression test for
+// an authorization that could not be interrupted.
+//
+// The flow waits for a human to finish authorizing in a browser, which they may
+// never do. The wait used to be a bare channel receive with no context, and the
+// cloudstic CLI installs signal.NotifyContext — which *replaces* SIGINT's
+// default "terminate the process" with "cancel this context". So Ctrl+C
+// cancelled a context nobody was watching and the command hung forever, with
+// further Ctrl+C doing nothing because the signal stays diverted.
+//
+// The bound matters as much as the assertion: a fix that returns eventually but
+// not promptly is not a fix a user would notice.
+func TestExchangeWithLocalServer_CancelledContextReturns(t *testing.T) {
+	stubBrowser(t, func(string) error { return nil })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel once the flow is under way, standing in for the user's Ctrl+C.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := ExchangeWithLocalServer(ctx, testOAuthConfig(), oauth2.AccessTypeOffline)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ExchangeWithLocalServer ignored a cancelled context and kept waiting; " +
+			"Ctrl+C cannot interrupt an authorization")
+	}
+}
+
+// A context cancelled before the call ever starts must not begin an
+// authorization the caller has already given up on.
+func TestExchangeWithLocalServer_AlreadyCancelled(t *testing.T) {
+	opened := false
+	stubBrowser(t, func(string) error {
+		opened = true
+		return nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := ExchangeWithLocalServer(ctx, testOAuthConfig(), oauth2.AccessTypeOffline)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ExchangeWithLocalServer did not return for an already-cancelled context")
+	}
+	_ = opened // the browser may or may not have been reached; the return is what matters
+}
+
+// The local callback server must not outlive the call. A leaked listener would
+// hold its port, so a second authorization in the same process could fail or,
+// worse, receive the first one's redirect.
+func TestExchangeWithLocalServer_ShutsDownItsListener(t *testing.T) {
+	var authURL string
+	stubBrowser(t, func(u string) error {
+		authURL = u
+		return nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+	if _, err := ExchangeWithLocalServer(ctx, testOAuthConfig(), oauth2.AccessTypeOffline); !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+
+	redirect := redirectURLFrom(t, authURL)
+	if redirect == "" {
+		t.Skip("could not recover the redirect URL from the auth URL")
+	}
+
+	// The server is shut down asynchronously; give it a moment to release.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		client := &http.Client{Timeout: 200 * time.Millisecond}
+		resp, err := client.Get(redirect) //nolint:noctx // short-lived liveness probe
+		if err != nil {
+			return // refused: the listener is gone, which is what we want
+		}
+		_ = resp.Body.Close()
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Errorf("the callback server at %s is still accepting connections after the call returned", redirect)
+}
+
+// redirectURLFrom extracts the redirect_uri the flow registered, which is where
+// its local server is listening.
+func redirectURLFrom(t *testing.T, authURL string) string {
+	t.Helper()
+	if authURL == "" {
+		return ""
+	}
+	u, err := url.Parse(authURL)
+	if err != nil {
+		return ""
+	}
+	return u.Query().Get("redirect_uri")
+}

--- a/pkg/source/gdrive/source.go
+++ b/pkg/source/gdrive/source.go
@@ -482,7 +482,7 @@ func oauthClient(ctx context.Context, config *oauth2.Config, r *secretref.Resolv
 	}
 
 	if err != nil {
-		tok, err = tokenFromWeb(config)
+		tok, err = tokenFromWeb(ctx, config)
 		if err != nil {
 			return nil, err
 		}
@@ -512,8 +512,8 @@ func oauthClient(ctx context.Context, config *oauth2.Config, r *secretref.Resolv
 	return oauth2.NewClient(ctx, pts), nil
 }
 
-func tokenFromWeb(config *oauth2.Config) (*oauth2.Token, error) {
-	return sourceoauth.ExchangeWithLocalServer(config, oauth2.AccessTypeOffline)
+func tokenFromWeb(ctx context.Context, config *oauth2.Config) (*oauth2.Token, error) {
+	return sourceoauth.ExchangeWithLocalServer(ctx, config, oauth2.AccessTypeOffline)
 }
 
 func tokenFromFile(file string) (*oauth2.Token, error) {

--- a/pkg/source/onedrive/source.go
+++ b/pkg/source/onedrive/source.go
@@ -135,7 +135,7 @@ func New(ctx context.Context, opts ...Option) (*Source, error) {
 	}
 
 	if err != nil {
-		token, err = sourceoauth.ExchangeWithLocalServer(conf, oauth2.AccessTypeOffline)
+		token, err = sourceoauth.ExchangeWithLocalServer(ctx, conf, oauth2.AccessTypeOffline)
 		if err != nil {
 			return nil, fmt.Errorf("onedrive auth: %w", err)
 		}


### PR DESCRIPTION
## Summary

After `Opening browser for authorization...`, the process could not be stopped with Ctrl+C — and pressing it again did not help either. The only ways out were SIGQUIT or another terminal.

`ExchangeWithLocalServer` waited for the browser redirect on a bare channel receive and took no `context.Context` at all:

```go
res := <-ch   // internal/sourceoauth/callback.go
```

On its own that would just be a process blocked on a channel, and SIGINT would still kill it. What made it *unkillable* is that `cmd/cloudstic` installs `signal.NotifyContext` ([main.go:32](https://github.com/Cloudstic/cli/blob/main/cmd/cloudstic/main.go#L32)), which **replaces** SIGINT's default "terminate the process" with "cancel this context". Ctrl+C therefore cancelled a context nobody was watching. And because the signal stays diverted until `stop()` runs, every subsequent Ctrl+C was swallowed too.

### Changes

- `ExchangeWithLocalServer` takes a `context.Context`; the wait selects on `ctx.Done()` alongside the callback.
- The token exchange uses `ctx` instead of `context.Background()`.
- `ctx` is threaded from both cloud sources' authorization paths — both already had one in scope and simply were not passing it.
- Server shutdown deliberately does **not** use `ctx`: on cancellation it is already done, and passing it would skip the graceful shutdown entirely. It gets a 2s bounded deadline derived with `context.WithoutCancel`, so an in-flight callback response can finish without a wedged connection holding the process open.
- The browser launcher is indirected behind an unexported package var, so the flow can be tested without opening a browser on the machine running the tests.

Cancellation surfaces as `context.Canceled`, which `runner.fail` already renders as `Interrupted.` with exit code 130 — so the user-visible behaviour matches every other interruptible command.

## Verification

All three regression tests were confirmed to **fail against the previous code**, not merely to pass against the new:

```
--- FAIL: TestExchangeWithLocalServer_CancelledContextReturns (5.00s)
    ExchangeWithLocalServer ignored a cancelled context and kept waiting; Ctrl+C cannot interrupt an authorization
--- FAIL: TestExchangeWithLocalServer_AlreadyCancelled (5.00s)
    ExchangeWithLocalServer did not return for an already-cancelled context
FAIL  github.com/cloudstic/cli/internal/sourceoauth  90.341s
```

The 90s package time is itself the third bug being caught: the listener test hung because the callback server outlived the call.

The tests assert a *bound*, not just eventual return — a fix that unblocks eventually but not promptly is not one a user would notice.

- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./...` passes
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./...` reports `0 issues`

## Not fixed here

`ExchangeWithLocalServer` writes its progress lines with `fmt.Printf` straight to `os.Stdout`, bypassing the runner's writers — so they are not capturable and would corrupt `-json` output. Pre-existing and unrelated to interruptibility; left for a separate change.

There is also still no overall deadline on the flow: a user who opens the browser and walks away leaves the command waiting indefinitely. Ctrl+C now works, which is what was reported, but a bounded default may be worth adding separately.