### PR TITLE
refactor: run repository commands from resolved configuration

### DIFF
--- a/cmd/cloudstic/cmd_backup.go
+++ b/cmd/cloudstic/cmd_backup.go
@@ -140,7 +140,11 @@ func execBackup(r *runner, ctx context.Context, a *backupArgs, bcfg config.Backu
 		return r.fail("Failed to init source: %v", err)
 	}
 
-	if err := r.openClient(ctx, a.globalFlags); err != nil {
+	cfg, err := resolveClientConfig(a.globalFlags)
+	if err != nil {
+		return r.fail("Failed to init store: %v", err)
+	}
+	if err := r.openClient(ctx, cfg); err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
 

--- a/cmd/cloudstic/cmd_breaklock.go
+++ b/cmd/cloudstic/cmd_breaklock.go
@@ -16,11 +16,7 @@ func declareBreakLockArgs(g *globalFlags) (*breakLockArgs, commandInput) {
 	return &breakLockArgs{globalFlags: g}, commandInput{}
 }
 
-func runBreakLock(r *runner, ctx context.Context, a *breakLockArgs) int {
-	cfg, err := resolveClientConfig(a.globalFlags)
-	if err != nil {
-		return r.fail("Failed to init store: %v", err)
-	}
+func runBreakLock(r *runner, ctx context.Context, a *breakLockArgs, cfg clientConfig) int {
 	if err := r.openClient(ctx, cfg); err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
@@ -54,6 +50,6 @@ func printBreakLockResult(errOut io.Writer, removed []*cloudstic.RepoLock) {
 
 // breakLockCommand declares the `break-lock` command.
 func breakLockCommand() command {
-	return leaf("break-lock", "Remove a stale repository lock left by a crashed process",
+	return repoLeaf("break-lock", "Remove a stale repository lock left by a crashed process",
 		repoCommandGroups, declareBreakLockArgs, runBreakLock)
 }

--- a/cmd/cloudstic/cmd_breaklock.go
+++ b/cmd/cloudstic/cmd_breaklock.go
@@ -17,7 +17,11 @@ func declareBreakLockArgs(g *globalFlags) (*breakLockArgs, commandInput) {
 }
 
 func runBreakLock(r *runner, ctx context.Context, a *breakLockArgs) int {
-	if err := r.openClient(ctx, a.globalFlags); err != nil {
+	cfg, err := resolveClientConfig(a.globalFlags)
+	if err != nil {
+		return r.fail("Failed to init store: %v", err)
+	}
+	if err := r.openClient(ctx, cfg); err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
 

--- a/cmd/cloudstic/cmd_cat.go
+++ b/cmd/cloudstic/cmd_cat.go
@@ -26,11 +26,7 @@ func declareCatArgs(g *globalFlags) (*catArgs, commandInput) {
 	}
 }
 
-func runCat(r *runner, ctx context.Context, a *catArgs) int {
-	cfg, err := resolveClientConfig(a.globalFlags)
-	if err != nil {
-		return r.fail("Failed to init store: %v", err)
-	}
+func runCat(r *runner, ctx context.Context, a *catArgs, cfg clientConfig) int {
 	if err := r.openClient(ctx, cfg); err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
@@ -80,6 +76,6 @@ func printCatResult(out io.Writer, errOut io.Writer, results []*cloudstic.CatRes
 
 // catCommand declares the `cat` command.
 func catCommand() command {
-	return leaf("cat", "Display raw JSON content of repository objects",
+	return repoLeaf("cat", "Display raw JSON content of repository objects",
 		repoCommandGroups, declareCatArgs, runCat)
 }

--- a/cmd/cloudstic/cmd_cat.go
+++ b/cmd/cloudstic/cmd_cat.go
@@ -27,7 +27,11 @@ func declareCatArgs(g *globalFlags) (*catArgs, commandInput) {
 }
 
 func runCat(r *runner, ctx context.Context, a *catArgs) int {
-	if err := r.openClient(ctx, a.globalFlags); err != nil {
+	cfg, err := resolveClientConfig(a.globalFlags)
+	if err != nil {
+		return r.fail("Failed to init store: %v", err)
+	}
+	if err := r.openClient(ctx, cfg); err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
 

--- a/cmd/cloudstic/cmd_check.go
+++ b/cmd/cloudstic/cmd_check.go
@@ -25,7 +25,11 @@ func declareCheckArgs(g *globalFlags) (*checkArgs, commandInput) {
 }
 
 func runCheck(r *runner, ctx context.Context, a *checkArgs) int {
-	if err := r.openClient(ctx, a.globalFlags); err != nil {
+	cfg, err := resolveClientConfig(a.globalFlags)
+	if err != nil {
+		return r.fail("Failed to init store: %v", err)
+	}
+	if err := r.openClient(ctx, cfg); err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
 

--- a/cmd/cloudstic/cmd_check.go
+++ b/cmd/cloudstic/cmd_check.go
@@ -24,11 +24,7 @@ func declareCheckArgs(g *globalFlags) (*checkArgs, commandInput) {
 	}
 }
 
-func runCheck(r *runner, ctx context.Context, a *checkArgs) int {
-	cfg, err := resolveClientConfig(a.globalFlags)
-	if err != nil {
-		return r.fail("Failed to init store: %v", err)
-	}
+func runCheck(r *runner, ctx context.Context, a *checkArgs, cfg clientConfig) int {
 	if err := r.openClient(ctx, cfg); err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
@@ -89,6 +85,6 @@ func printCheckResult(errOut io.Writer, result *cloudstic.CheckResult) bool {
 
 // checkCommand declares the `check` command.
 func checkCommand() command {
-	return leaf("check", "Verify repository integrity (reference chain, objects, data)",
+	return repoLeaf("check", "Verify repository integrity (reference chain, objects, data)",
 		repoCommandGroups, declareCheckArgs, runCheck)
 }

--- a/cmd/cloudstic/cmd_diff.go
+++ b/cmd/cloudstic/cmd_diff.go
@@ -22,11 +22,7 @@ func declareDiffArgs(g *globalFlags) (*diffArgs, commandInput) {
 	}}
 }
 
-func runDiff(r *runner, ctx context.Context, a *diffArgs) int {
-	cfg, err := resolveClientConfig(a.globalFlags)
-	if err != nil {
-		return r.fail("Failed to init store: %v", err)
-	}
+func runDiff(r *runner, ctx context.Context, a *diffArgs, cfg clientConfig) int {
 	if err := r.openClient(ctx, cfg); err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
@@ -61,6 +57,6 @@ func printDiffResult(out io.Writer, result *cloudstic.DiffResult) {
 
 // diffCommand declares the `diff` command.
 func diffCommand() command {
-	return leaf("diff", "Compare two snapshots or a snapshot against latest",
+	return repoLeaf("diff", "Compare two snapshots or a snapshot against latest",
 		repoCommandGroups, declareDiffArgs, runDiff)
 }

--- a/cmd/cloudstic/cmd_diff.go
+++ b/cmd/cloudstic/cmd_diff.go
@@ -23,7 +23,11 @@ func declareDiffArgs(g *globalFlags) (*diffArgs, commandInput) {
 }
 
 func runDiff(r *runner, ctx context.Context, a *diffArgs) int {
-	if err := r.openClient(ctx, a.globalFlags); err != nil {
+	cfg, err := resolveClientConfig(a.globalFlags)
+	if err != nil {
+		return r.fail("Failed to init store: %v", err)
+	}
+	if err := r.openClient(ctx, cfg); err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
 

--- a/cmd/cloudstic/cmd_find.go
+++ b/cmd/cloudstic/cmd_find.go
@@ -85,17 +85,13 @@ func declareFindArgs(g *globalFlags) (*findArgs, commandInput) {
 	}
 }
 
-func runFind(r *runner, ctx context.Context, a *findArgs) int {
+func runFind(r *runner, ctx context.Context, a *findArgs, cfg clientConfig) int {
 	opts, err := buildFindOpts(a)
 	if err != nil {
 		if !a.jsonEnabled() {
 			r.printUsage(r.errOut)
 		}
 		return r.parseError(err)
-	}
-	cfg, err := resolveClientConfig(a.globalFlags)
-	if err != nil {
-		return r.fail("Failed to init store: %v", err)
 	}
 	if err := r.openClient(ctx, cfg); err != nil {
 		return r.fail("Failed to init store: %v", err)
@@ -371,6 +367,6 @@ func formatFindTime(unix int64) string {
 
 // findCommand declares the `find` command.
 func findCommand() command {
-	return leaf("find", "Locate a file across every snapshot in the repository",
+	return repoLeaf("find", "Locate a file across every snapshot in the repository",
 		repoCommandGroups, declareFindArgs, runFind)
 }

--- a/cmd/cloudstic/cmd_find.go
+++ b/cmd/cloudstic/cmd_find.go
@@ -93,7 +93,11 @@ func runFind(r *runner, ctx context.Context, a *findArgs) int {
 		}
 		return r.parseError(err)
 	}
-	if err := r.openClient(ctx, a.globalFlags); err != nil {
+	cfg, err := resolveClientConfig(a.globalFlags)
+	if err != nil {
+		return r.fail("Failed to init store: %v", err)
+	}
+	if err := r.openClient(ctx, cfg); err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
 

--- a/cmd/cloudstic/cmd_find_test.go
+++ b/cmd/cloudstic/cmd_find_test.go
@@ -123,7 +123,7 @@ func TestRunFind_JSONEmitsResultAndKeepsWarningsOnStderr(t *testing.T) {
 	g.json = true
 	r := &runner{out: &out, errOut: &errOut, client: stub}
 
-	if code := runFind(r, context.Background(), &findArgs{globalFlags: g, pattern: "*.kdbx"}); code != 0 {
+	if code := runFind(r, context.Background(), &findArgs{globalFlags: g, pattern: "*.kdbx"}, clientConfig{}); code != 0 {
 		t.Fatalf("exit code = %d", code)
 	}
 
@@ -155,7 +155,7 @@ func TestRunFind_NoMatchesSucceeds(t *testing.T) {
 	stub := &stubClient{findResult: &cloudstic.FindResult{SnapshotsSearched: 2, Elapsed: "1ms"}}
 	r := &runner{out: &out, errOut: &errOut, client: stub}
 
-	if code := runFind(r, context.Background(), &findArgs{globalFlags: newTestGlobalFlags(), pattern: "nope"}); code != 0 {
+	if code := runFind(r, context.Background(), &findArgs{globalFlags: newTestGlobalFlags(), pattern: "nope"}, clientConfig{}); code != 0 {
 		t.Fatalf("exit code = %d, want 0", code)
 	}
 	if !strings.Contains(out.String(), "No matches") {
@@ -168,7 +168,7 @@ func TestRunFind_InvalidArgumentsFailBeforeOpeningTheRepository(t *testing.T) {
 	stub := &stubClient{}
 	r := &runner{out: &out, errOut: &errOut, client: stub}
 
-	code := runFind(r, context.Background(), &findArgs{globalFlags: newTestGlobalFlags(), size: "nonsense"})
+	code := runFind(r, context.Background(), &findArgs{globalFlags: newTestGlobalFlags(), size: "nonsense"}, clientConfig{})
 	if code == 0 {
 		t.Fatal("want a non-zero exit for an unparseable -size")
 	}

--- a/cmd/cloudstic/cmd_forget.go
+++ b/cmd/cloudstic/cmd_forget.go
@@ -146,7 +146,11 @@ func runForget(r *runner, ctx context.Context, a *forgetArgs) int {
 		}
 		return r.parseError(err)
 	}
-	if err := r.openClient(ctx, a.globalFlags); err != nil {
+	cfg, err := resolveClientConfig(a.globalFlags)
+	if err != nil {
+		return r.fail("Failed to init store: %v", err)
+	}
+	if err := r.openClient(ctx, cfg); err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
 

--- a/cmd/cloudstic/cmd_forget.go
+++ b/cmd/cloudstic/cmd_forget.go
@@ -139,16 +139,12 @@ func validateForgetArgs(a *forgetArgs) error {
 	return nil
 }
 
-func runForget(r *runner, ctx context.Context, a *forgetArgs) int {
+func runForget(r *runner, ctx context.Context, a *forgetArgs, cfg clientConfig) int {
 	if err := prepareForgetArgs(a); err != nil {
 		if !r.jsonEnabled() {
 			r.printUsage(r.errOut)
 		}
 		return r.parseError(err)
-	}
-	cfg, err := resolveClientConfig(a.globalFlags)
-	if err != nil {
-		return r.fail("Failed to init store: %v", err)
 	}
 	if err := r.openClient(ctx, cfg); err != nil {
 		return r.fail("Failed to init store: %v", err)
@@ -296,6 +292,6 @@ func printPolicyResult(out io.Writer, result *cloudstic.PolicyResult, dryRun boo
 
 // forgetCommand declares the `forget` command.
 func forgetCommand() command {
-	return leaf("forget", "Remove a specific snapshot from history",
+	return repoLeaf("forget", "Remove a specific snapshot from history",
 		repoCommandGroups, declareForgetArgs, runForget)
 }

--- a/cmd/cloudstic/cmd_init.go
+++ b/cmd/cloudstic/cmd_init.go
@@ -30,11 +30,7 @@ func declareInitArgs(g *globalFlags) (*initArgs, commandInput) {
 	}}
 }
 
-func runInit(r *runner, ctx context.Context, a *initArgs) int {
-	cfg, err := resolveClientConfig(a.globalFlags)
-	if err != nil {
-		return r.fail("Failed to init store: %v", err)
-	}
+func runInit(r *runner, ctx context.Context, a *initArgs, cfg clientConfig) int {
 	return execInit(r, ctx, a, cfg)
 }
 
@@ -132,6 +128,6 @@ func printRecoveryKey(errOut io.Writer, mnemonic string) {
 
 // initCommand declares the `init` command.
 func initCommand() command {
-	return leaf("init", "Initialize a new repository (must run before first backup)",
+	return repoLeaf("init", "Initialize a new repository (must run before first backup)",
 		repoCommandGroups, declareInitArgs, runInit)
 }

--- a/cmd/cloudstic/cmd_key.go
+++ b/cmd/cloudstic/cmd_key.go
@@ -23,11 +23,7 @@ func declareKeyListArgs(g *globalFlags) (*keyListArgs, commandInput) {
 	return &keyListArgs{globalFlags: g}, commandInput{}
 }
 
-func runKeyList(r *runner, ctx context.Context, a *keyListArgs) int {
-	cfg, err := resolveClientConfig(a.globalFlags)
-	if err != nil {
-		return r.fail("Failed to init store: %v", err)
-	}
+func runKeyList(r *runner, ctx context.Context, a *keyListArgs, cfg clientConfig) int {
 	raw, err := openStore(ctx, cfg.Store)
 	if err != nil {
 		return r.fail("Failed to init store: %v", err)
@@ -77,11 +73,7 @@ func declareKeyPasswdArgs(g *globalFlags) (*keyPasswdArgs, commandInput) {
 	}}
 }
 
-func runKeyPasswd(r *runner, ctx context.Context, a *keyPasswdArgs) int {
-	cfg, err := resolveClientConfig(a.globalFlags)
-	if err != nil {
-		return r.fail("Failed to init store: %v", err)
-	}
+func runKeyPasswd(r *runner, ctx context.Context, a *keyPasswdArgs, cfg clientConfig) int {
 	raw, err := openStore(ctx, cfg.Store)
 	if err != nil {
 		return r.fail("Failed to init store: %v", err)
@@ -133,11 +125,7 @@ func declareAddRecoveryKeyArgs(g *globalFlags) (*addRecoveryKeyArgs, commandInpu
 	}}
 }
 
-func runAddRecoveryKey(r *runner, ctx context.Context, a *addRecoveryKeyArgs) int {
-	cfg, err := resolveClientConfig(a.globalFlags)
-	if err != nil {
-		return r.fail("Failed to init store: %v", err)
-	}
+func runAddRecoveryKey(r *runner, ctx context.Context, a *addRecoveryKeyArgs, cfg clientConfig) int {
 	raw, err := openStore(ctx, cfg.Store)
 	if err != nil {
 		return r.fail("Failed to init store: %v", err)
@@ -172,11 +160,11 @@ func runAddRecoveryKey(r *runner, ctx context.Context, a *addRecoveryKeyArgs) in
 // keyCommand declares the `key` command group.
 func keyCommand() command {
 	return group("key", "Manage encryption key slots",
-		leaf("list", "List all encryption key slots in the repository",
+		repoLeaf("list", "List all encryption key slots in the repository",
 			repoCommandGroups, declareKeyListArgs, runKeyList),
-		leaf("add-recovery", "Generate a 24-word recovery key for an encrypted repository",
+		repoLeaf("add-recovery", "Generate a 24-word recovery key for an encrypted repository",
 			repoCommandGroups, declareAddRecoveryKeyArgs, runAddRecoveryKey),
-		leaf("passwd", "Change the repository password",
+		repoLeaf("passwd", "Change the repository password",
 			repoCommandGroups, declareKeyPasswdArgs, runKeyPasswd),
 	)
 }

--- a/cmd/cloudstic/cmd_list.go
+++ b/cmd/cloudstic/cmd_list.go
@@ -21,7 +21,11 @@ func declareListArgs(g *globalFlags) (*listArgs, commandInput) {
 }
 
 func runList(r *runner, ctx context.Context, a *listArgs) int {
-	if err := r.openClient(ctx, a.globalFlags); err != nil {
+	cfg, err := resolveClientConfig(a.globalFlags)
+	if err != nil {
+		return r.fail("Failed to init store: %v", err)
+	}
+	if err := r.openClient(ctx, cfg); err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
 

--- a/cmd/cloudstic/cmd_list.go
+++ b/cmd/cloudstic/cmd_list.go
@@ -20,11 +20,7 @@ func declareListArgs(g *globalFlags) (*listArgs, commandInput) {
 	}}
 }
 
-func runList(r *runner, ctx context.Context, a *listArgs) int {
-	cfg, err := resolveClientConfig(a.globalFlags)
-	if err != nil {
-		return r.fail("Failed to init store: %v", err)
-	}
+func runList(r *runner, ctx context.Context, a *listArgs, cfg clientConfig) int {
 	if err := r.openClient(ctx, cfg); err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
@@ -61,6 +57,6 @@ func printListResult(out io.Writer, result *cloudstic.ListResult, group bool) {
 
 // listCommand declares the `list` command.
 func listCommand() command {
-	return leaf("list", "List all backup snapshots in the repository",
+	return repoLeaf("list", "List all backup snapshots in the repository",
 		repoCommandGroups, declareListArgs, runList)
 }

--- a/cmd/cloudstic/cmd_ls.go
+++ b/cmd/cloudstic/cmd_ls.go
@@ -27,7 +27,11 @@ func declareLsArgs(g *globalFlags) (*lsArgs, commandInput) {
 }
 
 func runLsSnapshot(r *runner, ctx context.Context, a *lsArgs) int {
-	if err := r.openClient(ctx, a.globalFlags); err != nil {
+	cfg, err := resolveClientConfig(a.globalFlags)
+	if err != nil {
+		return r.fail("Failed to init store: %v", err)
+	}
+	if err := r.openClient(ctx, cfg); err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
 

--- a/cmd/cloudstic/cmd_ls.go
+++ b/cmd/cloudstic/cmd_ls.go
@@ -26,11 +26,7 @@ func declareLsArgs(g *globalFlags) (*lsArgs, commandInput) {
 	}}
 }
 
-func runLsSnapshot(r *runner, ctx context.Context, a *lsArgs) int {
-	cfg, err := resolveClientConfig(a.globalFlags)
-	if err != nil {
-		return r.fail("Failed to init store: %v", err)
-	}
+func runLsSnapshot(r *runner, ctx context.Context, a *lsArgs, cfg clientConfig) int {
 	if err := r.openClient(ctx, cfg); err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
@@ -99,6 +95,6 @@ func appendTreeNode(l list.Writer, ref string, refToMeta map[string]core.FileMet
 
 // lsCommand declares the `ls` command.
 func lsCommand() command {
-	return leaf("ls", "List files within a specific snapshot",
+	return repoLeaf("ls", "List files within a specific snapshot",
 		repoCommandGroups, declareLsArgs, runLsSnapshot)
 }

--- a/cmd/cloudstic/cmd_prune.go
+++ b/cmd/cloudstic/cmd_prune.go
@@ -22,7 +22,11 @@ func declarePruneArgs(g *globalFlags) (*pruneArgs, commandInput) {
 }
 
 func runPrune(r *runner, ctx context.Context, a *pruneArgs) int {
-	if err := r.openClient(ctx, a.globalFlags); err != nil {
+	cfg, err := resolveClientConfig(a.globalFlags)
+	if err != nil {
+		return r.fail("Failed to init store: %v", err)
+	}
+	if err := r.openClient(ctx, cfg); err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
 

--- a/cmd/cloudstic/cmd_prune.go
+++ b/cmd/cloudstic/cmd_prune.go
@@ -21,11 +21,7 @@ func declarePruneArgs(g *globalFlags) (*pruneArgs, commandInput) {
 	}}
 }
 
-func runPrune(r *runner, ctx context.Context, a *pruneArgs) int {
-	cfg, err := resolveClientConfig(a.globalFlags)
-	if err != nil {
-		return r.fail("Failed to init store: %v", err)
-	}
+func runPrune(r *runner, ctx context.Context, a *pruneArgs, cfg clientConfig) int {
 	if err := r.openClient(ctx, cfg); err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
@@ -70,6 +66,6 @@ func printPruneStats(out io.Writer, res *cloudstic.PruneResult) {
 
 // pruneCommand declares the `prune` command.
 func pruneCommand() command {
-	return leaf("prune", "Remove unused data chunks from the repository",
+	return repoLeaf("prune", "Remove unused data chunks from the repository",
 		repoCommandGroups, declarePruneArgs, runPrune)
 }

--- a/cmd/cloudstic/cmd_restore.go
+++ b/cmd/cloudstic/cmd_restore.go
@@ -38,7 +38,7 @@ func declareRestoreArgs(g *globalFlags) (*restoreArgs, commandInput) {
 	}
 }
 
-func runRestore(r *runner, ctx context.Context, a *restoreArgs) int {
+func runRestore(r *runner, ctx context.Context, a *restoreArgs, cfg clientConfig) int {
 	a.format = strings.TrimSpace(strings.ToLower(a.format))
 	format, err := resolveRestoreFormat(a.format, a.output)
 	if err != nil {
@@ -46,10 +46,6 @@ func runRestore(r *runner, ctx context.Context, a *restoreArgs) int {
 	}
 	a.format = format
 
-	cfg, err := resolveClientConfig(a.globalFlags)
-	if err != nil {
-		return r.fail("Failed to init store: %v", err)
-	}
 	if err := r.openClient(ctx, cfg); err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
@@ -159,6 +155,6 @@ func resolveRestoreFormat(explicitFormat, output string) (string, error) {
 
 // restoreCommand declares the `restore` command.
 func restoreCommand() command {
-	return leaf("restore", "Restore files from a backup snapshot",
+	return repoLeaf("restore", "Restore files from a backup snapshot",
 		repoCommandGroups, declareRestoreArgs, runRestore)
 }

--- a/cmd/cloudstic/cmd_restore.go
+++ b/cmd/cloudstic/cmd_restore.go
@@ -46,7 +46,11 @@ func runRestore(r *runner, ctx context.Context, a *restoreArgs) int {
 	}
 	a.format = format
 
-	if err := r.openClient(ctx, a.globalFlags); err != nil {
+	cfg, err := resolveClientConfig(a.globalFlags)
+	if err != nil {
+		return r.fail("Failed to init store: %v", err)
+	}
+	if err := r.openClient(ctx, cfg); err != nil {
 		return r.fail("Failed to init store: %v", err)
 	}
 

--- a/cmd/cloudstic/command.go
+++ b/cmd/cloudstic/command.go
@@ -162,21 +162,69 @@ func leaf[T any](
 	run func(r *runner, ctx context.Context, a *T) int,
 	opts ...commandOpt,
 ) command {
-	build := func() (*T, commandFlags) {
+	return leafWith(name, summary, groups, declare,
+		func(r *runner, ctx context.Context, a *T, _ *globalFlags) int {
+			return run(r, ctx, a)
+		}, opts...)
+}
+
+// repoLeaf declares a command that opens a repository.
+//
+// It resolves the client configuration once, after a successful parse, and hands
+// it to run — so the two-step "resolve, then connect" happens in one place
+// instead of once per command. Before this existed, every such command carried
+// its own copy of the resolve call and of the failure message for it, which is
+// eleven chances for them to drift and eleven error branches no test exercised.
+//
+// Resolution deliberately happens after parsing rather than before: it reads the
+// profiles file, and `-h`, completion and a parse failure must not.
+//
+// Not every repository command fits. `backup` runs its profile loop N times with
+// N configurations, one per profile, so a single value resolved before dispatch
+// would be wrong for it — it uses leaf and resolves per iteration.
+func repoLeaf[T any](
+	name, summary string,
+	groups []flagGroup,
+	declare declareArgs[T],
+	run func(r *runner, ctx context.Context, a *T, cfg clientConfig) int,
+	opts ...commandOpt,
+) command {
+	return leafWith(name, summary, groups, declare,
+		func(r *runner, ctx context.Context, a *T, g *globalFlags) int {
+			cfg, err := resolveClientConfig(g)
+			if err != nil {
+				return r.fail("Failed to init store: %v", err)
+			}
+			return run(r, ctx, a, cfg)
+		}, opts...)
+}
+
+// leafWith is the shared body of leaf and repoLeaf. invoke receives the parsed
+// args together with the global flags they were parsed into, which is what lets
+// repoLeaf resolve a configuration without every command having to hand its own
+// flag struct back.
+func leafWith[T any](
+	name, summary string,
+	groups []flagGroup,
+	declare declareArgs[T],
+	invoke func(r *runner, ctx context.Context, a *T, g *globalFlags) int,
+	opts ...commandOpt,
+) command {
+	build := func() (*T, *globalFlags, commandFlags) {
 		g := &globalFlags{}
 		a, input := declare(g)
-		return a, newCommandFlags(name, groups, g, input)
+		return a, g, newCommandFlags(name, groups, g, input)
 	}
 
-	_, declared := build()
+	_, _, declared := build()
 	var c command
 	c = command{
 		name:        name,
 		summary:     summary,
 		positionals: declared.positionals,
-		flags:       func() commandFlags { _, cf := build(); return cf },
+		flags:       func() commandFlags { _, _, cf := build(); return cf },
 		run: func(r *runner, ctx context.Context, path string) int {
-			a, cf := build()
+			a, g, cf := build()
 			if commandHelpRequested(cf.set, r.args) {
 				printCommandHelp(r.out, c, path)
 				return 0
@@ -194,7 +242,7 @@ func leaf[T any](
 				}
 				return r.parseError(err)
 			}
-			return run(r, ctx, a)
+			return invoke(r, ctx, a, g)
 		},
 	}
 	for _, opt := range opts {

--- a/cmd/cloudstic/runner.go
+++ b/cmd/cloudstic/runner.go
@@ -124,15 +124,18 @@ func (r *runner) fail(format string, args ...any) int {
 	return exitCode
 }
 
-// openClient opens the cloudstic client from the given global flags.
+// openClient connects to the repository described by cfg.
 // No-op if r.client is already set (e.g. injected for tests).
-func (r *runner) openClient(ctx context.Context, g *globalFlags) error {
+//
+// It takes a resolved configuration rather than the flags it came from. That
+// keeps this type to the I/O primitives it is meant to hold: resolving flags
+// against a profile means reading the profiles file, and hiding a file read
+// behind "open the client" put it out of sight of every call site. Each command
+// now resolves first — the same two steps `init` and the `key` subcommands
+// always used.
+func (r *runner) openClient(ctx context.Context, cfg clientConfig) error {
 	if r.client != nil {
 		return nil
-	}
-	cfg, err := resolveClientConfig(g)
-	if err != nil {
-		return err
 	}
 	client, err := openClient(ctx, cfg, nil)
 	if err != nil {

--- a/cmd/cloudstic/runner_boundary_test.go
+++ b/cmd/cloudstic/runner_boundary_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// TestRunnerHoldsNoConfigurationResolution keeps the runner to the I/O
+// primitives it is meant to hold.
+//
+// It used to take a *globalFlags and resolve it internally, which meant a call
+// reading as "open the client" also read the profiles file and applied
+// flag-versus-profile precedence — a file read and a precedence decision
+// invisible at all eleven call sites. Each command now resolves first and passes
+// the result, which is what `init` and the `key` subcommands always did.
+//
+// This is a structural guard in the same spirit as
+// TestGlobalFlagsHasNoConstructionMethods: it fails if runner.go regains a
+// reference to the flag struct or to configuration resolution, since either
+// would pull that hidden work back in.
+func TestRunnerHoldsNoConfigurationResolution(t *testing.T) {
+	banned := map[string]string{
+		"globalFlags":           "the runner must not see the flag struct; take a resolved clientConfig instead",
+		"resolveClientConfig":   "the runner must not resolve configuration; the command resolves and passes the result",
+		"resolveBackupConfig":   "the runner must not resolve configuration; the command resolves and passes the result",
+		"loadProfileStore":      "the runner must not read the profiles file",
+		"newSecretResolver":     "the runner must not build a secret resolver",
+		"backupConfigFromFlags": "the runner must not translate flags",
+	}
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "runner.go", nil, 0)
+	if err != nil {
+		t.Fatalf("ParseFile runner.go: %v", err)
+	}
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		ident, ok := n.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if reason, bad := banned[ident.Name]; bad {
+			t.Errorf("runner.go references %q at %s: %s",
+				ident.Name, fset.Position(ident.Pos()), reason)
+		}
+		return true
+	})
+
+	// Guard against the guard being vacuous: runner.go must still be the file
+	// this test thinks it is.
+	if len(file.Decls) == 0 {
+		t.Fatal("runner.go parsed to no declarations; this test is not checking anything")
+	}
+	var sawOpenClient bool
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if ok && fn.Name.Name == "openClient" && fn.Recv != nil {
+			sawOpenClient = true
+		}
+	}
+	if !sawOpenClient {
+		t.Error("runner.go no longer declares (*runner).openClient; if it moved, move this guard with it")
+	}
+}


### PR DESCRIPTION
## Summary

Three steps toward one idea: **flags are parsed once, converted to configuration, and never read again.**

### 1. `openClient` takes a resolved configuration

`runner.openClient` took a `*globalFlags` and resolved it internally — so a call reading as "open the client" also **read the profiles file** and applied flag-versus-profile precedence, invisibly, at eleven call sites. It now takes a `clientConfig`, and the runner references neither `globalFlags` nor `resolveClientConfig`.

### 2. Resolution happens once, in the dispatcher

Step 1 alone left the two-step ritual duplicated eleven times, with eleven error branches no test exercised — which is what the patch-coverage check objected to. `repoLeaf` declares a command that opens a repository and resolves once, after a successful parse. **Fourteen** commands lose their copy: the ten that called `openClient`, plus `init` and the three `key` subcommands that had been hand-rolling the same two steps all along.

`resolveClientConfig` goes from **15 call sites to 4** — `repoLeaf`, backup's per-profile loop, the TUI's store-by-name path, and its own definition.

### 3. Backup runs from configuration, not flags

`execBackup` took a `*backupArgs` and used it for exactly two things: resolving the repository half, and reading the output mode. The second was pure redundancy — `clientConfig` already carries `JSON`, populated from the same flag field `jsonEnabled()` returns. It now takes `(config.Backup, clientConfig)` and no args.

That also removed a leftover: the TUI was synthesizing a throwaway `backupArgs` just so `backupConfigFromFlags` could read it back out, in a component that has no flags. It now states its one input directly. **`backupArgs` is constructed in exactly one place: its flag declaration.**

## Design notes

**`repoLeaf` resolves but deliberately does not connect.** Three commands would break otherwise:

| command | why a pre-built client fails |
|---|---|
| `init` | runs against a repository that does not exist yet; `NewClient` reads the repo config and resolves the master key |
| `key list` | wants the **raw store** (`openStore` → `ListKeySlots`); listing slots must work without unlocking |
| `backup` | needs N clients, one per profile, and clears `r.client` between iterations |

There is a fourth reason: `openClient(ctx, cfg, reporterOverride)` is a per-command customization point the TUI uses, and connecting is I/O — `find` rejects `-size nonsense` before touching the store, and should keep doing so.

**Resolution happens after parsing, not before**, because it reads the profiles file and `-h`, shell completion and parse failures must not.

**`backup` stays on `leaf`.** Its profile loop resolves N configurations, so one value resolved before dispatch would be wrong for it. That resolution is now explicit in the loop rather than hidden behind a mutated flag copy.

**The `*globalFlags` embedding in args structs is left alone.** All ten repository commands read `jsonEnabled`, `verbose` or `quiet` from it, and those are command-line input rather than resolved configuration; removing the embedding would only re-thread them under another name.

**Error messages are unchanged.** `init` and `key` already reported a resolution failure as `Failed to init store`, so matching them keeps this a refactor with no user-visible difference. (I initially wrote a more accurate `Failed to resolve configuration` and reverted it for that reason.)

## Behavior change

One, deliberate: a profile whose **store** cannot be resolved now fails that profile and continues, matching how a profile *merge* failure already behaved, instead of aborting the whole `-all-profiles` run.

## Verification

`TestRunnerHoldsNoConfigurationResolution` guards the boundary, in the spirit of the existing `TestGlobalFlagsHasNoConstructionMethods`. The compiler catches a changed signature, so the guard covers what it cannot — a helper that compiles cleanly while dragging flag knowledge back in. That case was verified to fail it:

```
--- FAIL: TestRunnerHoldsNoConfigurationResolution
    runner.go references "globalFlags" ...: the runner must not see the flag struct
    runner.go references "resolveClientConfig" ...: the runner must not resolve configuration
```

It also asserts `runner.go` still declares `(*runner).openClient`, so it cannot pass vacuously if the method moves.

- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./...` passes
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./...` reports `0 issues`
- `gofmt -l .` clean

<sub>One E2E job failed mid-review on `mkfs.ext4 failed: exit status 1` in the portable-drive test — a privileged loopback filesystem the runner could not create, unrelated to command wiring. Re-run and green.</sub>