### PR TITLE
refactor: Find takes the query it always had (RFC 0022 §9)

### DIFF
--- a/cmd/cloudstic/client_iface.go
+++ b/cmd/cloudstic/client_iface.go
@@ -15,7 +15,7 @@ type cloudsticClient interface {
 	RestoreToDir(ctx context.Context, outputDir, snapshotRef string, opts ...cloudstic.RestoreOption) (*cloudstic.RestoreResult, error)
 	List(ctx context.Context, opts ...cloudstic.ListOption) (*cloudstic.ListResult, error)
 	LsSnapshot(ctx context.Context, snapshotID string, opts ...cloudstic.LsSnapshotOption) (*cloudstic.LsSnapshotResult, error)
-	Find(ctx context.Context, opts ...cloudstic.FindOption) (*cloudstic.FindResult, error)
+	Find(ctx context.Context, q cloudstic.FindQuery) (*cloudstic.FindResult, error)
 	Prune(ctx context.Context, opts ...cloudstic.PruneOption) (*cloudstic.PruneResult, error)
 	Forget(ctx context.Context, snapshotID string, opts ...cloudstic.ForgetOption) (*cloudstic.ForgetResult, error)
 	ForgetPolicy(ctx context.Context, opts ...cloudstic.ForgetOption) (*cloudstic.PolicyResult, error)

--- a/cmd/cloudstic/cmd_find.go
+++ b/cmd/cloudstic/cmd_find.go
@@ -86,7 +86,7 @@ func declareFindArgs(g *globalFlags) (*findArgs, commandInput) {
 }
 
 func runFind(r *runner, ctx context.Context, a *findArgs, cfg clientConfig) int {
-	opts, err := buildFindOpts(a)
+	q, err := buildFindQuery(a)
 	if err != nil {
 		if !a.jsonEnabled() {
 			r.printUsage(r.errOut)
@@ -97,7 +97,7 @@ func runFind(r *runner, ctx context.Context, a *findArgs, cfg clientConfig) int 
 		return r.fail("Failed to init store: %v", err)
 	}
 
-	result, err := r.client.Find(ctx, opts...)
+	result, err := r.client.Find(ctx, q)
 	if err != nil {
 		return r.fail("Find failed: %v", err)
 	}
@@ -114,86 +114,59 @@ func runFind(r *runner, ctx context.Context, a *findArgs, cfg clientConfig) int 
 	return 0
 }
 
-// buildFindOpts turns the parsed flags into engine options, doing the semantic
-// validation and derivation that depends on more than one value.
-func buildFindOpts(a *findArgs) ([]cloudstic.FindOption, error) {
-	var opts []cloudstic.FindOption
+// buildFindQuery turns the parsed flags into the query they describe, doing the
+// semantic validation and derivation that depends on more than one value.
+//
+// Most fields are assigned unconditionally: a zero field already means "not
+// constrained", so guarding each one would only restate that. What is left is
+// the parts that are decisions — the mutually exclusive pattern shorthand, and
+// the two values that have to be parsed before they can be a constraint.
+func buildFindQuery(a *findArgs) (cloudstic.FindQuery, error) {
+	var q cloudstic.FindQuery
 
+	if a.pattern != "" && (a.name != "" || a.path != "") {
+		return q, fmt.Errorf("the positional pattern is shorthand for -name or -path; give one or the other")
+	}
+
+	q.Name = a.name
+	q.Path = a.path
+	q.Regex = a.regex
+	q.IgnoreCase = a.ignoreCase
+	q.FileID = a.fileID
+	q.ContentHash = a.contentHash
+	q.Ref = a.ref
+	q.Newer = a.newer
+	q.Older = a.older
+	q.Snapshots = a.snapshots
+	q.Source = a.source
+	q.Tags = a.tags
+	q.Latest = a.latest
+	q.Since = a.since
+	q.Until = a.until
+	q.GroupByContent = a.byContent
+	q.MaxResults = a.maxResults
+	q.NoDelta = a.noDelta
+
+	// Routes by shape, so it must run after Name and Path are assigned.
 	if a.pattern != "" {
-		if a.name != "" || a.path != "" {
-			return nil, fmt.Errorf("the positional pattern is shorthand for -name or -path; give one or the other")
-		}
-		opts = append(opts, cloudstic.WithFindPattern(a.pattern))
+		q.SetPattern(a.pattern)
 	}
-	if a.name != "" {
-		opts = append(opts, cloudstic.WithFindName(a.name))
-	}
-	if a.path != "" {
-		opts = append(opts, cloudstic.WithFindPath(a.path))
-	}
-	if a.regex != "" {
-		opts = append(opts, cloudstic.WithFindRegex(a.regex))
-	}
-	if a.ignoreCase {
-		opts = append(opts, cloudstic.WithFindIgnoreCase())
-	}
-	if a.fileID != "" {
-		opts = append(opts, cloudstic.WithFindFileID(a.fileID))
-	}
-	if a.contentHash != "" {
-		opts = append(opts, cloudstic.WithFindContentHash(a.contentHash))
-	}
-	if a.ref != "" {
-		opts = append(opts, cloudstic.WithFindRef(a.ref))
-	}
+
 	if a.fileType != "" {
 		t, err := parseFindType(a.fileType)
 		if err != nil {
-			return nil, err
+			return q, err
 		}
-		opts = append(opts, cloudstic.WithFindType(t))
+		q.Type = t
 	}
 	if a.size != "" {
 		cmp, err := cloudstic.ParseSizeCompare(a.size)
 		if err != nil {
-			return nil, fmt.Errorf("-size: %w", err)
+			return q, fmt.Errorf("-size: %w", err)
 		}
-		opts = append(opts, cloudstic.WithFindSize(cmp))
+		q.Size = &cmp
 	}
-	if a.newer != "" {
-		opts = append(opts, cloudstic.WithFindNewer(a.newer))
-	}
-	if a.older != "" {
-		opts = append(opts, cloudstic.WithFindOlder(a.older))
-	}
-	if len(a.snapshots) > 0 {
-		opts = append(opts, cloudstic.WithFindSnapshots(a.snapshots...))
-	}
-	if a.source != "" {
-		opts = append(opts, cloudstic.WithFindSource(a.source))
-	}
-	if len(a.tags) > 0 {
-		opts = append(opts, cloudstic.WithFindTags(a.tags...))
-	}
-	if a.latest > 0 {
-		opts = append(opts, cloudstic.WithFindLatest(a.latest))
-	}
-	if a.since != "" {
-		opts = append(opts, cloudstic.WithFindSince(a.since))
-	}
-	if a.until != "" {
-		opts = append(opts, cloudstic.WithFindUntil(a.until))
-	}
-	if a.byContent {
-		opts = append(opts, cloudstic.WithFindGroupByContent())
-	}
-	if a.maxResults > 0 {
-		opts = append(opts, cloudstic.WithFindMaxResults(a.maxResults))
-	}
-	if a.noDelta {
-		opts = append(opts, cloudstic.WithFindNoDelta())
-	}
-	return opts, nil
+	return q, nil
 }
 
 // parseFindType accepts find(1)'s single-letter type vocabulary as well as the

--- a/cmd/cloudstic/cmd_find_test.go
+++ b/cmd/cloudstic/cmd_find_test.go
@@ -15,7 +15,7 @@ import (
 // Argument handling
 // ---------------------------------------------------------------------------
 
-func TestBuildFindOpts_PositionalPatternRoutesByShape(t *testing.T) {
+func TestBuildFindQuery_PositionalPatternRoutesByShape(t *testing.T) {
 	// The positional is shorthand: a pattern with a separator constrains the
 	// full path, one without it constrains the basename.
 	for _, tc := range []struct {
@@ -34,14 +34,14 @@ func TestBuildFindOpts_PositionalPatternRoutesByShape(t *testing.T) {
 	}
 }
 
-func TestBuildFindOpts_PositionalConflictsWithExplicitPattern(t *testing.T) {
+func TestBuildFindQuery_PositionalConflictsWithExplicitPattern(t *testing.T) {
 	a := &findArgs{globalFlags: newTestGlobalFlags(), pattern: "*.pdf", name: "*.txt"}
-	if _, err := buildFindOpts(a); err == nil {
+	if _, err := buildFindQuery(a); err == nil {
 		t.Fatal("want an error when the positional and -name are both given")
 	}
 }
 
-func TestBuildFindOpts_TypeAcceptsFindVocabulary(t *testing.T) {
+func TestBuildFindQuery_TypeAcceptsFindVocabulary(t *testing.T) {
 	for _, tc := range []struct {
 		raw  string
 		want core.FileType
@@ -58,24 +58,24 @@ func TestBuildFindOpts_TypeAcceptsFindVocabulary(t *testing.T) {
 	}
 
 	a := &findArgs{globalFlags: newTestGlobalFlags(), fileType: "symlink"}
-	if _, err := buildFindOpts(a); err == nil {
+	if _, err := buildFindQuery(a); err == nil {
 		t.Fatal("want an error for an unsupported -type")
 	}
 }
 
-func TestBuildFindOpts_SizeUsesFindSuffixSyntax(t *testing.T) {
+func TestBuildFindQuery_SizeUsesFindSuffixSyntax(t *testing.T) {
 	q := queryFromArgs(t, &findArgs{globalFlags: newTestGlobalFlags(), size: "+10M"})
 	if q.Size == nil || q.Size.Op != cloudstic.SizeAtLeast || q.Size.Bytes != 10<<20 {
 		t.Fatalf("-size +10M parsed to %+v", q.Size)
 	}
 
 	a := &findArgs{globalFlags: newTestGlobalFlags(), size: "10Q"}
-	if _, err := buildFindOpts(a); err == nil {
+	if _, err := buildFindQuery(a); err == nil {
 		t.Fatal("want an error for an unknown size suffix")
 	}
 }
 
-func TestBuildFindOpts_SnapshotAndFileTimeSelectorsStaySeparate(t *testing.T) {
+func TestBuildFindQuery_SnapshotAndFileTimeSelectorsStaySeparate(t *testing.T) {
 	// -since/-until select snapshots; -newer/-older select files. The two
 	// vocabularies collide easily, so this pins that they land in distinct
 	// fields rather than one silently overwriting the other.
@@ -95,16 +95,15 @@ func TestBuildFindOpts_SnapshotAndFileTimeSelectorsStaySeparate(t *testing.T) {
 	}
 }
 
-// queryFromArgs resolves the options a command would build into the query the
-// engine will actually receive, so tests assert on meaning rather than on the
-// opaque option closures.
+// queryFromArgs builds the query a set of flags describes, failing the test if
+// they are invalid.
 func queryFromArgs(t *testing.T, a *findArgs) engine.FindQuery {
 	t.Helper()
-	opts, err := buildFindOpts(a)
+	q, err := buildFindQuery(a)
 	if err != nil {
-		t.Fatalf("buildFindOpts: %v", err)
+		t.Fatalf("buildFindQuery: %v", err)
 	}
-	return engine.QueryFromOptions(opts...)
+	return q
 }
 
 // ---------------------------------------------------------------------------
@@ -172,7 +171,7 @@ func TestRunFind_InvalidArgumentsFailBeforeOpeningTheRepository(t *testing.T) {
 	if code == 0 {
 		t.Fatal("want a non-zero exit for an unparseable -size")
 	}
-	if stub.findOpts != nil {
+	if stub.findCalled {
 		t.Error("the client was called despite an argument error")
 	}
 }

--- a/cmd/cloudstic/stub_client_test.go
+++ b/cmd/cloudstic/stub_client_test.go
@@ -25,7 +25,8 @@ type stubClient struct {
 	lsErr           error
 	findResult      *cloudstic.FindResult
 	findErr         error
-	findOpts        []cloudstic.FindOption
+	findQuery       cloudstic.FindQuery
+	findCalled      bool
 	pruneResult     *cloudstic.PruneResult
 	pruneErr        error
 	forgetResult    *cloudstic.ForgetResult
@@ -66,8 +67,8 @@ func (s *stubClient) LsSnapshot(_ context.Context, _ string, _ ...cloudstic.LsSn
 	return s.lsResult, s.lsErr
 }
 
-func (s *stubClient) Find(_ context.Context, opts ...cloudstic.FindOption) (*cloudstic.FindResult, error) {
-	s.findOpts = opts
+func (s *stubClient) Find(_ context.Context, q cloudstic.FindQuery) (*cloudstic.FindResult, error) {
+	s.findQuery, s.findCalled = q, true
 	return s.findResult, s.findErr
 }
 

--- a/internal/apicheck/testdata/externalmod/go.mod
+++ b/internal/apicheck/testdata/externalmod/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.33.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.45.0 // indirect
-	github.com/aws/smithy-go v1.27.4 // indirect
+	github.com/aws/smithy-go v1.27.5 // indirect
 	github.com/keybase/go-keychain v0.0.1 // indirect
 	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	golang.org/x/crypto v0.54.0 // indirect

--- a/internal/apicheck/testdata/externalmod/go.sum
+++ b/internal/apicheck/testdata/externalmod/go.sum
@@ -28,6 +28,7 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.45.0 h1:Pd6PNlp4t8PTXxqzstICl52Wsy78
 github.com/aws/aws-sdk-go-v2/service/sts v1.45.0/go.mod h1:rmQ0TnHzuLPmabgjPcsywhsSOmaBDgzR4zvDxSPsGdg=
 github.com/aws/smithy-go v1.27.4 h1:JQcphmBN4f0q/sPqXqROIItRNV/hy10cgu7CsFy616M=
 github.com/aws/smithy-go v1.27.4/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aws/smithy-go v1.27.5/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=

--- a/internal/engine/find.go
+++ b/internal/engine/find.go
@@ -198,119 +198,20 @@ func (r *FindResult) TotalSnapshots() int {
 // Options
 // ---------------------------------------------------------------------------
 
-// FindOption configures a find operation.
-type FindOption func(*findConfig)
-
-type findConfig struct {
-	query FindQuery
-}
-
-// WithFindPattern applies the positional pattern, routing it by shape: a
-// pattern containing a separator constrains the full path, one without it
-// constrains the basename. This split is what keeps the common case cheap —
-// a basename is on the metadata object already, a path has to be reconstructed.
-func WithFindPattern(pattern string) FindOption {
-	return func(c *findConfig) {
-		if pathPatternLooksLikePath(pattern) {
-			c.query.Path = pattern
-			return
-		}
-		c.query.Name = pattern
+// SetPattern applies a positional pattern, routing it by shape: a pattern
+// containing a separator constrains the full path, one without it constrains
+// the basename. This split is what keeps the common case cheap — a basename is
+// on the metadata object already, a path has to be reconstructed.
+//
+// It is a method rather than a plain field because that routing is a decision,
+// not a value: a caller who assigned Path directly would silently make every
+// basename search pay for path reconstruction.
+func (q *FindQuery) SetPattern(pattern string) {
+	if pathPatternLooksLikePath(pattern) {
+		q.Path = pattern
+		return
 	}
-}
-
-func WithFindName(pattern string) FindOption {
-	return func(c *findConfig) { c.query.Name = pattern }
-}
-
-func WithFindPath(pattern string) FindOption {
-	return func(c *findConfig) { c.query.Path = pattern }
-}
-
-func WithFindRegex(expr string) FindOption {
-	return func(c *findConfig) { c.query.Regex = expr }
-}
-
-func WithFindIgnoreCase() FindOption {
-	return func(c *findConfig) { c.query.IgnoreCase = true }
-}
-
-func WithFindFileID(id string) FindOption {
-	return func(c *findConfig) { c.query.FileID = id }
-}
-
-func WithFindContentHash(hash string) FindOption {
-	return func(c *findConfig) { c.query.ContentHash = hash }
-}
-
-func WithFindRef(ref string) FindOption {
-	return func(c *findConfig) { c.query.Ref = ref }
-}
-
-func WithFindType(t core.FileType) FindOption {
-	return func(c *findConfig) { c.query.Type = t }
-}
-
-func WithFindSize(cmp SizeCompare) FindOption {
-	return func(c *findConfig) { c.query.Size = &cmp }
-}
-
-// WithFindNewer and WithFindOlder filter by a file's Mtime. They accept RFC3339
-// or a duration such as "7d", which is read relative to now.
-func WithFindNewer(spec string) FindOption {
-	return func(c *findConfig) { c.query.Newer = spec }
-}
-
-func WithFindOlder(spec string) FindOption {
-	return func(c *findConfig) { c.query.Older = spec }
-}
-
-// WithFindSnapshots restricts the search to the named snapshots. Refs may be
-// full ("snapshot/<hash>"), bare hashes, unambiguous prefixes, or "latest".
-func WithFindSnapshots(refs ...string) FindOption {
-	return func(c *findConfig) { c.query.Snapshots = append(c.query.Snapshots, refs...) }
-}
-
-func WithFindSource(uri string) FindOption {
-	return func(c *findConfig) { c.query.Source = uri }
-}
-
-func WithFindTags(tags ...string) FindOption {
-	return func(c *findConfig) { c.query.Tags = append(c.query.Tags, tags...) }
-}
-
-// WithFindLatest restricts the search to the n newest selected snapshots.
-func WithFindLatest(n int) FindOption {
-	return func(c *findConfig) { c.query.Latest = n }
-}
-
-// WithFindSince and WithFindUntil filter by a snapshot's creation time, not by
-// any file's Mtime — that is what WithFindNewer and WithFindOlder do.
-func WithFindSince(spec string) FindOption {
-	return func(c *findConfig) { c.query.Since = spec }
-}
-
-func WithFindUntil(spec string) FindOption {
-	return func(c *findConfig) { c.query.Until = spec }
-}
-
-// WithFindGroupByContent regroups the same matches by content hash instead of
-// by file identity, which is how duplicate content is found. It changes
-// grouping only, never which entries matched.
-func WithFindGroupByContent() FindOption {
-	return func(c *findConfig) { c.query.GroupByContent = true }
-}
-
-func WithFindMaxResults(n int) FindOption {
-	return func(c *findConfig) { c.query.MaxResults = n }
-}
-
-// WithFindNoDelta forces the straightforward per-snapshot walk instead of the
-// delta scan. It exists so a suspected delta-scan bug can be confirmed against
-// an implementation with nowhere to hide, and so the two can be compared in
-// tests.
-func WithFindNoDelta() FindOption {
-	return func(c *findConfig) { c.query.NoDelta = true }
+	q.Name = pattern
 }
 
 // ---------------------------------------------------------------------------
@@ -336,29 +237,18 @@ func NewFindManager(s store.ObjectStore, logWriter io.Writer) *FindManager {
 	return &FindManager{store: s, tree: hamt.NewTree(s), log: SnapshotLogger(logWriter)}
 }
 
-// QueryFromOptions resolves a set of options into the query they describe,
-// defaults filled in. Run uses it; callers that want to show or record what a
-// query will do before running it can too.
-func QueryFromOptions(opts ...FindOption) FindQuery {
-	return newFindConfig(opts...).query
-}
-
-func newFindConfig(opts ...FindOption) findConfig {
-	cfg := findConfig{query: FindQuery{MaxResults: defaultFindMaxResults}}
-	for _, opt := range opts {
-		opt(&cfg)
-	}
-	if cfg.query.MaxResults <= 0 {
-		cfg.query.MaxResults = defaultFindMaxResults
-	}
-	return cfg
-}
-
 // Run executes the query.
-func (fm *FindManager) Run(ctx context.Context, opts ...FindOption) (*FindResult, error) {
-	cfg := newFindConfig(opts...)
+//
+// A zero FindQuery is a valid search — every file in every snapshot, capped at
+// the default result limit. MaxResults is normalized here rather than being a
+// required field so that filling in only the predicates you care about behaves
+// the way the rest of this module's configuration values do.
+func (fm *FindManager) Run(ctx context.Context, q FindQuery) (*FindResult, error) {
+	if q.MaxResults <= 0 {
+		q.MaxResults = defaultFindMaxResults
+	}
 
-	pred, err := compileFindPredicate(cfg.query)
+	pred, err := compileFindPredicate(q)
 	if err != nil {
 		return nil, err
 	}
@@ -369,29 +259,29 @@ func (fm *FindManager) Run(ctx context.Context, opts ...FindOption) (*FindResult
 	if err != nil {
 		return nil, fmt.Errorf("load snapshot catalog: %w", err)
 	}
-	selected, err := selectFindSnapshots(fm.store, catalog, cfg.query)
+	selected, err := selectFindSnapshots(fm.store, catalog, q)
 	if err != nil {
 		return nil, err
 	}
 
 	result := &FindResult{
-		Query:             cfg.query,
+		Query:             q,
 		SnapshotsSearched: len(selected),
 		GroupedBy:         "file",
 	}
-	if cfg.query.GroupByContent {
+	if q.GroupByContent {
 		result.GroupedBy = "content"
 	}
 	if w := pred.prefilterWarning(); w != "" {
 		result.Warnings = append(result.Warnings, w)
 	}
 
-	collector := newFindCollector(cfg.query.GroupByContent, cfg.query.MaxResults)
+	collector := newFindCollector(q.GroupByContent, q.MaxResults)
 	scanner := newFindScanner(fm.store, fm.tree, pred, collector, fm.log)
 
 	for _, lineage := range groupFindLineages(selected) {
 		fm.log.Debugf("Scanning %d snapshot(s) for %s", len(lineage.snapshots), lineage.key)
-		if err := scanner.scanLineage(ctx, lineage, cfg.query.NoDelta); err != nil {
+		if err := scanner.scanLineage(ctx, lineage, q.NoDelta); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/engine/find_test.go
+++ b/internal/engine/find_test.go
@@ -128,15 +128,30 @@ func localSource(path string) *core.SourceInfo {
 // runFind executes a query against the repository under both scanners and
 // requires them to agree, so every test in this file doubles as a check that
 // the delta scan matches the straightforward walk.
-func (r *findRepo) runFind(opts ...FindOption) *FindResult {
+// withNoDelta returns q with delta scanning disabled, which the full-scan
+// comparison in runFind uses as its control.
+func withNoDelta(q FindQuery) FindQuery {
+	q.NoDelta = true
+	return q
+}
+
+// patternQuery builds a query from a positional pattern, routing by shape the
+// way the CLI's positional argument does.
+func patternQuery(pattern string) FindQuery {
+	var q FindQuery
+	q.SetPattern(pattern)
+	return q
+}
+
+func (r *findRepo) runFind(q FindQuery) *FindResult {
 	r.t.Helper()
 	ctx := context.Background()
 
-	delta, err := NewFindManager(r.store, nil).Run(ctx, opts...)
+	delta, err := NewFindManager(r.store, nil).Run(ctx, q)
 	if err != nil {
 		r.t.Fatalf("find (delta): %v", err)
 	}
-	full, err := NewFindManager(r.store, nil).Run(ctx, append(append([]FindOption{}, opts...), WithFindNoDelta())...)
+	full, err := NewFindManager(r.store, nil).Run(ctx, withNoDelta(q))
 	if err != nil {
 		r.t.Fatalf("find (no-delta): %v", err)
 	}
@@ -194,7 +209,7 @@ func TestFind_UnchangedFileCollapsesToOneVersion(t *testing.T) {
 		r.snapshot(fmt.Sprintf("2026-01-0%dT00:00:00Z", day), src, docs, vault)
 	}
 
-	result := r.runFind(WithFindPattern("vault.kdbx"))
+	result := r.runFind(patternQuery("vault.kdbx"))
 
 	if len(result.Matches) != 1 {
 		t.Fatalf("want 1 match, got %d: %s", len(result.Matches), renderMatches(result.Matches))
@@ -229,7 +244,7 @@ func TestFind_EditedFileYieldsOrderedVersions(t *testing.T) {
 	r.snapshot("2026-01-03T00:00:00Z", src, docs, vault.withSize(200).withContent("v2"))
 	r.snapshot("2026-01-04T00:00:00Z", src, docs, vault.withSize(300).withContent("v3"))
 
-	result := r.runFind(WithFindPattern("vault.kdbx"))
+	result := r.runFind(patternQuery("vault.kdbx"))
 
 	if len(result.Matches) != 1 {
 		t.Fatalf("an edited file stays one match, got %d: %s", len(result.Matches), renderMatches(result.Matches))
@@ -270,7 +285,7 @@ func TestFind_EditedFileWithinSameSecondStaysOrderedBySeq(t *testing.T) {
 	r.snapshot(sameSecond, src, docs, vault.withSize(100))
 	r.snapshot(sameSecond, src, docs, vault.withSize(200).withContent("v2"))
 
-	result := r.runFind(WithFindPattern("vault.kdbx"))
+	result := r.runFind(patternQuery("vault.kdbx"))
 
 	versions := result.Matches[0].Versions
 	if len(versions) != 2 {
@@ -298,7 +313,7 @@ func TestFind_IdenticalContentAtDifferentPathsStaysSeparate(t *testing.T) {
 		file("f2", "report.pdf", "d2").withContent("same-bytes"),
 	)
 
-	result := r.runFind(WithFindPattern("report.pdf"))
+	result := r.runFind(patternQuery("report.pdf"))
 	if len(result.Matches) != 2 {
 		t.Fatalf("two distinct files must stay separate matches, got %d: %s",
 			len(result.Matches), renderMatches(result.Matches))
@@ -307,7 +322,7 @@ func TestFind_IdenticalContentAtDifferentPathsStaysSeparate(t *testing.T) {
 		t.Errorf("matches share a FileID %q", a)
 	}
 
-	grouped := r.runFind(WithFindPattern("report.pdf"), WithFindGroupByContent())
+	grouped := r.runFind(FindQuery{Name: "report.pdf", GroupByContent: true})
 	if len(grouped.Matches) != 1 {
 		t.Fatalf("-by-content must group them into one, got %d: %s",
 			len(grouped.Matches), renderMatches(grouped.Matches))
@@ -336,7 +351,7 @@ func TestFind_MultiParentEntryReportsEveryPath(t *testing.T) {
 		file("f1", "spec.md", "d1", "d2"),
 	)
 
-	result := r.runFind(WithFindPattern("spec.md"))
+	result := r.runFind(patternQuery("spec.md"))
 	if len(result.Matches) != 1 {
 		t.Fatalf("want 1 match, got %d", len(result.Matches))
 	}
@@ -350,7 +365,7 @@ func TestFind_MultiParentEntryReportsEveryPath(t *testing.T) {
 
 	// Either path is a valid way to ask for it.
 	for _, pattern := range []string{"Work/spec.md", "Shared/spec.md"} {
-		got := r.runFind(WithFindPattern(pattern))
+		got := r.runFind(patternQuery(pattern))
 		if len(got.Matches) != 1 {
 			t.Errorf("pattern %q matched %d entries, want 1", pattern, len(got.Matches))
 		}
@@ -369,7 +384,7 @@ func TestFind_RenameIsOneMatchWithDifferingVersionNames(t *testing.T) {
 	r.snapshot("2026-01-01T00:00:00Z", src, docs, file("f1", "old-name.txt", "d1"))
 	r.snapshot("2026-01-02T00:00:00Z", src, docs, file("f1", "new-name.txt", "d1"))
 
-	byID := r.runFind(WithFindFileID("f1"))
+	byID := r.runFind(FindQuery{FileID: "f1"})
 	if len(byID.Matches) != 1 {
 		t.Fatalf("a renamed file is one match, got %d: %s", len(byID.Matches), renderMatches(byID.Matches))
 	}
@@ -383,7 +398,7 @@ func TestFind_RenameIsOneMatchWithDifferingVersionNames(t *testing.T) {
 
 	// A name query matches only the versions bearing that name. Pulling in the
 	// post-rename versions would make the result set depend on grouping.
-	byName := r.runFind(WithFindPattern("old-name.txt"))
+	byName := r.runFind(patternQuery("old-name.txt"))
 	if len(byName.Matches) != 1 {
 		t.Fatalf("want 1 match, got %d", len(byName.Matches))
 	}
@@ -409,7 +424,7 @@ func TestFind_DeletedAndReaddedFileHasNonContiguousSnapshots(t *testing.T) {
 	r.snapshot("2026-01-02T00:00:00Z", src, docs) // deleted
 	third := r.snapshot("2026-01-03T00:00:00Z", src, docs, notes)
 
-	result := r.runFind(WithFindPattern("notes.txt"))
+	result := r.runFind(patternQuery("notes.txt"))
 	if len(result.Matches) != 1 {
 		t.Fatalf("want 1 match, got %d", len(result.Matches))
 	}
@@ -440,7 +455,7 @@ func TestFind_LegacyStoredPathIsHonored(t *testing.T) {
 		file("f1", "legacy.txt", "missing-parent").withPaths("Archive/2019/legacy.txt"),
 	)
 
-	result := r.runFind(WithFindPath("Archive/**/legacy.txt"))
+	result := r.runFind(FindQuery{Path: "Archive/**/legacy.txt"})
 	if len(result.Matches) != 1 {
 		t.Fatalf("a stored path must be usable for matching, got %d matches", len(result.Matches))
 	}
@@ -461,7 +476,7 @@ func TestFind_AncestorRenameSplitsVersionsByPath(t *testing.T) {
 	r.snapshot("2026-01-01T00:00:00Z", src, folder("d1", "Documents"), notes)
 	r.snapshot("2026-01-02T00:00:00Z", src, folder("d1", "Papers"), notes)
 
-	result := r.runFind(WithFindPattern("notes.txt"))
+	result := r.runFind(patternQuery("notes.txt"))
 	if len(result.Matches) != 1 {
 		t.Fatalf("want 1 match, got %d", len(result.Matches))
 	}
@@ -479,7 +494,7 @@ func TestFind_AncestorRenameSplitsVersionsByPath(t *testing.T) {
 	}
 
 	// A path query sees only the snapshots where the file was really there.
-	old := r.runFind(WithFindPath("Documents/notes.txt"))
+	old := r.runFind(FindQuery{Path: "Documents/notes.txt"})
 	if len(old.Matches) != 1 || len(old.Matches[0].Versions[0].Snapshots) != 1 {
 		t.Errorf("the old path must match only the first snapshot: %s", renderMatches(old.Matches))
 	}
@@ -503,36 +518,38 @@ func TestFind_Predicates(t *testing.T) {
 
 	cases := []struct {
 		name  string
-		opts  []FindOption
+		query FindQuery
 		paths []string
 	}{
-		{"name glob", []FindOption{WithFindPattern("*.pdf")},
+		// The first three exercise SetPattern's shape routing: no separator
+		// constrains the basename, a separator constrains the full path.
+		{"name glob", patternQuery("*.pdf"),
 			[]string{"Documents/2026/report.pdf", "Documents/report.pdf"}},
-		{"path glob", []FindOption{WithFindPattern("Documents/*.pdf")},
+		{"path glob", patternQuery("Documents/*.pdf"),
 			[]string{"Documents/report.pdf"}},
-		{"double star", []FindOption{WithFindPattern("Documents/**/report.pdf")},
+		{"double star", patternQuery("Documents/**/report.pdf"),
 			[]string{"Documents/2026/report.pdf", "Documents/report.pdf"}},
-		{"regex", []FindOption{WithFindRegex(`2026/.*\.pdf$`)},
+		{"regex", FindQuery{Regex: `2026/.*\.pdf$`},
 			[]string{"Documents/2026/report.pdf"}},
-		{"case insensitive", []FindOption{WithFindName("REPORT.PDF"), WithFindIgnoreCase()},
+		{"case insensitive", FindQuery{Name: "REPORT.PDF", IgnoreCase: true},
 			[]string{"Documents/2026/report.pdf", "Documents/report.pdf"}},
-		{"type folder", []FindOption{WithFindType(core.FileTypeFolder)},
+		{"type folder", FindQuery{Type: core.FileTypeFolder},
 			[]string{"Documents", "Documents/2026"}},
-		{"size at least", []FindOption{WithFindName("*"), WithFindSize(SizeCompare{Op: SizeAtLeast, Bytes: 10 << 20})},
+		{"size at least", FindQuery{Name: "*", Size: &SizeCompare{Op: SizeAtLeast, Bytes: 10 << 20}},
 			[]string{"Documents/2026/report.pdf"}},
-		{"size at most", []FindOption{WithFindName("*.txt"), WithFindSize(SizeCompare{Op: SizeAtMost, Bytes: 2 << 10})},
+		{"size at most", FindQuery{Name: "*.txt", Size: &SizeCompare{Op: SizeAtMost, Bytes: 2 << 10}},
 			[]string{"Documents/2026/notes.txt"}},
-		{"content hash", []FindOption{WithFindContentHash("shared")},
+		{"content hash", FindQuery{ContentHash: "shared"},
 			[]string{"Documents/2026/report.pdf"}},
-		{"file id", []FindOption{WithFindFileID("f2")},
+		{"file id", FindQuery{FileID: "f2"},
 			[]string{"Documents/2026/notes.txt"}},
-		{"conjunction", []FindOption{WithFindPattern("*.pdf"), WithFindSize(SizeCompare{Op: SizeAtMost, Bytes: 10 << 20})},
+		{"conjunction", FindQuery{Name: "*.pdf", Size: &SizeCompare{Op: SizeAtMost, Bytes: 10 << 20}},
 			[]string{"Documents/report.pdf"}},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := r.runFind(tc.opts...)
+			result := r.runFind(tc.query)
 			var got []string
 			for _, m := range result.Matches {
 				got = append(got, m.Path())
@@ -555,13 +572,13 @@ func TestFind_RefPredicateMatchesExactlyOneMetadataObject(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ref: %v", err)
 	}
-	result := r.runFind(WithFindRef(ref))
+	result := r.runFind(FindQuery{Ref: ref})
 	if len(result.Matches) != 1 || result.Matches[0].Versions[0].Ref != ref {
 		t.Fatalf("want exactly the named object, got %s", renderMatches(result.Matches))
 	}
 
 	// A bare hash is accepted as well.
-	bare := r.runFind(WithFindRef(strings.TrimPrefix(ref, "filemeta/")))
+	bare := r.runFind(FindQuery{Ref: strings.TrimPrefix(ref, "filemeta/")})
 	if len(bare.Matches) != 1 {
 		t.Errorf("a bare hash must resolve to the same object, got %d matches", len(bare.Matches))
 	}
@@ -578,11 +595,11 @@ func TestFind_MtimePredicates(t *testing.T) {
 		file("f2", "recent.txt", "d1").withMtime(recent.Unix()),
 	)
 
-	newer := r.runFind(WithFindName("*.txt"), WithFindNewer("2023-01-01"))
+	newer := r.runFind(FindQuery{Name: "*.txt", Newer: "2023-01-01"})
 	if len(newer.Matches) != 1 || newer.Matches[0].Versions[0].Name != "recent.txt" {
 		t.Errorf("-newer selected %s", renderMatches(newer.Matches))
 	}
-	older := r.runFind(WithFindName("*.txt"), WithFindOlder("2023-01-01"))
+	older := r.runFind(FindQuery{Name: "*.txt", Older: "2023-01-01"})
 	if len(older.Matches) != 1 || older.Matches[0].Versions[0].Name != "old.txt" {
 		t.Errorf("-older selected %s", renderMatches(older.Matches))
 	}
@@ -602,7 +619,7 @@ func TestFind_SnapshotSelectors(t *testing.T) {
 	r.snapshot("2026-03-01T00:00:00Z", src, docs, file("f1", "notes.txt", "d1").withSize(30))
 
 	t.Run("explicit snapshot", func(t *testing.T) {
-		result := r.runFind(WithFindPattern("notes.txt"), WithFindSnapshots(first))
+		result := r.runFind(FindQuery{Name: "notes.txt", Snapshots: []string{first}})
 		if result.SnapshotsSearched != 1 {
 			t.Fatalf("searched %d snapshots, want 1", result.SnapshotsSearched)
 		}
@@ -613,28 +630,28 @@ func TestFind_SnapshotSelectors(t *testing.T) {
 
 	t.Run("hash prefix", func(t *testing.T) {
 		short := strings.TrimPrefix(first, "snapshot/")[:8]
-		result := r.runFind(WithFindPattern("notes.txt"), WithFindSnapshots(short))
+		result := r.runFind(FindQuery{Name: "notes.txt", Snapshots: []string{short}})
 		if result.SnapshotsSearched != 1 {
 			t.Errorf("a hash prefix must resolve to one snapshot, searched %d", result.SnapshotsSearched)
 		}
 	})
 
 	t.Run("latest", func(t *testing.T) {
-		result := r.runFind(WithFindPattern("notes.txt"), WithFindSnapshots("latest"))
+		result := r.runFind(FindQuery{Name: "notes.txt", Snapshots: []string{"latest"}})
 		if got := result.Matches[0].Versions[0].Size; got != 30 {
 			t.Errorf("size = %d, want the newest version", got)
 		}
 	})
 
 	t.Run("latest n", func(t *testing.T) {
-		result := r.runFind(WithFindPattern("notes.txt"), WithFindLatest(2))
+		result := r.runFind(FindQuery{Name: "notes.txt", Latest: 2})
 		if result.SnapshotsSearched != 2 {
 			t.Errorf("searched %d snapshots, want 2", result.SnapshotsSearched)
 		}
 	})
 
 	t.Run("since selects snapshots not files", func(t *testing.T) {
-		result := r.runFind(WithFindPattern("notes.txt"), WithFindSince("2026-02-15"))
+		result := r.runFind(FindQuery{Name: "notes.txt", Since: "2026-02-15"})
 		if result.SnapshotsSearched != 1 {
 			t.Errorf("searched %d snapshots, want 1", result.SnapshotsSearched)
 		}
@@ -642,7 +659,7 @@ func TestFind_SnapshotSelectors(t *testing.T) {
 
 	t.Run("unknown snapshot is an error", func(t *testing.T) {
 		_, err := NewFindManager(r.store, nil).Run(context.Background(),
-			WithFindPattern("notes.txt"), WithFindSnapshots("deadbeef"))
+			FindQuery{Name: "notes.txt", Snapshots: []string{"deadbeef"}})
 		if err == nil {
 			t.Fatal("want an error for an unknown snapshot")
 		}
@@ -660,13 +677,13 @@ func TestFind_SeparateLineagesAreScannedSeparately(t *testing.T) {
 	r.snapshot("2026-01-01T00:00:00Z", laptop, folder("d1", "Documents"), file("f1", "notes.txt", "d1"))
 	r.snapshot("2026-01-02T00:00:00Z", desktop, folder("d2", "Documents"), file("f2", "notes.txt", "d2"))
 
-	all := r.runFind(WithFindPattern("notes.txt"))
+	all := r.runFind(patternQuery("notes.txt"))
 	if len(all.Matches) != 2 {
 		t.Fatalf("two sources hold distinct files, want 2 matches, got %d: %s",
 			len(all.Matches), renderMatches(all.Matches))
 	}
 
-	filtered := r.runFind(WithFindPattern("notes.txt"), WithFindSource("local:./laptop"))
+	filtered := r.runFind(FindQuery{Name: "notes.txt", Source: "local:./laptop"})
 	if len(filtered.Matches) != 1 || filtered.Matches[0].FileID != "f1" {
 		t.Errorf("-source must narrow to one lineage: %s", renderMatches(filtered.Matches))
 	}
@@ -685,7 +702,7 @@ func TestFind_MaxResultsTruncatesButKeepsCountersAccurate(t *testing.T) {
 	}
 	r.snapshot("2026-01-01T00:00:00Z", src, entries...)
 
-	result := r.runFind(WithFindPattern("*.txt"), WithFindMaxResults(3))
+	result := r.runFind(FindQuery{Name: "*.txt", MaxResults: 3})
 	if len(result.Matches) != 3 {
 		t.Fatalf("want the cap honored, got %d matches", len(result.Matches))
 	}
@@ -699,20 +716,20 @@ func TestFind_MaxResultsTruncatesButKeepsCountersAccurate(t *testing.T) {
 
 func TestFind_EmptyQueryIsRejected(t *testing.T) {
 	r := newFindRepo(t)
-	if _, err := NewFindManager(r.store, nil).Run(context.Background()); err == nil {
+	if _, err := NewFindManager(r.store, nil).Run(context.Background(), FindQuery{}); err == nil {
 		t.Fatal("a query with no predicate must be refused rather than dumping the repository")
 	}
 }
 
 func TestFind_InvalidPatternsFailBeforeScanning(t *testing.T) {
 	r := newFindRepo(t)
-	for _, opt := range []FindOption{
-		WithFindName("[unterminated"),
-		WithFindRegex("("),
-		WithFindType("symlink"),
-		WithFindNewer("not-a-time"),
+	for _, q := range []FindQuery{
+		{Name: "[unterminated"},
+		{Regex: "("},
+		{Type: "symlink"},
+		{Newer: "not-a-time"},
 	} {
-		if _, err := NewFindManager(r.store, nil).Run(context.Background(), opt); err == nil {
+		if _, err := NewFindManager(r.store, nil).Run(context.Background(), q); err == nil {
 			t.Error("want a compile error before the scan starts")
 		}
 	}
@@ -722,7 +739,7 @@ func TestFind_NoMatchesIsNotAnError(t *testing.T) {
 	r := newFindRepo(t)
 	r.snapshot("2026-01-01T00:00:00Z", localSource("./docs"), folder("d1", "Documents"))
 
-	result := r.runFind(WithFindPattern("nothing-here.txt"))
+	result := r.runFind(patternQuery("nothing-here.txt"))
 	if len(result.Matches) != 0 {
 		t.Errorf("want no matches, got %d", len(result.Matches))
 	}
@@ -744,7 +761,7 @@ func TestFind_MissingMetadataObjectIsAnError(t *testing.T) {
 			break
 		}
 	}
-	if _, err := NewFindManager(r.store, nil).Run(context.Background(), WithFindPattern("*.txt")); err == nil {
+	if _, err := NewFindManager(r.store, nil).Run(context.Background(), patternQuery("*.txt")); err == nil {
 		t.Fatal("want an error when a referenced filemeta cannot be read")
 	}
 }
@@ -774,11 +791,11 @@ func TestFind_DeltaScanReadsFarFewerObjectsThanFullScan(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	delta, err := NewFindManager(r.store, nil).Run(ctx, WithFindPattern("*.txt"))
+	delta, err := NewFindManager(r.store, nil).Run(ctx, patternQuery("*.txt"))
 	if err != nil {
 		t.Fatalf("delta: %v", err)
 	}
-	full, err := NewFindManager(r.store, nil).Run(ctx, WithFindPattern("*.txt"), WithFindNoDelta())
+	full, err := NewFindManager(r.store, nil).Run(ctx, withNoDelta(patternQuery("*.txt")))
 	if err != nil {
 		t.Fatalf("full: %v", err)
 	}

--- a/query.go
+++ b/query.go
@@ -37,7 +37,6 @@ func (c *Client) LsSnapshot(ctx context.Context, snapshotID string, opts ...LsSn
 // Find
 // ---------------------------------------------------------------------------
 
-type FindOption = engine.FindOption
 type FindQuery = engine.FindQuery
 type FindResult = engine.FindResult
 type FileMatch = engine.FileMatch
@@ -53,28 +52,6 @@ const (
 )
 
 var (
-	WithFindPattern        = engine.WithFindPattern
-	WithFindName           = engine.WithFindName
-	WithFindPath           = engine.WithFindPath
-	WithFindRegex          = engine.WithFindRegex
-	WithFindIgnoreCase     = engine.WithFindIgnoreCase
-	WithFindFileID         = engine.WithFindFileID
-	WithFindContentHash    = engine.WithFindContentHash
-	WithFindRef            = engine.WithFindRef
-	WithFindType           = engine.WithFindType
-	WithFindSize           = engine.WithFindSize
-	WithFindNewer          = engine.WithFindNewer
-	WithFindOlder          = engine.WithFindOlder
-	WithFindSnapshots      = engine.WithFindSnapshots
-	WithFindSource         = engine.WithFindSource
-	WithFindTags           = engine.WithFindTags
-	WithFindLatest         = engine.WithFindLatest
-	WithFindSince          = engine.WithFindSince
-	WithFindUntil          = engine.WithFindUntil
-	WithFindGroupByContent = engine.WithFindGroupByContent
-	WithFindMaxResults     = engine.WithFindMaxResults
-	WithFindNoDelta        = engine.WithFindNoDelta
-
 	ParseSizeCompare = engine.ParseSizeCompare
 	ParseFindTime    = engine.ParseFindTime
 )
@@ -88,9 +65,16 @@ var (
 //
 // It is a pure read path — no lock is taken, nothing is written, and the
 // repository format is not stamped.
-func (c *Client) Find(ctx context.Context, opts ...FindOption) (*FindResult, error) {
+//
+// The query is a value rather than a list of options because it already was
+// one: FindQuery is JSON-tagged and grouped into predicates, snapshot selectors
+// and presentation, so twenty-one option constructors existed only to set its
+// fields one at a time. Building it directly also makes a query serializable —
+// storable, loggable, sendable — which a closure over a private struct is not.
+// Use FindQuery.SetPattern for a positional pattern, which routes by shape.
+func (c *Client) Find(ctx context.Context, q FindQuery) (*FindResult, error) {
 	mgr := engine.NewFindManager(c.store, c.logWriter)
-	return mgr.Run(ctx, opts...)
+	return mgr.Run(ctx, q)
 }
 
 // ---------------------------------------------------------------------------

--- a/rfcs/0022-public-go-api-boundaries.md
+++ b/rfcs/0022-public-go-api-boundaries.md
@@ -1,8 +1,8 @@
 # RFC 0022: Public Go API Boundaries
 
-- **Status:** §1–§8 implemented. Outstanding: extending the external-module
-  fixture to *consume* the library, not only implement its contracts (see
-  Testing strategy)
+- **Status:** §1–§9 implemented, except the naming rule and Check's snapshot
+  argument in §9. Outstanding: extending the external-module fixture to
+  *consume* the library, not only implement its contracts (see Testing strategy)
 - **Date:** 2026-07-28
 - **Affects:** `client.go`, `pkg/source`, `pkg/store`, `pkg/crypto`, `pkg/config`,
   `pkg/open`, `internal/logger`, `internal/storelayer`, `cmd/cloudstic`, `docs/`
@@ -579,6 +579,60 @@ apply here: that rejection was about *`DebugStore` wrapping* — the
 `NewClient`, and `init`/`key` operate on a raw store with no Client at all. A
 logger sink has neither property. `DebugStore` construction stays exactly where
 §4a put it.
+
+### 9. The operation surface: one vocabulary for three channels
+
+Sections 1–8 made the library reachable. Reviewing what a caller then *reaches*
+found the option surface inconsistent in four ways, all of which are the same
+mistake: a cross-cutting concern expressed once per operation.
+
+**Verbosity was nine options.** `WithVerbose`, `WithCheckVerbose`,
+`WithDiffVerbose`, `WithFindVerbose`, `WithLsVerbose`, `WithForgetVerbose`,
+`WithPruneVerbose`, `WithListVerbose`, `WithRestoreVerbose` — one per operation,
+each setting a `verbose bool` that gated a log call. That put a *presentation*
+decision in the producer: the reporter is injected by the caller, who is the only
+one who knows how much they want shown, yet what to emit was decided nine layers
+down. It also meant formatting strings that would be discarded, once per object
+verified.
+
+Verbosity is now a level on the reporter (`ui.Detail`, `Phase.Logf`). The engine
+reports what happens; the reporter decides what is worth showing.
+
+**Three output channels, and the rule between them.** The client takes both a
+`Reporter` and a logger, which looks redundant and is not:
+
+- The **reporter** carries *progress*: a bounded unit of work with a count, which
+  a caller can render as a bar. Only operations that have phases use it.
+- The **logger** carries *diagnostics*: unstructured lines from layers that have
+  no phases at all — the pack store, the HAMT, the sources.
+- An operation with no phases uses the logger for both. `list`, `ls`, `diff` and
+  `find` are queries, not long-running work; their detail is diagnostics.
+
+That rule was implicit, and the cost of leaving it so was immediate: moving
+verbosity onto the reporter silently broke `list -verbose`, because the CLI wired
+the logger only under `-debug`. The two share a writer so their lines interleave
+above the progress bar, but they must not share a switch — `-debug` attaches a
+store decorator that logs every operation, which asking for progress detail must
+not drag in.
+
+**Debug is not another detail level**, for the same reason. Verbosity is a
+runtime filter the reporter applies per message; store tracing is a *decorator in
+the store chain*, chosen when the chain is built. Calling it a level would promise
+a runtime switch the architecture cannot honour.
+
+**`find` took twenty-one options over a struct that already existed.**
+`FindQuery` was already exported, already JSON-tagged, already grouped into
+predicates, snapshot selectors and presentation. The options existed only to set
+its fields one at a time, and a query expressed as closures over a private struct
+cannot be stored, logged or sent. `Find` takes the value. The one option carrying
+a decision rather than a value — routing a positional pattern to the basename or
+the full path by shape — survives as `FindQuery.SetPattern`.
+
+**What this costs.** These remove exported symbols from a released v1. The
+alternative was to keep an incoherent surface permanently, since the point of
+this RFC is that the library is only now becoming something to consume: shipping
+a stable-but-wrong API ahead of its first real consumer would preserve the
+mistake rather than the compatibility.
 
 ## Compatibility
 


### PR DESCRIPTION
## Summary

`FindQuery` was **already exported**, already JSON-tagged, already grouped into predicates / snapshot selectors / presentation. The twenty-one `WithFind*` options existed only to set its fields one at a time.

```go
// before
result, err := client.Find(ctx, WithFindName("*.pdf"), WithFindSize(cmp), WithFindLatest(3))
// after
result, err := client.Find(ctx, FindQuery{Name: "*.pdf", Size: &cmp, Latest: 3})
```

| | before | after |
|---|---:|---:|
| exported `WithFind*` symbols | 21 | **0** |
| CLI query builder | 79 lines | **47** |

The CLI builder was sixty lines of `if x != "" { opts = append(opts, WithX(x)) }` — restating that a zero field means "not constrained". Most of it is now plain assignment; what survives is the three things that are decisions: the mutually exclusive pattern shorthand and the two values that must be parsed before they can be a constraint.

A query is also **serializable** now — storable, loggable, sendable — which a closure over a private struct never was.

### The one option that carried a decision

`WithFindPattern` routed a positional pattern by *shape*: a separator constrains the full path, no separator constrains the basename — which is what keeps the common case cheap, since a basename is already on the metadata object while a path has to be reconstructed.

It survives as `FindQuery.SetPattern`, deliberately a **method rather than a field**: a caller assigning `Path` directly would silently make every basename search pay for path reconstruction.

`MaxResults` is normalized in `Run`, so a zero `FindQuery` is a valid search — every file, capped at the default — matching how the rest of this module's configuration values treat their zero value.

## RFC 0022 gains §9

Recording what this review found and the rule §8 left implicit:

- **verbosity was nine options**, one per operation, putting a presentation decision in the producer (fixed in #415)
- **the reporter/logger rule** — the reporter carries *progress* (bounded work with a count); the logger carries *diagnostics* from layers with no phases (the pack store, the HAMT, sources); an operation with no phases uses the logger for both. Leaving this implicit is what let #415 silently break `list -verbose`.
- **debug is not another detail level** — verbosity is a runtime filter, store tracing is a decorator chosen when the chain is built. Calling it a level would promise a switch the architecture cannot honour.
- **why removing exported symbols from a released v1 is right here** — shipping a stable-but-wrong API ahead of the library's first real consumer preserves the mistake, not the compatibility.

## Verification

- `go test -count=1 ./...` passes
- `golangci-lint run ./...` reports `0 issues`
- `gofmt -l .` clean

Behaviour checked against a built binary on a real repository, not just unit tests:

```
find "notes.txt"            → matches Documents/notes.txt   (basename → Name)
find "Documents/notes.txt"  → matches Documents/notes.txt   (path → Path)
find "Documents/report.pdf" → No matches                    (report.pdf is at the root)
find "x" -name "y"          → the positional pattern is shorthand for -name or -path
```

The last two matter: they show the routing still discriminates, rather than everything matching everything.

The engine's find tests read better for the change — a table of option slices became a table of queries, and the three rows that exercise `SetPattern`'s routing now say so explicitly.

## Remaining from the review

Items 3 (one naming rule, `With<Operation><Thing>`) and 4 (`Check` taking its snapshot ref positionally, like `Restore`/`Ls`/`Forget`) are not in this PR.