### PR TITLE
refactor: name the two forget options that claimed a shared concept (RFC 0022 §9)

### DIFF
--- a/cmd/cloudstic/cmd_forget.go
+++ b/cmd/cloudstic/cmd_forget.go
@@ -159,10 +159,10 @@ func runForget(r *runner, ctx context.Context, a *forgetArgs, cfg clientConfig) 
 func execForgetSingle(r *runner, ctx context.Context, a *forgetArgs) int {
 	var forgetOpts []cloudstic.ForgetOption
 	if a.prune {
-		forgetOpts = append(forgetOpts, cloudstic.WithPrune())
+		forgetOpts = append(forgetOpts, cloudstic.WithForgetPrune())
 	}
 	if a.dryRun {
-		forgetOpts = append(forgetOpts, cloudstic.WithDryRun())
+		forgetOpts = append(forgetOpts, cloudstic.WithForgetDryRun())
 	}
 	result, err := r.client.Forget(ctx, a.snapshotID, forgetOpts...)
 	if err != nil {
@@ -202,10 +202,10 @@ func execForgetPolicy(r *runner, ctx context.Context, a *forgetArgs) int {
 func buildForgetPolicyOpts(a *forgetArgs) []cloudstic.ForgetOption {
 	var opts []cloudstic.ForgetOption
 	if a.prune {
-		opts = append(opts, cloudstic.WithPrune())
+		opts = append(opts, cloudstic.WithForgetPrune())
 	}
 	if a.dryRun {
-		opts = append(opts, cloudstic.WithDryRun())
+		opts = append(opts, cloudstic.WithForgetDryRun())
 	}
 	if a.keepLast > 0 {
 		opts = append(opts, cloudstic.WithKeepLast(a.keepLast))

--- a/internal/engine/forget.go
+++ b/internal/engine/forget.go
@@ -27,13 +27,17 @@ type forgetConfig struct {
 	filter     snapshotFilter
 }
 
-// WithPrune runs a prune pass after forgetting snapshots.
-func WithPrune() ForgetOption {
+// WithForgetPrune runs a prune pass after forgetting snapshots.
+func WithForgetPrune() ForgetOption {
 	return func(cfg *forgetConfig) { cfg.prune = true }
 }
 
-// WithDryRun shows what would be removed without actually removing anything.
-func WithDryRun() ForgetOption {
+// WithForgetDryRun shows what would be removed without removing anything.
+//
+// Named for its operation because four operations have a dry run and this one
+// used to claim the bare WithDryRun, so a caller reaching for backup's or
+// prune's found forget's and got a compile error at best.
+func WithForgetDryRun() ForgetOption {
 	return func(cfg *forgetConfig) { cfg.dryRun = true }
 }
 

--- a/internal/engine/forget_test.go
+++ b/internal/engine/forget_test.go
@@ -172,7 +172,7 @@ func TestForgetManager_DryRunRemovesNothing(t *testing.T) {
 	_ = s.Put(ctx, "index/latest", createIndex(snapRef, 1))
 
 	fm := NewForgetManager(s, ui.NewNoOpReporter(), nil)
-	result, err := fm.Run(ctx, snapRef, WithDryRun())
+	result, err := fm.Run(ctx, snapRef, WithForgetDryRun())
 	if err != nil {
 		t.Fatalf("dry run: %v", err)
 	}

--- a/repo_format_test.go
+++ b/repo_format_test.go
@@ -500,7 +500,7 @@ func TestDryRunsDoNotStampTheFormat(t *testing.T) {
 	})
 
 	t.Run("forget", func(t *testing.T) {
-		if _, err := client.Forget(ctx, "latest", WithDryRun()); err != nil {
+		if _, err := client.Forget(ctx, "latest", WithForgetDryRun()); err != nil {
 			t.Fatalf("forget dry run: %v", err)
 		}
 		assertFormatVersion(t, base, 1)

--- a/retention.go
+++ b/retention.go
@@ -38,8 +38,8 @@ type ForgetOption = engine.ForgetOption
 type ForgetResult = engine.ForgetResult
 
 var (
-	WithPrune         = engine.WithPrune
-	WithDryRun        = engine.WithDryRun
+	WithForgetPrune   = engine.WithForgetPrune
+	WithForgetDryRun  = engine.WithForgetDryRun
 	WithKeepLast      = engine.WithKeepLast
 	WithKeepHourly    = engine.WithKeepHourly
 	WithKeepDaily     = engine.WithKeepDaily

--- a/rfcs/0022-public-go-api-boundaries.md
+++ b/rfcs/0022-public-go-api-boundaries.md
@@ -1,8 +1,8 @@
 # RFC 0022: Public Go API Boundaries
 
-- **Status:** §1–§9 implemented, except the naming rule and Check's snapshot
-  argument in §9. Outstanding: extending the external-module fixture to
-  *consume* the library, not only implement its contracts (see Testing strategy)
+- **Status:** §1–§9 implemented. Outstanding: extending the external-module
+  fixture to *consume* the library, not only implement its contracts (see
+  Testing strategy)
 - **Date:** 2026-07-28
 - **Affects:** `client.go`, `pkg/source`, `pkg/store`, `pkg/crypto`, `pkg/config`,
   `pkg/open`, `internal/logger`, `internal/storelayer`, `cmd/cloudstic`, `docs/`
@@ -627,6 +627,28 @@ its fields one at a time, and a query expressed as closures over a private struc
 cannot be stored, logged or sent. `Find` takes the value. The one option carrying
 a decision rather than a value — routing a positional pattern to the basename or
 the full path by shape — survives as `FindQuery.SetPattern`.
+
+**Two of the four inconsistencies did not survive inspection**, and the review
+is more useful for recording that than for the count.
+
+*The snapshot argument is not misplaced.* `Restore`, `LsSnapshot`, `Forget` and
+`Diff` take a snapshot positionally; `Check` and `Find` take one as an option,
+which looked like the same input in two places. It is not. For the first group
+the snapshot is the *subject* and is required — `Forget` errors without one. For
+the second it is an optional *narrowing filter* with a meaningful default:
+`Check` verifies every snapshot unless told otherwise. Moving it positionally
+would introduce an empty string meaning "all", which is worse than an option that
+is simply absent. The rule is: a required subject is positional, an optional
+filter is an option — and the surface already follows it.
+
+*Prefixing every option would make it worse, not better.* The defect was never
+"some names lack a prefix"; it was that a bare name was claimed by one operation
+while others shared the concept. `WithDryRun` belonged to forget while backup,
+restore and prune each had a prefixed one, and `WithPrune` — a `ForgetOption` —
+sat in retention.go beside genuine `PruneOption`s. Those two are renamed.
+`WithKeepDaily`, `WithFilterTag`, `WithReadData` and `WithTags` are unique to one
+operation, and `WithForgetKeepDaily` would be longer without being clearer. The
+rule is: prefix a concept more than one operation has, everywhere it appears.
 
 **What this costs.** These remove exported symbols from a released v1. The
 alternative was to keep an incoherent surface permanently, since the point of


### PR DESCRIPTION
## Summary

The last two items of the option-surface review — and **both shrank on inspection**, which is the more useful result.

### What changed: two renames

| before | after | why |
|---|---|---|
| `WithDryRun` | `WithForgetDryRun` | a `ForgetOption`, while backup, restore and prune each had a prefixed one — so a caller reaching for backup's found forget's |
| `WithPrune` | `WithForgetPrune` | a `ForgetOption` sitting in `retention.go` immediately beside genuine `PruneOption`s, where a reader would reasonably take it for one |

### What did *not* change, and why

**Prefixing every option would make it worse.** The defect was never "some names lack a prefix" — it was that a **bare name was claimed by one operation while others shared the concept**. `WithKeepDaily`, `WithFilterTag`, `WithReadData` and `WithTags` each belong to exactly one operation; `WithForgetKeepDaily` is longer without being clearer.

The rule: *prefix a concept more than one operation has, everywhere it appears.*

**`Check` keeps its snapshot argument as an option.** I had this down as an inconsistency — positional for `Restore`/`LsSnapshot`/`Forget`/`Diff`, an option for `Check`/`Find`. It is not the same input:

- the first group take a **required subject** — `Forget` errors without one
- `Check` takes an **optional narrowing filter** with a meaningful default: it verifies *every* snapshot unless told otherwise

Making it positional would introduce an empty string meaning "all", which is worse than an option that is simply absent. The rule the surface already follows: *a required subject is positional, an optional filter is an option.*

## Verification

- `go test -count=1 ./...` passes
- `golangci-lint run ./...` reports `0 issues`
- `gofmt -l .` clean

The rename used a whole-word pattern with an explicit guard so `WithPrune` could not eat `WithPruneDryRun` or `WithPruneVerbose` — a plain substring replace would have silently corrupted two unrelated `PruneOption`s.

## The review, closed out

| # | item | outcome |
|---|---|---|
| 1 | verbosity owned by the reporter | done (#415) — 9 options → 1 reporter level |
| 2 | `Find` takes its query | done (#416) — 21 options → 0 |
| 3 | naming rule | **shrank to 2 renames**, not ~15 |
| 4 | `Check` snapshot positional | **retracted** — the two placements are principled |

Two of four recommendations did not survive contact with the code. RFC 0022 §9 records both retractions alongside what landed, because the reasoning for *not* changing something is the part that gets lost otherwise.