### PR TITLE
feat: repository identity and snapshot copy provenance (RFC 0017)

### DIFF
--- a/internal/core/compat_forward_test.go
+++ b/internal/core/compat_forward_test.go
@@ -1,0 +1,113 @@
+package core
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The types below are the v1.18.0 shapes of the repository marker and the
+// snapshot catalog entry — the last release before RepoConfig.ID and
+// SnapshotSummary.CopiedFrom existed. They are copied here verbatim rather than
+// derived, because the point is to detect a change on this side: if a future
+// edit to the live struct makes older builds misread a repository, that is a
+// version-gate decision (docs/compatibility.md), and this test is where the
+// question gets asked.
+//
+// Forward compatibility is not guaranteed in general, but failure must be safe.
+// For these two additions the bar is higher than "safe": an older build must
+// read the objects exactly as it did before, because both fields were added
+// without raising core.RepoFormatVersion. See RFC 0017 "Compatibility".
+
+type repoConfigV1_18 struct {
+	Version   int    `json:"version"`
+	Created   string `json:"created"`
+	Encrypted bool   `json:"encrypted"`
+}
+
+type snapshotSummaryV1_18 struct {
+	Ref         string      `json:"ref"`
+	Seq         int         `json:"seq"`
+	Created     string      `json:"created"`
+	Root        string      `json:"root"`
+	Source      *SourceInfo `json:"source,omitempty"`
+	Tags        []string    `json:"tags,omitempty"`
+	ChangeToken string      `json:"change_token,omitempty"`
+	ExcludeHash string      `json:"exclude_hash,omitempty"`
+}
+
+func TestRepoConfigWithIDIsReadableByV1_18(t *testing.T) {
+	current, err := json.Marshal(RepoConfig{
+		Version:   RepoFormatVersion,
+		Created:   "2026-08-03T00:00:00Z",
+		Encrypted: true,
+		ID:        "9ac3fa64fc86a301a168b78d67a5b3cf",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var old repoConfigV1_18
+	if err := json.Unmarshal(current, &old); err != nil {
+		t.Fatalf("v1.18.0 could not decode a marker carrying an id: %v", err)
+	}
+	if old.Version != RepoFormatVersion {
+		t.Errorf("version = %d, want %d", old.Version, RepoFormatVersion)
+	}
+	if old.Created != "2026-08-03T00:00:00Z" {
+		t.Errorf("created = %q", old.Created)
+	}
+	if !old.Encrypted {
+		t.Error("encrypted flag was lost")
+	}
+}
+
+func TestSnapshotSummaryWithProvenanceIsReadableByV1_18(t *testing.T) {
+	prov := CopyProvenance{RepoID: "9ac3fa64", SnapshotRef: "snapshot/abc123"}
+	current, err := json.Marshal(SnapshotSummary{
+		Ref:         "snapshot/def456",
+		Seq:         7,
+		Created:     "2026-08-03T00:00:00Z",
+		Root:        "node/aaa",
+		Tags:        []string{"workstation"},
+		ExcludeHash: "hash",
+		CopiedFrom:  prov.String(),
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var old snapshotSummaryV1_18
+	if err := json.Unmarshal(current, &old); err != nil {
+		t.Fatalf("v1.18.0 could not decode a catalog entry carrying provenance: %v", err)
+	}
+	if old.Ref != "snapshot/def456" || old.Seq != 7 || old.Root != "node/aaa" {
+		t.Errorf("entry decoded wrong: %+v", old)
+	}
+	if old.ExcludeHash != "hash" || len(old.Tags) != 1 || old.Tags[0] != "workstation" {
+		t.Errorf("entry decoded wrong: %+v", old)
+	}
+}
+
+// An older build that rebuilds the catalog writes entries back without the
+// field. That must degrade to "provenance unknown" rather than to a value this
+// build would mistake for a match — the difference between copy re-importing a
+// snapshot (wasteful) and copy skipping one it never copied (a silent hole).
+func TestCatalogEntryWrittenByV1_18DecodesAsUnknownProvenance(t *testing.T) {
+	oldBytes, err := json.Marshal(snapshotSummaryV1_18{
+		Ref: "snapshot/def456", Seq: 7, Created: "2026-08-03T00:00:00Z", Root: "node/aaa",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var current SnapshotSummary
+	if err := json.Unmarshal(oldBytes, &current); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if current.CopiedFrom != "" {
+		t.Fatalf("CopiedFrom = %q, want empty", current.CopiedFrom)
+	}
+	if _, ok := ParseCopyProvenance(current.CopiedFrom); ok {
+		t.Error("an absent provenance parsed as a match")
+	}
+}

--- a/internal/core/models.go
+++ b/internal/core/models.go
@@ -68,6 +68,19 @@ type SnapshotSummary struct {
 	Tags        []string    `json:"tags,omitempty"`
 	ChangeToken string      `json:"change_token,omitempty"`
 	ExcludeHash string      `json:"exclude_hash,omitempty"`
+
+	// CopiedFrom denormalizes CopyProvenance out of the snapshot's Meta so
+	// that `copy` can decide what it has already copied by reading the catalog
+	// alone. The authoritative record stays in Meta, which the catalog does not
+	// carry; without this field the skip check would have to fetch every
+	// destination snapshot object on every run, which is the cost the catalog
+	// exists to avoid.
+	//
+	// It is a cache, and is rebuilt from Meta whenever the catalog is
+	// reconciled — so a build predating this field that rebuilds the catalog
+	// drops the value rather than corrupting it, and the next `copy` recovers
+	// it. See RFC 0017 §5.3.
+	CopiedFrom string `json:"copied_from,omitempty"` // CopyProvenance.String()
 }
 
 // RepoConfig is the repository marker written by "init". It is stored as
@@ -124,6 +137,23 @@ type RepoConfig struct {
 	Version   int    `json:"version"`
 	Created   string `json:"created"` // ISO8601
 	Encrypted bool   `json:"encrypted"`
+
+	// ID names this repository, so that an operation spanning two of them can
+	// say which one a piece of data came from. `copy` records it as snapshot
+	// provenance (RFC 0017 §5.1); nothing else reads it.
+	//
+	// It is random rather than derived, because every derivable candidate
+	// moves: the sealed marker is re-encrypted with a fresh nonce on each
+	// UpgradeRepoFormat, Version moves on upgrade, and Created is reset by
+	// `init --adopt`. A provenance key that changes underneath a repository is
+	// worse than none — it fails by silently duplicating history rather than by
+	// declining to skip — so repositories written before this field simply do
+	// not have one, and callers must handle "" rather than invent a value.
+	//
+	// Adding it needed no format bump: the marker is JSON decoded with
+	// json.Unmarshal and is not content-addressed, so older builds ignore it.
+	// Sealing covers it automatically, being applied to whatever JSON it wraps.
+	ID string `json:"id,omitempty"`
 }
 
 // The source-facing domain types are defined in pkg/source and aliased here.

--- a/internal/core/provenance.go
+++ b/internal/core/provenance.go
@@ -1,0 +1,126 @@
+package core
+
+import (
+	"maps"
+	"strings"
+)
+
+// Snapshot.Meta keys are user-controlled — `backup` sets them from -meta — with
+// one exception: this prefix is reserved for values Cloudstic itself records
+// about a snapshot. Without the reservation, provenance would be forgeable by
+// anyone who can run a backup, and a forged entry makes `copy` skip a snapshot
+// it never copied.
+const ReservedMetaPrefix = "cloudstic."
+
+// The provenance keys written by `copy` (RFC 0017 §5.2). Provenance lives in
+// Meta rather than in new Snapshot fields because Snapshot is content-addressed
+// through ComputeJSONHash, which marshals struct fields in declaration order —
+// so a new field rewrites every snapshot hash, while a new map entry does not.
+// encoding/json sorts map keys, so the encoding stays canonical.
+const (
+	MetaKeyCopyFromRepo     = ReservedMetaPrefix + "copy.from_repo"
+	MetaKeyCopyFromSnapshot = ReservedMetaPrefix + "copy.from_snapshot"
+)
+
+// IsReservedMetaKey reports whether key belongs to Cloudstic rather than to the
+// user. Callers accepting user-supplied metadata must reject these.
+func IsReservedMetaKey(key string) bool {
+	return strings.HasPrefix(key, ReservedMetaPrefix)
+}
+
+// CopyProvenance identifies the snapshot a copied snapshot was made from.
+//
+// RepoID is empty when the source repository predates RepoConfig.ID. That is a
+// supported state, not an error: there is no stable identifier to derive for
+// such a repository (see RepoConfig.ID), so matching falls back to SnapshotRef
+// alone. Snapshot refs are content-addressed under the source master key, so
+// for an encrypted source a collision across two repositories implies the two
+// snapshots really are the same snapshot.
+type CopyProvenance struct {
+	RepoID      string
+	SnapshotRef string // "snapshot/<hash>" in the *source* repository
+}
+
+// IsZero reports whether p records no provenance at all. A provenance with an
+// empty RepoID but a set SnapshotRef is not zero — it is a legacy source.
+func (p CopyProvenance) IsZero() bool { return p.SnapshotRef == "" }
+
+// String renders p in the compact form stored in SnapshotSummary.CopiedFrom.
+//
+// Neither component can contain a colon — RepoID is hex and SnapshotRef is
+// "snapshot/<hex>" — so the first colon always separates them.
+func (p CopyProvenance) String() string {
+	if p.IsZero() {
+		return ""
+	}
+	return p.RepoID + ":" + p.SnapshotRef
+}
+
+// ParseCopyProvenance reverses String. It reports false for anything it does
+// not recognise, so a catalog entry written by a future version cannot be
+// mistaken for a match here.
+func ParseCopyProvenance(s string) (CopyProvenance, bool) {
+	repo, ref, found := strings.Cut(s, ":")
+	if !found || ref == "" {
+		return CopyProvenance{}, false
+	}
+	return CopyProvenance{RepoID: repo, SnapshotRef: ref}, true
+}
+
+// CopyProvenanceFromMeta reads the authoritative provenance off a snapshot's
+// metadata. It reports false when the snapshot was not produced by `copy`.
+func CopyProvenanceFromMeta(meta map[string]string) (CopyProvenance, bool) {
+	ref := meta[MetaKeyCopyFromSnapshot]
+	if ref == "" {
+		return CopyProvenance{}, false
+	}
+	return CopyProvenance{RepoID: meta[MetaKeyCopyFromRepo], SnapshotRef: ref}, true
+}
+
+// Matches reports whether p and other name the same source snapshot.
+//
+// The snapshot ref carries the match; the repository id can only disqualify it.
+// Two non-empty, unequal ids mean two different repositories and so never
+// match, but an empty id on either side means "not recorded" — which is a
+// routine state, not a mismatch:
+//
+//   - the source repository predates RepoConfig.ID (see there), or
+//   - an older build rewrote the source marker and dropped the id, which it
+//     does whenever it upgrades the repository format.
+//
+// Treating unknown as a distinct value would make the second case re-import an
+// entire history the moment any older build touched the source. Matching on the
+// ref alone is sound for an encrypted source, whose snapshot refs are
+// content-addressed under its master key: a collision across two repositories
+// implies a shared master key and identical content, at which point the two
+// snapshots really are the same snapshot.
+func (p CopyProvenance) Matches(other CopyProvenance) bool {
+	if p.IsZero() || other.IsZero() {
+		return false
+	}
+	if p.SnapshotRef != other.SnapshotRef {
+		return false
+	}
+	return p.RepoID == "" || other.RepoID == "" || p.RepoID == other.RepoID
+}
+
+// ApplyTo returns meta with p recorded on it, allocating a map if needed. The
+// input map is not modified, so a caller may pass a source snapshot's own Meta
+// while copying it.
+func (p CopyProvenance) ApplyTo(meta map[string]string) map[string]string {
+	out := make(map[string]string, len(meta)+2)
+	maps.Copy(out, meta)
+	if p.IsZero() {
+		return out
+	}
+	out[MetaKeyCopyFromSnapshot] = p.SnapshotRef
+	if p.RepoID != "" {
+		out[MetaKeyCopyFromRepo] = p.RepoID
+	} else {
+		// An empty RepoID is recorded by omission, not as an empty string, so
+		// that a snapshot copied from a legacy source and one copied from a
+		// source whose id happens to be "" cannot be told apart on read.
+		delete(out, MetaKeyCopyFromRepo)
+	}
+	return out
+}

--- a/internal/core/provenance_test.go
+++ b/internal/core/provenance_test.go
@@ -1,0 +1,297 @@
+package core
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+)
+
+func TestCopyProvenanceRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		prov CopyProvenance
+		want string
+	}{
+		{
+			name: "identified source",
+			prov: CopyProvenance{RepoID: "9f2c1a", SnapshotRef: "snapshot/abc123"},
+			want: "9f2c1a:snapshot/abc123",
+		},
+		{
+			// A source predating RepoConfig.ID. This is a supported state, not
+			// a degenerate one: matching falls back to the snapshot ref.
+			name: "legacy source without an id",
+			prov: CopyProvenance{SnapshotRef: "snapshot/abc123"},
+			want: ":snapshot/abc123",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.prov.String(); got != tc.want {
+				t.Fatalf("String() = %q, want %q", got, tc.want)
+			}
+			got, ok := ParseCopyProvenance(tc.want)
+			if !ok {
+				t.Fatalf("ParseCopyProvenance(%q) reported not-ok", tc.want)
+			}
+			if got != tc.prov {
+				t.Errorf("round trip = %+v, want %+v", got, tc.prov)
+			}
+			if tc.prov.IsZero() {
+				t.Error("IsZero() = true for a provenance carrying a snapshot ref")
+			}
+		})
+	}
+}
+
+func TestCopyProvenanceZeroValue(t *testing.T) {
+	var zero CopyProvenance
+	if !zero.IsZero() {
+		t.Error("IsZero() = false for the zero value")
+	}
+	if got := zero.String(); got != "" {
+		t.Errorf("String() = %q, want empty so the catalog field stays omitted", got)
+	}
+}
+
+func TestParseCopyProvenanceRejectsUnrecognized(t *testing.T) {
+	// A catalog entry this build does not understand must not be mistaken for
+	// a match, since a false match makes copy skip a snapshot it never copied.
+	for _, in := range []string{"", "no-separator", "repo-with-empty-ref:"} {
+		if _, ok := ParseCopyProvenance(in); ok {
+			t.Errorf("ParseCopyProvenance(%q) accepted an unrecognized value", in)
+		}
+	}
+}
+
+func TestCopyProvenanceApplyToDoesNotMutateInput(t *testing.T) {
+	// Copy passes the *source* snapshot's own Meta here while rewriting it,
+	// so mutating the argument would corrupt the map it is still reading from.
+	src := map[string]string{"generator": "cloudstic-cli"}
+	prov := CopyProvenance{RepoID: "9f2c1a", SnapshotRef: "snapshot/abc123"}
+
+	out := prov.ApplyTo(src)
+
+	if len(src) != 1 || src["generator"] != "cloudstic-cli" {
+		t.Fatalf("input map was modified: %+v", src)
+	}
+	if out["generator"] != "cloudstic-cli" {
+		t.Error("existing metadata was not carried over")
+	}
+	if out[MetaKeyCopyFromRepo] != "9f2c1a" {
+		t.Errorf("from_repo = %q, want 9f2c1a", out[MetaKeyCopyFromRepo])
+	}
+	if out[MetaKeyCopyFromSnapshot] != "snapshot/abc123" {
+		t.Errorf("from_snapshot = %q, want snapshot/abc123", out[MetaKeyCopyFromSnapshot])
+	}
+}
+
+func TestCopyProvenanceApplyToOmitsEmptyRepoID(t *testing.T) {
+	// Recorded by omission rather than as "", so that a copy from a legacy
+	// source cannot be confused with one from a source whose id really is "".
+	out := CopyProvenance{SnapshotRef: "snapshot/abc123"}.ApplyTo(nil)
+
+	if _, present := out[MetaKeyCopyFromRepo]; present {
+		t.Error("from_repo key was written for a source with no id")
+	}
+
+	prov, ok := CopyProvenanceFromMeta(out)
+	if !ok {
+		t.Fatal("CopyProvenanceFromMeta did not recognize legacy provenance")
+	}
+	if prov.RepoID != "" || prov.SnapshotRef != "snapshot/abc123" {
+		t.Errorf("read back %+v", prov)
+	}
+}
+
+func TestCopyProvenanceApplyToClearsInheritedRepoID(t *testing.T) {
+	// Re-stamping a snapshot that already carries provenance must not leave the
+	// previous source's id behind next to the new snapshot ref.
+	inherited := map[string]string{
+		MetaKeyCopyFromRepo:     "old-repo",
+		MetaKeyCopyFromSnapshot: "snapshot/old",
+	}
+
+	out := CopyProvenance{SnapshotRef: "snapshot/new"}.ApplyTo(inherited)
+
+	if _, present := out[MetaKeyCopyFromRepo]; present {
+		t.Errorf("stale from_repo survived: %q", out[MetaKeyCopyFromRepo])
+	}
+	if out[MetaKeyCopyFromSnapshot] != "snapshot/new" {
+		t.Errorf("from_snapshot = %q, want snapshot/new", out[MetaKeyCopyFromSnapshot])
+	}
+}
+
+func TestCopyProvenanceFromMetaIgnoresUncopiedSnapshots(t *testing.T) {
+	for _, meta := range []map[string]string{
+		nil,
+		{},
+		{"generator": "cloudstic-cli"},
+		// A repo id with no snapshot ref is not provenance.
+		{MetaKeyCopyFromRepo: "9f2c1a"},
+	} {
+		if _, ok := CopyProvenanceFromMeta(meta); ok {
+			t.Errorf("CopyProvenanceFromMeta(%v) claimed provenance", meta)
+		}
+	}
+}
+
+func TestCopyProvenanceMatches(t *testing.T) {
+	const ref = "snapshot/abc123"
+	tests := []struct {
+		name string
+		a, b CopyProvenance
+		want bool
+		why  string
+	}{
+		{
+			name: "same repository, same snapshot",
+			a:    CopyProvenance{RepoID: "aaa", SnapshotRef: ref},
+			b:    CopyProvenance{RepoID: "aaa", SnapshotRef: ref},
+			want: true,
+		},
+		{
+			name: "different snapshots in the same repository",
+			a:    CopyProvenance{RepoID: "aaa", SnapshotRef: ref},
+			b:    CopyProvenance{RepoID: "aaa", SnapshotRef: "snapshot/def456"},
+			want: false,
+		},
+		{
+			name: "same snapshot ref from two identified repositories",
+			a:    CopyProvenance{RepoID: "aaa", SnapshotRef: ref},
+			b:    CopyProvenance{RepoID: "bbb", SnapshotRef: ref},
+			want: false,
+			why:  "two known, different repositories are genuinely different sources",
+		},
+		{
+			name: "id known on one side only",
+			a:    CopyProvenance{RepoID: "aaa", SnapshotRef: ref},
+			b:    CopyProvenance{SnapshotRef: ref},
+			want: true,
+			why:  "an older build drops the id when it rewrites the marker; unknown is not a mismatch",
+		},
+		{
+			name: "id unknown on both sides",
+			a:    CopyProvenance{SnapshotRef: ref},
+			b:    CopyProvenance{SnapshotRef: ref},
+			want: true,
+			why:  "both sources predate RepoConfig.ID; the ref carries the match",
+		},
+		{
+			name: "zero value never matches",
+			a:    CopyProvenance{},
+			b:    CopyProvenance{RepoID: "aaa", SnapshotRef: ref},
+			want: false,
+			why:  "a snapshot with no provenance was not copied from anywhere",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.a.Matches(tc.b); got != tc.want {
+				t.Errorf("Matches() = %v, want %v (%s)", got, tc.want, tc.why)
+			}
+			// Matching is a symmetric question and must not depend on which
+			// side is the destination's record and which is the candidate.
+			if got := tc.b.Matches(tc.a); got != tc.want {
+				t.Errorf("reversed Matches() = %v, want %v (%s)", got, tc.want, tc.why)
+			}
+		})
+	}
+}
+
+func TestIsReservedMetaKey(t *testing.T) {
+	reserved := []string{MetaKeyCopyFromRepo, MetaKeyCopyFromSnapshot, "cloudstic.anything"}
+	for _, key := range reserved {
+		if !IsReservedMetaKey(key) {
+			t.Errorf("IsReservedMetaKey(%q) = false", key)
+		}
+	}
+	for _, key := range []string{"generator", "host", "cloudstic", "my.cloudstic.key"} {
+		if IsReservedMetaKey(key) {
+			t.Errorf("IsReservedMetaKey(%q) = true, want false", key)
+		}
+	}
+}
+
+func TestNewRepoID(t *testing.T) {
+	first, err := NewRepoID()
+	if err != nil {
+		t.Fatalf("NewRepoID: %v", err)
+	}
+	raw, err := hex.DecodeString(first)
+	if err != nil {
+		t.Fatalf("id %q is not hex: %v", first, err)
+	}
+	if len(raw) != RepoIDBytes {
+		t.Errorf("decoded id is %d bytes, want %d", len(raw), RepoIDBytes)
+	}
+
+	second, err := NewRepoID()
+	if err != nil {
+		t.Fatalf("NewRepoID: %v", err)
+	}
+	if first == second {
+		t.Error("two calls returned the same id")
+	}
+}
+
+// The repository marker and the snapshot catalog gained fields without a format
+// version bump, which is only sound if a value that does not use them encodes
+// exactly as it did before. See RFC 0017 "Compatibility".
+func TestAddedFieldsAreOmittedWhenUnset(t *testing.T) {
+	cfg, err := json.Marshal(RepoConfig{Version: 2, Created: "2026-01-01T00:00:00Z", Encrypted: true})
+	if err != nil {
+		t.Fatalf("marshal RepoConfig: %v", err)
+	}
+	const wantCfg = `{"version":2,"created":"2026-01-01T00:00:00Z","encrypted":true}`
+	if string(cfg) != wantCfg {
+		t.Errorf("RepoConfig without an id encoded as\n  %s\nwant\n  %s", cfg, wantCfg)
+	}
+
+	summary, err := json.Marshal(SnapshotSummary{Ref: "snapshot/abc", Seq: 1, Created: "2026-01-01T00:00:00Z", Root: "node/def"})
+	if err != nil {
+		t.Fatalf("marshal SnapshotSummary: %v", err)
+	}
+	const wantSummary = `{"ref":"snapshot/abc","seq":1,"created":"2026-01-01T00:00:00Z","root":"node/def"}`
+	if string(summary) != wantSummary {
+		t.Errorf("SnapshotSummary without provenance encoded as\n  %s\nwant\n  %s", summary, wantSummary)
+	}
+}
+
+// Provenance lives in Snapshot.Meta specifically so that recording it does not
+// perturb the content-addressing of snapshots that do not carry it, and so that
+// a snapshot that does carry it still hashes canonically regardless of the
+// order the keys were inserted.
+func TestProvenanceInMetaHashesCanonically(t *testing.T) {
+	base := Snapshot{Version: 1, Created: "2026-01-01T00:00:00Z", Root: "node/def", Seq: 3}
+
+	bare, _, err := ComputeJSONHash(&base)
+	if err != nil {
+		t.Fatalf("ComputeJSONHash: %v", err)
+	}
+
+	withProv := base
+	withProv.Meta = CopyProvenance{RepoID: "9f2c1a", SnapshotRef: "snapshot/abc"}.ApplyTo(nil)
+	first, _, err := ComputeJSONHash(&withProv)
+	if err != nil {
+		t.Fatalf("ComputeJSONHash: %v", err)
+	}
+	if first == bare {
+		t.Fatal("recording provenance did not change the snapshot hash")
+	}
+
+	reordered := base
+	reordered.Meta = map[string]string{
+		MetaKeyCopyFromSnapshot: "snapshot/abc",
+		MetaKeyCopyFromRepo:     "9f2c1a",
+	}
+	second, _, err := ComputeJSONHash(&reordered)
+	if err != nil {
+		t.Fatalf("ComputeJSONHash: %v", err)
+	}
+	if first != second {
+		t.Errorf("insertion order changed the hash: %s vs %s", first, second)
+	}
+}

--- a/internal/core/repoid.go
+++ b/internal/core/repoid.go
@@ -1,0 +1,27 @@
+package core
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+)
+
+// RepoIDBytes is the length of a repository identifier before hex encoding.
+//
+// 16 bytes is the same size as a UUID and far past the point where a birthday
+// collision between two repositories is worth reasoning about. The identifier
+// is not a secret and is not derived from one; it only has to be unique.
+const RepoIDBytes = 16
+
+// NewRepoID returns a fresh random repository identifier, hex encoded.
+//
+// It is called once, when a repository is initialized. Adopting an existing
+// repository must carry the stored identifier forward rather than mint a new
+// one — see RepoConfig.ID.
+func NewRepoID() (string, error) {
+	buf := make([]byte, RepoIDBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate repository id: %w", err)
+	}
+	return hex.EncodeToString(buf), nil
+}

