### PR TITLE
fix: honour GOOGLE_APPLICATION_CREDENTIALS and ONEDRIVE_CLIENT_ID in auth login

### DIFF
--- a/cmd/cloudstic/cmd_auth.go
+++ b/cmd/cloudstic/cmd_auth.go
@@ -196,8 +196,12 @@ func runAuthNew(r *runner, ctx context.Context, a *authNewArgs) int {
 
 type authLoginArgs struct {
 	*globalFlags
-	profilesFile string
-	name         string
+	profilesFile     string
+	name             string
+	googleCreds      string
+	googleCredsRef   string
+	googleCredsJSON  string
+	onedriveClientID string
 }
 
 func declareAuthLoginArgs(g *globalFlags) (*authLoginArgs, commandInput) {
@@ -206,9 +210,50 @@ func declareAuthLoginArgs(g *globalFlags) (*authLoginArgs, commandInput) {
 		flags: []flagSpec{
 			profilesFileFlag(&a.profilesFile, g),
 			stringFlag(&a.name, "name", "", "Auth reference name", withPlaceholder("<name>"), withCompleter("_cloudstic_auth_names")),
+			// Which OAuth client to authorize with. The entry normally says,
+			// but these let a caller supply one it does not have — and carry
+			// the environment bindings that make a build without the
+			// ldflags-injected default client usable at all.
+			stringFlag(&a.googleCreds, "google-credentials", "", "Path to Google OAuth client or service account credentials JSON file",
+				withEnv("GOOGLE_APPLICATION_CREDENTIALS"), withPlaceholder("<path>"), withCompleter("_files")),
+			stringFlag(&a.googleCredsRef, "google-credentials-ref", "", "Secret reference to Google credentials JSON",
+				withPlaceholder("<ref>")),
+			stringFlag(&a.googleCredsJSON, "google-credentials-json", "", "Inline Google credentials JSON",
+				withEnv("GOOGLE_CREDENTIALS_JSON"), withPlaceholder("<json>"), asSecret()),
+			stringFlag(&a.onedriveClientID, "onedrive-client-id", "", "OneDrive OAuth client ID",
+				withEnv("ONEDRIVE_CLIENT_ID"), withPlaceholder("<id>")),
 		},
 		positionals: []positionalSpec{optionalPositional(&a.name, "auth name", "", "_cloudstic_auth_names")},
 	}
+}
+
+// applyAuthLoginCredentialFlags folds this command's credential flags over the
+// auth entry's own values.
+//
+// The precedence is the one the rest of the CLI applies (see the
+// resolution-precedence note in config.go): an explicitly passed flag wins, then
+// what the auth entry says, then an environment value. That ordering is why this
+// consults flagProvided rather than just checking for a non-empty flag —
+// an environment value must not override an entry that names something
+// different, but must still fill an entry that names nothing.
+//
+// The environment bindings are what make a locally built binary usable: the
+// built-in OAuth client is injected via ldflags at release time, so a plain
+// `go build` has an empty client ID and any authorization it starts is rejected
+// for having no client_id at all.
+func applyAuthLoginCredentialFlags(cfg *config.Source, a *authLoginArgs) {
+	fold := func(flag, val string, dest *string) {
+		if val == "" {
+			return
+		}
+		if a.flagProvided(flag) || *dest == "" {
+			*dest = val
+		}
+	}
+	fold("google-credentials", a.googleCreds, &cfg.Google.CredsPath)
+	fold("google-credentials-ref", a.googleCredsRef, &cfg.Google.CredsRef)
+	fold("google-credentials-json", a.googleCredsJSON, &cfg.Google.CredsJSON)
+	fold("onedrive-client-id", a.onedriveClientID, &cfg.OneDrive.ClientID)
 }
 
 func runAuthLogin(r *runner, ctx context.Context, a *authLoginArgs) int {
@@ -238,6 +283,7 @@ func runAuthLogin(r *runner, ctx context.Context, a *authLoginArgs) int {
 		return r.fail("Auth %q: %v", a.name, err)
 	}
 	srcCfg.ConfigDir = a.configDir
+	applyAuthLoginCredentialFlags(&srcCfg, a)
 
 	src, err := open.Source(ctx, srcCfg, open.WithSecretResolver(newSecretResolver(a.configDir)))
 	if err != nil {

--- a/cmd/cloudstic/cmd_auth_login_test.go
+++ b/cmd/cloudstic/cmd_auth_login_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/cloudstic/cli/pkg/config"
+	"github.com/cloudstic/cli/pkg/profile"
+)
+
+// The built-in OAuth client is injected via ldflags at release time, so a plain
+// `go build` has an empty client ID and any authorization it starts is rejected
+// for carrying no client_id. GOOGLE_APPLICATION_CREDENTIALS is the documented
+// way out (internal/sourceoauth/defaults.go), but until these flags existed
+// nothing on the `auth login` path consulted it — the variable was bound only to
+// `backup`'s flag of the same name.
+func TestApplyAuthLoginCredentialFlags(t *testing.T) {
+	entry := profile.Auth{
+		Provider:    config.ProviderGoogle,
+		GoogleCreds: "/from-entry.json",
+	}
+
+	t.Run("environment fills an entry that names nothing", func(t *testing.T) {
+		srcCfg, err := config.SourceForAuth(profile.Auth{Provider: config.ProviderGoogle})
+		if err != nil {
+			t.Fatalf("SourceForAuth: %v", err)
+		}
+		// An environment value lands in the flag variable without being marked
+		// as explicitly provided, which is what applyEnvDefaults does.
+		a := &authLoginArgs{globalFlags: newTestGlobalFlags(), googleCreds: "/from-env.json"}
+
+		applyAuthLoginCredentialFlags(&srcCfg, a)
+
+		if srcCfg.Google.CredsPath != "/from-env.json" {
+			t.Errorf("creds = %q, want the environment value: an entry naming no "+
+				"credentials leaves a locally built binary with no OAuth client at all",
+				srcCfg.Google.CredsPath)
+		}
+	})
+
+	// The documented precedence is flag > entry > environment. An environment
+	// value must not silently redirect an entry that names something else.
+	t.Run("entry beats the environment", func(t *testing.T) {
+		srcCfg, err := config.SourceForAuth(entry)
+		if err != nil {
+			t.Fatalf("SourceForAuth: %v", err)
+		}
+		a := &authLoginArgs{globalFlags: newTestGlobalFlags(), googleCreds: "/from-env.json"}
+
+		applyAuthLoginCredentialFlags(&srcCfg, a)
+
+		if srcCfg.Google.CredsPath != "/from-entry.json" {
+			t.Errorf("creds = %q, want the entry's value", srcCfg.Google.CredsPath)
+		}
+	})
+
+	t.Run("an explicit flag beats the entry", func(t *testing.T) {
+		srcCfg, err := config.SourceForAuth(entry)
+		if err != nil {
+			t.Fatalf("SourceForAuth: %v", err)
+		}
+		a := &authLoginArgs{
+			globalFlags: testProvided(newTestGlobalFlags(), "google-credentials"),
+			googleCreds: "/from-flag.json",
+		}
+
+		applyAuthLoginCredentialFlags(&srcCfg, a)
+
+		if srcCfg.Google.CredsPath != "/from-flag.json" {
+			t.Errorf("creds = %q, want the explicitly passed flag", srcCfg.Google.CredsPath)
+		}
+	})
+
+	t.Run("every credential input is folded", func(t *testing.T) {
+		srcCfg, err := config.SourceForAuth(profile.Auth{Provider: config.ProviderGoogle})
+		if err != nil {
+			t.Fatalf("SourceForAuth: %v", err)
+		}
+		a := &authLoginArgs{
+			globalFlags:     newTestGlobalFlags(),
+			googleCreds:     "/creds.json",
+			googleCredsRef:  "keychain://creds",
+			googleCredsJSON: `{"x":1}`,
+		}
+
+		applyAuthLoginCredentialFlags(&srcCfg, a)
+
+		if srcCfg.Google.CredsPath != "/creds.json" ||
+			srcCfg.Google.CredsRef != "keychain://creds" ||
+			srcCfg.Google.CredsJSON != `{"x":1}` {
+			t.Errorf("Google = %+v, want every credential input carried over", srcCfg.Google)
+		}
+	})
+
+	t.Run("onedrive client id", func(t *testing.T) {
+		srcCfg, err := config.SourceForAuth(profile.Auth{Provider: config.ProviderOneDrive})
+		if err != nil {
+			t.Fatalf("SourceForAuth: %v", err)
+		}
+		a := &authLoginArgs{globalFlags: newTestGlobalFlags(), onedriveClientID: "client-from-env"}
+
+		applyAuthLoginCredentialFlags(&srcCfg, a)
+
+		if srcCfg.OneDrive.ClientID != "client-from-env" {
+			t.Errorf("client ID = %q, want the environment value", srcCfg.OneDrive.ClientID)
+		}
+	})
+
+	// Nothing configured anywhere must leave the config untouched rather than
+	// writing empty strings over the entry's values.
+	t.Run("no inputs leaves the entry alone", func(t *testing.T) {
+		srcCfg, err := config.SourceForAuth(entry)
+		if err != nil {
+			t.Fatalf("SourceForAuth: %v", err)
+		}
+		a := &authLoginArgs{globalFlags: newTestGlobalFlags()}
+
+		applyAuthLoginCredentialFlags(&srcCfg, a)
+
+		if srcCfg.Google.CredsPath != "/from-entry.json" {
+			t.Errorf("creds = %q, want the entry's value untouched", srcCfg.Google.CredsPath)
+		}
+	})
+}
+
+// TestAuthLoginBindsTheDocumentedEnvironmentVariables pins the bindings this fix
+// exists for. Losing one would silently restore the original bug: a locally
+// built binary starting an authorization with no client_id.
+func TestAuthLoginBindsTheDocumentedEnvironmentVariables(t *testing.T) {
+	_, input := declareAuthLoginArgs(newTestGlobalFlags())
+
+	bound := map[string]string{}
+	for _, f := range input.flags {
+		if f.env != "" {
+			bound[f.name] = f.env
+		}
+	}
+
+	want := map[string]string{
+		"google-credentials":      "GOOGLE_APPLICATION_CREDENTIALS",
+		"google-credentials-json": "GOOGLE_CREDENTIALS_JSON",
+		"onedrive-client-id":      "ONEDRIVE_CLIENT_ID",
+	}
+	for flag, env := range want {
+		if bound[flag] != env {
+			t.Errorf("flag -%s binds %q, want %q", flag, bound[flag], env)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`internal/sourceoauth/defaults.go` states that users can override the built-in OAuth client *"at runtime via environment variables (GOOGLE_APPLICATION_CREDENTIALS, ONEDRIVE_CLIENT_ID)"*, and `docs/user-guide.md` documents both. Neither was true for `auth login` — the variables were bound only to `backup`'s flags of the same name, so nothing on the login path read them.

This is invisible in a release build, where the default client ID is injected via ldflags, and breaks local development, where a plain `go build` leaves it empty:

1. `auth login` builds its source from the auth entry alone.
2. Entry has no `google_credentials` → `credsPath` empty → `loadCredsBytes` reports "nothing configured".
3. Falls through to the built-in client, whose `DefaultGoogleClientID` is `""`.
4. An authorization starts carrying **no `client_id`**, which the provider rejects.

### Changes

`auth login` declares the credential flags with their documented environment bindings, so the standard `applyEnvDefaults` pass supplies them:

| flag | environment |
|---|---|
| `-google-credentials` | `GOOGLE_APPLICATION_CREDENTIALS` |
| `-google-credentials-json` | `GOOGLE_CREDENTIALS_JSON` |
| `-onedrive-client-id` | `ONEDRIVE_CLIENT_ID` |
| `-google-credentials-ref` | — (no standard variable) |

They fold over the auth entry with the precedence the rest of the CLI applies (the resolution-precedence note in `config.go`): **explicit flag > entry > environment**. Consulting `flagProvided` rather than just checking for a non-empty flag is what keeps an ambient environment value from redirecting an entry that names something different, while still letting it fill an entry that names nothing.

Keeping the environment reading in `cmd/cloudstic` rather than in the source packages is deliberate: `pkg/source/gdrive` and `pkg/source/onedrive` stay free of process-environment lookups, so a Go library caller gets exactly the credentials it passes.

`auth new` deliberately does **not** gain these bindings. It writes what it is given into the profiles file, so an environment default there would persist a machine-specific path into a file that may be shared or committed.

## Verification

Against a built binary, with an auth entry naming no credentials:

```
# variable unset — still falls through to the empty built-in client
$ cloudstic auth login -profiles-file ./profiles.yaml -no-prompt google-work
Opening browser for authorization...

# variable set to a malformed file — proves the file is now read
$ GOOGLE_APPLICATION_CREDENTIALS=./bad.json cloudstic auth login ... google-work
Failed to initialize auth source: create drive client (service account): credentials: unsupported unidentified file type

# variable set to a valid desktop OAuth client — authorizes with that file's client ID
$ GOOGLE_APPLICATION_CREDENTIALS=./credentials.json cloudstic auth login ... google-work
Opening browser for authorization...
```

Unit tests cover each precedence rule separately — environment fills an empty entry, the entry beats the environment, an explicit flag beats the entry, and no inputs leave the entry untouched — plus `TestAuthLoginBindsTheDocumentedEnvironmentVariables`, which fails if a binding is ever dropped and the original bug silently returns.

- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./...` passes
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./...` reports `0 issues`

No golden files needed regenerating — `auth login` is not among the four commands with pinned help output, and the completion generators picked the new flags up from the command tree automatically.

<sub>One flake seen during the full-suite run: `TestCLI_Feature_ProfilesAllProfilesJSON` failed on a `covmeta` rename inside the shared `GOCOVERDIR`, with the command's own JSON output intact below the error. It passes in isolation. Pre-existing and unrelated — the e2e harness shares one coverage directory across parallel coverage-instrumented subprocesses.</sub>