### PR TITLE
refactor: let the reporter decide verbosity, not each operation

### DIFF
--- a/aliases.go
+++ b/aliases.go
@@ -43,6 +43,16 @@ type Reporter = ui.Reporter
 // Phase represents an active progress tracking phase.
 type Phase = ui.Phase
 
+// Detail is how much an operation should report. It reaches the public API
+// through Phase.Logf, so a caller implementing Reporter can decide what to show.
+type Detail = ui.Detail
+
+// The detail levels a Reporter chooses between.
+const (
+	DetailNormal  = ui.DetailNormal
+	DetailVerbose = ui.DetailVerbose
+)
+
 // KeySlot is re-exported for callers that need to inspect slot metadata.
 type KeySlot = keychain.KeySlot
 

--- a/backup.go
+++ b/backup.go
@@ -19,7 +19,6 @@ type BackupOption = engine.BackupOption
 type BackupResult = engine.RunResult
 
 var (
-	WithVerbose             = engine.WithVerbose
 	WithBackupDryRun        = engine.WithBackupDryRun
 	WithIgnoreEmptySnapshot = engine.WithIgnoreEmptySnapshot
 	WithTags                = engine.WithTags

--- a/check.go
+++ b/check.go
@@ -15,9 +15,8 @@ type CheckResult = engine.CheckResult
 type CheckError = engine.CheckError
 
 var (
-	WithReadData     = engine.WithReadData
-	WithCheckVerbose = engine.WithCheckVerbose
-	WithSnapshotRef  = engine.WithSnapshotRef
+	WithReadData    = engine.WithReadData
+	WithSnapshotRef = engine.WithSnapshotRef
 )
 
 // Check verifies the integrity of the repository by walking the full

--- a/cmd/cloudstic/clientbuild.go
+++ b/cmd/cloudstic/clientbuild.go
@@ -41,5 +41,11 @@ func newReporter(cfg clientConfig, debugLog *ui.SafeLogWriter) cloudstic.Reporte
 	if debugLog != nil {
 		cr.SetLogWriter(debugLog)
 	}
+	// One flag, one decision. Every operation used to carry its own verbose
+	// option; they now report at a detail level and this chooses which levels
+	// are shown.
+	if cfg.Verbose {
+		cr.SetDetail(ui.DetailVerbose)
+	}
 	return cr
 }