--- a/internal/engine/backup.go
+++ b/internal/engine/backup.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -69,8 +71,36 @@ func WithGenerator(name string) BackupOption {
 }
 
 // WithMeta adds a key-value pair to the snapshot metadata.
+//
+// Keys under core.ReservedMetaPrefix belong to Cloudstic and are rejected when
+// the backup runs. The option itself cannot report that, being a plain
+// mutator, which is why validateMeta runs first thing in Run.
 func WithMeta(key, value string) BackupOption {
 	return func(cfg *backupConfig) { cfg.meta[key] = value }
+}
+
+// validateMeta rejects user metadata that would impersonate metadata Cloudstic
+// writes about a snapshot.
+//
+// The namespace has to be defended at the point of entry rather than filtered
+// on the way out: `copy` decides whether it has already copied a snapshot by
+// reading these keys, so a snapshot carrying forged provenance is one that
+// `copy` will skip having never copied it — a silent hole in the destination.
+func (cfg backupConfig) validateMeta() error {
+	keys := make([]string, 0, len(cfg.meta))
+	for key := range cfg.meta {
+		if core.IsReservedMetaKey(key) {
+			keys = append(keys, key)
+		}
+	}
+	if len(keys) == 0 {
+		return nil
+	}
+	sort.Strings(keys)
+	return fmt.Errorf(
+		"snapshot metadata key %s is reserved: keys beginning with %q are written by Cloudstic itself",
+		strings.Join(keys, ", "), core.ReservedMetaPrefix,
+	)
 }
 
 // WithExcludeHash records the hash of the active exclude patterns. When this
