### PR TITLE
fix: the OAuth flow writes where the caller says, not to os.Stdout

### DIFF
--- a/cmd/cloudstic/cmd_auth.go
+++ b/cmd/cloudstic/cmd_auth.go
@@ -285,7 +285,12 @@ func runAuthLogin(r *runner, ctx context.Context, a *authLoginArgs) int {
 	srcCfg.ConfigDir = a.configDir
 	applyAuthLoginCredentialFlags(&srcCfg, a)
 
-	src, err := open.Source(ctx, srcCfg, open.WithSecretResolver(newSecretResolver(a.configDir)))
+	// The browser banner goes to errOut, where this CLI puts everything a human
+	// reads while stdout carries data — so `auth login -json` stays a clean
+	// stream.
+	src, err := open.Source(ctx, srcCfg,
+		open.WithSecretResolver(newSecretResolver(a.configDir)),
+		open.WithPromptWriter(r.errOut))
 	if err != nil {
 		return r.fail("Failed to initialize auth source: %v", err)
 	}

--- a/cmd/cloudstic/cmd_backup.go
+++ b/cmd/cloudstic/cmd_backup.go
@@ -135,7 +135,9 @@ func runBackup(r *runner, ctx context.Context, a *backupArgs) int {
 // r.openClient resolves from the flags and the selected profile, and the output
 // mode.
 func execBackup(r *runner, ctx context.Context, a *backupArgs, bcfg config.Backup) int {
-	job, err := open.Backup(ctx, bcfg, open.WithSecretResolver(newSecretResolver(bcfg.Source.ConfigDir)))
+	job, err := open.Backup(ctx, bcfg,
+		open.WithSecretResolver(newSecretResolver(bcfg.Source.ConfigDir)),
+		open.WithPromptWriter(r.errOut))
 	if err != nil {
 		return r.fail("Failed to init source: %v", err)
 	}

--- a/internal/sourceoauth/callback.go
+++ b/internal/sourceoauth/callback.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os/exec"
@@ -19,8 +20,14 @@ import (
 // opens the user's default browser to the consent page and automatically
 // captures the authorization code, eliminating the need to copy-paste.
 //
-// If the browser cannot be opened, the auth URL is printed so the user can
-// navigate to it manually; the local server still captures the redirect.
+// If the browser cannot be opened, the auth URL is written to out so the user
+// can navigate to it manually; the local server still captures the redirect.
+//
+// out receives the two lines this flow must show a human: that a browser is
+// opening, and the URL to visit if it did not. A nil out discards them. They
+// are written there rather than to os.Stdout because a library has no claim on
+// the process's stdout — and because the cloudstic CLI offers `auth login
+// -json`, where a stray line corrupts the caller's parse stream.
 //
 // ctx governs the wait. This is the whole reason it is a parameter: the flow
 // blocks until a human finishes authorizing in a browser, which they may never
@@ -28,7 +35,10 @@ import (
 // rather than killing the process — so a wait that ignored ctx could not be
 // interrupted with Ctrl+C at all, and pressing it again would not help either.
 // Cancellation returns ctx.Err() promptly and shuts the local server down.
-func ExchangeWithLocalServer(ctx context.Context, config *oauth2.Config, authCodeOpts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
+func ExchangeWithLocalServer(ctx context.Context, out io.Writer, config *oauth2.Config, authCodeOpts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
+	if out == nil {
+		out = io.Discard
+	}
 	state, err := randomState()
 	if err != nil {
 		return nil, fmt.Errorf("generate state: %w", err)
@@ -87,9 +97,9 @@ func ExchangeWithLocalServer(ctx context.Context, config *oauth2.Config, authCod
 	opts := append([]oauth2.AuthCodeOption{oauth2.S256ChallengeOption(verifier)}, authCodeOpts...)
 	authURL := config.AuthCodeURL(state, opts...)
 
-	fmt.Printf("Opening browser for authorization...\n")
+	_, _ = fmt.Fprintln(out, "Opening browser for authorization...")
 	if err := openBrowserFn(authURL); err != nil {
-		fmt.Printf("Could not open browser automatically.\nPlease visit this URL:\n%s\n", authURL)
+		_, _ = fmt.Fprintf(out, "Could not open browser automatically.\nPlease visit this URL:\n%s\n", authURL)
 	}
 
 	var res result

--- a/internal/sourceoauth/interrupt_test.go
+++ b/internal/sourceoauth/interrupt_test.go
@@ -55,7 +55,7 @@ func TestExchangeWithLocalServer_CancelledContextReturns(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		_, err := ExchangeWithLocalServer(ctx, testOAuthConfig(), oauth2.AccessTypeOffline)
+		_, err := ExchangeWithLocalServer(ctx, nil, testOAuthConfig(), oauth2.AccessTypeOffline)
 		done <- err
 	}()
 
@@ -84,7 +84,7 @@ func TestExchangeWithLocalServer_AlreadyCancelled(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		_, err := ExchangeWithLocalServer(ctx, testOAuthConfig(), oauth2.AccessTypeOffline)
+		_, err := ExchangeWithLocalServer(ctx, nil, testOAuthConfig(), oauth2.AccessTypeOffline)
 		done <- err
 	}()
 
@@ -114,7 +114,7 @@ func TestExchangeWithLocalServer_ShutsDownItsListener(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 		cancel()
 	}()
-	if _, err := ExchangeWithLocalServer(ctx, testOAuthConfig(), oauth2.AccessTypeOffline); !errors.Is(err, context.Canceled) {
+	if _, err := ExchangeWithLocalServer(ctx, nil, testOAuthConfig(), oauth2.AccessTypeOffline); !errors.Is(err, context.Canceled) {
 		t.Fatalf("err = %v, want context.Canceled", err)
 	}
 

--- a/internal/sourceoauth/output_test.go
+++ b/internal/sourceoauth/output_test.go
@@ -1,0 +1,96 @@
+package sourceoauth
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// TestExchangeWithLocalServer_WritesToTheGivenWriter is the regression test for
+// a library writing to the process's stdout.
+//
+// The flow has two lines it must show a human — that a browser is opening, and
+// the URL to visit if it did not. They went to os.Stdout via fmt.Printf, which a
+// library has no claim on: a caller could neither capture nor redirect them, and
+// `cloudstic auth login -json` had them land in the middle of its JSON stream.
+func TestExchangeWithLocalServer_WritesToTheGivenWriter(t *testing.T) {
+	stubBrowser(t, func(string) error { return nil })
+
+	var out bytes.Buffer
+	stdout := captureStdout(t, func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			cancel()
+		}()
+		_, _ = ExchangeWithLocalServer(ctx, &out, testOAuthConfig(), oauth2.AccessTypeOffline)
+	})
+
+	if !strings.Contains(out.String(), "Opening browser") {
+		t.Errorf("the writer received %q, want the browser banner", out.String())
+	}
+	if stdout != "" {
+		t.Errorf("the flow wrote %q to os.Stdout; a library must write only where "+
+			"the caller told it to, or -json output is corrupted", stdout)
+	}
+}
+
+// A caller with nowhere to write must not have the lines fall back to stdout.
+func TestExchangeWithLocalServer_NilWriterDiscards(t *testing.T) {
+	stubBrowser(t, func(string) error { return nil })
+
+	stdout := captureStdout(t, func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			cancel()
+		}()
+		_, _ = ExchangeWithLocalServer(ctx, nil, testOAuthConfig(), oauth2.AccessTypeOffline)
+	})
+	if stdout != "" {
+		t.Errorf("a nil writer leaked %q to os.Stdout", stdout)
+	}
+}
+
+// When the browser cannot be opened, the URL is the only way for the user to
+// proceed — so it must reach the writer, not vanish.
+func TestExchangeWithLocalServer_UnopenableBrowserPrintsTheURL(t *testing.T) {
+	stubBrowser(t, func(string) error { return os.ErrNotExist })
+
+	var out bytes.Buffer
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+	_, _ = ExchangeWithLocalServer(ctx, &out, testOAuthConfig(), oauth2.AccessTypeOffline)
+
+	got := out.String()
+	if !strings.Contains(got, "Could not open browser") || !strings.Contains(got, "https://example.invalid/auth") {
+		t.Errorf("writer received %q, want the fallback message and the auth URL", got)
+	}
+}
+
+// captureStdout runs fn while capturing os.Stdout.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+
+	_ = w.Close()
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	return buf.String()
+}

--- a/pkg/open/open.go
+++ b/pkg/open/open.go
@@ -58,6 +58,7 @@ type options struct {
 	promptResolve  func() (string, error)
 	promptWrap     func() (string, error)
 	secretResolver *secretref.Resolver
+	promptWriter   io.Writer
 	decidedConfig  config.Client
 	decidedFields  config.FieldSet
 }
@@ -174,6 +175,18 @@ func WithSecretResolver(r *secretref.Resolver) Option {
 // configuration afterwards, which could not skip the resolution.
 func WithDecided(cfg config.Client, decided config.FieldSet) Option {
 	return func(o *options) { o.decidedConfig, o.decidedFields = cfg, decided }
+}
+
+// WithPromptWriter sets where an interactive OAuth flow writes what a human
+// needs to read: that a browser is opening, and the URL to visit if it did not.
+//
+// Supplying it is what makes the flow usable at all when the browser cannot
+// open. It is separate from WithLogger and WithDebugWriter because it is not
+// diagnostics — a caller who routes it to a debug sink leaves the user staring
+// at a stalled command. Without one the lines are discarded, which is right for
+// a caller that has no terminal to write to.
+func WithPromptWriter(w io.Writer) Option {
+	return func(o *options) { o.promptWriter = w }
 }
 
 // Store constructs the object store described by cfg.

--- a/pkg/open/source.go
+++ b/pkg/open/source.go
@@ -106,6 +106,7 @@ func googleOpts(cfg config.Source, uri *config.SourceURI, o *options) ([]gdrive.
 		gdrive.WithDriveName(uri.Host),
 		gdrive.WithRootPath(uri.Path),
 		gdrive.WithExcludePatterns(cfg.Excludes),
+		gdrive.WithPromptWriter(o.promptWriter),
 	}
 	if cfg.SkipNativeFiles {
 		opts = append(opts, gdrive.WithSkipNativeFiles())
@@ -126,6 +127,7 @@ func oneDriveOpts(cfg config.Source, uri *config.SourceURI, o *options) ([]onedr
 		onedrive.WithDriveName(uri.Host),
 		onedrive.WithRootPath(uri.Path),
 		onedrive.WithExcludePatterns(cfg.Excludes),
+		onedrive.WithPromptWriter(o.promptWriter),
 	}, nil
 }
 

--- a/pkg/source/gdrive/auth_test.go
+++ b/pkg/source/gdrive/auth_test.go
@@ -86,7 +86,7 @@ func TestGDrive_Options(t *testing.T) {
 
 func TestOAuthClient_RequiresResolverForTokenRef(t *testing.T) {
 	config := &oauth2.Config{}
-	_, err := oauthClient(context.Background(), config, nil, "config-token://google/tok", "", nil)
+	_, err := oauthClient(context.Background(), config, nil, "config-token://google/tok", "", nil, nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/pkg/source/gdrive/source.go
+++ b/pkg/source/gdrive/source.go
@@ -27,7 +27,10 @@ import (
 // gDriveOptions holds configuration for a Google Drive source.
 type gDriveOptions struct {
 	// logWriter is where this source sends its debug output; nil means none.
-	logWriter       io.Writer
+	logWriter io.Writer
+	// promptWriter is where the interactive OAuth flow writes what a human
+	// needs to read. Distinct from logWriter: this is not diagnostics.
+	promptWriter    io.Writer
 	service         *drive.Service // pre-built service; highest priority
 	httpClient      *http.Client
 	resolver        *secretref.Resolver
@@ -54,6 +57,17 @@ type Option func(*gDriveOptions)
 // cannot reach them; this is how a caller supplies one (RFC 0022 §8).
 func WithLogger(w io.Writer) Option {
 	return func(o *gDriveOptions) { o.logWriter = w }
+}
+
+// WithPromptWriter sets where the interactive OAuth flow writes the two lines a
+// human needs to see: that a browser is opening, and the URL to visit if it did
+// not open. A nil writer discards them.
+//
+// It is separate from WithLogger because this is not diagnostics — hiding it
+// behind a debug flag would leave the user waiting with no idea a browser was
+// meant to open.
+func WithPromptWriter(w io.Writer) Option {
+	return func(o *gDriveOptions) { o.promptWriter = w }
 }
 
 // WithDriveService injects a fully-constructed *drive.Service.
@@ -275,7 +289,7 @@ func buildDriveService(ctx context.Context, cfg gDriveOptions) (*drive.Service, 
 		Scopes:       []string{drive.DriveReadonlyScope},
 		Endpoint:     google.Endpoint,
 	}
-	client, err := oauthClient(ctx, config, cfg.resolver, cfg.tokenRef, cfg.tokenPath, cfg.logWriter)
+	client, err := oauthClient(ctx, config, cfg.resolver, cfg.tokenRef, cfg.tokenPath, cfg.logWriter, cfg.promptWriter)
 	if err != nil {
 		return nil, err
 	}
@@ -317,7 +331,7 @@ func serviceFromCredsBytes(ctx context.Context, cfg gDriveOptions, b []byte) (*d
 	// Try OAuth user config first.
 	oauthCfg, err := google.ConfigFromJSON(b, drive.DriveReadonlyScope)
 	if err == nil {
-		client, err := oauthClient(ctx, oauthCfg, cfg.resolver, cfg.tokenRef, cfg.tokenPath, cfg.logWriter)
+		client, err := oauthClient(ctx, oauthCfg, cfg.resolver, cfg.tokenRef, cfg.tokenPath, cfg.logWriter, cfg.promptWriter)
 		if err != nil {
 			return nil, err
 		}
@@ -466,7 +480,7 @@ func (s *Source) resolvePathToFolderID(ctx context.Context, path string) (string
 // OAuth helpers
 // ---------------------------------------------------------------------------
 
-func oauthClient(ctx context.Context, config *oauth2.Config, r *secretref.Resolver, tokRef, tokFile string, logWriter io.Writer) (*http.Client, error) {
+func oauthClient(ctx context.Context, config *oauth2.Config, r *secretref.Resolver, tokRef, tokFile string, logWriter, promptWriter io.Writer) (*http.Client, error) {
 	var tok *oauth2.Token
 	var err error
 	if tokRef != "" && r == nil {
@@ -482,7 +496,7 @@ func oauthClient(ctx context.Context, config *oauth2.Config, r *secretref.Resolv
 	}
 
 	if err != nil {
-		tok, err = tokenFromWeb(ctx, config)
+		tok, err = tokenFromWeb(ctx, promptWriter, config)
 		if err != nil {
 			return nil, err
 		}
@@ -512,8 +526,8 @@ func oauthClient(ctx context.Context, config *oauth2.Config, r *secretref.Resolv
 	return oauth2.NewClient(ctx, pts), nil
 }
 
-func tokenFromWeb(ctx context.Context, config *oauth2.Config) (*oauth2.Token, error) {
-	return sourceoauth.ExchangeWithLocalServer(ctx, config, oauth2.AccessTypeOffline)
+func tokenFromWeb(ctx context.Context, out io.Writer, config *oauth2.Config) (*oauth2.Token, error) {
+	return sourceoauth.ExchangeWithLocalServer(ctx, out, config, oauth2.AccessTypeOffline)
 }
 
 func tokenFromFile(file string) (*oauth2.Token, error) {

--- a/pkg/source/onedrive/source.go
+++ b/pkg/source/onedrive/source.go
@@ -24,7 +24,10 @@ import (
 // oneDriveOptions holds configuration for a OneDrive source.
 type oneDriveOptions struct {
 	// logWriter is where this source sends its debug output; nil means none.
-	logWriter       io.Writer
+	logWriter io.Writer
+	// promptWriter is where the interactive OAuth flow writes what a human
+	// needs to read. Distinct from logWriter: this is not diagnostics.
+	promptWriter    io.Writer
 	clientID        string
 	resolver        *secretref.Resolver
 	tokenPath       string
@@ -43,6 +46,17 @@ type Option func(*oneDriveOptions)
 // cannot reach them; this is how a caller supplies one (RFC 0022 §8).
 func WithLogger(w io.Writer) Option {
 	return func(o *oneDriveOptions) { o.logWriter = w }
+}
+
+// WithPromptWriter sets where the interactive OAuth flow writes the two lines a
+// human needs to see: that a browser is opening, and the URL to visit if it did
+// not open. A nil writer discards them.
+//
+// It is separate from WithLogger because this is not diagnostics — hiding it
+// behind a debug flag would leave the user waiting with no idea a browser was
+// meant to open.
+func WithPromptWriter(w io.Writer) Option {
+	return func(o *oneDriveOptions) { o.promptWriter = w }
 }
 
 // WithClientID sets the OAuth client ID. If empty, uses the built-in default.
@@ -135,7 +149,7 @@ func New(ctx context.Context, opts ...Option) (*Source, error) {
 	}
 
 	if err != nil {
-		token, err = sourceoauth.ExchangeWithLocalServer(ctx, conf, oauth2.AccessTypeOffline)
+		token, err = sourceoauth.ExchangeWithLocalServer(ctx, cfg.promptWriter, conf, oauth2.AccessTypeOffline)
 		if err != nil {
 			return nil, fmt.Errorf("onedrive auth: %w", err)
 		}


### PR DESCRIPTION
## Summary

`ExchangeWithLocalServer` printed its two human-facing lines with `fmt.Printf`:

```go
fmt.Printf("Opening browser for authorization...\n")
fmt.Printf("Could not open browser automatically.\nPlease visit this URL:\n%s\n", authURL)
```

A library has no claim on the process's stdout. A caller could neither capture nor redirect them, and **`cloudstic auth login` accepts `-json`** — so those lines landed in the middle of a JSON consumer's parse stream.

Both facts were confirmed rather than assumed: `auth login -h` lists `-json`, and a probe capturing `os.Stdout` around the flow caught the banner there:

```
captured from os.Stdout: "Opening browser for authorization...\n"
```

### Changes

- `ExchangeWithLocalServer` takes an `io.Writer`. A nil writer **discards** rather than falling back to stdout — the right answer for a caller with no terminal.
- Both cloud sources gain `WithPromptWriter`, and `pkg/open` exposes the same option.
- The CLI passes `r.errOut` — where this program already puts everything a human reads (`promptSelect` and friends) while stdout carries data. That is what makes `-json` a clean stream.

**`WithPromptWriter` is deliberately separate from `WithLogger`.** Routing this to a debug sink would hide it behind `-debug` and leave the user staring at a command that appears to have stalled, with no idea a browser was meant to open. It is not diagnostics.

### No deadline, and why

I had flagged "the OAuth flow has no overall timeout" as an open item. **Retracting that.** The flow waits for a person to finish authorizing in a browser; `gcloud` and `aws sso` wait the same way. A default timeout would fail a slow but legitimate authorization to solve a problem `Ctrl+C` already solves (#408). `ctx` governs, so a caller wanting a bound can set one — which is the correct place for that policy.

## Verification

All three tests were confirmed to **fail against the previous code**:

```
--- FAIL: TestExchangeWithLocalServer_WritesToTheGivenWriter
    the writer received "", want the browser banner
    the flow wrote "Opening browser for authorization...\n" to os.Stdout; a library must
    write only where the caller told it to, or -json output is corrupted
--- FAIL: TestExchangeWithLocalServer_NilWriterDiscards
```

The third covers the case that matters most when things go wrong: when the browser **cannot** be opened, the URL is the only way for the user to proceed, so it must reach the writer rather than vanish.

- `go test -count=1 ./...` passes
- `golangci-lint run ./...` reports `0 issues`
- `gofmt -l .` clean