### PR TITLE
refactor: keep only I/O primitives on the runner

### DIFF
--- a/cmd/cloudstic/cmd_auth_test.go
+++ b/cmd/cloudstic/cmd_auth_test.go
@@ -273,9 +273,9 @@ func TestPromptAuthSelection_DerivesTokenRef(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	name, code := r.promptAuthSelection(ctx, cfg, "google", "test-profile")
-	if code != 0 {
-		t.Fatalf("promptAuthSelection failed with code %d", code)
+	name, err := promptAuthSelection(r, ctx, cfg, "google", "test-profile")
+	if err != nil {
+		t.Fatalf("promptAuthSelection: %v", err)
 	}
 	if name != "my-google" {
 		t.Fatalf("expected name 'my-google', got %q", name)

--- a/cmd/cloudstic/cmd_profile.go
+++ b/cmd/cloudstic/cmd_profile.go
@@ -239,9 +239,9 @@ func runProfileNew(r *runner, ctx context.Context, a *profileNewArgs) int {
 	} else {
 		// No store provided — prompt or fail.
 		if r.canPrompt() {
-			ref, created, code := r.promptStoreSelection(ctx, cfg)
-			if code != 0 {
-				return code
+			ref, created, selErr := promptStoreSelection(r, ctx, cfg)
+			if selErr != nil {
+				return r.fail("Failed to %v", selErr)
 			}
 			a.storeRef = ref
 			createdStore = created
@@ -254,7 +254,7 @@ func runProfileNew(r *runner, ctx context.Context, a *profileNewArgs) int {
 	if createdStore && r.canPrompt() {
 		s := cfg.Stores[a.storeRef]
 		if !storeHasExplicitEncryption(s) {
-			r.promptEncryptionConfig(ctx, cfg, a.storeRef, a.profilesFile, a.configDir)
+			promptEncryptionConfig(r, ctx, cfg, a.storeRef, a.profilesFile, a.configDir)
 		}
 		if err := checkOrInitStoreWithRecovery(r, ctx, cfg, a.storeRef, a.profilesFile, checkOrInitOptions{
 			configDir:            a.configDir,
@@ -299,9 +299,9 @@ func runProfileNew(r *runner, ctx context.Context, a *profileNewArgs) int {
 	} else if requiredProvider != "" {
 		// Cloud source without -auth-ref — prompt or fail.
 		if r.canPrompt() {
-			ref, code := r.promptAuthSelection(ctx, cfg, requiredProvider, a.name)
-			if code != 0 {
-				return code
+			ref, selErr := promptAuthSelection(r, ctx, cfg, requiredProvider, a.name)
+			if selErr != nil {
+				return r.fail("Failed to %v", selErr)
 			}
 			a.authRef = ref
 		}
@@ -342,7 +342,21 @@ func runProfileNew(r *runner, ctx context.Context, a *profileNewArgs) int {
 // promptStoreSelection prompts the user to pick an existing store or create a
 // new one. It returns the chosen store-ref name, whether a new store was
 // created, and exit code 0 on success.
-func (r *runner) promptStoreSelection(ctx context.Context, cfg *profile.Config) (string, bool, int) {
+// promptStoreSelection asks the user to pick an existing store or describe a new
+// one, adding the new entry to cfg in place. It reports the chosen reference name
+// and whether it was just created.
+//
+// A free function taking the runner rather than a method on it: this is a
+// profiles-domain workflow that happens to prompt, not a capability of the
+// runner, which holds only I/O primitives. It returns an error rather than an
+// exit code for the same reason — deciding a process exit status is the
+// command's job.
+//
+// Its errors start with a verb phrase ("select store: …") so a caller reporting
+// them as `r.fail("Failed to %v", err)` reproduces the message this produced
+// when it formatted its own failures, which keeps the refactor invisible to
+// users.
+func promptStoreSelection(r *runner, ctx context.Context, cfg *profile.Config) (name string, created bool, err error) {
 	options := []string{"Create new store"}
 	for name := range cfg.Stores {
 		options = append(options, name)
@@ -351,11 +365,11 @@ func (r *runner) promptStoreSelection(ctx context.Context, cfg *profile.Config) 
 
 	picked, err := r.promptSelect(ctx, "Select a store", options)
 	if err != nil {
-		return "", false, r.fail("Failed to select store: %v", err)
+		return "", false, fmt.Errorf("select store: %w", err)
 	}
 
 	if picked != "Create new store" {
-		return picked, false, 0
+		return picked, false, nil
 	}
 
 	// Create a new store inline.
@@ -366,7 +380,7 @@ func (r *runner) promptStoreSelection(ctx context.Context, cfg *profile.Config) 
 		return validateRefName("store", v)
 	})
 	if err != nil {
-		return "", false, r.fail("Failed to read store reference name: %v", err)
+		return "", false, fmt.Errorf("read store reference name: %w", err)
 	}
 	uri, err := r.promptValidatedLine(ctx, "Store URI (e.g. s3:bucket/path, local:/path, sftp://host/path)", "", func(v string) error {
 		if v == "" {
@@ -379,16 +393,19 @@ func (r *runner) promptStoreSelection(ctx context.Context, cfg *profile.Config) 
 		return nil
 	})
 	if err != nil {
-		return "", false, r.fail("Failed to read store URI: %v", err)
+		return "", false, fmt.Errorf("read store URI: %w", err)
 	}
 	cfg.Stores[refName] = profile.Store{URI: uri}
-	return refName, true, 0
+	return refName, true, nil
 }
 
 // promptAuthSelection prompts the user to pick an existing auth entry (filtered
-// by provider) or create a new one. It returns the chosen auth-ref name and
-// exit code 0 on success. The new entry is added to cfg.Auth in place.
-func (r *runner) promptAuthSelection(ctx context.Context, cfg *profile.Config, provider, profileName string) (string, int) {
+// by provider) or create a new one, adding the new entry to cfg.Auth in place.
+// It reports the chosen auth-ref name.
+//
+// See promptStoreSelection for why this is a free function returning an error
+// rather than a runner method returning an exit code.
+func promptAuthSelection(r *runner, ctx context.Context, cfg *profile.Config, provider, profileName string) (string, error) {
 	options := []string{"Create new auth"}
 	for name, auth := range cfg.Auth {
 		if auth.Provider == provider {
@@ -399,10 +416,10 @@ func (r *runner) promptAuthSelection(ctx context.Context, cfg *profile.Config, p
 
 	picked, err := r.promptSelect(ctx, fmt.Sprintf("Select %s auth entry", provider), options)
 	if err != nil {
-		return "", r.fail("Failed to select auth entry: %v", err)
+		return "", fmt.Errorf("select auth entry: %w", err)
 	}
 	if picked != "Create new auth" {
-		return picked, 0
+		return picked, nil
 	}
 
 	refName, err := r.promptValidatedLine(ctx, "Auth reference name", provider+"-"+profileName, func(v string) error {
@@ -412,13 +429,13 @@ func (r *runner) promptAuthSelection(ctx context.Context, cfg *profile.Config, p
 		return validateRefName("auth", v)
 	})
 	if err != nil {
-		return "", r.fail("Failed to read auth reference name: %v", err)
+		return "", fmt.Errorf("read auth reference name: %w", err)
 	}
 
 	defTokenRef := config.DefaultAuthTokenRef(provider, refName)
 	tokenStorage, err := r.promptLine(ctx, "Token storage (file path or secret ref)", defTokenRef)
 	if err != nil {
-		return "", r.fail("Failed to read token storage: %v", err)
+		return "", fmt.Errorf("read token storage: %w", err)
 	}
 	if tokenStorage == "" {
 		tokenStorage = defTokenRef
@@ -441,7 +458,7 @@ func (r *runner) promptAuthSelection(ctx context.Context, cfg *profile.Config, p
 		}
 	}
 	cfg.Auth[refName] = auth
-	return refName, 0
+	return refName, nil
 }
 
 func prefillProfileArgs(a *profileNewArgs, p profile.Profile) {

--- a/cmd/cloudstic/cmd_setup.go
+++ b/cmd/cloudstic/cmd_setup.go
@@ -49,15 +49,15 @@ func runSetupWorkstation(r *runner, ctx context.Context, args *setupWorkstationA
 			if !r.canPrompt() || args.yes {
 				return r.fail("No store is configured; create one first with 'cloudstic store new' or rerun interactively")
 			}
-			ref, created, code := r.promptStoreSelection(ctx, cfg)
-			if code != 0 {
-				return code
+			ref, created, selErr := promptStoreSelection(r, ctx, cfg)
+			if selErr != nil {
+				return r.fail("Failed to %v", selErr)
 			}
 			args.storeRef = ref
 			if created {
 				s := cfg.Stores[args.storeRef]
 				if !storeHasExplicitEncryption(s) {
-					r.promptEncryptionConfig(ctx, cfg, args.storeRef, args.profilesFile, args.configDir)
+					promptEncryptionConfig(r, ctx, cfg, args.storeRef, args.profilesFile, args.configDir)
 				}
 				if err := checkOrInitStoreWithRecovery(r, ctx, cfg, args.storeRef, args.profilesFile, checkOrInitOptions{
 					configDir:            args.configDir,
@@ -72,9 +72,9 @@ func runSetupWorkstation(r *runner, ctx context.Context, args *setupWorkstationA
 			if !r.canPrompt() || args.yes {
 				return r.fail("Multiple stores are configured; pass -store-ref or rerun interactively")
 			}
-			ref, _, code := r.promptStoreSelection(ctx, cfg)
-			if code != 0 {
-				return code
+			ref, _, selErr := promptStoreSelection(r, ctx, cfg)
+			if selErr != nil {
+				return r.fail("Failed to %v", selErr)
 			}
 			args.storeRef = ref
 		}

--- a/cmd/cloudstic/cmd_store.go
+++ b/cmd/cloudstic/cmd_store.go
@@ -218,7 +218,7 @@ func runStoreNew(r *runner, ctx context.Context, a *storeNewArgs) int {
 			forcePromptEncryption = !keepCurrent
 		}
 		if forcePromptEncryption || !storeHasExplicitEncryption(s) {
-			r.promptEncryptionConfig(ctx, cfg, a.name, a.profilesFile, a.configDir)
+			promptEncryptionConfig(r, ctx, cfg, a.name, a.profilesFile, a.configDir)
 		}
 		if err := checkOrInitStoreWithRecovery(r, ctx, cfg, a.name, a.profilesFile, checkOrInitOptions{
 			configDir:            a.configDir,
@@ -475,7 +475,12 @@ func checkOrInitStoreWithRecovery(r *runner, ctx context.Context, cfg *profile.C
 // promptEncryptionConfig guides the user through encryption configuration
 // and saves the chosen settings to profiles.yaml. It does not build a keychain
 // or prompt for the actual password — that happens later during init.
-func (r *runner) promptEncryptionConfig(ctx context.Context, cfg *profile.Config, storeName, profilesFile, configDir string) {
+// promptEncryptionConfig walks the user through choosing an encryption method for
+// a store and records the choice in the profiles file.
+//
+// A free function taking the runner: it reads and writes a profiles file and
+// mutates cfg, which is profiles-domain work rather than a runner capability.
+func promptEncryptionConfig(r *runner, ctx context.Context, cfg *profile.Config, storeName, profilesFile, configDir string) {
 	_, _ = fmt.Fprintln(r.out)
 	_, _ = fmt.Fprintln(r.out, "No encryption is configured for this store.")
 
@@ -497,7 +502,7 @@ func (r *runner) promptEncryptionConfig(ctx context.Context, cfg *profile.Config
 		storeName,
 		picked,
 		func(ctx context.Context, storeName, secretLabel, defaultEnvName, defaultAccount string) (string, error) {
-			return r.promptSecretReference(ctx, configDir, storeName, secretLabel, defaultEnvName, defaultAccount)
+			return promptSecretReference(r, ctx, configDir, storeName, secretLabel, defaultEnvName, defaultAccount)
 		},
 		r.promptLine,
 		r.out,
@@ -559,7 +564,9 @@ func configureStoreEncryptionSelection(
 	return s, nil
 }
 
-func (r *runner) promptSecretReference(ctx context.Context, configDir, storeName, secretLabel, defaultEnvName, defaultAccount string) (string, error) {
+// promptSecretReference asks where a store credential should be stored and
+// returns the secret reference for it.
+func promptSecretReference(r *runner, ctx context.Context, configDir, storeName, secretLabel, defaultEnvName, defaultAccount string) (string, error) {
 	return promptSecretReferenceWithFns(
 		ctx,
 		storeName,

--- a/cmd/cloudstic/cmd_store_test.go
+++ b/cmd/cloudstic/cmd_store_test.go
@@ -1264,7 +1264,7 @@ func TestPromptSecretReference_EnvInteractive(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	got, err := r.promptSecretReference(context.Background(), "", "prod", "repository password", "CLOUDSTIC_PASSWORD", "password")
+	got, err := promptSecretReference(r, context.Background(), "", "prod", "repository password", "CLOUDSTIC_PASSWORD", "password")
 	if err != nil {
 		t.Fatalf("promptSecretReference: %v", err)
 	}
@@ -1293,7 +1293,7 @@ func TestPromptEncryptionConfig_PasswordViaEnvRef(t *testing.T) {
 	var errOut strings.Builder
 	r := &runner{out: &out, errOut: &errOut}
 
-	r.promptEncryptionConfig(context.Background(), cfg, "prod", profilesPath, "")
+	promptEncryptionConfig(r, context.Background(), cfg, "prod", profilesPath, "")
 
 	s := cfg.Stores["prod"]
 	if s.PasswordSecret != "env://MY_BACKUP_PASSWORD" {

--- a/cmd/cloudstic/runner_boundary_test.go
+++ b/cmd/cloudstic/runner_boundary_test.go
@@ -4,6 +4,8 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -62,5 +64,72 @@ func TestRunnerHoldsNoConfigurationResolution(t *testing.T) {
 	}
 	if !sawOpenClient {
 		t.Error("runner.go no longer declares (*runner).openClient; if it moved, move this guard with it")
+	}
+}
+
+// TestRunnerMethodsAreIOPrimitivesOnly pins the runner's method set to the I/O
+// primitives AGENTS.md describes it as holding.
+//
+// The list had drifted: four profiles-domain workflows had accumulated as
+// methods — two of them mutating a profile config and returning a process exit
+// code, one of them writing the profiles file. Being methods on the runner made
+// them look like runner capabilities and made command flow inseparable from
+// prompting. They are free functions taking the runner now, the same shape the
+// commands and the print helpers already use.
+//
+// Adding a genuine primitive here is fine; adding a domain workflow is what this
+// catches. If a new entry needs a profile.Config, writes a file, or returns an
+// exit code, it belongs outside this list.
+func TestRunnerMethodsAreIOPrimitivesOnly(t *testing.T) {
+	allowed := map[string]bool{
+		// Output and process result.
+		"fail": true, "parseError": true, "writeJSON": true,
+		"failJSONFlagConflict": true, "jsonEnabled": true, "printUsage": true,
+		// Input.
+		"canPrompt": true, "lineReader": true, "promptLine": true,
+		"promptValidatedLine": true, "promptConfirm": true, "promptSelect": true,
+		"promptSecret": true,
+		// Connection and dispatch plumbing.
+		"openClient": true, "withArgs": true, "withUsage": true,
+	}
+
+	sources, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("Glob: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	seen := 0
+	for _, path := range sources {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("ParseFile %s: %v", path, err)
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv == nil || len(fn.Recv.List) == 0 {
+				continue
+			}
+			star, ok := fn.Recv.List[0].Type.(*ast.StarExpr)
+			if !ok {
+				continue
+			}
+			ident, ok := star.X.(*ast.Ident)
+			if !ok || ident.Name != "runner" {
+				continue
+			}
+			seen++
+			if !allowed[fn.Name.Name] {
+				t.Errorf("%s: runner must not have method %q; make it a free function "+
+					"taking the runner, as the commands and print helpers do",
+					path, fn.Name.Name)
+			}
+		}
+	}
+	if seen == 0 {
+		t.Fatal("found no runner methods; this test is not checking anything")
 	}
 }


### PR DESCRIPTION
## Summary

`AGENTS.md` states that the runner carries `out`/`errOut`/`client` and that *"only I/O primitives (`fail`, `writeJSON`, `openClient`, `prompt*`) remain methods on it"*. Four profiles-domain workflows had drifted onto it:

| method | what it actually did |
|---|---|
| `promptStoreSelection` | mutates `cfg.Stores`, **returns an exit code** |
| `promptAuthSelection` | mutates `cfg.Auth`, **returns an exit code** |
| `promptEncryptionConfig` | mutates `cfg.Stores` and **writes the profiles file** |
| `promptSecretReference` | store-specific credential placement |

Being methods made them look like runner capabilities. And returning an exit code from something named `prompt` coupled prompting to command dispatch — the caller could only propagate the code, never decide what to do about the failure:

```go
ref, created, code := r.promptStoreSelection(ctx, cfg)
if code != 0 {
    return code
}
```

They are free functions taking the runner now, the same shape the commands and the print helpers already use. The two that returned exit codes return errors instead.

The genuine primitives in `interactive.go` — `promptLine`, `promptSelect`, `promptSecret`, `promptConfirm`, `promptValidatedLine`, `canPrompt` — stay. They take strings, return values, and know nothing about profiles.

The runner's method set is now exactly:

```
canPrompt  fail  failJSONFlagConflict  jsonEnabled  lineReader  openClient
parseError  printUsage  promptConfirm  promptLine  promptSecret  promptSelect
promptValidatedLine  withArgs  withUsage  writeJSON
```

### No user-visible change

The converted errors begin with a verb phrase (`"select store: %w"`), so a caller reporting them as `r.fail("Failed to %v", err)` reproduces the exact text these printed before — `Failed to select store: …`. All six messages are byte-identical to what they were. That composition is deliberate rather than accidental, and is documented on the function it relies on.

## Verification

`TestRunnerMethodsAreIOPrimitivesOnly` pins the method set with an allowlist — the same mechanism `TestGlobalFlagsHasNoConstructionMethods` already uses for `globalFlags` — so the list cannot drift again unnoticed. Adding a primitive to the list is fine; adding a workflow is what it catches, and that case was verified to fail it:

```
--- FAIL: TestRunnerMethodsAreIOPrimitivesOnly
    cmd_profile.go: runner must not have method "promptSomethingDomainish";
    make it a free function taking the runner, as the commands and print helpers do
```

It also fails if it finds no runner methods at all, so it cannot pass vacuously.

- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./...` passes
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./...` reports `0 issues`
- `gofmt -l .` clean

## Not done, and why

I had suggested `forget`/`find`/`restore` as the next "resolved config per command" candidates. **That was wrong and I'm not doing it.** `profile.Profile` carries no retention or find fields, so there is no profile-to-command fold to share, and `cloudstic.WithKeepLast` and friends are already public — a library caller can build them today. A `config.Forget` would be a verbatim copy of `forgetArgs`. The backup case earned its type because the exclude hash was a *hidden derivation* a caller could not reproduce; forget and find have no equivalent.