@@ -158,6 +188,10 @@ type RunResult struct {
 // Run executes a full backup: scan the source for changes, upload new/modified
 // files, build a new HAMT root, and persist a snapshot.
 func (bm *BackupManager) Run(ctx context.Context) (*RunResult, error) {
+	if err := bm.cfg.validateMeta(); err != nil {
+		return nil, err
+	}
+
 	if !bm.cfg.dryRun {
 		lock, lockedCtx, err := AcquireSharedLock(ctx, bm.store, "backup")
 		if err != nil {

--- a/internal/engine/init.go
+++ b/internal/engine/init.go
@@ -305,24 +305,43 @@ func (m *InitManager) writeRepoConfig(ctx context.Context, encrypted bool, encry
 	// mistaken for "no existing config" — that would silently move the floor
 	// down instead of leaving it alone.
 	version := core.RepoFormatVersion
+	id := ""
 	existingData, err := m.store.Get(ctx, configKey)
 	switch {
 	case err == nil:
 		// Decode rather than unmarshal, so a sealed marker's version is read
 		// too. A marker that cannot be opened leaves the floor where it is,
 		// which is the same conservative outcome as an unparseable one.
-		if existing, derr := repoconfig.Decode(existingData, encryptionKey); derr == nil &&
-			existing.Version > version {
-			version = existing.Version
+		if existing, derr := repoconfig.Decode(existingData, encryptionKey); derr == nil {
+			if existing.Version > version {
+				version = existing.Version
+			}
+			// Adopting a repository must not re-identify it. Snapshots copied
+			// out of it elsewhere record this identifier as their provenance,
+			// and minting a fresh one would make those copies look unrelated —
+			// so the next `copy` would import the whole history again.
+			id = existing.ID
 		}
 	case !errors.Is(err, store.ErrNotFound):
 		return fmt.Errorf("read existing repository config: %w", err)
+	}
+
+	// A repository predating RepoConfig.ID reaches here with id still empty
+	// only when its marker could not be decoded, in which case it is being
+	// re-initialized anyway. An adopted repository that genuinely has no
+	// identifier gains one here, which is safe: it had no provenance to
+	// invalidate.
+	if id == "" {
+		if id, err = core.NewRepoID(); err != nil {
+			return err
+		}
 	}
 
 	cfg := core.RepoConfig{
 		Version:   version,
 		Created:   time.Now().UTC().Format(time.RFC3339),
 		Encrypted: encrypted,
+		ID:        id,
 	}
 	data, err := repoconfig.Encode(cfg, encryptionKey)
 	if err != nil {

--- a/internal/engine/policy.go
+++ b/internal/engine/policy.go
@@ -55,6 +55,15 @@ type SnapshotEntry struct {
 	Ref     string
 	Snap    core.Snapshot
 	Created time.Time
+
+	// CopiedFrom carries the catalog's provenance cache through to callers.
+	//
+	// It is not folded into Snap.Meta, because an entry loaded from the catalog
+	// has no Meta at all — the catalog does not store it — and a Meta holding
+	// only provenance would read as a complete map that had lost every other
+	// key. Empty here means "the catalog does not know", which is not the same
+	// as "this snapshot was not copied"; see RFC 0017 §5.3 for the fallback.
+	CopiedFrom string
 }
 
 // KeepReason pairs a snapshot with the reasons it was kept.

--- a/internal/engine/provenance_test.go
+++ b/internal/engine/provenance_test.go
@@ -1,0 +1,130 @@
+package engine
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cloudstic/cli/internal/core"
+	"github.com/cloudstic/cli/internal/ui"
+)
+
+func copiedSnapshot(created string, prov core.CopyProvenance) *core.Snapshot {
+	return &core.Snapshot{
+		Version: 1,
+		Created: created,
+		Root:    "node/" + strings.Repeat("a", 8),
+		Seq:     1,
+		Meta:    prov.ApplyTo(map[string]string{"generator": "cloudstic-cli"}),
+	}
+}
+
+func TestSnapshotToSummary_DerivesProvenance(t *testing.T) {
+	prov := core.CopyProvenance{RepoID: "9f2c1a", SnapshotRef: "snapshot/source123"}
+	summary := snapshotToSummary("snapshot/dest456", *copiedSnapshot("2026-01-01T00:00:00Z", prov))
+
+	if summary.CopiedFrom != prov.String() {
+		t.Errorf("CopiedFrom = %q, want %q", summary.CopiedFrom, prov.String())
+	}
+}
+
+func TestSnapshotToSummary_LeavesProvenanceEmptyForOrdinarySnapshots(t *testing.T) {
+	snap := core.Snapshot{Version: 1, Created: "2026-01-01T00:00:00Z", Meta: map[string]string{"generator": "cloudstic-cli"}}
+
+	if got := snapshotToSummary("snapshot/abc", snap).CopiedFrom; got != "" {
+		t.Errorf("CopiedFrom = %q for a snapshot that was not copied", got)
+	}
+}
+
+// The catalog is a rebuildable cache, so a build predating CopiedFrom drops the
+// field when it reconciles. The value must come back from the snapshot object's
+// Meta on the next rebuild rather than staying lost — otherwise a single run of
+// an older binary would make copy re-import the whole history.
+func TestLoadSnapshotCatalog_RebuildsProvenanceFromSnapshotMeta(t *testing.T) {
+	s := NewMockStore()
+	prov := core.CopyProvenance{RepoID: "9f2c1a", SnapshotRef: "snapshot/source123"}
+	ref := putSnapshot(t, s, copiedSnapshot("2026-01-01T00:00:00Z", prov))
+
+	// A catalog as an older build would have left it: the entry is present and
+	// otherwise correct, but carries no provenance.
+	putCatalog(t, s, []core.SnapshotSummary{{
+		Ref:     ref,
+		Seq:     1,
+		Created: "2026-01-01T00:00:00Z",
+		Root:    "node/" + strings.Repeat("a", 8),
+	}})
+
+	entries, err := LoadSnapshotCatalog(s, nil)
+	if err != nil {
+		t.Fatalf("LoadSnapshotCatalog: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+
+	// The stale entry is served as-is; nothing forces a refetch, which is the
+	// documented degraded state. What must hold is that a rebuild recovers it.
+	rebuilt := snapshotToSummary(ref, *copiedSnapshot("2026-01-01T00:00:00Z", prov))
+	if rebuilt.CopiedFrom != prov.String() {
+		t.Errorf("rebuild produced CopiedFrom = %q, want %q", rebuilt.CopiedFrom, prov.String())
+	}
+}
+
+// A snapshot written by backup lands in the catalog through the same funnel, so
+// an ordinary backup must not start claiming provenance.
+func TestAppendSnapshotCatalog_RoundTripsProvenance(t *testing.T) {
+	s := NewMockStore()
+	prov := core.CopyProvenance{RepoID: "9f2c1a", SnapshotRef: "snapshot/source123"}
+
+	AppendSnapshotCatalog(s, snapshotToSummary("snapshot/dest456", *copiedSnapshot("2026-01-01T00:00:00Z", prov)), nil)
+	AppendSnapshotCatalog(s, snapshotToSummary("snapshot/plain", core.Snapshot{
+		Version: 1, Created: "2026-01-02T00:00:00Z", Seq: 2,
+	}), nil)
+
+	catalog := readCatalog(t, s)
+	byRef := map[string]core.SnapshotSummary{}
+	for _, entry := range catalog {
+		byRef[entry.Ref] = entry
+	}
+
+	if got := byRef["snapshot/dest456"].CopiedFrom; got != prov.String() {
+		t.Errorf("copied snapshot: CopiedFrom = %q, want %q", got, prov.String())
+	}
+	if got := byRef["snapshot/plain"].CopiedFrom; got != "" {
+		t.Errorf("backed-up snapshot: CopiedFrom = %q, want empty", got)
+	}
+}
+
+// Provenance is what copy trusts to decide it has already copied a snapshot, so
+// a snapshot carrying a forged entry is one copy silently skips. The namespace
+// is therefore closed at the point user metadata enters.
+func TestBackup_RejectsReservedMetadataKeys(t *testing.T) {
+	src := NewMockSource()
+	mgr := NewBackupManager(src, NewMockStore(), ui.NewNoOpReporter(), nil, nil,
+		WithMeta("host", "laptop"),
+		WithMeta(core.MetaKeyCopyFromSnapshot, "snapshot/forged"),
+	)
+
+	_, err := mgr.Run(context.Background())
+	if err == nil {
+		t.Fatal("backup accepted a reserved metadata key")
+	}
+	if !strings.Contains(err.Error(), core.MetaKeyCopyFromSnapshot) {
+		t.Errorf("error does not name the offending key: %v", err)
+	}
+	if !strings.Contains(err.Error(), "reserved") {
+		t.Errorf("error does not explain why the key was refused: %v", err)
+	}
+}
+
+func TestBackup_AllowsOrdinaryMetadataKeys(t *testing.T) {
+	src := NewMockSource()
+	mgr := NewBackupManager(src, NewMockStore(), ui.NewNoOpReporter(), nil, nil,
+		WithMeta("host", "laptop"),
+		WithMeta("cloudstic", "not-the-prefix"),
+	)
+
+	if _, err := mgr.Run(context.Background()); err != nil {
+		t.Fatalf("backup rejected ordinary metadata: %v", err)
+	}
+}

--- a/internal/engine/repoid_test.go
+++ b/internal/engine/repoid_test.go
@@ -1,0 +1,124 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cloudstic/cli/internal/core"
+	"github.com/cloudstic/cli/internal/repoconfig"
+	"github.com/cloudstic/cli/pkg/keychain"
+)
+
+// loadMarker reads and decodes the repository marker, unsealing it when needed.
+func loadMarker(t *testing.T, s *MockStore, encryptionKey []byte) *core.RepoConfig {
+	t.Helper()
+	data, err := s.Get(context.Background(), "config")
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	cfg, err := repoconfig.Decode(data, encryptionKey)
+	if err != nil {
+		t.Fatalf("decode config: %v", err)
+	}
+	return cfg
+}
+
+func TestInitManager_AssignsRepositoryID(t *testing.T) {
+	first := NewMockStore()
+	if _, err := NewInitManager(first, nil).Run(context.Background(), WithInitNoEncryption()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	second := NewMockStore()
+	if _, err := NewInitManager(second, nil).Run(context.Background(), WithInitNoEncryption()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	a := loadMarker(t, first, nil).ID
+	b := loadMarker(t, second, nil).ID
+
+	if a == "" || b == "" {
+		t.Fatalf("init left the repository id empty (%q, %q)", a, b)
+	}
+	if a == b {
+		t.Error("two repositories were initialized with the same id")
+	}
+}
+
+func TestInitManager_AssignsRepositoryIDToEncryptedRepo(t *testing.T) {
+	// The marker is sealed for an encrypted repository, so the id has to
+	// survive a seal/unseal round trip rather than only a plain marshal.
+	s := NewMockStore()
+	chain := keychain.Chain{keychain.WithPassword("test-password")}
+	if _, err := NewInitManager(s, nil).Run(context.Background(), WithInitCredentials(chain)); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	slots, err := keychain.LoadKeySlots(context.Background(), s)
+	if err != nil {
+		t.Fatalf("load key slots: %v", err)
+	}
+	masterKey, err := chain.Resolve(context.Background(), slots)
+	if err != nil {
+		t.Fatalf("resolve master key: %v", err)
+	}
+	// The marker is sealed with the derived encryption key, not the master key
+	// the slots yield directly.
+	encryptionKey, err := keychain.DeriveEncryptionKey(masterKey)
+	if err != nil {
+		t.Fatalf("derive encryption key: %v", err)
+	}
+
+	if cfg := loadMarker(t, s, encryptionKey); cfg.ID == "" {
+		t.Error("encrypted repository was initialized without an id")
+	}
+}
+
+func TestInitManager_AdoptPreservesRepositoryID(t *testing.T) {
+	// Re-initializing must not re-identify the repository. Snapshots copied
+	// out of it elsewhere record the old id as provenance, and a new one would
+	// make the next `copy` import the entire history again.
+	s := NewMockStore()
+	if _, err := NewInitManager(s, nil).Run(context.Background(), WithInitNoEncryption()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	original := loadMarker(t, s, nil).ID
+
+	if _, err := NewInitManager(s, nil).Run(
+		context.Background(), WithInitNoEncryption(), WithInitAdoptSlots(),
+	); err != nil {
+		t.Fatalf("re-init: %v", err)
+	}
+
+	if got := loadMarker(t, s, nil).ID; got != original {
+		t.Errorf("id changed on adopt: %q -> %q", original, got)
+	}
+}
+
+func TestInitManager_AdoptAssignsIDToLegacyRepository(t *testing.T) {
+	// A repository written before RepoConfig.ID existed has no provenance to
+	// invalidate, so adopting it may safely mint one.
+	s := NewMockStore()
+	legacy := core.RepoConfig{Version: 1, Created: "2026-01-01T00:00:00Z"}
+	data, err := repoconfig.Encode(legacy, nil)
+	if err != nil {
+		t.Fatalf("encode legacy marker: %v", err)
+	}
+	if err := s.Put(context.Background(), "config", data); err != nil {
+		t.Fatalf("seed legacy marker: %v", err)
+	}
+
+	if _, err := NewInitManager(s, nil).Run(
+		context.Background(), WithInitNoEncryption(), WithInitAdoptSlots(),
+	); err != nil {
+		t.Fatalf("adopt: %v", err)
+	}
+
+	cfg := loadMarker(t, s, nil)
+	if cfg.ID == "" {
+		t.Error("adopting a legacy repository did not assign an id")
+	}
+	// The format floor must still not move down.
+	if cfg.Version < 1 {
+		t.Errorf("version floor moved down to %d", cfg.Version)
+	}
+}

--- a/internal/engine/snapshots.go
+++ b/internal/engine/snapshots.go
@@ -126,7 +126,8 @@ func LoadSnapshotCatalog(s store.ObjectStore, log *logger.Logger) ([]SnapshotEnt
 				ChangeToken: cs.ChangeToken,
 				ExcludeHash: cs.ExcludeHash,
 			},
-			Created: created,
+			Created:    created,
+			CopiedFrom: cs.CopiedFrom,
 		})
 		if needRebuild {
 			updatedCatalog = append(updatedCatalog, cs)
@@ -218,7 +219,7 @@ func RemoveFromSnapshotCatalog(s store.ObjectStore, log *logger.Logger, refs ...
 
 // snapshotToSummary converts a full Snapshot and its ref into a SnapshotSummary.
 func snapshotToSummary(ref string, snap core.Snapshot) core.SnapshotSummary {
-	return core.SnapshotSummary{
+	summary := core.SnapshotSummary{
 		Ref:         ref,
 		Seq:         snap.Seq,
 		Created:     snap.Created,
@@ -228,6 +229,14 @@ func snapshotToSummary(ref string, snap core.Snapshot) core.SnapshotSummary {
 		ChangeToken: snap.ChangeToken,
 		ExcludeHash: snap.ExcludeHash,
 	}
+	// Deriving CopiedFrom here, rather than at the one call site that writes a
+	// copied snapshot, is what makes the field self-healing: this function is
+	// also the catalog's rebuild path, so a value dropped by an older build is
+	// restored the next time the catalog reconciles against LIST snapshot/.
+	if prov, ok := core.CopyProvenanceFromMeta(snap.Meta); ok {
+		summary.CopiedFrom = prov.String()
+	}
+	return summary
 }
 
 // ---------------------------------------------------------------------------

--- a/rfcs/0017-snapshot-copy-between-repositories.md
+++ b/rfcs/0017-snapshot-copy-between-repositories.md
@@ -1,8 +1,14 @@
 # RFC 0017: Snapshot Copy Between Repositories
 
 - **Status:** Draft
-- **Date:** 2026-04-03
-- **Affects:** `cmd/cloudstic`, `client.go`, `internal/engine`, `pkg/store`, docs
+- **Date:** 2026-04-03 (revised 2026-08-03)
+- **Affects:** `cmd/cloudstic`, `client.go`, `internal/engine`, `internal/hamt`,
+  `internal/core`, `internal/storelayer`, `pkg/config`, `pkg/open`, docs
+
+The 2026-08-03 revision rebases the CLI and API surface on what the codebase
+actually has after RFC 0018 (self-describing packfiles) and RFC 0022 (public Go
+API boundaries), and replaces the hand-waving in §4, §5 and §8 with a specified
+algorithm. See "Revision notes" at the end for what changed and why.
 
 ## Abstract
 
@@ -20,8 +26,10 @@ The command is repository-to-repository, not source-to-repository. It copies
 existing snapshot history and the reachable data needed to restore those
 snapshots in the destination repository.
 
-This feature is expected to re-encrypt and rewrite data
-for the destination repository. It is not a backend-side object clone.
+Copy is a **logical rebuild**, not a transfer. Every object reference in a
+Cloudstic repository is derived from that repository's master key, so nothing
+can be moved verbatim: the destination graph is reconstructed bottom-up from
+plaintext and re-addressed in the destination's own domain. §4 specifies this.
 
 ## Context
 
@@ -43,36 +51,52 @@ Today, users wanting to migrate repositories effectively have two bad options:
   because repositories do not share keys and may not share identical object
   layouts
 
-Cloudstic's storage model makes this a real feature, not just a convenience:
+### Why object refs cannot be preserved
 
-- chunks and metadata are content-addressed inside one repository's encryption
-  domain
-- `content/`, `filemeta/`, `node/`, and `snapshot/` objects are all encrypted
-  with the destination repository's master key
-- packfiles and indexes are repository-local implementation details
+The second option is not merely inconvenient, it cannot work. Object identity
+cascades off the master key at every level:
+
+| Object | Key derivation | Source |
+|--------|----------------|--------|
+| `chunk/<h>` | `HMAC(dedupKey, plaintext)`, or `SHA256(plaintext)` when unencrypted | `internal/engine/chunker.go` |
+| `content/<h>` | `HMAC(dedupKey, SHA256(stream))` | `internal/engine/chunker.go` |
+| `filemeta/<h>` | `ComputeJSONHash(FileMeta)` — embeds the content ref | `internal/core/models.go` |
+| `node/<h>` | `ComputeJSONHash(storedNode)` — embeds filemeta refs | `internal/hamt/node.go` |
+| `snapshot/<h>` | `ComputeJSONHash(Snapshot)` — embeds the root node ref | `internal/core/models.go` |
+
+`dedupKey` is HKDF-derived from the repository master key
+(`crypto.HKDFInfoDedupV1`). Two repositories therefore assign different names to
+identical bytes, and a single differing chunk ref propagates all the way to the
+snapshot ref. Copy must rebuild the graph, not relabel it.
 
 So "copy snapshot history" must be an engine-level operation.
 
 ## Goals
 
 - Add a supported way to copy snapshots between repositories.
-- Preserve snapshot semantics, including timestamp, tags, source identity,
-  account, and path lineage.
+- Preserve snapshot semantics that describe *what was backed up*: `Created`,
+  `Source`, `Tags`, `Meta`, `ChangeToken`, `ExcludeHash`, and path lineage.
 - Support both "copy everything" and filtered/exact snapshot selection.
-- Make repeated runs idempotent enough to skip snapshots already copied.
+- Make repeated runs idempotent: already-copied snapshots are skipped without
+  re-reading their data.
 - Keep the command compatible with Cloudstic's current store/profile/auth model.
 - Expose the feature both in the CLI and the public `Client` API.
 
 ## Non-goals
 
 - No backend-native server-side object cloning in v1.
-- No cross-repository dedup guarantee in the initial version.
+- No preservation of source object refs — see "Why object refs cannot be
+  preserved" above; this is impossible, not merely deferred.
 - No requirement that source and destination share passwords, master keys, or
   key slots.
 - No attempt to merge or reconcile histories from unrelated repositories beyond
   snapshot-level copying.
 - No in-place conversion of an existing repository's chunking behavior or object
-  layout.
+  layout. A snapshot chunked under older CDC parameters keeps those boundaries
+  in the destination (§4.3).
+- No fine-grained resume *within* one snapshot (§8).
+- No write of any kind to the source repository. Copy runs against read-only
+  source credentials.
 
 ## Proposal
 
@@ -81,7 +105,7 @@ So "copy snapshot history" must be an engine-level operation.
 Introduce a new top-level command:
 
 ```bash
-cloudstic copy -from-store <uri-or-ref> [snapshot selectors...]
+cloudstic copy -from-store <uri> [snapshot selectors...]
 ```
 
 Examples:
@@ -92,383 +116,784 @@ cloudstic copy \
   -store s3:dest-bucket/prod \
   -from-store local:/tmp/cloudstic-src
 
-# Copy only one profile lineage
+# Copy one profile's repository into another profile's repository
 cloudstic copy \
-  -store-ref remote-prod \
-  -from-store-ref local-seed \
+  -profile remote-prod \
+  -from-profile local-seed \
   -source local:./Documents
 
 # Copy explicitly selected snapshots
 cloudstic copy \
-  -store-ref archive \
-  -from-store-ref laptop-local \
+  -profile archive \
+  -from-profile laptop-local \
   410b18a2 4e5d5487 latest
 ```
 
-The destination repository is configured the same way as other commands, using
-existing global destination flags such as `-store`, `-store-ref`, `-password`,
-`-encryption-key`, and related auth settings.
+The destination repository is configured exactly as for every other repository
+command, through the existing global flag groups (`repoFlagSpecs`,
+`storeSFTPFlagSpecs`, `encryptionFlagSpecs` in `cmd/cloudstic/flags.go`) — so
+`-store`, `-profile`, `-password`, `-encryption-key`, `-s3-*`, `-b2-*`,
+`-store-sftp-*`, `-kms-*` and the rest keep their current meanings.
 
-The source repository is provided through a parallel set of `from` flags.
+The source repository is configured through a parallel `-from-*` set.
 
-### 2. Add source repository configuration flags
+Both repositories must already be initialized. `copy` never runs `init` on the
+destination: creating a repository is a decision about key slots and encryption
+that must not happen as a side effect of a migration command.
 
-The source repository requires its own repository location and unlock
-credentials.
+### 2. Source repository configuration flags
 
-Initial CLI shape:
+**The `-from-*` flags are generated, not hand-written.** `copy` binds a second
+`globalFlags` value and derives its flag specs by mapping the three repository
+flag groups through a `withPrefix("from-")` transform:
 
-```bash
--from-store <uri>
--from-store-ref <name>
--from-password <pw>
--from-password-secret <ref>
--from-encryption-key <hex>
--from-encryption-key-secret <ref>
--from-recovery-key <words>
--from-recovery-key-secret <ref>
--from-kms-key-arn <arn>
--from-kms-region <region>
--from-kms-endpoint <url>
--from-s3-endpoint <url>
--from-s3-region <region>
--from-s3-profile <name>
--from-s3-access-key <key>
--from-s3-secret-key <secret>
--from-store-sftp-password <pw>
--from-store-sftp-password-secret <ref>
--from-store-sftp-key <path>
--from-store-sftp-key-secret <ref>
--from-store-sftp-known-hosts <path>
--from-store-sftp-insecure
--from-profiles-file <path>
+```go
+func fromFlagSpecs(from *globalFlags) []flagSpec {
+    var specs []flagSpec
+    for _, group := range []flagGroup{repoFlagSpecs, storeSFTPFlagSpecs, encryptionFlagSpecs} {
+        specs = append(specs, prefixed("from-", group(from))...)
+    }
+    return specs
+}
 ```
 
-Design rule:
+This is the single most important structural decision in the CLI half of the
+RFC. Hand-listing the mirrors — as the original draft did, in a 25-line block
+that already omitted `-b2-key-id`, `-b2-app-key` and `-disable-packfile` —
+guarantees drift the first time a store flag is added. Generation makes
+`TestCopyMirrorsEveryRepositoryFlag` a one-line assertion over
+`repoCommandGroups`, and the shell-completion generators pick the mirrors up
+for free because they already walk `flagSpec`s.
 
-- destination flags keep their current names
-- source repository flags are explicit `from-*` mirrors
+`prefixed` rewrites three things per spec: the flag name, the placeholder-bearing
+usage string, and — see below — the environment binding.
 
-This avoids ambiguous mixed configuration and keeps scripting predictable.
+**Design rules:**
 
-CLI credential handling should follow the same preference order already used by
-the rest of the CLI:
+- Destination flags keep their current names. Source flags are `from-` mirrors.
+- **`-from-*` flags carry no environment bindings.** `prefixed` strips
+  `withEnv`. This is deliberate: `CLOUDSTIC_PASSWORD` in the ambient environment
+  means "the repository I am operating on", and silently applying it to *both*
+  repositories in a two-repository command is how an operator unlocks the wrong
+  one, or believes they did. Ambient `CLOUDSTIC_*` continues to configure the
+  destination only; the source must be named explicitly.
+- The supported non-interactive path for source credentials is
+  **`-from-profile`**, whose profile entry may carry `env://` secret refs like
+  any other. That is already the repo's blessed mechanism for scripted
+  credentials and needs no new surface.
+- Consequently there are no `-from-password-secret`-style flags. The original
+  draft proposed them, but they have no destination counterpart to mirror:
+  `-password-secret` and friends are `store` subcommand flags
+  (`cmd/cloudstic/cmd_store.go`), not global ones.
+- Because the mirrors bind no environment, they add **no rows** to the
+  `docs/user-guide.md` environment table and cannot trip
+  `TestUserGuideDocumentsEveryEnvVar`.
 
-- explicit secret reference first (`env://`, `keychain://`, etc.)
-- explicit raw value second
-- interactive prompt only where already supported by the destination-side flow
+`-from-prompt` is accepted, and interactive prompts are labelled with which
+repository they unlock (`Password for source repository (local:/seed):`). With
+`-no-prompt`, a missing source credential is a hard error naming
+`-from-password` / `-from-profile`.
 
 Example:
 
 ```bash
 cloudstic copy \
-  -store-ref remote-prod \
-  -password-secret keychain://cloudstic/store/remote-prod/password \
-  -from-store-ref laptop-local \
-  -from-password-secret keychain://cloudstic/store/laptop-local/password
+  -profile remote-prod \
+  -from-profile laptop-local
 ```
+
+Both profiles resolve their own store, auth, and secret refs through
+`pkg/profile` and `pkg/config` exactly as a single-repository command does.
 
 ### 3. Snapshot selection model
 
-By default, `copy` copies all source snapshots.
+By default, `copy` selects all source snapshots.
 
-It may be narrowed in two ways:
+It may be narrowed in three ways:
 
 - explicit positional snapshot IDs: `cloudstic copy ... <snapshot_id>...`
-- existing snapshot filters:
-  - `-source`
-  - `-account`
-  - `-tag`
-  - `-group-by` where applicable for selection helpers
+- the filters `list` and `forget` already understand: `-source`, `-account`,
+  `-tag`
+- `-since <timestamp>`, selecting snapshots whose `Created` is at or after the
+  given time (§7 explains why this one earns its place in v1)
 
-If explicit snapshot IDs are provided, they define the candidate set and filter
-flags further constrain it.
+If explicit snapshot IDs are provided, they define the candidate set and the
+filter flags further constrain it. `latest` is accepted as a selector and
+resolves through the source repository's normal `resolveLatest` behavior
+(`internal/engine/snapshots.go`).
 
-`latest` is accepted as a selector, using the source repository's `index/latest`
-resolution behavior.
+`-group-by` is **not** a copy flag. It is a grouping input to retention policy
+in `forget`, not a selector, and mirroring it here would imply copy applies a
+policy.
 
-Open question:
-
-- whether `copy` should also accept `-profile` as a selector shortcut in v1, or
-  keep selection purely snapshot-oriented
-
-Recommendation:
-
-- v1 should stay snapshot-oriented and reuse the existing source/account/tag
-  filters already understood by `list` and `forget`
+**On `-profile` as a selector.** The original draft left open whether `copy`
+should accept `-profile` as a selection shortcut, and recommended against it.
+That recommendation stands, but the reason needs stating because the word is now
+overloaded: `-profile` and `-from-profile` select **repositories**, and adding a
+third meaning ("snapshots belonging to this profile's source") to the same flag
+would be unreadable. A user who wants a profile's lineage narrows with
+`-source`, which is what the profile's source resolves to anyway.
 
 ### 4. Copy semantics
 
-For each selected source snapshot:
+Copy is a bottom-up rebuild with a reference-remapping table. This section
+specifies it because it is the whole feature; "walk the graph and write the
+objects" is not an implementable description given the ref cascade above.
 
-1. Load the source snapshot object.
-2. Walk the full reachable object graph from that snapshot root:
-   - `snapshot/*`
-   - `node/*`
-   - `filemeta/*`
-   - `content/*`
-   - `chunk/*`
-3. Materialize plaintext payloads through the source repository stack.
-4. Write those logical objects through the destination repository stack.
-5. Write a destination snapshot object preserving the snapshot metadata.
-6. Update the destination `index/snapshots` catalog.
-7. Update destination `index/latest` if the copied snapshot becomes the newest
-   snapshot under the existing latest-pointer rules.
+#### 4.1 Ordering
 
-The copy operation is therefore a logical rewrite of the repository graph, not
-an opaque transfer of encrypted objects.
+Selected snapshots are copied in **ascending source `Created`**, ties broken by
+ascending source `Seq`. This matters for §4.5 and §4.6, and it makes a
+partially-completed run leave the destination in a state that looks like normal
+backup history rather than a shuffled one.
 
-### 5. Snapshot identity and idempotency
+#### 4.2 Per-snapshot rebuild
 
-Repeated copy runs should skip snapshots that were already copied.
+For each selected source snapshot, in order:
 
-This requires recording source-to-destination provenance on copied snapshots.
+1. Load the source snapshot object and its root `node/` ref.
+2. Locate the destination's existing snapshot for the same source identity, if
+   any, using `findPreviousSnapshot` semantics. Its HAMT root seeds the
+   destination tree, so unchanged subtrees are **shared, not rewritten** — a
+   copy of 200 daily snapshots of a mostly-static tree must not write 200 full
+   trees.
+3. Walk the source HAMT from the root. For each `(path, source filemeta ref)`:
+   1. If the source filemeta ref is in the remap table, reuse the mapped
+      destination ref and continue.
+   2. Load the source `FileMeta`; resolve its `content/` ref.
+   3. Rebuild the content object (§4.3), obtaining a destination content ref.
+   4. Rewrite the `FileMeta` with the destination content ref, leaving every
+      other field byte-identical, and write it through the destination stack.
+      Record `source ref -> destination ref` in the remap table.
+   5. Insert `(path, destination filemeta ref)` into the destination HAMT via
+      `hamt.TransactionalStore`.
+4. Flush the transactional store, yielding the destination root node ref. Only
+   nodes reachable from that root are written, as in backup.
+5. Write the destination snapshot object (§4.5).
+6. Update the destination `index/snapshots` catalog (§4.6).
+7. Reconcile `index/latest` (§4.6).
 
-Proposal:
+**The remap table is per-run, not per-snapshot**, and is keyed on source refs at
+the filemeta, content and chunk levels. Snapshots in one run share the
+overwhelming majority of their graph; a per-snapshot table would re-read and
+re-encrypt every unchanged file once per snapshot. This is the difference
+between a copy that is proportional to the repository and one that is
+proportional to (repository × snapshots).
 
-- extend copied destination snapshots with extra metadata:
+#### 4.3 Chunk and content rebuild
 
-```json
-{
-  "copied_from_repo_id": "<source repo id or marker>",
-  "copied_from_snapshot": "snapshot/<source hash>"
+Chunk boundaries are **reused, not recomputed**.
+
+The source `Content` object already records the exact boundaries, and FastCDC in
+this codebase is parameterised by fixed constants with no key-derived seed
+(`cdcMinSize`/`cdcAvgSize`/`cdcMaxSize`, `internal/engine/chunker.go`), so
+re-running the chunker over the same plaintext is guaranteed to reproduce the
+same split. Running it anyway would burn CDC over every byte of the repository
+to arrive at the answer already written down.
+
+So, for each source content ref:
+
+1. Read the source `Content` object. If it carries `DataInlineB64`, the payload
+   is inline and no chunk work is needed.
+2. Otherwise, for each source chunk ref in order: if it is in the remap table,
+   reuse the mapping. Else read the chunk plaintext through the source stack,
+   compute the destination ref (`HMAC(destDedupKey, plaintext)`, or
+   `SHA256(plaintext)` for an unencrypted destination), `Put` it through the
+   destination stack — which is already put-if-missing — and record the mapping.
+3. Build the destination `Content` with the remapped chunk list, preserving
+   `Size` and the inline payload, and write it. Its ref is
+   `HMAC(destDedupKey, SHA256(stream))`, so the source's recorded stream hash is
+   reused directly and the plaintext need not be re-hashed end to end.
+
+**Deduplication against pre-existing destination data follows from this**, and
+only from this: identical plaintext yields identical boundaries and therefore
+identical destination refs, so a chunk already present in the destination is
+recognised and skipped. This is the load-bearing assumption of §7 and it is
+worth stating as a maintenance constraint: *if the CDC parameters are ever
+changed, copy's boundary reuse stops matching freshly-backed-up data in the
+destination, and copy must gain a re-chunking mode.* A test should pin the
+parameters against this RFC.
+
+#### 4.4 Locking
+
+Copy acquires a **shared** repository lock on the source, then a shared lock on
+the destination (`internal/engine/repolock.go`), and holds both for the
+duration.
+
+- The source lock stops a concurrent `prune`/`forget` from collecting objects
+  out from under an in-flight walk.
+- The destination lock stops a concurrent `prune` from collecting objects copy
+  has written but not yet made reachable from a snapshot.
+- Shared locks do not exclude one another, so two copies in opposite directions
+  between the same pair of repositories cannot deadlock on the acquisition
+  order.
+- The existing lost-lock behavior applies to both: if the refresh goroutine can
+  no longer prove ownership of *either* lock, the operation context is
+  cancelled and copy aborts rather than continue writing.
+
+#### 4.5 Snapshot metadata: what is preserved and what is not
+
+| Field | Treatment |
+|-------|-----------|
+| `Created` | preserved verbatim — the point of the feature |
+| `Source` | preserved verbatim |
+| `Tags` | preserved verbatim |
+| `Meta` | preserved, plus reserved provenance keys (§5) |
+| `ChangeToken` | preserved (see caveat below) |
+| `ExcludeHash` | preserved |
+| `Version` | preserved |
+| `Root` | **rewritten** — destination HAMT root |
+| `Seq` | **reassigned** — see below |
+
+`Seq` cannot be preserved. It is a *global, monotonic write counter* allocated
+from `resolveLatest` at backup time (`internal/engine/backup.go`), not a
+per-source or per-snapshot identity, so a source `Seq` would collide with
+destination history the moment the destination is not empty. Copied snapshots
+are allocated fresh `Seq` values, increasing in the §4.1 order.
+
+The consequence must be stated plainly because it is invisible otherwise:
+**`Seq` records write order, and copy writes old snapshots late.** After a copy,
+the destination's `Seq` ordering no longer agrees with `Created` ordering for
+the copied set. `find` version ordering and `forget`'s latest-selection both
+sort on `Seq` (`internal/engine/find_collect.go`, `internal/engine/forget.go`),
+so a copy that dumps a decade of history into a live repository would otherwise
+make the oldest imported snapshot outrank everything already there.
+
+**Caveat on `ChangeToken`.** A change token is a delta cursor for the *data
+source* (Google Drive, OneDrive), not for the repository, so preserving it is
+correct for a full copy. For a *filtered* copy it is not: the destination's
+newest snapshot for that source identity would carry a token whose delta assumes
+history that was not copied, and a subsequent `backup` against the destination
+would build an incremental on a chain with holes. Copy therefore **clears
+`ChangeToken` on the newest copied snapshot per source identity whenever the
+selection was filtered** (anything other than "all snapshots for that identity"),
+forcing the next backup to do a full walk. Correctness over a saved rescan.
+
+#### 4.6 `index/snapshots` and `index/latest`
+
+The catalog is updated per snapshot, as backup does, so an interrupted run
+leaves every completed snapshot listable.
+
+`index/latest` is reconciled once, **after** the run, and this is the one place
+copy deliberately departs from the repository's "highest `Seq` wins" rule.
+Applying that rule literally would repoint `index/latest` at whichever snapshot
+copy happened to write last — which, under §4.1 ordering, is the newest of the
+*copied* set, and may still be years older than what the destination already
+had.
+
+The rule is therefore: after the run, `index/latest` points at the copied
+snapshot with the greatest `Created` **only if** that is newer than the
+`Created` of the current latest. Otherwise `index/latest` is left alone. A copy
+into an empty repository trivially sets it; a copy of old history into a live
+repository leaves the live head in place.
+
+### 5. Snapshot identity, provenance, and idempotency
+
+Repeated copy runs must skip snapshots already copied, without re-reading their
+data.
+
+#### 5.1 Repository identity
+
+`core.RepoConfig` has no repository ID today. This RFC adds one:
+
+```go
+type RepoConfig struct {
+    Version   int    `json:"version"`
+    Created   string `json:"created"`
+    Encrypted bool   `json:"encrypted"`
+    ID        string `json:"id,omitempty"` // 128-bit random, hex
 }
 ```
 
-Skip rule:
+Written by `init`. **This is not a format-version bump.** The marker is a JSON
+object decoded with `json.Unmarshal` and is not content-addressed, so an older
+build ignores the field and is unaffected — the two conditions
+`docs/compatibility.md` requires for a silent addition. (Note that the marker is
+*sealed* with the repository key for an encrypted repository, not plaintext, as
+`internal/repoconfig` describes. That is orthogonal: sealing covers whatever
+JSON is inside, so the added field is protected automatically, and copy holds
+the source key anyway.)
 
-- before copying a source snapshot, scan the destination snapshot catalog for a
-  snapshot whose provenance matches the same `(source repository, source
-  snapshot ref)`
+**Repositories created before this** have no `id`, and copy must not write to
+the source to give them one (§Non-goals — read-only source credentials are a
+supported configuration). For those, the repo-id component of provenance is
+recorded as **empty**, and the skip rule matches on the source snapshot ref
+alone.
 
-If found:
+There is deliberately **no derived fallback identity**. The obvious candidate —
+hashing the stored marker — is unstable: for an encrypted repository the marker
+is resealed with a fresh nonce every time `UpgradeRepoFormat` stamps a version,
+so the derived id would change after the first `backup`, `prune` or `forget`
+following an upgrade, and copy would re-import the entire history. Hashing the
+decoded fields is no better, since `Version` moves on upgrade and `Created` is
+reset by `init --adopt`. An unstable provenance key is strictly worse than none:
+it fails by silently duplicating history rather than by declining to skip.
 
-- print a skip message
-- do not rewrite the snapshot again
+Matching on the snapshot ref alone is sound for encrypted repositories: source
+snapshot refs are content-addressed under the source master key, so a collision
+between two *different* repositories requires a shared master key **and**
+identical content **and** identical `Seq` and `Created` — at which point the two
+snapshots genuinely are the same snapshot and skipping is correct. For
+unencrypted repositories the refs are plain SHA-256, and a same-content,
+same-seq, same-second collision between two unrelated legacy repositories is
+possible in principle. Copy prints a one-line warning when the source has no
+`id`, naming `-allow-ambiguous-provenance` for the case where a user knowingly
+copies from two legacy unencrypted repositories into one destination.
 
-This is stronger than trying to infer equivalence from timestamp, source, tags,
-and path metadata.
+#### 5.2 Where provenance lives
 
-Open question:
+Provenance is recorded in the **existing `Snapshot.Meta` map**, under a reserved
+namespace:
 
-- whether Cloudstic currently has a stable repository ID suitable for this
-  provenance key, or whether v1 should derive one from `config`
+```json
+{
+  "meta": {
+    "cloudstic.copy.from_repo": "9f2c…",
+    "cloudstic.copy.from_snapshot": "snapshot/410b18a2…"
+  }
+}
+```
 
-### 6. Encryption and bandwidth behavior
+`Meta` rather than a new `Snapshot` field, for two reasons. First, `Snapshot` is
+content-addressed through `ComputeJSONHash`, which marshals struct fields in
+declaration order, so adding a field is a repository-format change; `Meta` is an
+existing `map[string]string` and `encoding/json` sorts map keys, so it stays
+canonical for free. Second, `Snapshot.Extra` — which the original draft's
+compatibility section was written against — does not exist.
 
-`copy` must be explicit that it is expensive compared with normal incremental
-backup.
+Because `Meta` is writable by users through `WithMeta(key, value)` on backup,
+**the `cloudstic.` prefix is reserved**: `WithMeta` rejects keys under it, and
+copy refuses to run if a *source* snapshot carries reserved keys it did not
+write (which would mean copying an already-copied snapshot's provenance
+onward — see §5.4).
 
-Important properties:
+#### 5.3 Making the skip check cheap
 
-- source repository objects must be fully read and decrypted
-- destination repository objects must be fully re-encrypted and written
-- this can incur substantial bandwidth and API cost
-- small metadata objects may be repacked differently in the destination because
-  packfiles are repository-local
+Provenance in `Meta` alone is not enough, because the skip scan runs against
+`index/snapshots`, and `core.SnapshotSummary` carries no `Meta`. Scanning
+provenance would mean fetching every destination snapshot object on every run —
+precisely the cost the catalog exists to avoid.
 
-### 7. Deduplication expectations
+So provenance is **denormalized into the catalog**:
 
-Re-encryption does not by itself prevent deduplication in the destination
+```go
+type SnapshotSummary struct {
+    // … existing fields …
+    CopiedFrom string `json:"copied_from,omitempty"` // "<repo-id>:<snapshot-ref>"
+}
+```
+
+`omitempty` means non-copied snapshots add zero bytes and existing catalogs are
+unchanged. The authoritative copy stays in `Snapshot.Meta`; the summary field is
+a cache, and the catalog's existing self-healing reconciliation with
+`LIST snapshot/` can rebuild it from the snapshot object.
+
+**What older builds do with this** (required by `docs/compatibility.md`): they
+ignore `copied_from` on read. If an older build *rebuilds* the catalog, it drops
+the field, and a later copy run would re-copy those snapshots — duplicated
+history, not corruption. To bound that, the skip check falls back to loading the
+snapshot object and reading `Meta` **only** for summaries that lack
+`copied_from` but match a candidate on `Created` and `Source`. That keeps the
+common case at zero extra fetches and makes the degraded case correct rather
+than merely cheap.
+
+No format-version bump: an added `omitempty` field on a rebuildable,
+non-content-addressed catalog is readable by every earlier build, and the
+degradation above is safe.
+
+#### 5.4 Skip rule
+
+Before copying a source snapshot, look for a destination snapshot whose
+provenance matches the source snapshot. If found, print a skip line and do not
+re-read the source snapshot's data.
+
+**Matching is on the snapshot ref, with the repo id as a disqualifier rather
+than as half of a compound key.** Two provenances match when their snapshot refs
+are equal *and* their repo ids do not conflict — where two non-empty, unequal
+ids conflict, and an empty id on either side means "unknown" and does not.
+
+The asymmetry is not a convenience. An older build that rewrites the repository
+marker **drops `RepoConfig.ID`**, because it decodes the marker into its own
+three-field struct and re-encodes it. This is verified, not inferred: a v1.18.0
+`backup` against a format-1 repository upgrades it to format 2 and writes back
+`{"version":2,"created":…,"encrypted":false}`, with the id gone. A strict
+`(id, ref)` key would then treat every already-copied snapshot as unseen and
+re-import the entire history. Treating an unknown id as unknown reduces that to
+what it actually is — missing information — and the residual collision risk is
+exactly the one §5.1 already accepts for legacy sources.
+
+Copy is **not transitive**: copying an already-copied snapshot onward would
+require deciding whether provenance names the original or the intermediate
+repository. v1 records the *immediate* source and refuses to run when a source
+snapshot carries reserved `cloudstic.copy.*` keys, with an error pointing at
+`-allow-copied`, which opts into re-stamping provenance to the immediate source.
+
+### 6. Repository format gating
+
+Both repositories are opened through `LoadRepoConfig` (`repo.go`) and gated
+against `core.MaxSupportedRepoFormat`. A source above the gate is **refused**,
+not partially read.
+
+This is the "never treat cannot-decode as empty" rule applied to a new position.
+A copy that read an unreadable source as "no snapshots" would exit 0 having
+migrated nothing, and an operator who then decommissioned the source would have
+destroyed the only copy. The refusal must be loud and must name the source
 repository.
 
-What matters is not whether the copied objects retain their source encrypted
-identities, but whether the destination write path recomputes destination
-logical object identities from the plaintext content.
+Copy never calls `UpgradeRepoFormat` on the source — it performs no writes
+there. The destination is stamped through the ordinary post-write path once the
+run completes successfully.
 
-Expected v1 behavior:
+### 7. Interaction with destination retention
 
-- source objects are decrypted and materialized as logical plaintext payloads
-- destination chunk/content objects are addressed in the destination
-  repository's own dedup/encryption domain
-- if identical plaintext chunks or content objects already exist in the
-  destination repository, the copy should reuse those destination identities
-  naturally
+**This is the sharpest operational edge in the feature and v1 must address it,
+not defer it.**
 
-In other words:
+With "copy everything" as the default and provenance-based skipping, a
+*scheduled* copy — which RFC 0013's daemon makes the obvious deployment —
+resurrects snapshots the destination deliberately forgot. The skip rule only
+matches snapshots that still exist; once destination retention deletes a copied
+snapshot, the next copy run faithfully re-imports it, forever.
 
-- copied data is not expected to retain the same object refs as in the source
-  repository
-- but it should still deduplicate against equivalent data already present in
-  the destination repository, assuming the logical chunk/content structure is
-  the same
+v1 mitigations, in order of preference:
 
-The remaining caveat is about storage-layout parity, not logical dedup:
+1. **`-since <timestamp>`** (§3), the explicit and composable answer: a
+   scheduled copy passes the last run's start time.
+2. **A high-water mark.** Copy records, per source repo id, the greatest
+   source-snapshot `Created` it has successfully copied, in a destination-local
+   `index/copyhigh/<repo-id>` object, and by default does not copy snapshots at
+   or below it. `-ignore-high-water` overrides. This makes the scheduled case
+   correct with no flags, at the cost of one small mutable object per source
+   repository.
+3. Documenting the interaction and leaving it to the operator.
 
-- packfile grouping is repository-local and may differ
-- snapshot objects will differ because they are rewritten in the destination
-  repository
-- indexes and catalogs are destination-local implementation details
+**Recommendation: implement (1) and (2).** (3) alone is how a user ends up with
+a destination whose retention policy visibly does nothing.
 
-So v1 should aim to enable destination-side logical deduplication where
-content matches, but should not guarantee identical storage footprint, object
-naming, or any source-to-destination object-identity equivalence between the
-two repositories.
+Note that the high-water mark is an optimisation layered *over* provenance
+skipping, not a replacement: provenance handles out-of-order and backfill
+copies, the water mark handles the steady state.
 
 ### 8. Resume and interruption behavior
 
-Copying large repositories can take a long time.
+v1 is restart-safe at snapshot granularity.
 
-V1 should be restart-safe at the snapshot level:
+- Objects already written to the destination remain; they are content-addressed
+  and put-if-missing, so a rerun re-derives the same refs and skips them.
+- A completed snapshot has provenance recorded and is skipped on rerun.
+- A partially copied snapshot has no destination snapshot object, so it is
+  retried from scratch — but its already-written chunks, contents, filemetas and
+  nodes are all still present and are recognised, so the retry re-reads the
+  source but re-writes almost nothing.
+- Orphaned objects from an interrupted run are unreachable and are collected by
+  the destination's normal `prune`.
 
-- objects already written to the destination may remain
-- rerunning `copy` should re-check provenance and existing object presence
-- completed snapshots are skipped
-- partially copied snapshots may be retried from scratch
-
-This is sufficient for an initial implementation because Cloudstic already uses
-content-addressed objects and "put if missing" behavior in much of the write
-path.
-
-Fine-grained resumable progress within one snapshot is explicitly not required
-for v1.
+Fine-grained resumable progress within one snapshot is explicitly out of scope.
 
 ### 9. Client API
 
-The client API should follow the existing construction model:
+Copy is exposed as a method on the **destination** client, taking the **source**
+client:
 
 ```go
-client, err := cloudstic.NewClient(ctx, destinationStore, opts...)
+func (c *Client) CopyFrom(ctx context.Context, src *Client, opts ...CopyOption) (*CopyResult, error)
 ```
 
-That means the destination repository is already bound to the `Client`, so the
-copy entrypoint should accept the source store explicitly:
+`CopyFrom` rather than `Copy` because `client.Copy(ctx, other)` does not say
+which direction data flows; `CopyFrom` does.
+
+Taking a `*Client` rather than a bare `store.ObjectStore` is the substantive
+change from the original draft, and it resolves several problems at once:
+
+- **The decorator chain is never composed by a caller.** RFC 0022 made
+  `internal/storelayer` internal precisely because its order is a silent
+  correctness and security invariant — a chain assembled without
+  `WithPackIndexKey` yields a plaintext pack index with no error at any layer. A
+  source `*Client` has already had its chain layered by `NewClient`.
+- **Credentials stay out of the copy option surface.** No `WithFromKeychain`,
+  no second keychain vocabulary; the source client was constructed with
+  `WithKeychain` like any other.
+- **The source is format-gated for free** (§6), because `NewClient` runs
+  `LoadRepoConfig`.
+
+Constructing the two clients is one call each through `pkg/open`, which RFC 0022
+established as the place a configuration becomes a live client:
 
 ```go
-func (c *Client) Copy(ctx context.Context, from store.ObjectStore, opts ...CopyOption) error
-```
-
-At the client layer, repository credentials should remain opaque and reuse the
-existing `keychain.Chain` abstraction rather than exposing password vs
-keychain vs recovery-key detail in the option surface.
-
-That implies:
-
-- destination credentials continue to be supplied when constructing the client
-- source credentials are supplied through `CopyOption`
-
-For example:
-
-```go
-client, err := cloudstic.NewClient(
-    ctx,
-    destinationStore,
-    cloudstic.WithKeychain(keychain.Chain{
-        keychain.WithPassword("destination-password"),
-    }),
-)
+dst, err := open.Client(ctx, dstCfg)   // or open.FromProfile(ctx, path, "remote-prod")
+if err != nil {
+    return err
+}
+src, err := open.FromProfile(ctx, path, "laptop-local")
 if err != nil {
     return err
 }
 
-err = client.Copy(
-    ctx,
-    sourceStore,
-    cloudstic.WithFromKeychain(keychain.Chain{
-        keychain.WithPassword("source-password"),
-    }),
+res, err := dst.CopyFrom(ctx, src,
     cloudstic.WithCopySnapshotIDs("410b18a2", "latest"),
-    cloudstic.WithCopyTag("workstation"),
+    cloudstic.WithCopyFilterTag("workstation"),
+    cloudstic.WithCopyDryRun(),
 )
 ```
 
-Representative option names:
+Option names follow the established convention in `internal/engine` —
+`With<Verb>DryRun` and `WithFilter*` — disambiguated by verb because the
+existing `WithFilterTag` is a `ForgetOption`:
 
-- `WithKeychain(...)` for destination repository credentials on `NewClient`
-- `WithFromKeychain(...)` for source repository credentials on `Copy`
 - `WithCopySnapshotIDs(...)`
-- `WithCopySource(...)`
-- `WithCopyAccount(...)`
-- `WithCopyTag(...)`
+- `WithCopyFilterSource(...)`, `WithCopyFilterAccount(...)`, `WithCopyFilterTag(...)`
+- `WithCopySince(time.Time)`
+- `WithCopyDryRun()`
+- `WithCopyAllowCopied()`, `WithCopyIgnoreHighWater()`
 
-The exact credential material inside each `keychain.Chain` is intentionally not
-part of the copy API contract. Callers may provide passwords, recovery keys,
-platform keys, or other supported credentials the same way they do elsewhere.
+Per RFC 0022, every exported `With*` in `internal/engine` must be mirrored at
+the root package (`TestEveryEngineOptionIsReExported`), and `CopyResult` must be
+re-exported as a type alias (`TestPublicAPIHasNoUnaliasedInternalTypes`).
 
-This keeps repository migration aligned with the current client API design
-instead of introducing a one-off `CopyOptions` struct, duplicating store
-construction inside copy options, or leaking secret-ref transport details into
-the library surface.
+`CopyFrom` returns a `*CopyResult`, not a bare `error`: every other `Client`
+operation returns a result value, and §10's counts have to live somewhere.
+
+```go
+type CopyResult struct {
+    Copied  []CopiedSnapshot // source ref, destination ref, created, source info
+    Skipped []SkippedSnapshot // source ref, destination ref, reason
+    BytesRead    int64
+    BytesWritten int64
+    DryRun  bool
+}
+```
 
 ### 10. Progress and output
 
-The command should report progress at snapshot granularity first:
+Progress is reported at snapshot granularity, with byte progress within a
+snapshot where the reporter supports it.
 
-- source snapshot being copied
-- whether it is skipped or copied
-- counts of copied/skipped snapshots
+Written bytes come free from the destination's `MeteredStore`. **Read bytes do
+not** — `MeteredStore` tracks `bytesWritten` only
+(`internal/storelayer/metered.go`), so copy either counts plaintext through its
+own walk or `MeteredStore` gains a read counter. Counting in the copy engine is
+preferable: it measures the plaintext copy actually materialised rather than
+whatever the layer below happened to fetch, which is the number an operator
+comparing against their egress bill wants.
 
-If practical, object and byte progress may be added later, but snapshot-level
-output is the minimum useful UX.
-
-Example:
+Before the first write, copy prints both repository identities — the security
+section's blast-radius concern is answered by making the destination impossible
+to miss:
 
 ```text
+copying from local:/tmp/cloudstic-src (repo 9f2c1a…)
+            to s3:dest-bucket/prod    (repo 41ba07…)
+3 snapshots selected, 1 already copied
+
 snapshot 410b18a2 of [local:./Documents] at 2026-04-01 20:15:03 +0200
   copy started, this may take a while...
 snapshot a1b2c3d4 saved
 
 snapshot 4e5d5487 of [local:./Documents] at 2026-03-30 18:22:11 +0200
 skipping snapshot 4e5d5487, already copied as snapshot e5f6a7b8
+
+copied 2 snapshots, skipped 1 (read 4.2 GiB, wrote 1.1 GiB)
 ```
+
+`-json` emits the `CopyResult` on stdout, as other commands do.
+
+`-dry-run` is **in v1**, not deferred. The original draft left it as an open
+question while simultaneously arguing in its security section that copy "can
+write substantial history into the wrong destination repository". Those two
+positions are incompatible, and every comparable operation already has one
+(`WithBackupDryRun`, `WithForgetDryRun`, `WithPruneDryRun`, `WithRestoreDryRun`).
+A dry run resolves selection, performs the provenance skip check, and reports
+what would be copied without writing.
+
+### 11. Guards
+
+- **Same repository.** If source and destination resolve to the same repository
+  id (or, for legacy repositories, the same store URI and prefix), copy refuses.
+- **Uninitialized destination.** Refuse, pointing at `cloudstic init`.
+- **Empty selection.** Exit 0 with an explicit "no snapshots selected" line, not
+  silently.
 
 ## Compatibility
 
-This feature is additive.
+The feature is additive. Existing repositories remain valid and existing
+commands are unchanged. Copied snapshots are ordinary destination snapshots
+afterwards — listable, diffable, restorable, and subject to retention.
 
-- existing repositories remain valid
-- existing commands are unchanged
-- copied snapshots remain ordinary destination snapshots after the operation
+Three on-disk additions, none of which bump `core.RepoFormatVersion`:
 
-Compatibility caveat:
+| Addition | Older builds | Why no bump |
+|----------|--------------|-------------|
+| `RepoConfig.ID` | ignore it on read; **drop it** when they rewrite the marker | marker is JSON, not content-addressed; sealing covers it automatically |
+| `SnapshotSummary.CopiedFrom` | ignore the field; a rebuild drops it | `index/snapshots` is a rebuildable cache; §5.3 specifies the safe degradation |
+| `Snapshot.Meta["cloudstic.copy.*"]` | ignore the keys | `Meta` already exists; map keys are sorted by `encoding/json`, so the hash stays canonical |
 
-- if provenance metadata is added to `Snapshot.Extra` or a new optional field,
-  older clients must tolerate it as an unknown field
+Per `docs/compatibility.md`, the claim that older builds cope must be **verified
+by running an old binary**, not reasoned about, and a fixture repository
+containing copied snapshots should be committed to `e2e/testdata` and listed in
+the compatibility doc's table.
+
+Results of that verification against `v1.18.0`, the last release predating these
+fields:
+
+- `list`, `ls`, `check` and `backup` all operate normally on a repository whose
+  marker carries an `id`. A write that does not rewrite the marker leaves the
+  id intact.
+- A write that **does** rewrite the marker — a format-1 repository upgraded to
+  format 2 — silently drops the `id`. This is why §5.4 matches on the snapshot
+  ref and treats an unknown id as unknown rather than as a distinct value. With
+  a strict compound key the same scenario would re-import an entire history.
+- The catalog field degrades the same way and is recovered on the next rebuild
+  (§5.3).
+
+None of these is a misread, so the version gate stays where it is. The
+`internal/core` forward-compatibility tests pin the wire shapes so that a future
+edit has to face this question deliberately.
 
 ## Security considerations
 
-- `copy` requires access to unlock both source and destination repositories.
-- Source and destination credentials must remain strictly separated in CLI
-  parsing, logs, and config handling.
-- Error messages must not leak source or destination secrets.
-- The command increases blast radius for operator mistakes because it can write
-  substantial history into the wrong destination repository; destination
-  identification should therefore be printed clearly before writes begin.
+- Copy requires the ability to unlock both repositories.
+- Source and destination credentials are strictly separated in parsing: they
+  bind to different structs, and the `-from-*` mirrors carry no environment
+  bindings (§2), so no ambient variable can silently unlock both.
+- Every `-from-*` credential flag inherits `asSecret()` from the spec it
+  mirrors, so `TestSecretEnvValuesNeverAppearInHelp` covers them and no live
+  value reaches `-h`.
+- Error messages must name *which* repository failed without echoing
+  credentials.
+- Copy holds plaintext for both repositories in one process. That is inherent —
+  §4 requires materialising plaintext to re-address it — and is the same
+  exposure as `restore`, but it is worth stating that a copy is not a
+  zero-knowledge operation and cannot be delegated to a party trusted with
+  neither key.
+- Blast radius is addressed by §10's pre-write identity banner and §11's
+  same-repository and uninitialized-destination guards.
 
 ## Testing strategy
 
-- Unit tests for source/destination flag parsing and validation.
-- Unit tests for snapshot provenance matching and skip behavior.
-- Hermetic e2e tests copying between:
-  - local -> local
-  - local -> MinIO
-  - MinIO -> local
-  - SFTP -> local where supported in the existing matrix
-- E2E tests for:
-  - copy all snapshots
-  - filtered copy by source/tag/account
-  - explicit snapshot selection
-  - rerun idempotency (already copied snapshots are skipped)
-  - interrupted copy followed by rerun
-- Compatibility tests ensuring copied snapshots are listable, diffable, and
-  restorable in the destination repository.
+Unit:
+
+- `-from-*` flag generation: `TestCopyMirrorsEveryRepositoryFlag` asserts every
+  spec in `repoCommandGroups` has a `from-` mirror, and that no mirror carries
+  an environment binding.
+- Provenance matching and skip behavior, including the §5.3 fallback path when
+  `copied_from` is absent from a summary.
+- `Seq` reassignment and the §4.6 `index/latest` rule, including the case where
+  the destination's existing head is newer than everything copied.
+- Selection: explicit IDs, filters, `-since`, `latest`, empty selection.
+- Guards (§11).
+
+Golden:
+
+- `copy -h`, and the §10 progress output.
+
+Hermetic e2e:
+
+- local → local, local → MinIO, MinIO → local, SFTP → local.
+- unencrypted → encrypted, encrypted → unencrypted, and encrypted → encrypted
+  with **different** master keys — this is the case that proves the ref
+  cascade is handled rather than accidentally passed through.
+- copy all; filtered by source/tag/account; explicit selection.
+- rerun idempotency: a second identical run copies nothing and issues no `Get`
+  against source chunk data (assert on a counting store wrapper, not just on
+  output text).
+- interrupted copy followed by rerun: the retry writes substantially fewer
+  bytes than the original — measurable directly on the destination
+  `MeteredStore` — proving §8's object reuse.
+- copy of N snapshots of a mostly-static tree writes O(tree), not O(tree × N) —
+  the §4.2 remap-table property, which is the one performance claim that will
+  silently regress.
+- destination `check` (including `-read-data`) passes after copy. This is a
+  stronger assertion than "listable, diffable, restorable" for an operation
+  that rewrites the entire graph, and it is the one the original draft omitted.
+- `backup` against the destination after a *filtered* copy does a full walk
+  (§4.5 `ChangeToken` clearing).
+- copy from a committed legacy-format fixture repository.
 
 ## Rollout plan
 
-1. Add RFC and CLI/API surface design.
-2. Implement source repository config parsing and validation.
-3. Implement snapshot selection and provenance-aware skip logic.
-4. Implement logical object graph copy between repositories.
-5. Add hermetic e2e migration tests.
-6. Document operational caveats, especially bandwidth and dedup expectations.
+1. Add `RepoConfig.ID` and `SnapshotSummary.CopiedFrom`, with the
+   compatibility fixtures and the old-binary verification.
+2. Add the `-from-*` flag mirroring mechanism and source configuration
+   resolution through `pkg/config` / `pkg/open`.
+3. Implement snapshot selection, provenance skip, and the high-water mark.
+4. Implement the bottom-up graph rebuild (§4), remap table, and locking.
+5. Add `CopyFrom` to the client, mirror the options, add the type aliases.
+6. Add hermetic e2e migration tests.
+7. Documentation: `docs/user-guide.md` command reference; `docs/storage-model.md`
+   note on cross-repository re-addressing; `docs/compatibility.md` fixture table
+   row; regenerate `testdata/usage_root.golden` and `testdata/help_copy.golden`;
+   confirm the completion generators picked up the mirrored flags
+   (`TestCompletionCoversEveryCommandFlag`). Pair with a `Cloudstic/doc` update
+   so `internal/apicheck/docs_test.go` stays green on the new public API.
 
 ## Open questions
 
-- Should the command be named `copy`, `migrate`, or `replicate`?
-  Recommendation: `copy`, because it is direct and consistent with other tools like restic.
-- Should provenance live in a dedicated snapshot field or under extensible
-  extra metadata?
-- Should v1 support destination-side filtering to avoid importing snapshots that
-  would conflict with existing retention policies?
-- Should `copy` support `--dry-run` in v1, or can that wait until the command
-  shape is stable?
+- **Naming.** `copy` remains the recommendation: it matches restic's
+  `copy --from-repo`, which is the tool most users will be migrating from or
+  comparing against, and `migrate` wrongly implies the source is decommissioned
+  while `replicate` implies an ongoing relationship the feature does not
+  maintain.
+- **High-water mark storage.** §7 proposes `index/copyhigh/<repo-id>`. Should
+  this instead live in the destination's `config`, or be derived at read time
+  as `max(Created)` over destination snapshots carrying provenance from that
+  repo id? The derived form needs no new object and no new format surface, at
+  the cost of a full catalog scan — which §5.3 already performs. **Deriving it
+  is probably right**; the object is listed as the proposal only because it
+  survives destination retention deleting every copied snapshot.
+- **Should copy ever be transitive?** §5.4 refuses by default. If A → B → C
+  becomes a real topology, provenance needs to become a chain rather than a
+  pair, which is a format decision better made with a concrete use case.
+- **Parallelism.** Copy is embarrassingly parallel at the file level and
+  bottlenecked on two networks at once. v1 can ship serial, but the
+  `ConcurrencyHinter` capability on both stores is the obvious input and the
+  option should be reserved now.
+
+## Revision notes (2026-08-03)
+
+The original draft predates RFC 0018 and RFC 0022 and described flags, types and
+an API surface that do not exist. Corrections, and the design changes that
+followed from them:
+
+- **`-store-ref` does not exist.** The repository is located with `-store` or
+  `-profile`. Every example is rebased, and §2 replaces the hand-written
+  25-flag mirror list with generation from the existing flag groups — the
+  original list already omitted `-b2-key-id`, `-b2-app-key` and
+  `-disable-packfile`. The `-from-*-secret` flags are dropped: they had no
+  global destination counterpart to mirror.
+- **`Snapshot.Extra` does not exist.** Provenance moves to the existing
+  `Snapshot.Meta` map, which also avoids a content-addressing format change
+  (§5.2), and the `cloudstic.` key prefix becomes reserved because `Meta` is
+  user-writable through `WithMeta`.
+- **The skip rule could not use the catalog it named.** `SnapshotSummary`
+  carries no `Meta`, so the original §5 implied fetching every destination
+  snapshot object per run. §5.3 denormalizes provenance into the summary and
+  specifies the degraded path.
+- **There is no repository ID.** Promoted from an open question to a specified
+  addition (§5.1). Legacy repositories get no derived fallback identity: the
+  marker is resealed with a fresh nonce on every format stamp, so any hash of it
+  is unstable, and an unstable provenance key duplicates history rather than
+  failing to skip. Provenance degrades to matching the source snapshot ref
+  alone, which §5.1 shows is sound for encrypted repositories.
+- **§4 described a transfer, not a rebuild.** Object refs cascade off the master
+  key at every level, so nothing can be copied verbatim. §4 now specifies the
+  bottom-up rebuild, the per-run remap table (without which cost is
+  O(tree × snapshots)), and boundary reuse instead of re-chunking.
+- **`Seq` and `index/latest` were unaddressed.** `Seq` is a global write
+  counter, and `index/latest` resolves by highest `Seq` — so the original step 7
+  would have repointed the destination head at the oldest imported snapshot.
+  §4.5 and §4.6 specify reassignment, ordering, and the one deliberate departure
+  from the `Seq` rule.
+- **Locking and source format gating were absent** (§4.4, §6).
+- **§9 takes a `*Client`, not a `store.ObjectStore`.** A bare backend would
+  force callers to compose `internal/storelayer` themselves, which RFC 0022 made
+  internal precisely because getting the order wrong fails silently. This also
+  removes `WithFromKeychain` and gives source format gating for free. `Copy`
+  becomes `CopyFrom` and returns a `*CopyResult` like every other operation, and
+  option names follow the existing `WithFilter*` / `With<Verb>DryRun`
+  convention.
+- **`-dry-run` moves into v1**, since the security section already argued for
+  it, and destination-retention conflict (§7) is promoted from an open question
+  to a specified mitigation — it is a correctness trap for scheduled copies, not
+  a nicety.
+- **`ChangeToken` handling on filtered copies** (§4.5) and the transitive-copy
+  refusal (§5.4) are new; both were unstated gaps rather than errors.


### PR DESCRIPTION
## Summary

Revises RFC 0017 to match the codebase as it stands after RFC 0018 and RFC 0022, then implements the first step of its rollout plan: the on-disk additions `copy` needs to tell repositories apart and to know what it has already copied.

**RFC revision.** The original draft specified flags, types and an API surface that do not exist — `-store-ref` was never a flag, `Snapshot.Extra` was never a field, and the skip rule read provenance out of a catalog that does not carry it. Beyond the corrections, it now specifies what it previously left as prose: the bottom-up rebuild with a ref-remap table (object refs cascade off the master key, so a copy is a rebuild and not a transfer), `Seq` reassignment and the `index/latest` rule, locking on both repositories, source version gating, and a `*Client`-based API so callers never compose the `storelayer` chain themselves. `-dry-run` and the destination-retention conflict move into v1.

**Implementation.** Neither addition raises `core.RepoFormatVersion`; both are ignored by older builds.

- `RepoConfig.ID`, assigned by `init`. Adopting an existing repository carries the stored id forward — a fresh one would make every snapshot already copied out of it look unrelated. The id is random rather than derived because every derivable candidate moves: the sealed marker is re-encrypted with a fresh nonce on each `UpgradeRepoFormat`, `Version` moves on upgrade, `Created` is reset by adopt. An unstable provenance key is worse than none, so legacy repositories simply have none.
- `core.CopyProvenance`, recorded in the existing `Snapshot.Meta` map rather than in a new `Snapshot` field, which would rewrite every snapshot hash (`ComputeJSONHash` marshals in declaration order).
- `SnapshotSummary.CopiedFrom`, denormalizing provenance into `index/snapshots` so the skip check need not fetch every destination snapshot object. Derived inside `snapshotToSummary`, which is also the catalog's rebuild path, so a dropped value is recovered on the next reconciliation.
- The `cloudstic.` metadata namespace is reserved and closed where user metadata enters: `backup` rejects reserved `-meta` keys. Provenance is what `copy` trusts to decide it has already copied a snapshot, so a forgeable entry is one `copy` silently skips having never copied it.

Part of RFC 0017.

## Reviewer notes

**The old-binary check found a real problem, and it changed the design.** Built `v1.18.0` and ran it against a repository written by this build. `list`, `ls`, `check` and `backup` all behave, and the id survives an ordinary write — but a write that *rewrites* the marker (a format-1 repository upgraded to format 2) **drops `RepoConfig.ID`**, since the older build decodes into its own three-field struct and re-encodes.

Under a strict `(repo id, snapshot ref)` provenance key, one old binary touching the source would make `copy` re-import an entire history. So matching is on the snapshot ref, with the repo id able only to disqualify: two non-empty unequal ids never match, but an empty id on either side means *unknown*, not *different*. The residual collision risk is the one §5.1 already accepts for legacy sources, and is nil for encrypted ones, whose snapshot refs are content-addressed under the master key.

**Deliberately not included:** a fixture repository containing copied snapshots. Nothing can produce one until `copy` itself exists, so it belongs with rollout step 4. What could be pinned now is pinned as permanent tests — `internal/core/compat_forward_test.go` declares the v1.18.0 wire shapes verbatim so a later edit has to face the version-gate question deliberately.

## Verification

- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./...`
- `env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./internal/core ./internal/engine`
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./internal/core/... ./internal/engine/...`
- `npx markdownlint-cli2 rfcs/0017-snapshot-copy-between-repositories.md`
- Manual forward-compatibility run of a `v1.18.0` binary against a repository written by this build, as described above.