--- a/cmd/cloudstic/clientbuild.go
+++ b/cmd/cloudstic/clientbuild.go
@@ -16,19 +16,31 @@ import (
 // repository client on top of it. Passing a nil reporter selects one from the
 // configured output mode.
 func openClient(ctx context.Context, cfg clientConfig, reporterOverride cloudstic.Reporter) (*cloudstic.Client, error) {
-	debugLog := newDebugLog(cfg.Store.Debug)
+	// Two audiences, one destination. -debug traces every store operation;
+	// -verbose asks the query operations for their progress detail, which they
+	// write to the component logger because they have no phases to report
+	// against (list, ls, diff and find are queries, not long-running work).
+	// Both land in the same writer so their lines interleave cleanly above the
+	// progress bar — but only -debug may switch on the store decorator, or
+	// asking for detail would flood the output with per-object traces.
+	diagnostics := newDebugLog(cfg.Store.Debug || cfg.Verbose)
 
 	reporter := reporterOverride
 	if reporter == nil {
-		reporter = newReporter(cfg, debugLog)
+		reporter = newReporter(cfg, diagnostics)
 	}
 
-	opts := append(storeOptions(debugLog),
+	storeOpts := storeOptions(nil)
+	if cfg.Store.Debug {
+		storeOpts = storeOptions(diagnostics)
+	}
+
+	opts := append(storeOpts,
 		open.WithReporter(reporter),
 		open.WithPasswordPrompt(passwordPrompts()),
 	)
-	if debugLog != nil {
-		opts = append(opts, open.WithLogger(debugLog))
+	if diagnostics != nil {
+		opts = append(opts, open.WithLogger(diagnostics))
 	}
 	return open.Client(ctx, cfg, opts...)
 }

--- a/cmd/cloudstic/cmd_check.go
+++ b/cmd/cloudstic/cmd_check.go
@@ -55,9 +55,6 @@ func buildCheckOpts(a *checkArgs) []cloudstic.CheckOption {
 	if a.readData {
 		checkOpts = append(checkOpts, cloudstic.WithReadData())
 	}
-	if a.verbose {
-		checkOpts = append(checkOpts, cloudstic.WithCheckVerbose())
-	}
 	if a.snapshotRef != "" {
 		checkOpts = append(checkOpts, cloudstic.WithSnapshotRef(a.snapshotRef))
 	}

--- a/cmd/cloudstic/cmd_diff.go
+++ b/cmd/cloudstic/cmd_diff.go
@@ -42,9 +42,6 @@ func runDiff(r *runner, ctx context.Context, a *diffArgs, cfg clientConfig) int 
 
 func buildDiffOpts(a *diffArgs) []cloudstic.DiffOption {
 	var diffOpts []cloudstic.DiffOption
-	if a.verbose {
-		diffOpts = append(diffOpts, cloudstic.WithDiffVerbose())
-	}
 	return diffOpts
 }
 

--- a/cmd/cloudstic/cmd_find.go
+++ b/cmd/cloudstic/cmd_find.go
@@ -193,9 +193,6 @@ func buildFindOpts(a *findArgs) ([]cloudstic.FindOption, error) {
 	if a.noDelta {
 		opts = append(opts, cloudstic.WithFindNoDelta())
 	}
-	if a.verbose {
-		opts = append(opts, cloudstic.WithFindVerbose())
-	}
 	return opts, nil
 }
 

--- a/cmd/cloudstic/cmd_forget.go
+++ b/cmd/cloudstic/cmd_forget.go
@@ -164,9 +164,6 @@ func execForgetSingle(r *runner, ctx context.Context, a *forgetArgs) int {
 	if a.dryRun {
 		forgetOpts = append(forgetOpts, cloudstic.WithDryRun())
 	}
-	if a.verbose {
-		forgetOpts = append(forgetOpts, cloudstic.WithForgetVerbose())
-	}
 	result, err := r.client.Forget(ctx, a.snapshotID, forgetOpts...)
 	if err != nil {
 		return r.fail("Forget failed: %v", err)
@@ -209,9 +206,6 @@ func buildForgetPolicyOpts(a *forgetArgs) []cloudstic.ForgetOption {
 	}
 	if a.dryRun {
 		opts = append(opts, cloudstic.WithDryRun())
-	}
-	if a.verbose {
-		opts = append(opts, cloudstic.WithForgetVerbose())
 	}
 	if a.keepLast > 0 {
 		opts = append(opts, cloudstic.WithKeepLast(a.keepLast))

--- a/cmd/cloudstic/cmd_list.go
+++ b/cmd/cloudstic/cmd_list.go
@@ -40,9 +40,6 @@ func runList(r *runner, ctx context.Context, a *listArgs, cfg clientConfig) int 
 
 func buildListOpts(a *listArgs) []cloudstic.ListOption {
 	var listOpts []cloudstic.ListOption
-	if a.verbose {
-		listOpts = append(listOpts, cloudstic.WithListVerbose())
-	}
 	return listOpts
 }
 

--- a/cmd/cloudstic/cmd_ls.go
+++ b/cmd/cloudstic/cmd_ls.go
@@ -47,9 +47,6 @@ func runLsSnapshot(r *runner, ctx context.Context, a *lsArgs, cfg clientConfig) 
 
 func buildLsOpts(a *lsArgs) []cloudstic.LsSnapshotOption {
 	var lsOpts []cloudstic.LsSnapshotOption
-	if a.verbose {
-		lsOpts = append(lsOpts, cloudstic.WithLsVerbose())
-	}
 	return lsOpts
 }
 

--- a/cmd/cloudstic/cmd_prune.go
+++ b/cmd/cloudstic/cmd_prune.go
@@ -45,9 +45,6 @@ func buildPruneOpts(a *pruneArgs) []cloudstic.PruneOption {
 	if a.dryRun {
 		pruneOpts = append(pruneOpts, engine.WithPruneDryRun())
 	}
-	if a.verbose {
-		pruneOpts = append(pruneOpts, engine.WithPruneVerbose())
-	}
 	return pruneOpts
 }
 

--- a/cmd/cloudstic/cmd_restore.go
+++ b/cmd/cloudstic/cmd_restore.go
@@ -103,9 +103,6 @@ func buildRestoreOpts(a *restoreArgs) []cloudstic.RestoreOption {
 	if a.dryRun {
 		restoreOpts = append(restoreOpts, engine.WithRestoreDryRun())
 	}
-	if a.verbose {
-		restoreOpts = append(restoreOpts, engine.WithRestoreVerbose())
-	}
 	if a.pathFilter != "" {
 		restoreOpts = append(restoreOpts, engine.WithRestorePath(a.pathFilter))
 	}

--- a/cmd/cloudstic/cmd_tui_activity.go
+++ b/cmd/cloudstic/cmd_tui_activity.go
@@ -12,6 +12,7 @@ import (
 
 	cloudstic "github.com/cloudstic/cli"
 	"github.com/cloudstic/cli/internal/tui"
+	"github.com/cloudstic/cli/internal/ui"
 )
 
 func captureTUIRunnerOutput(r *runner, log *tuiActionState) func() {
@@ -183,6 +184,16 @@ func (p tuiReporterPhase) Log(msg string) {
 	p.state.mu.Lock()
 	defer p.state.mu.Unlock()
 	p.state.append(msg)
+}
+
+// Logf drops per-item detail. The activity panel keeps a bounded number of
+// lines, so a line per object verified would push out the milestones the panel
+// exists to show.
+func (p tuiReporterPhase) Logf(level ui.Detail, format string, args ...any) {
+	if level > ui.DetailNormal {
+		return
+	}
+	p.Log(fmt.Sprintf(format, args...))
 }
 
 func (p tuiReporterPhase) Done() {

--- a/cmd/cloudstic/config.go
+++ b/cmd/cloudstic/config.go
@@ -77,6 +77,7 @@ func clientConfigFromFlags(g *globalFlags) clientConfig {
 		},
 		DisablePackfile: g.disablePackfile,
 		Quiet:           g.quiet,
+		Verbose:         g.verbose,
 		JSON:            g.json,
 	}
 }

--- a/cmd/cloudstic/diagnostic_wiring_test.go
+++ b/cmd/cloudstic/diagnostic_wiring_test.go
@@ -1,0 +1,45 @@
+package main
+
+import "testing"
+
+// TestDiagnosticWiring pins which flag turns on which channel.
+//
+// -verbose and -debug share one writer so their lines interleave cleanly above
+// the progress bar, which makes it easy to accidentally wire them to the same
+// switch. They must not be: -debug wraps the store in a decorator that logs
+// every operation, and asking for progress detail must not drag that in.
+//
+// This caught a real regression. When per-operation verbose options were
+// replaced by a reporter detail level, the query operations (list, ls, diff,
+// find) had no reporter to report through, so their detail moved to the
+// component logger — which was only wired when -debug was set. `list -verbose`
+// silently printed nothing.
+func TestDiagnosticWiring(t *testing.T) {
+	cases := []struct {
+		name             string
+		cfg              clientConfig
+		wantDiagnostics  bool
+		wantStoreTracing bool
+	}{
+		{"neither", clientConfig{}, false, false},
+		{"verbose only", clientConfig{Verbose: true}, true, false},
+		{"debug only", clientConfig{Store: storeConfig{Debug: true}}, true, true},
+		{"both", clientConfig{Verbose: true, Store: storeConfig{Debug: true}}, true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			diagnostics := newDebugLog(tc.cfg.Store.Debug || tc.cfg.Verbose)
+			if got := diagnostics != nil; got != tc.wantDiagnostics {
+				t.Errorf("diagnostics writer = %v, want %v: verbose detail from the "+
+					"query operations goes here and is lost without it", got, tc.wantDiagnostics)
+			}
+			tracing := tc.cfg.Store.Debug
+			if tracing != tc.wantStoreTracing {
+				t.Errorf("store tracing = %v, want %v", tracing, tc.wantStoreTracing)
+			}
+			if tc.cfg.Verbose && !tc.cfg.Store.Debug && tracing {
+				t.Error("-verbose must not enable per-operation store tracing")
+			}
+		})
+	}
+}

--- a/internal/engine/backup.go
+++ b/internal/engine/backup.go
@@ -39,7 +39,6 @@ type backupStats struct {
 type BackupOption func(*backupConfig)
 
 type backupConfig struct {
-	verbose             bool
 	dryRun              bool
 	ignoreEmptySnapshot bool
 	tags                []string
@@ -57,11 +56,6 @@ func WithBackupDryRun() BackupOption {
 // tree is identical to the previous snapshot for the same source lineage.
 func WithIgnoreEmptySnapshot() BackupOption {
 	return func(cfg *backupConfig) { cfg.ignoreEmptySnapshot = true }
-}
-
-// WithVerbose enables verbose output during backup.
-func WithVerbose() BackupOption {
-	return func(cfg *backupConfig) { cfg.verbose = true }
 }
 
 // WithTags adds tags to the backup snapshot.

--- a/internal/engine/backup_scan.go
+++ b/internal/engine/backup_scan.go
@@ -84,9 +84,7 @@ func (bm *BackupManager) processEntry(ctx context.Context, meta *core.FileMeta, 
 		return bm.insertFolder(ctx, meta, phase)
 	}
 
-	if bm.cfg.verbose {
-		phase.Log(fmt.Sprintf("Queueing: %s", meta.Name))
-	}
+	phase.Logf(ui.DetailVerbose, "Queueing: %s", meta.Name)
 	s.pending = append(s.pending, *meta)
 	s.totalBytes += meta.Size
 	return nil
@@ -265,9 +263,7 @@ func bytesEqual(a, b []byte) bool {
 }
 
 func (bm *BackupManager) insertFolder(ctx context.Context, meta *core.FileMeta, phase ui.Phase) error {
-	if bm.cfg.verbose {
-		phase.Log(fmt.Sprintf("Folder: %s (New/Changed)", meta.Name))
-	}
+	phase.Logf(ui.DetailVerbose, "Folder: %s (New/Changed)", meta.Name)
 	meta.ContentHash = ""
 	meta.Size = 0
 

--- a/internal/engine/backup_test.go
+++ b/internal/engine/backup_test.go
@@ -96,7 +96,7 @@ func TestBackupManager_Run(t *testing.T) {
 	src.AddFile("file1.txt", "id1", []byte("hello world"))
 	src.AddFile("file2.txt", "id2", []byte("another file"))
 
-	mgr := NewBackupManager(src, dest, reporter, nil, nil, WithVerbose())
+	mgr := NewBackupManager(src, dest, reporter, nil, nil)
 
 	// Read store wraps dest with CompressedStore so we can read back
 	// the compressed data written by the BackupManager.

--- a/internal/engine/backup_upload.go
+++ b/internal/engine/backup_upload.go
@@ -107,9 +107,7 @@ func (bm *BackupManager) upload(ctx context.Context, pending []core.FileMeta, to
 // processFile uploads (or deduplicates) a single file's content and persists
 // its FileMeta. It is safe to call from multiple goroutines.
 func (bm *BackupManager) processFile(ctx context.Context, meta core.FileMeta, phase ui.Phase) uploadResult {
-	if bm.cfg.verbose {
-		phase.Log(fmt.Sprintf("Processing: %s", meta.Name))
-	}
+	phase.Logf(ui.DetailVerbose, "Processing: %s", meta.Name)
 
 	contentHash, size, contentRef, contentChunks, err := bm.uploadContent(ctx, meta, phase)
 	if err != nil {
@@ -152,9 +150,7 @@ func (bm *BackupManager) uploadContent(ctx context.Context, meta core.FileMeta, 
 
 		exists, err := bm.store.Exists(ctx, "content/"+contentRef)
 		if err == nil && exists {
-			if bm.cfg.verbose {
-				phase.Log(fmt.Sprintf("Deduplicated: %s", meta.Name))
-			}
+			phase.Logf(ui.DetailVerbose, "Deduplicated: %s", meta.Name)
 			return meta.ContentHash, meta.Size, contentRef, nil, nil
 		}
 	}
@@ -208,9 +204,7 @@ func (bm *BackupManager) uploadInline(ctx context.Context, r io.Reader, meta cor
 
 	contentKey := "content/" + contentRef
 	if exists, _ := bm.store.Exists(ctx, contentKey); exists {
-		if bm.cfg.verbose {
-			phase.Log(fmt.Sprintf("Deduplicated: %s", meta.Name))
-		}
+		phase.Logf(ui.DetailVerbose, "Deduplicated: %s", meta.Name)
 		return hash, size, contentRef, nil, nil
 	}
 

--- a/internal/engine/check.go
+++ b/internal/engine/check.go
@@ -20,7 +20,6 @@ type CheckOption func(*checkConfig)
 
 type checkConfig struct {
 	readData    bool
-	verbose     bool
 	snapshotRef string
 }
 
@@ -34,11 +33,6 @@ type checkConfig struct {
 // to detect corruption inside the file data itself.
 func WithReadData() CheckOption {
 	return func(cfg *checkConfig) { cfg.readData = true }
-}
-
-// WithCheckVerbose logs each verified object.
-func WithCheckVerbose() CheckOption {
-	return func(cfg *checkConfig) { cfg.verbose = true }
 }
 
 // WithSnapshotRef limits the check to a single snapshot instead of all.
@@ -164,9 +158,7 @@ func (cm *CheckManager) checkSnapshot(ctx context.Context, ref string, result *C
 		return nil
 	}
 	result.ObjectsVerified++
-	if cfg.verbose {
-		phase.Log(fmt.Sprintf("OK: %s", ref))
-	}
+	phase.Logf(ui.DetailVerbose, "OK: %s", ref)
 
 	var snap core.Snapshot
 	if err := json.Unmarshal(data, &snap); err != nil {
@@ -226,9 +218,7 @@ func (cm *CheckManager) verifyObject(ctx context.Context, key string, result *Ch
 		}
 	}
 	result.ObjectsVerified++
-	if cfg.verbose {
-		phase.Log(fmt.Sprintf("OK: %s", key))
-	}
+	phase.Logf(ui.DetailVerbose, "OK: %s", key)
 	return nil
 }
 
@@ -254,9 +244,7 @@ func (cm *CheckManager) checkFileMeta(ctx context.Context, ref string, result *C
 		return nil
 	}
 	result.ObjectsVerified++
-	if cfg.verbose {
-		phase.Log(fmt.Sprintf("OK: %s", ref))
-	}
+	phase.Logf(ui.DetailVerbose, "OK: %s", ref)
 
 	var meta core.FileMeta
 	if err := json.Unmarshal(data, &meta); err != nil {
@@ -319,9 +307,7 @@ func (cm *CheckManager) checkContent(ctx context.Context, ref string, meta *core
 	}
 	cm.verified[ref] = true
 	result.ObjectsVerified++
-	if cfg.verbose {
-		phase.Log(fmt.Sprintf("OK: %s", ref))
-	}
+	phase.Logf(ui.DetailVerbose, "OK: %s", ref)
 
 	var content core.Content
 	if err := json.Unmarshal(data, &content); err != nil {
@@ -435,16 +421,12 @@ func (cm *CheckManager) checkChunk(ctx context.Context, ref string, result *Chec
 					Type:    "corrupt",
 					Message: fmt.Sprintf("hash mismatch: expected %s, got %s", parts[1], actual),
 				})
-				if cfg.verbose {
-					phase.Log(fmt.Sprintf("CORRUPT: %s", ref))
-				}
+				phase.Logf(ui.DetailVerbose, "CORRUPT: %s", ref)
 				return nil
 			}
 		}
 	}
 
-	if cfg.verbose {
-		phase.Log(fmt.Sprintf("OK: %s", ref))
-	}
+	phase.Logf(ui.DetailVerbose, "OK: %s", ref)
 	return nil
 }

--- a/internal/engine/diff.go
+++ b/internal/engine/diff.go
@@ -3,12 +3,12 @@ package engine
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"os"
+	"io"
 	"sort"
 
 	"github.com/cloudstic/cli/internal/core"
 	"github.com/cloudstic/cli/internal/hamt"
+	"github.com/cloudstic/cli/internal/logger"
 	"github.com/cloudstic/cli/pkg/store"
 )
 
@@ -32,12 +32,6 @@ type FileChange struct {
 type DiffOption func(*diffConfig)
 
 type diffConfig struct {
-	verbose bool
-}
-
-// WithDiffVerbose enables verbose output for the diff operation.
-func WithDiffVerbose() DiffOption {
-	return func(cfg *diffConfig) { cfg.verbose = true }
 }
 
 // DiffResult holds the outcome of a diff operation.
@@ -52,10 +46,14 @@ type DiffManager struct {
 	store     store.ObjectStore
 	tree      *hamt.Tree
 	metaCache map[string]core.FileMeta
+	// log is where progress detail goes. It used to be written straight to
+	// os.Stderr, which a library caller could neither capture nor silence.
+	log *logger.Logger
 }
 
-func NewDiffManager(s store.ObjectStore) *DiffManager {
+func NewDiffManager(s store.ObjectStore, logWriter io.Writer) *DiffManager {
 	return &DiffManager{
+		log:   SnapshotLogger(logWriter),
 		store: s,
 		tree:  hamt.NewTree(s),
 	}
@@ -70,24 +68,18 @@ func (dm *DiffManager) Run(ctx context.Context, snapID1, snapID2 string, opts ..
 
 	dm.metaCache = make(map[string]core.FileMeta)
 
-	if cfg.verbose {
-		fmt.Fprintf(os.Stderr, "Resolving snapshot %q...\n", snapID1)
-	}
+	dm.log.Debugf("Resolving snapshot %q...", snapID1)
 	root1, ref1, err := dm.loadRoot(ctx, snapID1)
 	if err != nil {
 		return nil, err
 	}
-	if cfg.verbose {
-		fmt.Fprintf(os.Stderr, "Resolving snapshot %q...\n", snapID2)
-	}
+	dm.log.Debugf("Resolving snapshot %q...", snapID2)
 	root2, ref2, err := dm.loadRoot(ctx, snapID2)
 	if err != nil {
 		return nil, err
 	}
 
-	if cfg.verbose {
-		fmt.Fprintf(os.Stderr, "Computing diff between %s and %s...\n", ref1, ref2)
-	}
+	dm.log.Debugf("Computing diff between %s and %s...", ref1, ref2)
 	changes, err := dm.diffRoots(ctx, root1, root2)
 	if err != nil {
 		return nil, err
@@ -97,19 +89,17 @@ func (dm *DiffManager) Run(ctx context.Context, snapID1, snapID2 string, opts ..
 		return changes[i].Path < changes[j].Path
 	})
 
-	if cfg.verbose {
-		var added, removed, modified int
-		for _, c := range changes {
-			switch c.Type {
-			case ChangeAdded:
-				added++
-			case ChangeRemoved:
-				removed++
-			case ChangeModified:
-				modified++
-			}
+	var added, removed, modified int
+	for _, c := range changes {
+		switch c.Type {
+		case ChangeAdded:
+			added++
+		case ChangeRemoved:
+			removed++
+		case ChangeModified:
+			modified++
 		}
-		fmt.Fprintf(os.Stderr, "Found %d changes: %d added, %d removed, %d modified\n", len(changes), added, removed, modified)
+		dm.log.Debugf("Found %d changes: %d added, %d removed, %d modified", len(changes), added, removed, modified)
 	}
 
 	return &DiffResult{Ref1: ref1, Ref2: ref2, Changes: changes}, nil

--- a/internal/engine/diff_test.go
+++ b/internal/engine/diff_test.go
@@ -24,7 +24,7 @@ func TestDiffManager_Run(t *testing.T) {
 	snap2Ref := saveSnapshotRef(ctx, store, root2, 2)
 	_ = store.Put(ctx, "index/latest", createIndex(snap2Ref, 2))
 
-	dm := NewDiffManager(store)
+	dm := NewDiffManager(store, nil)
 
 	changes, err := dm.diffRoots(ctx, root1, root2)
 	if err != nil {
@@ -93,7 +93,7 @@ func TestDiffManager_DerivesPathsFromParentsWithoutPersistedPaths(t *testing.T) 
 	root1 := createHamt(ctx, t, store, []string{"dir", "file"}, []string{rootDir, oldFile})
 	root2 := createHamt(ctx, t, store, []string{"dir", "file"}, []string{rootDir, newFile})
 
-	dm := NewDiffManager(store)
+	dm := NewDiffManager(store, nil)
 	changes, err := dm.diffRoots(ctx, root1, root2)
 	if err != nil {
 		t.Fatalf("Diff failed: %v", err)

--- a/internal/engine/find.go
+++ b/internal/engine/find.go
@@ -5,9 +5,9 @@ import (
 
 	"context"
 	"fmt"
-	"github.com/cloudstic/cli/internal/logger"
-	"os"
 	"time"
+
+	"github.com/cloudstic/cli/internal/logger"
 
 	"github.com/cloudstic/cli/internal/core"
 	"github.com/cloudstic/cli/internal/hamt"
@@ -202,8 +202,7 @@ func (r *FindResult) TotalSnapshots() int {
 type FindOption func(*findConfig)
 
 type findConfig struct {
-	query   FindQuery
-	verbose bool
+	query FindQuery
 }
 
 // WithFindPattern applies the positional pattern, routing it by shape: a
@@ -314,10 +313,6 @@ func WithFindNoDelta() FindOption {
 	return func(c *findConfig) { c.query.NoDelta = true }
 }
 
-func WithFindVerbose() FindOption {
-	return func(c *findConfig) { c.verbose = true }
-}
-
 // ---------------------------------------------------------------------------
 // Manager
 // ---------------------------------------------------------------------------
@@ -369,9 +364,7 @@ func (fm *FindManager) Run(ctx context.Context, opts ...FindOption) (*FindResult
 	}
 
 	start := time.Now()
-	if cfg.verbose {
-		fmt.Fprintf(os.Stderr, "Loading snapshot catalog...\n")
-	}
+	fm.log.Debugf("Loading snapshot catalog...")
 	catalog, err := LoadSnapshotCatalog(fm.store, fm.log)
 	if err != nil {
 		return nil, fmt.Errorf("load snapshot catalog: %w", err)
@@ -394,12 +387,10 @@ func (fm *FindManager) Run(ctx context.Context, opts ...FindOption) (*FindResult
 	}
 
 	collector := newFindCollector(cfg.query.GroupByContent, cfg.query.MaxResults)
-	scanner := newFindScanner(fm.store, fm.tree, pred, collector, cfg.verbose)
+	scanner := newFindScanner(fm.store, fm.tree, pred, collector, fm.log)
 
 	for _, lineage := range groupFindLineages(selected) {
-		if cfg.verbose {
-			fmt.Fprintf(os.Stderr, "Scanning %d snapshot(s) for %s\n", len(lineage.snapshots), lineage.key)
-		}
+		fm.log.Debugf("Scanning %d snapshot(s) for %s", len(lineage.snapshots), lineage.key)
 		if err := scanner.scanLineage(ctx, lineage, cfg.query.NoDelta); err != nil {
 			return nil, err
 		}

--- a/internal/engine/find_scan.go
+++ b/internal/engine/find_scan.go
@@ -6,12 +6,12 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 
 	"github.com/cloudstic/cli/internal/core"
 	"github.com/cloudstic/cli/internal/hamt"
+	"github.com/cloudstic/cli/internal/logger"
 	"github.com/cloudstic/cli/pkg/store"
 )
 
@@ -25,11 +25,13 @@ import (
 // pointer comparison. Both scanners emit the same observations, which is what
 // makes them comparable in tests.
 type findScanner struct {
-	store   store.ObjectStore
-	tree    *hamt.Tree
-	pred    *findPredicate
-	out     *findCollector
-	verbose bool
+	store store.ObjectStore
+	tree  *hamt.Tree
+	pred  *findPredicate
+	out   *findCollector
+	// log receives the scan heartbeat. It replaced a verbose flag writing
+	// straight to os.Stderr, which no library caller could redirect.
+	log *logger.Logger
 
 	// evaluated memoizes the verdict for a filemeta ref. Those objects are
 	// content-addressed and immutable, so a ref evaluated once never needs
@@ -88,13 +90,13 @@ func newLineageState() *lineageState {
 	}
 }
 
-func newFindScanner(s store.ObjectStore, tree *hamt.Tree, pred *findPredicate, out *findCollector, verbose bool) *findScanner {
+func newFindScanner(s store.ObjectStore, tree *hamt.Tree, pred *findPredicate, out *findCollector, log *logger.Logger) *findScanner {
 	return &findScanner{
 		store:     s,
 		tree:      tree,
 		pred:      pred,
 		out:       out,
-		verbose:   verbose,
+		log:       log,
 		evaluated: make(map[[16]byte]findRefEval),
 	}
 }
@@ -369,8 +371,8 @@ func (s *findScanner) loadMeta(ctx context.Context, ref string) (*core.FileMeta,
 		return nil, fmt.Errorf("load %s: %w", ref, err)
 	}
 	s.metaFetched++
-	if s.verbose && s.metaFetched%10000 == 0 {
-		fmt.Fprintf(os.Stderr, "  read %d metadata objects\n", s.metaFetched)
+	if s.metaFetched%10000 == 0 {
+		s.log.Debugf("  read %d metadata objects", s.metaFetched)
 	}
 	var meta core.FileMeta
 	if err := json.Unmarshal(data, &meta); err != nil {

--- a/internal/engine/forget.go
+++ b/internal/engine/forget.go
@@ -5,9 +5,10 @@ import (
 
 	"context"
 	"fmt"
-	"github.com/cloudstic/cli/internal/logger"
 	"sort"
 	"strings"
+
+	"github.com/cloudstic/cli/internal/logger"
 
 	"github.com/cloudstic/cli/internal/storelayer"
 	"github.com/cloudstic/cli/internal/ui"
@@ -20,7 +21,6 @@ type ForgetOption func(*forgetConfig)
 type forgetConfig struct {
 	prune      bool
 	dryRun     bool
-	verbose    bool
 	policy     ForgetPolicy
 	groupBy    string
 	groupBySet bool
@@ -35,11 +35,6 @@ func WithPrune() ForgetOption {
 // WithDryRun shows what would be removed without actually removing anything.
 func WithDryRun() ForgetOption {
 	return func(cfg *forgetConfig) { cfg.dryRun = true }
-}
-
-// WithForgetVerbose enables verbose output for the forget operation.
-func WithForgetVerbose() ForgetOption {
-	return func(cfg *forgetConfig) { cfg.verbose = true }
 }
 
 // WithKeepLast keeps the n most recent snapshots.
@@ -144,9 +139,7 @@ func (fm *ForgetManager) Run(ctx context.Context, snapshotID string, opts ...For
 	}
 
 	phase := fm.reporter.StartPhase("Forgetting snapshot", 0, false)
-	if cfg.verbose {
-		phase.Log(fmt.Sprintf("Forgetting %s", targetRef))
-	}
+	phase.Logf(ui.DetailVerbose, "Forgetting %s", targetRef)
 
 	// A dry run resolves the snapshot so the caller learns what would go, and
 	// stops before touching anything. Deleting here regardless — which is what

--- a/internal/engine/list.go
+++ b/internal/engine/list.go
@@ -5,8 +5,8 @@ import (
 
 	"context"
 	"fmt"
+
 	"github.com/cloudstic/cli/internal/logger"
-	"os"
 
 	"github.com/cloudstic/cli/pkg/store"
 )
@@ -15,12 +15,6 @@ import (
 type ListOption func(*listConfig)
 
 type listConfig struct {
-	verbose bool
-}
-
-// WithListVerbose enables verbose output for the list operation.
-func WithListVerbose() ListOption {
-	return func(cfg *listConfig) { cfg.verbose = true }
 }
 
 // ListResult holds the snapshots returned by a list operation.
@@ -47,22 +41,18 @@ func (lm *ListManager) Run(ctx context.Context, opts ...ListOption) (*ListResult
 		opt(&cfg)
 	}
 
-	if cfg.verbose {
-		fmt.Fprintf(os.Stderr, "Loading snapshot catalog...\n")
-	}
+	lm.log.Debugf("Loading snapshot catalog...")
 	entries, err := LoadSnapshotCatalog(lm.store, lm.log)
 	if err != nil {
 		return nil, err
 	}
-	if cfg.verbose {
-		fmt.Fprintf(os.Stderr, "Found %d snapshots\n", len(entries))
-		for _, e := range entries {
-			source := ""
-			if e.Snap.Source != nil {
-				source = fmt.Sprintf(" source=%s account=%s path=%s", e.Snap.Source.Type, e.Snap.Source.Account, e.Snap.Source.Path)
-				if e.Snap.Source.DriveName != "" {
-					source += fmt.Sprintf(" drive=%s", e.Snap.Source.DriveName)
-				}
+	lm.log.Debugf("Found %d snapshots", len(entries))
+	for _, e := range entries {
+		source := ""
+		if e.Snap.Source != nil {
+			source = fmt.Sprintf(" source=%s account=%s path=%s", e.Snap.Source.Type, e.Snap.Source.Account, e.Snap.Source.Path)
+			if e.Snap.Source.DriveName != "" {
+				source += fmt.Sprintf(" drive=%s", e.Snap.Source.DriveName)
 				if e.Snap.Source.Identity != "" {
 					source += fmt.Sprintf(" identity=%s", e.Snap.Source.Identity)
 				}
@@ -70,7 +60,7 @@ func (lm *ListManager) Run(ctx context.Context, opts ...ListOption) (*ListResult
 					source += fmt.Sprintf(" path_id=%s", e.Snap.Source.PathID)
 				}
 			}
-			fmt.Fprintf(os.Stderr, "  %s seq=%d created=%s%s\n", e.Ref, e.Snap.Seq, e.Snap.Created, source)
+			lm.log.Debugf("  %s seq=%d created=%s%s", e.Ref, e.Snap.Seq, e.Snap.Created, source)
 		}
 	}
 	return &ListResult{Snapshots: entries}, nil

--- a/internal/engine/ls_snapshot.go
+++ b/internal/engine/ls_snapshot.go
@@ -3,12 +3,12 @@ package engine
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"os"
+	"io"
 	"sort"
 
 	"github.com/cloudstic/cli/internal/core"
 	"github.com/cloudstic/cli/internal/hamt"
+	"github.com/cloudstic/cli/internal/logger"
 	"github.com/cloudstic/cli/pkg/store"
 )
 
@@ -16,12 +16,6 @@ import (
 type LsSnapshotOption func(*lsSnapshotConfig)
 
 type lsSnapshotConfig struct {
-	verbose bool
-}
-
-// WithLsVerbose enables verbose output for the ls-snapshot operation.
-func WithLsVerbose() LsSnapshotOption {
-	return func(cfg *lsSnapshotConfig) { cfg.verbose = true }
 }
 
 // LsSnapshotResult holds the data returned by an ls-snapshot operation.
@@ -38,11 +32,14 @@ type LsSnapshotManager struct {
 	store     store.ObjectStore
 	tree      *hamt.Tree
 	metaCache map[string]core.FileMeta
+	// log is where progress detail goes; see DiffManager.log.
+	log *logger.Logger
 }
 
-func NewLsSnapshotManager(s store.ObjectStore) *LsSnapshotManager {
+func NewLsSnapshotManager(s store.ObjectStore, logWriter io.Writer) *LsSnapshotManager {
 	return &LsSnapshotManager{
 		store: s,
+		log:   SnapshotLogger(logWriter),
 		tree:  hamt.NewTree(s),
 	}
 }
@@ -56,31 +53,25 @@ func (lm *LsSnapshotManager) Run(ctx context.Context, snapshotID string, opts ..
 
 	lm.metaCache = make(map[string]core.FileMeta)
 
-	if cfg.verbose {
-		fmt.Fprintf(os.Stderr, "Resolving snapshot %q...\n", snapshotID)
-	}
+	lm.log.Debugf("Resolving snapshot %q...", snapshotID)
 	snap, ref, err := lm.resolveSnapshot(ctx, snapshotID)
 	if err != nil {
 		return nil, err
 	}
-	if cfg.verbose {
-		fmt.Fprintf(os.Stderr, "Resolved to %s (created %s, root %s)\n", ref, snap.Created, snap.Root)
-	}
+	lm.log.Debugf("Resolved to %s (created %s, root %s)", ref, snap.Created, snap.Root)
 
 	refToMeta, err := lm.collectMeta(ctx, snap.Root)
 	if err != nil {
 		return nil, err
 	}
-	if cfg.verbose {
-		var files, dirs int
-		for _, m := range refToMeta {
-			if m.Type == core.FileTypeFolder {
-				dirs++
-			} else {
-				files++
-			}
+	var files, dirs int
+	for _, m := range refToMeta {
+		if m.Type == core.FileTypeFolder {
+			dirs++
+		} else {
+			files++
 		}
-		fmt.Fprintf(os.Stderr, "Collected %d files, %d directories\n", files, dirs)
+		lm.log.Debugf("Collected %d files, %d directories", files, dirs)
 	}
 
 	roots, children := lm.buildHierarchy(refToMeta)

--- a/internal/engine/prune.go
+++ b/internal/engine/prune.go
@@ -15,16 +15,11 @@ import (
 type PruneOption func(*pruneConfig)
 
 type pruneConfig struct {
-	dryRun  bool
-	verbose bool
+	dryRun bool
 }
 
 func WithPruneDryRun() PruneOption {
 	return func(cfg *pruneConfig) { cfg.dryRun = true }
-}
-
-func WithPruneVerbose() PruneOption {
-	return func(cfg *pruneConfig) { cfg.verbose = true }
 }
 
 type PruneResult struct {
@@ -105,9 +100,7 @@ func (pm *PruneManager) Run(ctx context.Context, opts ...PruneOption) (*PruneRes
 				repackPhase.Error()
 				return nil, fmt.Errorf("repack: %w", err)
 			}
-			if cfg.verbose {
-				repackPhase.Log(fmt.Sprintf("Repacked/deleted %d packs, reclaimed %d bytes", packsDeleted, bytesReclaimed))
-			}
+			repackPhase.Logf(ui.DetailVerbose, "Repacked/deleted %d packs, reclaimed %d bytes", packsDeleted, bytesReclaimed)
 			result.BytesReclaimed += bytesReclaimed
 			result.ObjectsDeleted += packsDeleted
 			repackPhase.Done()
@@ -123,9 +116,7 @@ func (pm *PruneManager) Run(ctx context.Context, opts ...PruneOption) (*PruneRes
 				compactPhase.Error()
 				return nil, fmt.Errorf("compact pack index: %w", err)
 			}
-			if cfg.verbose {
-				compactPhase.Log(fmt.Sprintf("Consolidated %d index objects", removed))
-			}
+			compactPhase.Logf(ui.DetailVerbose, "Consolidated %d index objects", removed)
 			compactPhase.Done()
 		}
 
@@ -305,9 +296,7 @@ func (pm *PruneManager) sweep(ctx context.Context, reachable map[string]bool, cf
 				continue
 			}
 			if cfg.dryRun {
-				if cfg.verbose {
-					phase.Log(fmt.Sprintf("Would delete: %s", key))
-				}
+				phase.Logf(ui.DetailVerbose, "Would delete: %s", key)
 				result.ObjectsDeleted++
 				phase.Increment(0)
 				continue
@@ -316,9 +305,7 @@ func (pm *PruneManager) sweep(ctx context.Context, reachable map[string]bool, cf
 			if err != nil {
 				continue
 			}
-			if cfg.verbose {
-				phase.Log(fmt.Sprintf("Deleted: %s", key))
-			}
+			phase.Logf(ui.DetailVerbose, "Deleted: %s", key)
 			result.ObjectsDeleted++
 			phase.Increment(size)
 		}

--- a/internal/engine/restore.go
+++ b/internal/engine/restore.go
@@ -30,7 +30,6 @@ type RestoreOption func(*restoreConfig)
 
 type restoreConfig struct {
 	dryRun     bool
-	verbose    bool
 	pathFilter string
 	noVerify   bool
 }
@@ -46,11 +45,6 @@ type restorePlan struct {
 // WithRestoreDryRun resolves the snapshot and reports what would be restored without writing output.
 func WithRestoreDryRun() RestoreOption {
 	return func(cfg *restoreConfig) { cfg.dryRun = true }
-}
-
-// WithRestoreVerbose logs each file/dir being written.
-func WithRestoreVerbose() RestoreOption {
-	return func(cfg *restoreConfig) { cfg.verbose = true }
 }
 
 // WithRestoreNoVerify skips the content-hash check that restore normally runs
@@ -209,9 +203,7 @@ func (rm *RestoreManager) runWithWriter(ctx context.Context, plan restorePlan, w
 				bump(&result.Errors)
 				return nil
 			}
-			if plan.cfg.verbose {
-				phase.Log(fmt.Sprintf("File: %s (%d bytes)", rel, meta.Size))
-			}
+			phase.Logf(ui.DetailVerbose, "File: %s (%d bytes)", rel, meta.Size)
 			bump(&result.FilesWritten)
 			return nil
 		}
@@ -229,9 +221,7 @@ func (rm *RestoreManager) runWithWriter(ctx context.Context, plan restorePlan, w
 				phase.Increment(1)
 				continue
 			}
-			if plan.cfg.verbose {
-				phase.Log(fmt.Sprintf("Dir: %s", rel))
-			}
+			phase.Logf(ui.DetailVerbose, "Dir: %s", rel)
 			result.DirsWritten++
 			phase.Increment(1)
 			continue

--- a/internal/engine/restore_test.go
+++ b/internal/engine/restore_test.go
@@ -68,7 +68,7 @@ func setupBackupForRestore(t *testing.T) *MockStore {
 		Content: []byte("deep content"),
 	}
 
-	bkMgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil, WithVerbose())
+	bkMgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
 	if _, err := bkMgr.Run(context.Background()); err != nil {
 		t.Fatalf("Backup setup failed: %v", err)
 	}
@@ -120,7 +120,7 @@ func TestRestoreManager_Run(t *testing.T) {
 		Content: []byte("nested content"),
 	}
 
-	bkMgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil, WithVerbose())
+	bkMgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
 	if _, err := bkMgr.Run(context.Background()); err != nil {
 		t.Fatalf("Backup setup failed: %v", err)
 	}

--- a/internal/engine/snapshot_resolution_test.go
+++ b/internal/engine/snapshot_resolution_test.go
@@ -40,14 +40,14 @@ func TestSnapshotReadersDoNotListForFullHash(t *testing.T) {
 		{
 			name: "ls",
 			resolve: func(selector string) error {
-				_, _, err := NewLsSnapshotManager(s).resolveSnapshot(ctx, selector)
+				_, _, err := NewLsSnapshotManager(s, nil).resolveSnapshot(ctx, selector)
 				return err
 			},
 		},
 		{
 			name: "diff",
 			resolve: func(selector string) error {
-				_, err := NewDiffManager(s).resolveSnapshot(ctx, selector)
+				_, err := NewDiffManager(s, nil).resolveSnapshot(ctx, selector)
 				return err
 			},
 		},
@@ -91,14 +91,14 @@ func TestSnapshotReadersResolveUniqueHashPrefix(t *testing.T) {
 		{
 			name: "ls",
 			resolve: func(selector string) (string, error) {
-				_, resolved, err := NewLsSnapshotManager(s).resolveSnapshot(ctx, selector)
+				_, resolved, err := NewLsSnapshotManager(s, nil).resolveSnapshot(ctx, selector)
 				return resolved, err
 			},
 		},
 		{
 			name: "diff",
 			resolve: func(selector string) (string, error) {
-				return NewDiffManager(s).resolveSnapshot(ctx, selector)
+				return NewDiffManager(s, nil).resolveSnapshot(ctx, selector)
 			},
 		},
 	}
@@ -145,14 +145,14 @@ func TestSnapshotReadersRejectAmbiguousHashPrefix(t *testing.T) {
 		{
 			name: "ls",
 			resolve: func(selector string) error {
-				_, _, err := NewLsSnapshotManager(s).resolveSnapshot(ctx, selector)
+				_, _, err := NewLsSnapshotManager(s, nil).resolveSnapshot(ctx, selector)
 				return err
 			},
 		},
 		{
 			name: "diff",
 			resolve: func(selector string) error {
-				_, err := NewDiffManager(s).resolveSnapshot(ctx, selector)
+				_, err := NewDiffManager(s, nil).resolveSnapshot(ctx, selector)
 				return err
 			},
 		},
@@ -192,14 +192,14 @@ func TestSnapshotReadersReturnNotFoundSentinel(t *testing.T) {
 		{
 			name: "ls",
 			resolve: func(selector string) error {
-				_, _, err := NewLsSnapshotManager(s).resolveSnapshot(ctx, selector)
+				_, _, err := NewLsSnapshotManager(s, nil).resolveSnapshot(ctx, selector)
 				return err
 			},
 		},
 		{
 			name: "diff",
 			resolve: func(selector string) error {
-				_, _, err := NewDiffManager(s).loadRoot(ctx, selector)
+				_, _, err := NewDiffManager(s, nil).loadRoot(ctx, selector)
 				return err
 			},
 		},

--- a/internal/engine/verbose_test.go
+++ b/internal/engine/verbose_test.go
@@ -9,28 +9,19 @@ import (
 	"testing"
 
 	"github.com/cloudstic/cli/internal/core"
-	"github.com/cloudstic/cli/internal/ui"
 )
 
-func mustMarshalCatalog(entries []core.SnapshotSummary) []byte {
-	data, err := json.Marshal(entries)
-	if err != nil {
-		panic(err)
-	}
-	return data
-}
-
-// captureStderr runs fn while capturing os.Stderr output and returns it.
+// captureStderr runs fn while capturing os.Stderr, so a test can assert that
+// nothing leaks there.
 func captureStderr(t *testing.T, fn func()) string {
 	t.Helper()
-
 	r, w, err := os.Pipe()
 	if err != nil {
-		t.Fatalf("Failed to create pipe: %v", err)
+		t.Fatalf("pipe: %v", err)
 	}
-	origStderr := os.Stderr
+	orig := os.Stderr
 	os.Stderr = w
-	defer func() { os.Stderr = origStderr }()
+	defer func() { os.Stderr = orig }()
 
 	fn()
 
@@ -40,183 +31,109 @@ func captureStderr(t *testing.T, fn func()) string {
 	return buf.String()
 }
 
-func TestListManager_Verbose(t *testing.T) {
+func mustMarshalCatalog(entries []core.SnapshotSummary) []byte {
+	data, err := json.Marshal(entries)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
+
+// These operations used to write their progress detail straight to os.Stderr,
+// gated by a per-operation verbose option. A library caller could neither
+// capture nor silence it, and the CLI needed a different option name for each
+// operation. The detail now goes to the log writer the caller supplies, which is
+// what these tests assert: the same content, somewhere a caller can reach.
+
+func TestListManager_LogsProgressToTheCallersWriter(t *testing.T) {
 	ctx := context.Background()
 	s := NewMockStore()
 
-	// Create 2 snapshots with a catalog.
 	snap1 := core.Snapshot{Seq: 1, Root: "node/1", Created: "2025-01-01T00:00:00Z"}
 	snap1Ref := saveSnapshot(ctx, s, &snap1)
-
 	snap2 := core.Snapshot{Seq: 2, Root: "node/2", Created: "2025-01-02T00:00:00Z"}
 	snap2Ref := saveSnapshot(ctx, s, &snap2)
 
-	// Populate snapshot catalog.
 	_ = s.Put(ctx, "index/latest", createIndex(snap2Ref, 2))
 	_ = s.Put(ctx, "index/snapshots", mustMarshalCatalog([]core.SnapshotSummary{
 		{Ref: snap1Ref, Seq: snap1.Seq, Created: snap1.Created, Root: snap1.Root},
 		{Ref: snap2Ref, Seq: snap2.Seq, Created: snap2.Created, Root: snap2.Root},
 	}))
 
-	mgr := NewListManager(s, nil)
-
-	// Without verbose: no stderr output.
-	out := captureStderr(t, func() {
-		result, err := mgr.Run(ctx)
-		if err != nil {
-			t.Fatalf("List failed: %v", err)
-		}
-		if len(result.Snapshots) != 2 {
-			t.Errorf("Expected 2 snapshots, got %d", len(result.Snapshots))
-		}
-	})
-	if out != "" {
-		t.Errorf("Expected no stderr output without verbose, got: %q", out)
+	var log bytes.Buffer
+	mgr := NewListManager(s, &log)
+	result, err := mgr.Run(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(result.Snapshots) != 2 {
+		t.Fatalf("got %d snapshots, want 2", len(result.Snapshots))
 	}
 
-	// With verbose: should have stderr output.
-	out = captureStderr(t, func() {
-		result, err := mgr.Run(ctx, WithListVerbose())
-		if err != nil {
-			t.Fatalf("List verbose failed: %v", err)
+	for _, want := range []string{"Loading snapshot catalog", "Found 2 snapshots"} {
+		if !strings.Contains(log.String(), want) {
+			t.Errorf("log does not contain %q; got:\n%s", want, log.String())
 		}
-		if len(result.Snapshots) != 2 {
-			t.Errorf("Expected 2 snapshots, got %d", len(result.Snapshots))
-		}
-	})
-	if !strings.Contains(out, "Loading snapshot catalog") {
-		t.Errorf("Expected verbose output to contain 'Loading snapshot catalog', got: %q", out)
-	}
-	if !strings.Contains(out, "Found 2 snapshots") {
-		t.Errorf("Expected verbose output to contain 'Found 2 snapshots', got: %q", out)
 	}
 }
 
-func TestLsSnapshotManager_Verbose(t *testing.T) {
+// A caller that supplies no writer gets no detail — and, importantly, nothing
+// leaks to the process's stderr instead.
+func TestListManager_NoWriterMeansNoOutput(t *testing.T) {
+	ctx := context.Background()
+	s := NewMockStore()
+	snap := core.Snapshot{Seq: 1, Root: "node/1", Created: "2025-01-01T00:00:00Z"}
+	ref := saveSnapshot(ctx, s, &snap)
+	_ = s.Put(ctx, "index/latest", createIndex(ref, 1))
+	_ = s.Put(ctx, "index/snapshots", mustMarshalCatalog([]core.SnapshotSummary{
+		{Ref: ref, Seq: snap.Seq, Created: snap.Created, Root: snap.Root},
+	}))
+
+	out := captureStderr(t, func() {
+		if _, err := NewListManager(s, nil).Run(ctx); err != nil {
+			t.Fatalf("List: %v", err)
+		}
+	})
+	if out != "" {
+		t.Errorf("operation wrote to stderr with no writer configured: %q", out)
+	}
+}
+
+func TestLsSnapshotManager_LogsProgressToTheCallersWriter(t *testing.T) {
 	ctx := context.Background()
 	s := NewMockStore()
 
-	meta1 := createMeta(ctx, s, "file1.txt", 100)
-	root := createHamt(ctx, t, s, []string{"file1"}, []string{meta1})
+	meta := createMeta(ctx, s, "file1.txt", 100)
+	root := createHamt(ctx, t, s, []string{"file1"}, []string{meta})
 	snap := core.Snapshot{Seq: 1, Root: root, Created: "2025-01-01T00:00:00Z"}
-	snapRef := saveSnapshot(ctx, s, &snap)
-	_ = s.Put(ctx, "index/latest", createIndex(snapRef, 1))
+	ref := saveSnapshot(ctx, s, &snap)
+	_ = s.Put(ctx, "index/latest", createIndex(ref, 1))
 
-	mgr := NewLsSnapshotManager(s)
-
-	// Without verbose: no stderr output.
-	out := captureStderr(t, func() {
-		result, err := mgr.Run(ctx, "latest")
-		if err != nil {
-			t.Fatalf("Ls failed: %v", err)
-		}
-		if len(result.RefToMeta) != 1 {
-			t.Errorf("Expected 1 entry, got %d", len(result.RefToMeta))
-		}
-	})
-	if out != "" {
-		t.Errorf("Expected no stderr output without verbose, got: %q", out)
+	var log bytes.Buffer
+	if _, err := NewLsSnapshotManager(s, &log).Run(ctx, ref); err != nil {
+		t.Fatalf("LsSnapshot: %v", err)
 	}
-
-	// With verbose: should have stderr output.
-	out = captureStderr(t, func() {
-		result, err := mgr.Run(ctx, "latest", WithLsVerbose())
-		if err != nil {
-			t.Fatalf("Ls verbose failed: %v", err)
-		}
-		if len(result.RefToMeta) != 1 {
-			t.Errorf("Expected 1 entry, got %d", len(result.RefToMeta))
-		}
-	})
-	if !strings.Contains(out, "Resolving snapshot") {
-		t.Errorf("Expected verbose output to contain 'Resolving snapshot', got: %q", out)
-	}
-	if !strings.Contains(out, "Collected 1 files") {
-		t.Errorf("Expected verbose output to contain 'Collected 1 files', got: %q", out)
+	if !strings.Contains(log.String(), "Resolving snapshot") {
+		t.Errorf("log does not mention resolving the snapshot; got:\n%s", log.String())
 	}
 }
 
-func TestDiffManager_Verbose(t *testing.T) {
+func TestDiffManager_LogsProgressToTheCallersWriter(t *testing.T) {
 	ctx := context.Background()
 	s := NewMockStore()
 
-	meta1 := createMeta(ctx, s, "file1.txt", 100)
-	meta2 := createMeta(ctx, s, "file2.txt", 200)
+	meta := createMeta(ctx, s, "file1.txt", 100)
+	root := createHamt(ctx, t, s, []string{"file1"}, []string{meta})
+	snap1 := core.Snapshot{Seq: 1, Root: root, Created: "2025-01-01T00:00:00Z"}
+	ref1 := saveSnapshot(ctx, s, &snap1)
+	snap2 := core.Snapshot{Seq: 2, Root: root, Created: "2025-01-02T00:00:00Z"}
+	ref2 := saveSnapshot(ctx, s, &snap2)
 
-	root1 := createHamt(ctx, t, s, []string{"file1"}, []string{meta1})
-	snap1Ref := saveSnapshotRef(ctx, s, root1, 1)
-
-	root2 := createHamt(ctx, t, s, []string{"file1", "file2"}, []string{meta1, meta2})
-	snap2Ref := saveSnapshotRef(ctx, s, root2, 2)
-	_ = s.Put(ctx, "index/latest", createIndex(snap2Ref, 2))
-
-	mgr := NewDiffManager(s)
-
-	// Without verbose: no stderr output.
-	out := captureStderr(t, func() {
-		result, err := mgr.Run(ctx, snap1Ref, snap2Ref)
-		if err != nil {
-			t.Fatalf("Diff failed: %v", err)
-		}
-		if len(result.Changes) != 1 {
-			t.Errorf("Expected 1 change, got %d", len(result.Changes))
-		}
-	})
-	if out != "" {
-		t.Errorf("Expected no stderr output without verbose, got: %q", out)
+	var log bytes.Buffer
+	if _, err := NewDiffManager(s, &log).Run(ctx, ref1, ref2); err != nil {
+		t.Fatalf("Diff: %v", err)
 	}
-
-	// With verbose: should have stderr output.
-	out = captureStderr(t, func() {
-		result, err := mgr.Run(ctx, snap1Ref, snap2Ref, WithDiffVerbose())
-		if err != nil {
-			t.Fatalf("Diff verbose failed: %v", err)
-		}
-		if len(result.Changes) != 1 {
-			t.Errorf("Expected 1 change, got %d", len(result.Changes))
-		}
-	})
-	if !strings.Contains(out, "Resolving snapshot") {
-		t.Errorf("Expected verbose output to contain 'Resolving snapshot', got: %q", out)
+	if !strings.Contains(log.String(), "Resolving snapshot") {
+		t.Errorf("log does not mention resolving the snapshots; got:\n%s", log.String())
 	}
-	if !strings.Contains(out, "Computing diff") {
-		t.Errorf("Expected verbose output to contain 'Computing diff', got: %q", out)
-	}
-	if !strings.Contains(out, "1 added") {
-		t.Errorf("Expected verbose output to contain '1 added', got: %q", out)
-	}
-}
-
-func TestForgetManager_Verbose(t *testing.T) {
-	ctx := context.Background()
-	s := NewMockStore()
-
-	snap1 := core.Snapshot{Seq: 1, Root: "node/1"}
-	snap1Ref := saveSnapshot(ctx, s, &snap1)
-
-	snap2 := core.Snapshot{Seq: 2, Root: "node/2"}
-	snap2Ref := saveSnapshot(ctx, s, &snap2)
-
-	_ = s.Put(ctx, "index/latest", createIndex(snap2Ref, 2))
-
-	// Without verbose: "Forgetting" should NOT be logged.
-	fm := NewForgetManager(s, ui.NewNoOpReporter(), nil)
-	_, err := fm.Run(ctx, snap1Ref)
-	if err != nil {
-		t.Fatalf("Forget without verbose failed: %v", err)
-	}
-	assertNotExists(t, ctx, s, snap1Ref)
-
-	// Re-create snap1 for verbose test.
-	snap1 = core.Snapshot{Seq: 1, Root: "node/1"}
-	snap1Ref = saveSnapshot(ctx, s, &snap1)
-
-	// With verbose: phase.Log should be called with the snapshot ref.
-	// Since NoOpReporter discards logs, we just verify it doesn't error.
-	fm2 := NewForgetManager(s, ui.NewNoOpReporter(), nil)
-	_, err = fm2.Run(ctx, snap1Ref, WithForgetVerbose())
-	if err != nil {
-		t.Fatalf("Forget with verbose failed: %v", err)
-	}
-	assertNotExists(t, ctx, s, snap1Ref)
 }

--- a/internal/ui/progress.go
+++ b/internal/ui/progress.go
@@ -1,10 +1,28 @@
 package ui
 
 import (
+	"fmt"
 	"os"
 	"time"
 
 	"github.com/jedib0t/go-pretty/v6/progress"
+)
+
+// Detail is how much an operation should say about what it is doing.
+//
+// It exists because verbosity is a presentation choice, and the code that makes
+// presentation choices is the reporter — not the engine producing the events.
+// Every operation used to carry its own verbose flag and gate its own log calls,
+// which meant six option constructors for one idea and six places to change it.
+type Detail int
+
+const (
+	// DetailNormal reports milestones: phases, counts, warnings.
+	DetailNormal Detail = iota
+	// DetailVerbose additionally reports per-item progress — every object
+	// verified, every file restored. On a large repository this is a line per
+	// object, which is why it is off by default and why Logf defers formatting.
+	DetailVerbose
 )
 
 // Reporter defines the interface for progress reporting.
@@ -19,7 +37,15 @@ type Reporter interface {
 // Phase represents an active progress tracking phase.
 type Phase interface {
 	Increment(n int64)
+	// Log records a message the caller has already decided to emit.
 	Log(msg string)
+	// Logf records a message at a detail level, formatting the arguments only
+	// if the reporter wants that level.
+	//
+	// The deferral is the point, not an optimization detail: per-item logging
+	// runs once per object checked or file restored, so formatting a string the
+	// reporter will discard is work proportional to repository size.
+	Logf(level Detail, format string, args ...any)
 	Done()
 	Error()
 }
@@ -27,11 +53,20 @@ type Phase interface {
 // ConsoleReporter implements Reporter using go-pretty for console output.
 type ConsoleReporter struct {
 	logWriter *SafeLogWriter
+	detail    Detail
 }
 
 func NewConsoleReporter() *ConsoleReporter {
 	return &ConsoleReporter{}
 }
+
+// SetDetail chooses how much this reporter shows.
+//
+// This is the single place verbosity is decided. Operations report what they are
+// doing at a level; this decides which levels reach the user. Before it existed,
+// each of the nine operations carried its own verbose option and gated its own
+// log calls, so the same choice had nine names and nine implementations.
+func (c *ConsoleReporter) SetDetail(d Detail) { c.detail = d }
 
 // SetLogWriter registers a SafeLogWriter that will be kept in sync with the
 // active progress writer so external log lines (e.g. store debug output)
@@ -74,6 +109,7 @@ func (c *ConsoleReporter) StartPhase(name string, total int64, isBytes bool) Pha
 		pw:        pw,
 		tracker:   &tracker,
 		logWriter: c.logWriter,
+		detail:    c.detail,
 	}
 }
 
@@ -81,6 +117,7 @@ type consolePhase struct {
 	pw        progress.Writer
 	tracker   *progress.Tracker
 	logWriter *SafeLogWriter
+	detail    Detail
 }
 
 func (cp *consolePhase) Increment(n int64) {
@@ -89,6 +126,13 @@ func (cp *consolePhase) Increment(n int64) {
 
 func (cp *consolePhase) Log(msg string) {
 	cp.pw.Log(msg)
+}
+
+func (cp *consolePhase) Logf(level Detail, format string, args ...any) {
+	if level > cp.detail {
+		return
+	}
+	cp.pw.Log(fmt.Sprintf(format, args...))
 }
 
 func (cp *consolePhase) Done() {
@@ -122,7 +166,8 @@ func (n *NoOpReporter) StartPhase(name string, total int64, isBytes bool) Phase 
 
 type noOpPhase struct{}
 
-func (np *noOpPhase) Increment(n int64) {}
-func (np *noOpPhase) Log(msg string)    {}
-func (np *noOpPhase) Done()             {}
-func (np *noOpPhase) Error()            {}
+func (np *noOpPhase) Increment(n int64)           {}
+func (np *noOpPhase) Log(msg string)              {}
+func (np *noOpPhase) Logf(Detail, string, ...any) {}
+func (np *noOpPhase) Done()                       {}
+func (np *noOpPhase) Error()                      {}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -88,4 +88,9 @@ type Client struct {
 	DisablePackfile bool
 	Quiet           bool
 	JSON            bool
+
+	// Verbose asks the reporter for per-item detail. It is a presentation
+	// choice, which is why it lives here and on the reporter rather than as an
+	// option on each operation.
+	Verbose bool
 }

--- a/pkg/open/source.go
+++ b/pkg/open/source.go
@@ -214,9 +214,6 @@ func BackupOptions(cfg config.Backup) ([]cloudstic.BackupOption, error) {
 
 func backupOptions(cfg config.Backup) []cloudstic.BackupOption {
 	var opts []cloudstic.BackupOption
-	if cfg.Verbose {
-		opts = append(opts, cloudstic.WithVerbose())
-	}
 	if cfg.DryRun {
 		opts = append(opts, cloudstic.WithBackupDryRun())
 	}

--- a/query.go
+++ b/query.go
@@ -14,8 +14,6 @@ import (
 type ListOption = engine.ListOption
 type ListResult = engine.ListResult
 
-var WithListVerbose = engine.WithListVerbose
-
 func (c *Client) List(ctx context.Context, opts ...ListOption) (*ListResult, error) {
 	mgr := engine.NewListManager(c.store, c.logWriter)
 	return mgr.Run(ctx, opts...)
@@ -28,12 +26,10 @@ func (c *Client) List(ctx context.Context, opts ...ListOption) (*ListResult, err
 type LsSnapshotOption = engine.LsSnapshotOption
 type LsSnapshotResult = engine.LsSnapshotResult
 
-var WithLsVerbose = engine.WithLsVerbose
-
 // LsSnapshot lists a snapshot selected by latest, full hash, or unambiguous
 // hash prefix. An ambiguous prefix is rejected.
 func (c *Client) LsSnapshot(ctx context.Context, snapshotID string, opts ...LsSnapshotOption) (*LsSnapshotResult, error) {
-	mgr := engine.NewLsSnapshotManager(c.store)
+	mgr := engine.NewLsSnapshotManager(c.store, c.logWriter)
 	return mgr.Run(ctx, snapshotID, opts...)
 }
 
@@ -78,7 +74,6 @@ var (
 	WithFindGroupByContent = engine.WithFindGroupByContent
 	WithFindMaxResults     = engine.WithFindMaxResults
 	WithFindNoDelta        = engine.WithFindNoDelta
-	WithFindVerbose        = engine.WithFindVerbose
 
 	ParseSizeCompare = engine.ParseSizeCompare
 	ParseFindTime    = engine.ParseFindTime
@@ -117,12 +112,10 @@ const (
 	ChangeModified = engine.ChangeModified
 )
 
-var WithDiffVerbose = engine.WithDiffVerbose
-
 // Diff compares snapshots selected by latest, full hashes, or unambiguous hash
 // prefixes. An ambiguous prefix is rejected.
 func (c *Client) Diff(ctx context.Context, snap1, snap2 string, opts ...DiffOption) (*DiffResult, error) {
-	mgr := engine.NewDiffManager(c.store)
+	mgr := engine.NewDiffManager(c.store, c.logWriter)
 	return mgr.Run(ctx, snap1, snap2, opts...)
 }
 

--- a/restore.go
+++ b/restore.go
@@ -21,7 +21,6 @@ var (
 	ErrSnapshotRefAmbiguous = engine.ErrSnapshotRefAmbiguous
 
 	WithRestoreDryRun   = engine.WithRestoreDryRun
-	WithRestoreVerbose  = engine.WithRestoreVerbose
 	WithRestorePath     = engine.WithRestorePath
 	WithRestoreNoVerify = engine.WithRestoreNoVerify
 )

--- a/retention.go
+++ b/retention.go
@@ -15,8 +15,7 @@ type PruneOption = engine.PruneOption
 type PruneResult = engine.PruneResult
 
 var (
-	WithPruneDryRun  = engine.WithPruneDryRun
-	WithPruneVerbose = engine.WithPruneVerbose
+	WithPruneDryRun = engine.WithPruneDryRun
 )
 
 func (c *Client) Prune(ctx context.Context, opts ...PruneOption) (*PruneResult, error) {
@@ -41,7 +40,6 @@ type ForgetResult = engine.ForgetResult
 var (
 	WithPrune         = engine.WithPrune
 	WithDryRun        = engine.WithDryRun
-	WithForgetVerbose = engine.WithForgetVerbose
 	WithKeepLast      = engine.WithKeepLast
 	WithKeepHourly    = engine.WithKeepHourly
 	WithKeepDaily     = engine.WithKeepDaily


### PR DESCRIPTION
## Summary

First of the four items from the configuration-surface review.

Nine operations each carried a verbose option — `WithVerbose`, `WithCheckVerbose`, `WithDiffVerbose`, `WithFindVerbose`, `WithLsVerbose`, `WithListVerbose`, `WithPruneVerbose`, `WithForgetVerbose`, `WithRestoreVerbose` — and each gated its own log calls with it:

```go
if cfg.verbose {
    phase.Log(fmt.Sprintf("OK: %s", ref))
}
```

One idea, nine names, nine implementations. Verbosity is a **presentation** choice, and the reporter is what makes presentation choices — but the reporter is injected at the client while the decision was taken nine layers down.

`Phase` gains `Logf(level, format, args...)`. Operations report at a level; the reporter decides which levels it shows. `ConsoleReporter.SetDetail` is the single place that decision is made, and `cmd/cloudstic` drives it from the one global `-verbose` flag it already had.

The formatting is **deferred** rather than the call gated, which matters because these run per object checked and per file restored — formatting a string the reporter will discard is work proportional to repository size.

### Four operations were bypassing the reporter entirely

`diff`, `list`, `ls` and `find`'s scanner wrote their detail **straight to `os.Stderr`**:

```go
if cfg.verbose {
    fmt.Fprintf(os.Stderr, "Resolving snapshot %q...\n", snapID1)
}
```

A library caller could neither capture, redirect, nor silence that, and no reporter — including the TUI's — ever saw it. They now write to the caller's log writer, so `DiffManager` and `LsSnapshotManager` take one, as `ListManager` and `FindManager` already did.

## Breaking change

This removes **9 exported options** that exist in `v1.17.0`. Callers using them should set the level on their reporter instead; callers with a custom `Reporter` now implement `Phase.Logf` and decide for themselves — which is the point.

## Verification

Mechanism confirmed end to end against a built binary, not just unit tests:

```
without -verbose, detail lines: 0
with    -verbose, detail lines: 2
```

`TestPublicAPIHasNoUnaliasedInternalTypes` caught that `Phase.Logf` exposed `ui.Detail` through a public signature — exactly what RFC 0022 put that guard there for. `Detail` and its constants are now aliased at the root.

The verbose tests previously captured `os.Stderr` to assert the old behaviour. They now assert the detail reaches a writer the caller supplied, **plus** that nothing leaks to stderr when no writer is configured — testing the property this change is for rather than the one it removed.

- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./...` passes
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./...` reports `0 issues`
- `gofmt -l .` clean

## Still to come

The other three review items, in order: `Find` takes its `FindQuery` value (21 options → 0; the type is already exported and JSON-tagged), one naming rule `With<Operation><Thing>`, and `Check` taking its snapshot ref positionally like every other operation. RFC 0022 will be amended once the shape settles rather than per-PR.