### PR TITLE
feat: copy snapshots between repositories (RFC 0017)

### DIFF
--- a/cmd/cloudstic/client_iface.go
+++ b/cmd/cloudstic/client_iface.go
@@ -23,4 +23,5 @@ type cloudsticClient interface {
 	Check(ctx context.Context, opts ...cloudstic.CheckOption) (*cloudstic.CheckResult, error)
 	Cat(ctx context.Context, keys ...string) ([]*cloudstic.CatResult, error)
 	BreakLock(ctx context.Context) ([]*cloudstic.RepoLock, error)
+	CopyFrom(ctx context.Context, src *cloudstic.Client, opts ...cloudstic.CopyOption) (*cloudstic.CopyResult, error)
 }

--- a/cmd/cloudstic/cmd_copy.go
+++ b/cmd/cloudstic/cmd_copy.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	cloudstic "github.com/cloudstic/cli"
+	"github.com/cloudstic/cli/pkg/config"
+)
+
+// fromFlagPrefix distinguishes the source repository's flags from the
+// destination's. Destination flags keep their ordinary names, so every other
+// command's spelling carries over unchanged.
+const fromFlagPrefix = "from-"
+
+type copyArgs struct {
+	*globalFlags
+
+	// from holds the source repository's parsed flags. It is a second
+	// globalFlags rather than a bespoke struct so that resolveClientConfig,
+	// profile resolution and store construction all work on it unchanged.
+	from *globalFlags
+
+	dryRun          bool
+	allowCopied     bool
+	rawFilterSource string
+	filterSource    string
+	filterPath      string
+	filterAccount   string
+	filterTags      stringArrayFlags
+	since           string
+	sinceTime       time.Time
+	snapshotIDs     []string
+}
+
+// copyFromFlagSpecs derives the source repository's flags from the same groups
+// that describe the destination's.
+//
+// Deriving rather than restating is what keeps the two sets from drifting: a
+// repository flag added later is mirrored with no edit here. prefixed also
+// strips the environment bindings, so an ambient CLOUDSTIC_* value configures
+// the destination only and can never silently unlock both repositories.
+func copyFromFlagSpecs(from *globalFlags) []flagSpec {
+	var specs []flagSpec
+	for _, group := range []flagGroup{repoFlagSpecs, storeSFTPFlagSpecs, encryptionFlagSpecs} {
+		specs = append(specs, prefixed(fromFlagPrefix, "source repository", group(from))...)
+	}
+
+	// One profiles file serves both repositories. Mirroring it would offer a
+	// second file that no configuration needs, and its default is a path inside
+	// -config-dir, which is not mirrored either.
+	out := specs[:0]
+	for _, spec := range specs {
+		if spec.name == fromFlagPrefix+"profiles-file" {
+			continue
+		}
+		out = append(out, spec)
+	}
+	return out
+}
+
+func declareCopyArgs(g *globalFlags) (*copyArgs, commandInput) {
+	a := &copyArgs{globalFlags: g, from: &globalFlags{}}
+
+	flags := []flagSpec{
+		boolFlag(&a.dryRun, "dry-run", false, "Only show which snapshots would be copied"),
+		stringFlag(&a.rawFilterSource, "source", "", "Copy only snapshots of this source URI (e.g. local:./docs, gdrive)",
+			withPlaceholder("<uri>"), withCompleter("_cloudstic_source_prefixes"),
+			withShortUsage("Copy only snapshots of this source")),
+		stringFlag(&a.filterAccount, "account", "", "Copy only snapshots of this account", withPlaceholder("<id>")),
+		valueFlag(&a.filterTags, "tag", "Copy only snapshots carrying this tag (can be specified multiple times)",
+			withPlaceholder("<tag>"), asRepeatable(), withShortUsage("Copy only snapshots with this tag")),
+		stringFlag(&a.since, "since", "", "Copy only snapshots created at or after this time (RFC3339 or YYYY-MM-DD)",
+			withPlaceholder("<time>"), withShortUsage("Copy only snapshots newer than this")),
+		boolFlag(&a.allowCopied, "allow-copied", false,
+			"Allow copying snapshots that were themselves produced by copy"),
+	}
+	flags = append(flags, copyFromFlagSpecs(a.from)...)
+
+	return a, commandInput{
+		flags:       flags,
+		positionals: []positionalSpec{remainingPositionals(&a.snapshotIDs, "snapshot ID")},
+	}
+}
+
+func copyCommand() command {
+	return repoLeaf("copy",
+		"Copy snapshots from another repository into this one",
+		repoCommandGroups, declareCopyArgs, runCopy)
+}
+
+// prepareCopyArgs derives everything that depends on more than one flag, and
+// settles what the source repository inherits from the destination's
+// invocation.
+func prepareCopyArgs(a *copyArgs) error {
+	if a.rawFilterSource != "" {
+		switch a.rawFilterSource {
+		case "local", "sftp", "gdrive", "gdrive-changes", "onedrive", "onedrive-changes":
+			a.filterSource = a.rawFilterSource
+		default:
+			parts, err := config.ParseSourceURI(a.rawFilterSource)
+			if err != nil {
+				return fmt.Errorf("invalid -source filter: %w", err)
+			}
+			a.filterSource = parts.Scheme
+			a.filterPath = parts.Path
+		}
+	}
+
+	if a.since != "" {
+		parsed, err := parseSinceTime(a.since)
+		if err != nil {
+			return err
+		}
+		a.sinceTime = parsed
+	}
+
+	// Profile resolution asks whether a field was set explicitly, and the
+	// source's flags are recorded under their prefixed names. Translating the
+	// map lets the source reuse the same precedence rules as any other command
+	// rather than a parallel implementation of them.
+	fromOrigins := strippedOrigins(a.origins, fromFlagPrefix)
+
+	// The source must be named, and naming it means passing the flag — not
+	// leaving it at a default. -store defaults to a local path, which is
+	// reasonable for the one repository a command usually has and actively
+	// dangerous for the second: a bare `cloudstic copy` would otherwise read
+	// whatever happens to sit in ./backup_store rather than saying nothing was
+	// specified. There is no environment fallback to consider, because the
+	// mirrored flags deliberately have none.
+	if fromOrigins["store"] != originFlag && a.from.profile == "" {
+		return fmt.Errorf("specify the source repository with -from-store or -from-profile")
+	}
+
+	// The source is a second repository, not a second invocation: it shares
+	// where configuration lives and how output is rendered, and differs only in
+	// where it points and how it unlocks. Nothing credential-bearing is copied
+	// across, which is the whole point of keeping the two structs apart.
+	a.from.configDir = a.configDir
+	a.from.profilesFile = a.profilesFile
+	a.from.noPrompt = a.noPrompt
+	a.from.quiet = a.quiet
+	a.from.verbose = a.verbose
+	a.from.debug = a.debug
+	a.from.json = a.json
+
+	a.from.origins = fromOrigins
+	return nil
+}
+
+// strippedOrigins re-keys the flag provenance recorded for prefixed flags back
+// onto the names the resolution code knows.
+func strippedOrigins(origins map[string]flagOrigin, prefix string) map[string]flagOrigin {
+	out := make(map[string]flagOrigin, len(origins))
+	for name, origin := range origins {
+		if len(name) > len(prefix) && name[:len(prefix)] == prefix {
+			out[name[len(prefix):]] = origin
+		}
+	}
+	return out
+}
+
+// parseSinceTime accepts a full RFC3339 timestamp or a bare date, which is what
+// a person actually types.
+func parseSinceTime(raw string) (time.Time, error) {
+	for _, layout := range []string{time.RFC3339, "2006-01-02T15:04:05", "2006-01-02"} {
+		if t, err := time.Parse(layout, raw); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("invalid -since %q: use RFC3339 (2026-04-01T20:15:03Z) or a date (2026-04-01)", raw)
+}
+
+func runCopy(r *runner, ctx context.Context, a *copyArgs, cfg clientConfig) int {
+	if err := prepareCopyArgs(a); err != nil {
+		return r.fail("Error: %v", err)
+	}
+
+	fromCfg, err := resolveClientConfig(a.from)
+	if err != nil {
+		return r.fail("Failed to resolve source repository: %v", err)
+	}
+	if sameStoreTarget(cfg.Store, fromCfg.Store) {
+		return r.fail("Error: -from-store and -store name the same repository (%s)", cfg.Store.URI)
+	}
+
+	if err := r.openClient(ctx, cfg); err != nil {
+		return r.fail("Failed to open destination repository: %v", err)
+	}
+
+	src, err := openClient(ctx, fromCfg, nil)
+	if err != nil {
+		return r.fail("Failed to open source repository: %v", err)
+	}
+
+	if !a.json {
+		printCopyBanner(r.out, fromCfg.Store.URI, cfg.Store.URI, a.dryRun)
+	}
+
+	result, err := r.client.CopyFrom(ctx, src, copyOptions(a)...)
+	if err != nil {
+		return r.fail("Copy failed: %v", err)
+	}
+
+	if a.json {
+		return r.writeJSON(result)
+	}
+	printCopyResult(r.out, result)
+	return 0
+}
+
+func copyOptions(a *copyArgs) []cloudstic.CopyOption {
+	opts := []cloudstic.CopyOption{}
+	if len(a.snapshotIDs) > 0 {
+		opts = append(opts, cloudstic.WithCopySnapshotIDs(a.snapshotIDs...))
+	}
+	if a.filterSource != "" {
+		opts = append(opts, cloudstic.WithCopyFilterSource(a.filterSource))
+	}
+	if a.filterPath != "" {
+		opts = append(opts, cloudstic.WithCopyFilterPath(a.filterPath))
+	}
+	if a.filterAccount != "" {
+		opts = append(opts, cloudstic.WithCopyFilterAccount(a.filterAccount))
+	}
+	for _, tag := range a.filterTags {
+		opts = append(opts, cloudstic.WithCopyFilterTag(tag))
+	}
+	if !a.sinceTime.IsZero() {
+		opts = append(opts, cloudstic.WithCopySince(a.sinceTime))
+	}
+	if a.dryRun {
+		opts = append(opts, cloudstic.WithCopyDryRun())
+	}
+	if a.allowCopied {
+		opts = append(opts, cloudstic.WithCopyAllowCopied())
+	}
+	return opts
+}
+
+// sameStoreTarget reports whether two resolved store configurations address the
+// same repository.
+//
+// The client guards on repository id, which is exact but unavailable for a
+// repository that has none. This catches the common operator slip — the same
+// URI on both sides — before either repository is opened, and so before any
+// credential prompt.
+func sameStoreTarget(a, b config.Store) bool {
+	return a.URI != "" && a.URI == b.URI
+}

--- a/cmd/cloudstic/cmd_copy_test.go
+++ b/cmd/cloudstic/cmd_copy_test.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// The mirrors are generated from the repository flag groups so the two sets
+// cannot drift. This is the assertion that makes that guarantee real: add a
+// repository flag and it is mirrored automatically, or this fails.
+func TestCopyMirrorsEveryRepositoryFlag(t *testing.T) {
+	dest := &globalFlags{}
+	var want []string
+	for _, group := range []flagGroup{repoFlagSpecs, storeSFTPFlagSpecs, encryptionFlagSpecs} {
+		for _, spec := range group(dest) {
+			if spec.name == "profiles-file" {
+				continue // one profiles file serves both repositories
+			}
+			want = append(want, spec.name)
+		}
+	}
+
+	mirrored := map[string]flagSpec{}
+	for _, spec := range copyFromFlagSpecs(&globalFlags{}) {
+		mirrored[spec.name] = spec
+	}
+
+	for _, name := range want {
+		if _, ok := mirrored[fromFlagPrefix+name]; !ok {
+			t.Errorf("-%s has no -%s%s mirror", name, fromFlagPrefix, name)
+		}
+	}
+	if len(mirrored) != len(want) {
+		t.Errorf("mirrored %d flags, expected %d", len(mirrored), len(want))
+	}
+}
+
+// An ambient CLOUDSTIC_* value means "the repository I am operating on".
+// Letting one bind to both sides of a two-repository command is how an operator
+// unlocks the wrong one, or believes they did.
+func TestCopyFromFlagsCarryNoEnvironmentBindings(t *testing.T) {
+	for _, spec := range copyFromFlagSpecs(&globalFlags{}) {
+		if spec.env != "" {
+			t.Errorf("-%s reads %s; mirrored flags must have no environment binding", spec.name, spec.env)
+		}
+	}
+}
+
+// Every mirrored credential flag must stay marked secret, or it would start
+// rendering live values into help output.
+func TestCopyFromCredentialFlagsStaySecret(t *testing.T) {
+	secretByName := map[string]bool{}
+	dest := &globalFlags{}
+	for _, group := range []flagGroup{repoFlagSpecs, storeSFTPFlagSpecs, encryptionFlagSpecs} {
+		for _, spec := range group(dest) {
+			secretByName[spec.name] = spec.secret
+		}
+	}
+
+	for _, spec := range copyFromFlagSpecs(&globalFlags{}) {
+		original := strings.TrimPrefix(spec.name, fromFlagPrefix)
+		if want := secretByName[original]; want != spec.secret {
+			t.Errorf("-%s secret=%v, but -%s is secret=%v", spec.name, spec.secret, original, want)
+		}
+	}
+}
+
+// The mirrored usage text has to say which repository it configures: left
+// alone, the mirror of -store-sftp-password reads "SFTP store password" beside
+// a -source-* flag that means something else entirely.
+func TestCopyFromFlagsAreDescribedAsTheSource(t *testing.T) {
+	for _, spec := range copyFromFlagSpecs(&globalFlags{}) {
+		if !strings.Contains(spec.usage, "source repository") {
+			t.Errorf("-%s usage does not say which repository it configures: %q", spec.name, spec.usage)
+		}
+	}
+}
+
+func parseCopy(t *testing.T, args ...string) (*copyArgs, error) {
+	t.Helper()
+	return parseInto("copy", repoCommandGroups, declareCopyArgs, args)
+}
+
+// -store defaults to a local path, which is sensible for the one repository a
+// command usually has. Inheriting that default for the *source* would make a
+// bare `cloudstic copy` read whatever happens to be in ./backup_store.
+func TestCopyRequiresAnExplicitSource(t *testing.T) {
+	a, err := parseCopy(t, "-store", "local:/tmp/dst")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	err = prepareCopyArgs(a)
+	if err == nil {
+		t.Fatal("copy accepted an unspecified source repository")
+	}
+	if !strings.Contains(err.Error(), "-from-store") || !strings.Contains(err.Error(), "-from-profile") {
+		t.Errorf("error does not say how to name the source: %v", err)
+	}
+}
+
+func TestCopyAcceptsSourceByStoreOrProfile(t *testing.T) {
+	for _, args := range [][]string{
+		{"-store", "local:/tmp/dst", "-from-store", "local:/tmp/src"},
+		{"-store", "local:/tmp/dst", "-from-profile", "seed"},
+	} {
+		a, err := parseCopy(t, args...)
+		if err != nil {
+			t.Fatalf("parse %v: %v", args, err)
+		}
+		if err := prepareCopyArgs(a); err != nil {
+			t.Errorf("prepare %v: %v", args, err)
+		}
+	}
+}
+
+func TestCopySourceInheritsSharedSettingsButNoCredentials(t *testing.T) {
+	a, err := parseCopy(t,
+		"-store", "local:/tmp/dst",
+		"-password", "destination-secret",
+		"-config-dir", "/tmp/cfg",
+		"-quiet",
+		"-from-store", "local:/tmp/src",
+	)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if err := prepareCopyArgs(a); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	if a.from.configDir != "/tmp/cfg" {
+		t.Errorf("source config dir = %q, want the destination's", a.from.configDir)
+	}
+	if !a.from.quiet {
+		t.Error("source did not inherit -quiet, so the two halves would report differently")
+	}
+	// The whole reason the two structs are kept apart.
+	if a.from.password == "destination-secret" {
+		t.Error("the destination password leaked into the source repository's flags")
+	}
+}
+
+func TestCopySourceCredentialsAreIndependent(t *testing.T) {
+	a, err := parseCopy(t,
+		"-store", "local:/tmp/dst", "-password", "dst-pw",
+		"-from-store", "local:/tmp/src", "-from-password", "src-pw",
+	)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if err := prepareCopyArgs(a); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	if a.password != "dst-pw" {
+		t.Errorf("destination password = %q", a.password)
+	}
+	if a.from.password != "src-pw" {
+		t.Errorf("source password = %q", a.from.password)
+	}
+}
+
+func TestCopyParsesSinceAsDateOrTimestamp(t *testing.T) {
+	tests := map[string]time.Time{
+		"2026-04-01":           time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+		"2026-04-01T20:15:03Z": time.Date(2026, 4, 1, 20, 15, 3, 0, time.UTC),
+	}
+	for raw, want := range tests {
+		got, err := parseSinceTime(raw)
+		if err != nil {
+			t.Errorf("parseSinceTime(%q): %v", raw, err)
+			continue
+		}
+		if !got.Equal(want) {
+			t.Errorf("parseSinceTime(%q) = %s, want %s", raw, got, want)
+		}
+	}
+
+	if _, err := parseSinceTime("last tuesday"); err == nil {
+		t.Error("parseSinceTime accepted an unparseable value")
+	}
+}
+
+func TestCopySourceFilterSplitsURI(t *testing.T) {
+	a, err := parseCopy(t,
+		"-store", "local:/tmp/dst", "-from-store", "local:/tmp/src",
+		"-source", "local:./Documents",
+	)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if err := prepareCopyArgs(a); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	if a.filterSource != "local" {
+		t.Errorf("filterSource = %q, want local", a.filterSource)
+	}
+	if a.filterPath != "./Documents" {
+		t.Errorf("filterPath = %q, want ./Documents", a.filterPath)
+	}
+}
+
+func TestCopySourceFilterAcceptsBareType(t *testing.T) {
+	a, err := parseCopy(t,
+		"-store", "local:/tmp/dst", "-from-store", "local:/tmp/src", "-source", "gdrive",
+	)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if err := prepareCopyArgs(a); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	if a.filterSource != "gdrive" || a.filterPath != "" {
+		t.Errorf("filterSource=%q filterPath=%q, want gdrive with no path", a.filterSource, a.filterPath)
+	}
+}
+
+func TestCopyCollectsPositionalSnapshotIDs(t *testing.T) {
+	a, err := parseCopy(t,
+		"-store", "local:/tmp/dst", "-from-store", "local:/tmp/src",
+		"410b18a2", "4e5d5487", "latest",
+	)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(a.snapshotIDs) != 3 {
+		t.Fatalf("snapshotIDs = %v, want three selectors", a.snapshotIDs)
+	}
+	if a.snapshotIDs[2] != "latest" {
+		t.Errorf("last selector = %q, want latest", a.snapshotIDs[2])
+	}
+}
+
+func TestSameStoreTargetIgnoresUnsetURIs(t *testing.T) {
+	// Two repositories that both resolve to no URI are not thereby the same
+	// one; the guard must not fire on absence.
+	if sameStoreTarget(storeConfig{}, storeConfig{}) {
+		t.Error("two empty store configurations were reported as the same repository")
+	}
+	if !sameStoreTarget(storeConfig{URI: "local:/a"}, storeConfig{URI: "local:/a"}) {
+		t.Error("identical URIs were not recognised as the same repository")
+	}
+	if sameStoreTarget(storeConfig{URI: "local:/a"}, storeConfig{URI: "local:/b"}) {
+		t.Error("different URIs were reported as the same repository")
+	}
+}

--- a/cmd/cloudstic/commands.go
+++ b/cmd/cloudstic/commands.go
@@ -26,6 +26,7 @@ func commandRegistry() []command {
 		pruneCommand(),
 		forgetCommand(),
 		diffCommand(),
+		copyCommand(),
 		breakLockCommand(),
 		keyCommand(),
 		checkCommand(),

--- a/cmd/cloudstic/copy_output.go
+++ b/cmd/cloudstic/copy_output.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	cloudstic "github.com/cloudstic/cli"
+)
+
+// printCopyBanner names both repositories before anything is written.
+//
+// A copy can write a great deal of history into the wrong place, and the
+// destination is the one thing an operator cannot undo by rerunning. Printing
+// both ends first makes a mistyped -store visible while it is still cheap.
+func printCopyBanner(out io.Writer, sourceURI, destURI string, dryRun bool) {
+	_, _ = fmt.Fprintf(out, "copying from %s\n", sourceURI)
+	_, _ = fmt.Fprintf(out, "            to %s\n", destURI)
+	if dryRun {
+		_, _ = fmt.Fprintln(out, "dry run: nothing will be written")
+	}
+}
+
+// printCopySelection reports what a dry run would do.
+func printCopySelection(out io.Writer, result *cloudstic.CopyResult) {
+	if len(result.Copied) == 0 && len(result.Skipped) == 0 {
+		_, _ = fmt.Fprintln(out, "\nno snapshots selected")
+		return
+	}
+	_, _ = fmt.Fprintln(out)
+	for _, snap := range result.Skipped {
+		_, _ = fmt.Fprintf(out, "skipping snapshot %s, already copied as snapshot %s\n",
+			shortSnapshotRef(snap.SourceRef), shortSnapshotRef(snap.DestRef))
+	}
+	for _, snap := range result.Copied {
+		_, _ = fmt.Fprintf(out, "would copy snapshot %s%s\n",
+			shortSnapshotRef(snap.SourceRef), copySnapshotSuffix(snap.Source, snap.Created))
+	}
+}
+
+// printCopyResult renders the outcome of a completed run.
+func printCopyResult(out io.Writer, result *cloudstic.CopyResult) {
+	if result.DryRun {
+		printCopyPending(out, result)
+		return
+	}
+
+	_, _ = fmt.Fprintln(out)
+	for _, snap := range result.Skipped {
+		_, _ = fmt.Fprintf(out, "skipping snapshot %s, already copied as snapshot %s\n",
+			shortSnapshotRef(snap.SourceRef), shortSnapshotRef(snap.DestRef))
+	}
+	for _, snap := range result.Copied {
+		_, _ = fmt.Fprintf(out, "snapshot %s%s\n",
+			shortSnapshotRef(snap.SourceRef), copySnapshotSuffix(snap.Source, snap.Created))
+		_, _ = fmt.Fprintf(out, "snapshot %s saved\n", shortSnapshotRef(snap.DestRef))
+	}
+
+	_, _ = fmt.Fprintf(out, "\ncopied %s, skipped %s (read %s, wrote %s) in %s\n",
+		pluralSnapshots(len(result.Copied)),
+		pluralSnapshots(len(result.Skipped)),
+		formatBytes(result.BytesRead),
+		formatBytes(result.BytesWritten),
+		result.Duration.Round(time.Millisecond),
+	)
+}
+
+// printCopyPending is the dry-run summary: what a real run would do.
+func printCopyPending(out io.Writer, result *cloudstic.CopyResult) {
+	printCopySelection(out, result)
+	if len(result.Copied) == 0 && len(result.Skipped) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintf(out, "\nwould copy %s, skip %s\n",
+		pluralSnapshots(len(result.Copied)), pluralSnapshots(len(result.Skipped)))
+}
+
+func copySnapshotSuffix(source *cloudstic.SourceInfo, created string) string {
+	label := ""
+	if source != nil {
+		if source.Path != "" {
+			label = fmt.Sprintf(" of [%s:%s]", source.Type, source.Path)
+		} else {
+			label = fmt.Sprintf(" of [%s]", source.Type)
+		}
+	}
+	if at, err := time.Parse(time.RFC3339, created); err == nil {
+		return label + " at " + at.Local().Format("2006-01-02 15:04:05 -0700")
+	}
+	return label
+}
+
+func pluralSnapshots(n int) string {
+	if n == 1 {
+		return "1 snapshot"
+	}
+	return fmt.Sprintf("%d snapshots", n)
+}

--- a/cmd/cloudstic/copy_output_test.go
+++ b/cmd/cloudstic/copy_output_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	cloudstic "github.com/cloudstic/cli"
+)
+
+func sampleCopyResult() *cloudstic.CopyResult {
+	source := &cloudstic.SourceInfo{Type: "local", Path: "/Users/ada/Documents"}
+	return &cloudstic.CopyResult{
+		Copied: []cloudstic.CopiedSnapshot{{
+			SourceRef: "snapshot/410b18a2c0ffee00",
+			DestRef:   "snapshot/a1b2c3d4deadbeef",
+			Created:   "2026-04-01T18:15:03Z",
+			Source:    source,
+		}},
+		Skipped: []cloudstic.SkippedSnapshot{{
+			SourceRef: "snapshot/4e5d5487feedface",
+			DestRef:   "snapshot/e5f6a7b8badc0de1",
+			Created:   "2026-03-30T16:22:11Z",
+			Source:    source,
+			Reason:    "already copied",
+		}},
+		BytesRead:    4_509_715_660,
+		BytesWritten: 1_181_116_006,
+		Duration:     92 * time.Second,
+	}
+}
+
+func TestPrintCopyResultGolden(t *testing.T) {
+	// Timestamps render in local time, so pin the zone rather than the machine.
+	t.Setenv("TZ", "UTC")
+	time.Local = time.UTC
+
+	var out strings.Builder
+	printCopyBanner(&out, "local:/tmp/cloudstic-src", "s3:dest-bucket/prod", false)
+	printCopyResult(&out, sampleCopyResult())
+
+	assertGolden(t, "print_copy_result", out.String())
+}
+
+func TestPrintCopyResultDryRunGolden(t *testing.T) {
+	t.Setenv("TZ", "UTC")
+	time.Local = time.UTC
+
+	result := sampleCopyResult()
+	result.DryRun = true
+	// A dry run cannot know destination refs: they name objects not yet written.
+	result.Copied[0].DestRef = ""
+
+	var out strings.Builder
+	printCopyBanner(&out, "local:/tmp/cloudstic-src", "s3:dest-bucket/prod", true)
+	printCopyResult(&out, result)
+
+	assertGolden(t, "print_copy_dry_run", out.String())
+}
+
+func TestPrintCopyResultEmptySelection(t *testing.T) {
+	var out strings.Builder
+	printCopyResult(&out, &cloudstic.CopyResult{DryRun: true})
+
+	if !strings.Contains(out.String(), "no snapshots selected") {
+		t.Errorf("an empty selection should say so explicitly, got:\n%s", out.String())
+	}
+}
+
+func TestPrintCopyBannerNamesBothRepositories(t *testing.T) {
+	var out strings.Builder
+	printCopyBanner(&out, "local:/seed", "s3:prod/backups", false)
+
+	got := out.String()
+	// The destination is the one thing a rerun cannot undo, so both ends have
+	// to be visible before the first write.
+	if !strings.Contains(got, "local:/seed") || !strings.Contains(got, "s3:prod/backups") {
+		t.Errorf("banner does not name both repositories:\n%s", got)
+	}
+}
+
+func TestPluralSnapshots(t *testing.T) {
+	for n, want := range map[int]string{0: "0 snapshots", 1: "1 snapshot", 2: "2 snapshots"} {
+		if got := pluralSnapshots(n); got != want {
+			t.Errorf("pluralSnapshots(%d) = %q, want %q", n, got, want)
+		}
+	}
+}

--- a/cmd/cloudstic/flagspec.go
+++ b/cmd/cloudstic/flagspec.go
@@ -46,7 +46,12 @@ type flagSpec struct {
 	// bind registers the flag on a flag set, using only the built-in default.
 	// Environment values are applied after parsing so that help output can
 	// never render a live environment value (see applyEnvDefaults).
-	bind func(fs *flag.FlagSet)
+	//
+	// It takes the name and usage to register under rather than closing over
+	// them, so that a spec can be renamed after construction — which is what
+	// lets `copy` derive its -from-* mirrors from the existing groups instead
+	// of restating every repository flag. See prefixed.
+	bind func(fs *flag.FlagSet, name, usage string)
 	// setValue sets the flag's target from a raw string, returning an
 	// actionable error when the value cannot be parsed. It serves both of the
 	// after-parsing resolution steps — environment values and late defaults —
@@ -127,8 +132,8 @@ func applyOpts(s *flagSpec, opts []flagOpt) *flagSpec {
 func stringFlag(target *string, name, def, usage string, opts ...flagOpt) flagSpec {
 	s := applyOpts(&flagSpec{name: name, usage: usage}, opts)
 	spec := *s
-	spec.bind = func(fs *flag.FlagSet) {
-		fs.StringVar(target, name, def, spec.bindUsage())
+	spec.bind = func(fs *flag.FlagSet, name, usage string) {
+		fs.StringVar(target, name, def, usage)
 	}
 	spec.setValue = func(raw string) error {
 		*target = raw
@@ -141,8 +146,8 @@ func stringFlag(target *string, name, def, usage string, opts ...flagOpt) flagSp
 func boolFlag(target *bool, name string, def bool, usage string, opts ...flagOpt) flagSpec {
 	s := applyOpts(&flagSpec{name: name, usage: usage, isBool: true}, opts)
 	spec := *s
-	spec.bind = func(fs *flag.FlagSet) {
-		fs.BoolVar(target, name, def, spec.bindUsage())
+	spec.bind = func(fs *flag.FlagSet, name, usage string) {
+		fs.BoolVar(target, name, def, usage)
 	}
 	spec.setValue = func(raw string) error {
 		parsed, err := strconv.ParseBool(raw)
@@ -159,8 +164,8 @@ func boolFlag(target *bool, name string, def bool, usage string, opts ...flagOpt
 func intFlag(target *int, name string, def int, usage string, opts ...flagOpt) flagSpec {
 	s := applyOpts(&flagSpec{name: name, usage: usage}, opts)
 	spec := *s
-	spec.bind = func(fs *flag.FlagSet) {
-		fs.IntVar(target, name, def, spec.bindUsage())
+	spec.bind = func(fs *flag.FlagSet, name, usage string) {
+		fs.IntVar(target, name, def, usage)
 	}
 	spec.setValue = func(raw string) error {
 		parsed, err := strconv.Atoi(raw)
@@ -178,8 +183,8 @@ func intFlag(target *int, name string, def int, usage string, opts ...flagOpt) f
 func valueFlag(target flag.Value, name, usage string, opts ...flagOpt) flagSpec {
 	s := applyOpts(&flagSpec{name: name, usage: usage}, opts)
 	spec := *s
-	spec.bind = func(fs *flag.FlagSet) {
-		fs.Var(target, name, spec.bindUsage())
+	spec.bind = func(fs *flag.FlagSet, name, usage string) {
+		fs.Var(target, name, usage)
 	}
 	return spec
 }
@@ -287,10 +292,52 @@ func applyLateDefaults(specs []flagSpec, origins map[string]flagOrigin) error {
 	return nil
 }
 
+// prefixed returns specs renamed with the given prefix and re-described with
+// the given label, for a command that addresses a second instance of something
+// the global flags already describe — `copy`, which needs a whole second
+// repository (RFC 0017 §2).
+//
+// The label is appended to each usage string because the original text is
+// written for the only repository a command usually has: left alone, the mirror
+// of -store-sftp-password would read "SFTP store password" next to a -source-*
+// flag that means something else entirely.
+//
+// Deriving the mirrors rather than restating them is what keeps the two sets
+// from drifting: a repository flag added later is mirrored without a matching
+// edit here, which is not true of a hand-written list. The original specs are
+// left untouched; flagSpec is copied by value and its closures write to the
+// targets bound at construction, so a caller mirrors a group built over a
+// *different* destination struct.
+//
+// Environment bindings are deliberately dropped. CLOUDSTIC_PASSWORD means "the
+// repository I am operating on", and silently applying one ambient value to
+// both repositories of a two-repository command is how an operator unlocks the
+// wrong one — or believes they did. Ambient variables configure the
+// destination; the source is named explicitly, or through a profile whose
+// entry may carry env:// secret references like any other.
+//
+// Late defaults are dropped for the same reason they exist: one computes a path
+// inside -config-dir, which is not mirrored, so a mirrored late default would
+// resolve against a struct that has no config directory set.
+func prefixed(prefix, label string, specs []flagSpec) []flagSpec {
+	out := make([]flagSpec, 0, len(specs))
+	for _, s := range specs {
+		s.name = prefix + s.name
+		s.env = ""
+		s.lateDefault = nil
+		s.usage = s.usage + " (" + label + ")"
+		if s.shortUsage != "" {
+			s.shortUsage = s.shortUsage + " (" + label + ")"
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
 // bindFlags registers every spec on fs, in declaration order.
 func bindFlags(fs *flag.FlagSet, specs []flagSpec) {
 	for _, s := range specs {
-		s.bind(fs)
+		s.bind(fs, s.name, s.bindUsage())
 	}
 }
 

--- a/cmd/cloudstic/stub_client_test.go
+++ b/cmd/cloudstic/stub_client_test.go
@@ -13,6 +13,8 @@ import (
 // stubClient is a test double that implements cloudsticClient.
 // Each field pair holds the value to return and an optional error.
 type stubClient struct {
+	copyResult      *cloudstic.CopyResult
+	copyErr         error
 	backupResult    *cloudstic.BackupResult
 	backupErr       error
 	setupPlan       *workstation.SetupPlan
@@ -98,4 +100,8 @@ func (s *stubClient) Cat(_ context.Context, _ ...string) ([]*cloudstic.CatResult
 
 func (s *stubClient) BreakLock(_ context.Context) ([]*cloudstic.RepoLock, error) {
 	return s.breakLockResult, s.breakLockErr
+}
+
+func (s *stubClient) CopyFrom(_ context.Context, _ *cloudstic.Client, _ ...cloudstic.CopyOption) (*cloudstic.CopyResult, error) {
+	return s.copyResult, s.copyErr
 }

--- a/cmd/cloudstic/testdata/print_copy_dry_run.golden
+++ b/cmd/cloudstic/testdata/print_copy_dry_run.golden
@@ -1,0 +1,8 @@
+copying from local:/tmp/cloudstic-src
+            to s3:dest-bucket/prod
+dry run: nothing will be written
+
+skipping snapshot 4e5d5487, already copied as snapshot e5f6a7b8
+would copy snapshot 410b18a2 of [local:/Users/ada/Documents] at 2026-04-01 18:15:03 +0000
+
+would copy 1 snapshot, skip 1 snapshot

--- a/cmd/cloudstic/testdata/print_copy_result.golden
+++ b/cmd/cloudstic/testdata/print_copy_result.golden
@@ -1,0 +1,8 @@
+copying from local:/tmp/cloudstic-src
+            to s3:dest-bucket/prod
+
+skipping snapshot 4e5d5487, already copied as snapshot e5f6a7b8
+snapshot 410b18a2 of [local:/Users/ada/Documents] at 2026-04-01 18:15:03 +0000
+snapshot a1b2c3d4 saved
+
+copied 1 snapshot, skipped 1 snapshot (read 4.2 GiB, wrote 1.1 GiB) in 1m32s

--- a/cmd/cloudstic/testdata/scripts/copy_between_repositories.txtar
+++ b/cmd/cloudstic/testdata/scripts/copy_between_repositories.txtar
@@ -1,0 +1,57 @@
+# `copy` moves snapshot history between two repositories that share no key.
+#
+# The interesting property is that nothing is transferred verbatim: object names
+# are derived from each repository's own master key, so the destination graph is
+# rebuilt. What the user should see is that the history survives anyway —
+# timestamps, tags and file contents intact — and that running it twice is a
+# no-op rather than a duplication.
+
+exec cloudstic init -store local:$WORK/src -password src-pw
+exec cloudstic init -store local:$WORK/dst -password dst-pw
+
+exec cloudstic backup -store local:$WORK/src -password src-pw -source local:$WORK/data -tag nightly
+stdout 'saved'
+
+# A dry run reports the selection and writes nothing.
+exec cloudstic copy -store local:$WORK/dst -password dst-pw -from-store local:$WORK/src -from-password src-pw -dry-run
+stdout 'dry run: nothing will be written'
+stdout 'would copy 1 snapshot'
+exec cloudstic list -store local:$WORK/dst -password dst-pw
+! stdout 'local'
+
+# The real run names both repositories before it writes anything, so a mistyped
+# destination is visible while it is still cheap.
+exec cloudstic copy -store local:$WORK/dst -password dst-pw -from-store local:$WORK/src -from-password src-pw
+stdout 'copying from local:'
+stdout 'snapshot .* saved'
+stdout 'copied 1 snapshot, skipped 0 snapshots'
+
+# The copied snapshot is an ordinary snapshot of the destination afterwards:
+# listable, verifiable and restorable, with its tag carried over.
+exec cloudstic list -store local:$WORK/dst -password dst-pw
+stdout 'nightly'
+
+exec cloudstic check -store local:$WORK/dst -password dst-pw -read-data
+stderr 'No errors found'
+
+exec cloudstic restore -store local:$WORK/dst -password dst-pw -output $WORK/restored
+exists $WORK/restored/notes.txt
+grep 'hello from the source' $WORK/restored/notes.txt
+
+# Rerunning skips rather than duplicating, and does so without re-reading the
+# source: that is what the recorded provenance buys.
+exec cloudstic copy -store local:$WORK/dst -password dst-pw -from-store local:$WORK/src -from-password src-pw
+stdout 'already copied as snapshot'
+stdout 'copied 0 snapshots, skipped 1 snapshot'
+stdout 'read 0 B'
+
+# Naming one repository on both sides is refused before either is opened.
+! exec cloudstic copy -store local:$WORK/dst -password dst-pw -from-store local:$WORK/dst
+stderr 'name the same repository'
+
+# The source repository has to be named at all.
+! exec cloudstic copy -store local:$WORK/dst -password dst-pw
+stderr '-from-store or -from-profile'
+
+-- data/notes.txt --
+hello from the source repository

--- a/cmd/cloudstic/testdata/usage_root.golden
+++ b/cmd/cloudstic/testdata/usage_root.golden
@@ -28,6 +28,7 @@ COMMANDS
   prune              Remove unused data chunks from the repository
   forget             Remove a specific snapshot from history
   diff               Compare two snapshots or a snapshot against latest
+  copy               Copy snapshots from another repository into this one
   break-lock         Remove a stale repository lock left by a crashed process
   key list           List all encryption key slots in the repository
   key add-recovery   Generate a 24-word recovery key for an encrypted repository

--- a/copy.go
+++ b/copy.go
@@ -1,0 +1,176 @@
+package cloudstic
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cloudstic/cli/internal/core"
+	"github.com/cloudstic/cli/internal/engine"
+)
+
+// ---------------------------------------------------------------------------
+// Copy
+// ---------------------------------------------------------------------------
+
+// CopyOption configures a copy run.
+type CopyOption = engine.CopyOption
+
+// CopyResult reports what a copy run did.
+type CopyResult = engine.CopyResult
+
+// CopiedSnapshot records one snapshot transferred into the destination.
+type CopiedSnapshot = engine.CopiedSnapshot
+
+// SkippedSnapshot records one snapshot the destination already had.
+type SkippedSnapshot = engine.SkippedSnapshot
+
+var (
+	WithCopySnapshotIDs   = engine.WithCopySnapshotIDs
+	WithCopyFilterSource  = engine.WithCopyFilterSource
+	WithCopyFilterPath    = engine.WithCopyFilterPath
+	WithCopyFilterAccount = engine.WithCopyFilterAccount
+	WithCopyFilterTag     = engine.WithCopyFilterTag
+	WithCopySince         = engine.WithCopySince
+	WithCopyDryRun        = engine.WithCopyDryRun
+	WithCopyAllowCopied   = engine.WithCopyAllowCopied
+)
+
+// CopyFrom transfers snapshots from src into this repository.
+//
+// It is a method on the *destination* — the client that will be written to —
+// and takes the source as another client rather than as a bare store. That is
+// deliberate on three counts:
+//
+//   - The store decorator chain is never composed by a caller. Its order is a
+//     correctness and security invariant, and a chain assembled without a pack
+//     index key yields a repository whose index is plaintext with no error at
+//     any layer. A *Client has already had that chain built for it.
+//   - Source credentials stay out of the copy option surface: the source client
+//     was constructed with WithKeychain like any other.
+//   - The source is format-gated for free, because NewClient reads and checks
+//     its repository marker.
+//
+// Nothing is written to the source. A copy needs only read access there, which
+// is what makes read-only source credentials a supported configuration.
+//
+// Copying is expensive compared with an incremental backup: every object in the
+// selected snapshots is read and decrypted through the source, then re-encrypted
+// and written through the destination, because object names are derived from
+// each repository's own key and so cannot be carried across. Data the
+// destination already holds is still recognised and skipped.
+func (c *Client) CopyFrom(ctx context.Context, src *Client, opts ...CopyOption) (*CopyResult, error) {
+	if src == nil {
+		return nil, fmt.Errorf("copy: no source repository given")
+	}
+	if src == c {
+		return nil, fmt.Errorf("copy: source and destination are the same client")
+	}
+
+	srcID, err := src.repoID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read source repository config: %w", err)
+	}
+	dstID, err := c.repoID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read destination repository config: %w", err)
+	}
+
+	same, err := sameRepository(ctx, src, c, srcID, dstID)
+	if err != nil {
+		return nil, err
+	}
+	if same {
+		return nil, fmt.Errorf(
+			"copy: source and destination are the same repository -- copying one into itself " +
+				"would duplicate every snapshot in its history",
+		)
+	}
+
+	mgr := engine.NewCopyManager(
+		engine.CopySide{Store: src.store, RepoID: srcID},
+		c.store,
+		c.hmacKey,
+		dstID,
+		c.reporter,
+		c.logWriter,
+	)
+
+	// Bytes written are metered as they land in the backend — after compression
+	// and encryption — which is the number that matches what the destination is
+	// billed for. Bytes read are counted by the manager as plaintext, since that
+	// is the volume it actually had to materialise.
+	c.storedMeter.Reset()
+	result, err := mgr.Run(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+	result.BytesWritten = c.storedMeter.BytesWritten()
+
+	if !result.DryRun && len(result.Copied) > 0 {
+		c.stampWriteFormat(ctx)
+	}
+	return result, nil
+}
+
+// sameRepository reports whether two clients address one repository.
+//
+// Copying a repository into itself is not merely pointless: every source
+// snapshot is rewritten as a *new* snapshot object carrying provenance, so the
+// history doubles. No data is duplicated — every object re-addresses to the ref
+// it already has — but retention grouping, `latest` and every count are wrong
+// afterwards, and undoing it means forgetting half the snapshots by hand.
+//
+// Repository identifiers settle the question when both repositories have one.
+// When either does not — a repository written before the marker carried an id,
+// or one whose marker an older build has since rewritten — the two stores are
+// probed instead: a uniquely named object is written to the destination and
+// looked for through the source.
+//
+// The probe is exact where every cheaper test is not. Comparing store URIs
+// misses "local:/srv/repo" against "local:/srv/repo/.", a symlink, a bind mount
+// or one bucket reachable under two endpoints. Comparing the stored markers
+// misses nothing structurally but collides in practice: strip the identifier
+// and two repositories created in the same second are byte-identical, so it
+// refuses legitimate copies between distinct id-less repositories.
+//
+// It writes only to the destination, which this call is about to write a great
+// deal more into, and removes what it wrote. The source is only ever read, so
+// read-only source credentials remain sufficient.
+func sameRepository(ctx context.Context, src, dst *Client, srcID, dstID string) (bool, error) {
+	if srcID != "" && dstID != "" {
+		return srcID == dstID, nil
+	}
+
+	nonce, err := core.NewRepoID()
+	if err != nil {
+		return false, err
+	}
+	// Under index/, which is never packed and never content-addressed, so the
+	// probe cannot be mistaken for repository data if a crash strands it.
+	key := "index/copy-probe/" + nonce
+
+	if err := dst.base.Put(ctx, key, []byte(nonce)); err != nil {
+		return false, fmt.Errorf("probe destination repository: %w", err)
+	}
+	defer func() { _ = dst.base.Delete(ctx, key) }()
+
+	seen, err := src.base.Exists(ctx, key)
+	if err != nil {
+		return false, fmt.Errorf("probe source repository: %w", err)
+	}
+	return seen, nil
+}
+
+// repoID returns this repository's identifier, or "" for a repository written
+// before the marker carried one — including one whose marker an older build
+// has since rewritten, dropping the field.
+func (c *Client) repoID(ctx context.Context) (string, error) {
+	cfg, _, err := c.openRepoConfig(ctx, c.base)
+	if err != nil {
+		return "", err
+	}
+	if cfg == nil {
+		return "", fmt.Errorf("repository not initialized")
+	}
+	return cfg.ID, nil
+}

--- a/copy_bench_test.go
+++ b/copy_bench_test.go
@@ -1,0 +1,334 @@
+package cloudstic
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cloudstic/cli/pkg/keychain"
+	localsource "github.com/cloudstic/cli/pkg/source/local"
+	"github.com/cloudstic/cli/pkg/store"
+	localstore "github.com/cloudstic/cli/pkg/store/local"
+)
+
+// countingStore records the operation mix a run performs.
+//
+// Wall-clock time on a local disk is the wrong measure for this feature: a copy
+// between real repositories is bound by round trips to two backends, so what
+// has to stay bounded is the *number* of Gets, Puts and Exists calls, not how
+// fast a laptop can service them.
+type countingStore struct {
+	store.ObjectStore
+	gets, puts, exists, lists atomic.Int64
+	bytesGet, bytesPut        atomic.Int64
+}
+
+func newCountingStore(inner store.ObjectStore) *countingStore {
+	return &countingStore{ObjectStore: inner}
+}
+
+func (c *countingStore) Get(ctx context.Context, key string) ([]byte, error) {
+	data, err := c.ObjectStore.Get(ctx, key)
+	c.gets.Add(1)
+	c.bytesGet.Add(int64(len(data)))
+	return data, err
+}
+
+func (c *countingStore) Put(ctx context.Context, key string, data []byte) error {
+	c.puts.Add(1)
+	c.bytesPut.Add(int64(len(data)))
+	return c.ObjectStore.Put(ctx, key, data)
+}
+
+func (c *countingStore) Exists(ctx context.Context, key string) (bool, error) {
+	c.exists.Add(1)
+	return c.ObjectStore.Exists(ctx, key)
+}
+
+func (c *countingStore) List(ctx context.Context, prefix string) ([]string, error) {
+	c.lists.Add(1)
+	return c.ObjectStore.List(ctx, prefix)
+}
+
+func (c *countingStore) reset() {
+	c.gets.Store(0)
+	c.puts.Store(0)
+	c.exists.Store(0)
+	c.lists.Store(0)
+	c.bytesGet.Store(0)
+	c.bytesPut.Store(0)
+}
+
+func (c *countingStore) String() string {
+	return fmt.Sprintf("get=%d put=%d exists=%d list=%d readB=%d writeB=%d",
+		c.gets.Load(), c.puts.Load(), c.exists.Load(), c.lists.Load(),
+		c.bytesGet.Load(), c.bytesPut.Load())
+}
+
+// countedRepo opens a repository whose backend operations are counted.
+func countedRepo(tb testing.TB, dir, password string) (*Client, *countingStore) {
+	tb.Helper()
+	ctx := context.Background()
+
+	backend, err := localstore.New(dir)
+	if err != nil {
+		tb.Fatalf("open store: %v", err)
+	}
+	counted := newCountingStore(backend)
+
+	initOpts := []InitOption{WithInitNoEncryption()}
+	clientOpts := []ClientOption{}
+	if password != "" {
+		chain := keychain.Chain{keychain.WithPassword(password)}
+		initOpts = []InitOption{WithInitCredentials(chain)}
+		clientOpts = append(clientOpts, WithKeychain(chain))
+	}
+	if _, err := InitRepo(ctx, counted, initOpts...); err != nil {
+		tb.Fatalf("init: %v", err)
+	}
+	client, err := NewClient(ctx, counted, clientOpts...)
+	if err != nil {
+		tb.Fatalf("open client: %v", err)
+	}
+	return client, counted
+}
+
+// writeCorpus lays out a directory of files with deterministic pseudo-random
+// content, large enough that chunking and encryption actually do work.
+func writeCorpus(tb testing.TB, dir string, files, sizeEach int) {
+	tb.Helper()
+	rng := rand.New(rand.NewSource(1))
+	buf := make([]byte, sizeEach)
+	for i := range files {
+		if _, err := rng.Read(buf); err != nil {
+			tb.Fatalf("rand: %v", err)
+		}
+		path := filepath.Join(dir, fmt.Sprintf("sub%02d", i%8), fmt.Sprintf("file%04d.bin", i))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			tb.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(path, buf, 0o644); err != nil {
+			tb.Fatalf("write: %v", err)
+		}
+	}
+}
+
+// touchOne rewrites a single file, so the next snapshot differs from the last
+// by exactly one file.
+func touchOne(tb testing.TB, dir string, n int) {
+	tb.Helper()
+	path := filepath.Join(dir, fmt.Sprintf("sub%02d", n%8), fmt.Sprintf("file%04d.bin", n))
+	data, err := os.ReadFile(path)
+	if err != nil {
+		tb.Fatalf("read: %v", err)
+	}
+	data[0] ^= 0xff
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		tb.Fatalf("write: %v", err)
+	}
+}
+
+// TestCopyScalesWithRepositoryNotSnapshotCount is the measurement behind the
+// per-run remap table (RFC 0017 §4.2).
+//
+// Consecutive snapshots of one source share nearly all of their graph. Without
+// a table spanning the whole run, every unchanged file would be re-read and
+// re-encrypted once per snapshot, and the cost of copying a history would be
+// the size of the repository multiplied by the number of snapshots in it. This
+// is the property that would regress silently, so it is asserted rather than
+// merely reported.
+func TestCopyScalesWithRepositoryNotSnapshotCount(t *testing.T) {
+	if testing.Short() {
+		t.Skip("writes a multi-file corpus")
+	}
+	ctx := context.Background()
+
+	const files = 40
+	// BytesRead is the manager's own count of plaintext pulled through the
+	// source, which is precisely what the remap table governs. Backend
+	// operation counts are the wrong probe here: PackStore bundles small
+	// objects, so its cache would absorb repeated reads and make a missing
+	// table look free.
+	measure := func(snapshots int) (plaintextRead int64, dstPuts int64) {
+		srcDir, dstDir, dataDir := t.TempDir(), t.TempDir(), t.TempDir()
+		writeCorpus(t, dataDir, files, 4096)
+
+		src, srcCount := countedRepo(t, srcDir, "src-pw")
+		dst, _ := countedRepo(t, dstDir, "dst-pw")
+
+		for i := range snapshots {
+			if i > 0 {
+				touchOne(t, dataDir, i)
+			}
+			if _, err := src.Backup(ctx, localsource.New(dataDir)); err != nil {
+				t.Fatalf("backup %d: %v", i, err)
+			}
+		}
+
+		srcCount.reset()
+		dstCounted := dst.base.(*countingStore)
+		dstCounted.reset()
+
+		res, err := dst.CopyFrom(ctx, src)
+		if err != nil {
+			t.Fatalf("CopyFrom: %v", err)
+		}
+		if len(res.Copied) != snapshots {
+			t.Fatalf("copied %d snapshots, want %d", len(res.Copied), snapshots)
+		}
+		t.Logf("%2d snapshots: plaintext read %d B, written %d B", snapshots, res.BytesRead, res.BytesWritten)
+		t.Logf("%2d snapshots: source backend %s", snapshots, srcCount)
+		t.Logf("%2d snapshots: dest   backend %s", snapshots, dstCounted)
+		return res.BytesRead, dstCounted.puts.Load()
+	}
+
+	oneRead, onePuts := measure(1)
+	manyRead, manyPuts := measure(8)
+
+	// Eight snapshots differing by one file each must not cost eight times one
+	// snapshot. Allow generous headroom for per-snapshot overhead (the snapshot
+	// object, the changed file's chunks, the rewritten HAMT spine and the
+	// catalog) while still failing loudly if the per-file work is repeated.
+	if manyRead > oneRead*3 {
+		t.Errorf("plaintext read scaled with snapshot count: %d B for 1 snapshot, %d B for 8"+
+			" (expected well under %d; the remap table is not spanning the run)",
+			oneRead, manyRead, oneRead*3)
+	}
+	if manyPuts > onePuts*3 {
+		t.Errorf("destination writes scaled with snapshot count: %d for 1 snapshot, %d for 8"+
+			" (expected well under %d; unchanged subtrees are not being shared)",
+			onePuts, manyPuts, onePuts*3)
+	}
+}
+
+// BenchmarkCopy measures a copy of a single snapshot against the backup that
+// produced it, so the overhead of re-addressing a graph is expressed against
+// the cost of writing it in the first place.
+func BenchmarkCopy(b *testing.B) {
+	for _, size := range []struct {
+		name            string
+		files, sizeEach int
+	}{
+		{"40x4KiB", 40, 4096},
+		{"20x1MiB", 20, 1 << 20},
+	} {
+		b.Run(size.name, func(b *testing.B) {
+			ctx := context.Background()
+			for b.Loop() {
+				b.StopTimer()
+				srcDir, dstDir, dataDir := b.TempDir(), b.TempDir(), b.TempDir()
+				writeCorpus(b, dataDir, size.files, size.sizeEach)
+				src, _ := countedRepo(b, srcDir, "src-pw")
+				dst, dstCount := countedRepo(b, dstDir, "dst-pw")
+				if _, err := src.Backup(ctx, localsource.New(dataDir)); err != nil {
+					b.Fatalf("backup: %v", err)
+				}
+				dstCount.reset()
+				b.StartTimer()
+
+				if _, err := dst.CopyFrom(ctx, src); err != nil {
+					b.Fatalf("CopyFrom: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkCopyRerun measures the cost of a copy that has nothing to do, which
+// is what a scheduled copy does almost every time it runs.
+func BenchmarkCopyRerun(b *testing.B) {
+	ctx := context.Background()
+	srcDir, dstDir, dataDir := b.TempDir(), b.TempDir(), b.TempDir()
+	writeCorpus(b, dataDir, 40, 4096)
+	src, _ := countedRepo(b, srcDir, "src-pw")
+	dst, _ := countedRepo(b, dstDir, "dst-pw")
+	for i := range 8 {
+		if i > 0 {
+			touchOne(b, dataDir, i)
+		}
+		if _, err := src.Backup(ctx, localsource.New(dataDir)); err != nil {
+			b.Fatalf("backup: %v", err)
+		}
+	}
+	if _, err := dst.CopyFrom(ctx, src); err != nil {
+		b.Fatalf("seed copy: %v", err)
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		res, err := dst.CopyFrom(ctx, src)
+		if err != nil {
+			b.Fatalf("CopyFrom: %v", err)
+		}
+		if len(res.Copied) != 0 {
+			b.Fatalf("rerun copied %d snapshots, want 0", len(res.Copied))
+		}
+	}
+}
+
+// TestScheduledCopyIsIncrementalAcrossRuns covers the shape a scheduled copy
+// actually has: the destination is already current, one new snapshot appears,
+// and a fresh process brings it over.
+//
+// Each run starts with an empty remap table, so without recovering the tree
+// pairing from provenance the first snapshot of every run rebuilds a whole tree
+// — a cost proportional to the repository, paid daily, to record a day's
+// changes. Measured on a 2000-file tree that was 706 KB of plaintext read per
+// run against 1.6 KB once the pairing is recovered.
+func TestScheduledCopyIsIncrementalAcrossRuns(t *testing.T) {
+	if testing.Short() {
+		t.Skip("writes a multi-file corpus")
+	}
+	ctx := context.Background()
+
+	srcDir, dstDir, dataDir := t.TempDir(), t.TempDir(), t.TempDir()
+	const files = 400
+	writeCorpus(t, dataDir, files, 512)
+	src, _ := countedRepo(t, srcDir, "src-pw")
+	dst, _ := countedRepo(t, dstDir, "dst-pw")
+
+	for i := range 3 {
+		if i > 0 {
+			touchOne(t, dataDir, i)
+		}
+		if _, err := src.Backup(ctx, localsource.New(dataDir)); err != nil {
+			t.Fatalf("backup %d: %v", i, err)
+		}
+	}
+	seed, err := dst.CopyFrom(ctx, src)
+	if err != nil {
+		t.Fatalf("seed copy: %v", err)
+	}
+	if len(seed.Copied) != 3 {
+		t.Fatalf("seed copy took %d snapshots, want 3", len(seed.Copied))
+	}
+
+	// One new snapshot, then a run that has no in-process state to lean on.
+	touchOne(t, dataDir, 7)
+	if _, err := src.Backup(ctx, localsource.New(dataDir)); err != nil {
+		t.Fatalf("incremental backup: %v", err)
+	}
+
+	catchUp, err := dst.CopyFrom(ctx, src)
+	if err != nil {
+		t.Fatalf("catch-up copy: %v", err)
+	}
+	if len(catchUp.Copied) != 1 {
+		t.Fatalf("catch-up copied %d snapshots, want 1", len(catchUp.Copied))
+	}
+
+	t.Logf("catch-up over a %d-file tree read %d B (seed run read %d B)",
+		files, catchUp.BytesRead, seed.BytesRead)
+
+	// The catch-up brought over one changed file. Reading anything close to what
+	// the seed run read means the tree was rebuilt rather than diffed.
+	if catchUp.BytesRead > seed.BytesRead/10 {
+		t.Errorf("catch-up read %d B against a seed run of %d B: a run that adds one"+
+			" snapshot is rebuilding the whole tree instead of applying a diff",
+			catchUp.BytesRead, seed.BytesRead)
+	}
+}

--- a/copy_test.go
+++ b/copy_test.go
@@ -1,0 +1,535 @@
+package cloudstic
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/cloudstic/cli/pkg/keychain"
+	localsource "github.com/cloudstic/cli/pkg/source/local"
+	localstore "github.com/cloudstic/cli/pkg/store/local"
+)
+
+// openRepo initializes a repository under dir and returns a client for it.
+// An empty password means an unencrypted repository.
+func openRepo(t *testing.T, dir, password string) *Client {
+	t.Helper()
+	ctx := context.Background()
+
+	backend, err := localstore.New(dir)
+	if err != nil {
+		t.Fatalf("open store %s: %v", dir, err)
+	}
+
+	initOpts := []InitOption{WithInitNoEncryption()}
+	clientOpts := []ClientOption{}
+	if password != "" {
+		chain := keychain.Chain{keychain.WithPassword(password)}
+		initOpts = []InitOption{WithInitCredentials(chain)}
+		clientOpts = append(clientOpts, WithKeychain(chain))
+	}
+	if _, err := InitRepo(ctx, backend, initOpts...); err != nil {
+		t.Fatalf("init %s: %v", dir, err)
+	}
+
+	client, err := NewClient(ctx, backend, clientOpts...)
+	if err != nil {
+		t.Fatalf("open client %s: %v", dir, err)
+	}
+	return client
+}
+
+// backupTree writes files into a fresh directory and backs it up into client.
+func backupTree(t *testing.T, client *Client, files map[string]string) *BackupResult {
+	t.Helper()
+	dir := t.TempDir()
+	for name, content := range files {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	src := localsource.New(dir)
+	res, err := client.Backup(context.Background(), src)
+	if err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+	return res
+}
+
+// restoredFiles reads every file of a snapshot back out of a repository.
+func restoredFiles(t *testing.T, client *Client, snapshotRef string) map[string]string {
+	t.Helper()
+	out := t.TempDir()
+	if _, err := client.RestoreToDir(context.Background(), out, snapshotRef); err != nil {
+		t.Fatalf("restore %s: %v", snapshotRef, err)
+	}
+
+	files := map[string]string{}
+	err := filepath.Walk(out, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		rel, err := filepath.Rel(out, path)
+		if err != nil {
+			return err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		files[rel] = string(data)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk restored tree: %v", err)
+	}
+	return files
+}
+
+func listRefs(t *testing.T, client *Client) []string {
+	t.Helper()
+	res, err := client.List(context.Background())
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	refs := make([]string, 0, len(res.Snapshots))
+	for _, s := range res.Snapshots {
+		refs = append(refs, s.Ref)
+	}
+	return refs
+}
+
+// The case that proves the reference cascade is genuinely rebuilt rather than
+// accidentally passed through: two encrypted repositories with *different*
+// master keys name the same bytes differently at every level, so a copy that
+// moved objects verbatim would produce a destination that cannot be read.
+func TestCopyFrom_BetweenEncryptedRepositoriesWithDifferentKeys(t *testing.T) {
+	ctx := context.Background()
+	src := openRepo(t, t.TempDir(), "source-password")
+	dst := openRepo(t, t.TempDir(), "destination-password")
+
+	files := map[string]string{
+		"notes.txt":       "hello from the source repository",
+		"nested/deep.txt": "a file below a directory",
+	}
+	backupTree(t, src, files)
+
+	res, err := dst.CopyFrom(ctx, src)
+	if err != nil {
+		t.Fatalf("CopyFrom: %v", err)
+	}
+	if len(res.Copied) != 1 {
+		t.Fatalf("copied %d snapshots, want 1", len(res.Copied))
+	}
+	if res.BytesRead == 0 {
+		t.Error("BytesRead was not accounted for")
+	}
+
+	got := restoredFiles(t, dst, res.Copied[0].DestRef)
+	for name, want := range files {
+		if got[name] != want {
+			t.Errorf("restored %q = %q, want %q", name, got[name], want)
+		}
+	}
+
+	// The destination snapshot is a different object than the source one: it
+	// is rebuilt under the destination's key, not relabelled.
+	if res.Copied[0].DestRef == res.Copied[0].SourceRef {
+		t.Error("destination snapshot kept the source ref, so nothing was re-addressed")
+	}
+}
+
+func TestCopyFrom_PreservesSnapshotMetadata(t *testing.T) {
+	ctx := context.Background()
+	src := openRepo(t, t.TempDir(), "source-password")
+	dst := openRepo(t, t.TempDir(), "destination-password")
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("payload"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	source := localsource.New(dir)
+	if _, err := src.Backup(ctx, source, WithTags("workstation", "nightly")); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+
+	srcList, err := src.List(ctx)
+	if err != nil {
+		t.Fatalf("list source: %v", err)
+	}
+	original := srcList.Snapshots[0]
+
+	if _, err := dst.CopyFrom(ctx, src); err != nil {
+		t.Fatalf("CopyFrom: %v", err)
+	}
+
+	dstList, err := dst.List(ctx)
+	if err != nil {
+		t.Fatalf("list destination: %v", err)
+	}
+	if len(dstList.Snapshots) != 1 {
+		t.Fatalf("destination holds %d snapshots, want 1", len(dstList.Snapshots))
+	}
+	copied := dstList.Snapshots[0]
+
+	// Created is the whole point of the feature: a copy is not a re-backup.
+	if copied.Snap.Created != original.Snap.Created {
+		t.Errorf("Created = %q, want %q", copied.Snap.Created, original.Snap.Created)
+	}
+	if len(copied.Snap.Tags) != 2 {
+		t.Errorf("Tags = %v, want the source's two tags", copied.Snap.Tags)
+	}
+	if original.Snap.Source == nil || copied.Snap.Source == nil ||
+		copied.Snap.Source.Path != original.Snap.Source.Path {
+		t.Errorf("source identity was not preserved: %+v", copied.Snap.Source)
+	}
+}
+
+// A rerun must skip what it already copied, and must not re-read the source
+// data to work that out.
+func TestCopyFrom_IsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	src := openRepo(t, t.TempDir(), "source-password")
+	dst := openRepo(t, t.TempDir(), "destination-password")
+	backupTree(t, src, map[string]string{"a.txt": "first"})
+
+	first, err := dst.CopyFrom(ctx, src)
+	if err != nil {
+		t.Fatalf("first CopyFrom: %v", err)
+	}
+	if len(first.Copied) != 1 {
+		t.Fatalf("first run copied %d snapshots, want 1", len(first.Copied))
+	}
+
+	second, err := dst.CopyFrom(ctx, src)
+	if err != nil {
+		t.Fatalf("second CopyFrom: %v", err)
+	}
+	if len(second.Copied) != 0 {
+		t.Errorf("second run copied %d snapshots, want 0", len(second.Copied))
+	}
+	if len(second.Skipped) != 1 {
+		t.Fatalf("second run skipped %d snapshots, want 1", len(second.Skipped))
+	}
+	if second.Skipped[0].DestRef != first.Copied[0].DestRef {
+		t.Errorf("skip named %q, want the snapshot written first (%q)",
+			second.Skipped[0].DestRef, first.Copied[0].DestRef)
+	}
+	// Reading the source's snapshot data again would defeat the point of
+	// recording provenance: the skip decision comes from the destination
+	// catalog alone.
+	if second.BytesRead != 0 {
+		t.Errorf("second run read %d bytes from the source, want 0", second.BytesRead)
+	}
+	if len(listRefs(t, dst)) != 1 {
+		t.Error("rerunning the copy duplicated the snapshot in the destination")
+	}
+}
+
+// Snapshots after the first in a run are applied as a diff against the previous
+// one, so a file that disappeared between two source snapshots has to be
+// *removed* from the destination tree rather than merely not re-added. Getting
+// this wrong leaves deleted files visible forever in every copied snapshot,
+// which no amount of restoring the latest snapshot would reveal.
+func TestCopyFrom_PropagatesDeletionsBetweenSnapshots(t *testing.T) {
+	ctx := context.Background()
+	src := openRepo(t, t.TempDir(), "source-password")
+	dst := openRepo(t, t.TempDir(), "destination-password")
+
+	dir := t.TempDir()
+	for _, name := range []string{"keep.txt", "doomed.txt"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("content of "+name), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	if _, err := src.Backup(ctx, localsource.New(dir)); err != nil {
+		t.Fatalf("first backup: %v", err)
+	}
+
+	if err := os.Remove(filepath.Join(dir, "doomed.txt")); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "added.txt"), []byte("new file"), 0o644); err != nil {
+		t.Fatalf("write added.txt: %v", err)
+	}
+	if _, err := src.Backup(ctx, localsource.New(dir)); err != nil {
+		t.Fatalf("second backup: %v", err)
+	}
+
+	res, err := dst.CopyFrom(ctx, src)
+	if err != nil {
+		t.Fatalf("CopyFrom: %v", err)
+	}
+	if len(res.Copied) != 2 {
+		t.Fatalf("copied %d snapshots, want 2", len(res.Copied))
+	}
+
+	// Copy order is ascending Created, so the first entry is the older snapshot.
+	older := restoredFiles(t, dst, res.Copied[0].DestRef)
+	newer := restoredFiles(t, dst, res.Copied[1].DestRef)
+
+	if _, ok := older["doomed.txt"]; !ok {
+		t.Error("the older copied snapshot lost a file that existed when it was taken")
+	}
+	if _, ok := newer["doomed.txt"]; ok {
+		t.Error("the newer copied snapshot still contains a file deleted before it was taken")
+	}
+	if newer["added.txt"] != "new file" {
+		t.Errorf("added.txt = %q in the newer snapshot, want its content", newer["added.txt"])
+	}
+	if newer["keep.txt"] != "content of keep.txt" {
+		t.Errorf("keep.txt = %q, want it carried through unchanged", newer["keep.txt"])
+	}
+}
+
+// The incremental path must produce trees that are *semantically* identical to
+// the ones a whole-tree rebuild produces: same files, same contents, in every
+// copied snapshot.
+//
+// Semantic rather than byte-for-byte, deliberately. The HAMT is not
+// history-independent — identical content reached through different insertion
+// histories yields different roots, which is true of `backup` as well — so
+// comparing snapshot refs would assert a property the data structure has never
+// had and would fail for reasons unrelated to copying.
+func TestCopyFrom_IncrementalTreesMatchWholeTreeRebuild(t *testing.T) {
+	ctx := context.Background()
+	src := openRepo(t, t.TempDir(), "source-password")
+
+	dir := t.TempDir()
+	for i := range 6 {
+		name := filepath.Join(dir, fmt.Sprintf("f%d.txt", i))
+		if err := os.WriteFile(name, []byte(fmt.Sprintf("payload %d", i)), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if i == 4 {
+			// A deletion partway through, so the diff path's Delete branch is
+			// part of what is being compared.
+			if err := os.Remove(filepath.Join(dir, "f1.txt")); err != nil {
+				t.Fatalf("remove: %v", err)
+			}
+		}
+		if _, err := src.Backup(ctx, localsource.New(dir)); err != nil {
+			t.Fatalf("backup %d: %v", i, err)
+		}
+	}
+
+	// One batched run: the first snapshot takes the whole-tree path and the
+	// rest are applied as diffs against their predecessor.
+	batched := openRepo(t, t.TempDir(), "destination-password")
+	batchedRes, err := batched.CopyFrom(ctx, src)
+	if err != nil {
+		t.Fatalf("batched CopyFrom: %v", err)
+	}
+	if len(batchedRes.Copied) != 6 {
+		t.Fatalf("batched copy produced %d snapshots, want 6", len(batchedRes.Copied))
+	}
+
+	// One snapshot per run, in the order the batched run used. Each run starts
+	// with no previously copied tree for the lineage, so every snapshot takes
+	// the whole-tree path. Driving the order from the batched result keeps the
+	// pairing exact: several of these snapshots share a Created second, so list
+	// order would not be a reliable stand-in.
+	individual := openRepo(t, t.TempDir(), "destination-password")
+	var oneAtATime []CopiedSnapshot
+	for _, want := range batchedRes.Copied {
+		res, err := individual.CopyFrom(ctx, src, WithCopySnapshotIDs(want.SourceRef))
+		if err != nil {
+			t.Fatalf("individual CopyFrom %s: %v", want.SourceRef, err)
+		}
+		oneAtATime = append(oneAtATime, res.Copied...)
+	}
+
+	if len(oneAtATime) != len(batchedRes.Copied) {
+		t.Fatalf("one-at-a-time copied %d snapshots, want %d", len(oneAtATime), len(batchedRes.Copied))
+	}
+	for i := range batchedRes.Copied {
+		if batchedRes.Copied[i].SourceRef != oneAtATime[i].SourceRef {
+			t.Fatalf("run %d compared different source snapshots", i)
+		}
+		viaDiff := restoredFiles(t, batched, batchedRes.Copied[i].DestRef)
+		viaWhole := restoredFiles(t, individual, oneAtATime[i].DestRef)
+		if !reflect.DeepEqual(viaDiff, viaWhole) {
+			t.Errorf("snapshot %d: diff path restored %v, whole-tree path restored %v",
+				i, sortedKeys(viaDiff), sortedKeys(viaWhole))
+		}
+	}
+}
+
+func sortedKeys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestCopyFrom_DryRunWritesNothing(t *testing.T) {
+	ctx := context.Background()
+	src := openRepo(t, t.TempDir(), "source-password")
+	dst := openRepo(t, t.TempDir(), "destination-password")
+	backupTree(t, src, map[string]string{"a.txt": "first"})
+
+	res, err := dst.CopyFrom(ctx, src, WithCopyDryRun())
+	if err != nil {
+		t.Fatalf("CopyFrom: %v", err)
+	}
+	if !res.DryRun {
+		t.Error("result does not record that it was a dry run")
+	}
+	if len(listRefs(t, dst)) != 0 {
+		t.Error("a dry run wrote a snapshot into the destination")
+	}
+}
+
+// Copying into a repository that already holds the same plaintext must reuse
+// what is there. This is the property that makes seeding a shared destination
+// affordable, and it holds only because chunk boundaries are reproducible.
+func TestCopyFrom_DeduplicatesAgainstExistingDestinationData(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	for _, name := range []string{"a.txt", "b.txt"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("shared payload"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	src := openRepo(t, t.TempDir(), "source-password")
+	dst := openRepo(t, t.TempDir(), "destination-password")
+
+	source := localsource.New(dir)
+	if _, err := src.Backup(ctx, source, WithGenerator("test")); err != nil {
+		t.Fatalf("backup into source: %v", err)
+	}
+	// The destination backs up the very same directory, so it independently
+	// holds every chunk the copy is about to bring over.
+	source2 := localsource.New(dir)
+	if _, err := dst.Backup(ctx, source2, WithGenerator("test")); err != nil {
+		t.Fatalf("backup into destination: %v", err)
+	}
+
+	res, err := dst.CopyFrom(ctx, src)
+	if err != nil {
+		t.Fatalf("CopyFrom: %v", err)
+	}
+	if len(res.Copied) != 1 {
+		t.Fatalf("copied %d snapshots, want 1", len(res.Copied))
+	}
+	if res.BytesWritten > 4096 {
+		t.Errorf("copy wrote %d bytes into a destination that already held the data", res.BytesWritten)
+	}
+}
+
+// stripRepoID rewrites an unencrypted repository's marker to drop its
+// identifier, reproducing what an older build leaves behind when it rewrites
+// the marker during a format upgrade.
+func stripRepoID(t *testing.T, dir string) {
+	t.Helper()
+	path := filepath.Join(dir, "config")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read marker: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("parse marker: %v", err)
+	}
+	delete(cfg, "id")
+	out, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("encode marker: %v", err)
+	}
+	if err := os.WriteFile(path, out, 0o644); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+}
+
+// A repository with no identifier still must not be copied into itself. The
+// identifier is the exact test, but it is absent on repositories written before
+// it existed and on any whose marker an older build has rewritten — and a
+// self-copy doubles the history rather than failing loudly.
+func TestCopyFrom_RefusesTheSameRepositoryWithoutAnID(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	client := openRepo(t, dir, "")
+	backupTree(t, client, map[string]string{"a.txt": "payload"})
+	stripRepoID(t, dir)
+
+	before := len(listRefs(t, client))
+
+	backend, err := localstore.New(dir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	twin, err := NewClient(ctx, backend)
+	if err != nil {
+		t.Fatalf("open twin client: %v", err)
+	}
+	// Reopen the destination too, so neither guard can succeed by pointer
+	// identity alone.
+	destBackend, err := localstore.New(dir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	dest, err := NewClient(ctx, destBackend)
+	if err != nil {
+		t.Fatalf("open destination client: %v", err)
+	}
+
+	if _, err := dest.CopyFrom(ctx, twin); err == nil {
+		t.Fatal("copying an id-less repository into itself was allowed")
+	}
+	if after := len(listRefs(t, client)); after != before {
+		t.Errorf("history changed from %d to %d snapshots", before, after)
+	}
+}
+
+// The fallback must not refuse legitimate work: two distinct repositories that
+// both lack an identifier are still two repositories.
+func TestCopyFrom_AllowsDistinctRepositoriesWithoutIDs(t *testing.T) {
+	ctx := context.Background()
+	srcDir, dstDir := t.TempDir(), t.TempDir()
+	src := openRepo(t, srcDir, "")
+	dst := openRepo(t, dstDir, "")
+	backupTree(t, src, map[string]string{"a.txt": "payload"})
+	stripRepoID(t, srcDir)
+	stripRepoID(t, dstDir)
+
+	res, err := dst.CopyFrom(ctx, src)
+	if err != nil {
+		t.Fatalf("CopyFrom between two id-less repositories: %v", err)
+	}
+	if len(res.Copied) != 1 {
+		t.Errorf("copied %d snapshots, want 1", len(res.Copied))
+	}
+}
+
+func TestCopyFrom_RefusesTheSameRepository(t *testing.T) {
+	dir := t.TempDir()
+	client := openRepo(t, dir, "password")
+
+	backend, err := localstore.New(dir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	twin, err := NewClient(context.Background(), backend,
+		WithKeychain(keychain.Chain{keychain.WithPassword("password")}))
+	if err != nil {
+		t.Fatalf("open twin client: %v", err)
+	}
+
+	_, err = client.CopyFrom(context.Background(), twin)
+	if err == nil {
+		t.Fatal("copying a repository into itself was allowed")
+	}
+}

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -23,6 +23,7 @@ Cloudstic is a content-addressable backup tool that creates encrypted, deduplica
   - [ls](#ls)
   - [find](#find)
   - [diff](#diff)
+  - [copy](#copy)
   - [forget](#forget)
   - [prune](#prune)
   - [break-lock](#break-lock)
@@ -1052,6 +1053,91 @@ Each hash may be shortened to any unambiguous prefix. Cloudstic reports an error
 instead of choosing a snapshot when a prefix is ambiguous.
 
 Shows added, modified, and removed files between the two snapshots.
+
+---
+
+### copy
+
+Copy snapshot history from another repository into this one — to seed a new
+repository, migrate between backends, or promote local snapshots into a remote.
+
+```bash
+# Copy every snapshot from one repository into another
+cloudstic copy -store s3:dest-bucket/prod \
+  -from-store local:/tmp/cloudstic-src -from-password <source-password>
+
+# Copy one profile's repository into another profile's repository
+cloudstic copy -profile remote-prod -from-profile laptop-local
+
+# Copy only selected snapshots
+cloudstic copy -profile archive -from-profile laptop-local 410b18a2 4e5d5487 latest
+```
+
+The destination is configured exactly as for any other command. The source
+repository gets a parallel set of `-from-*` flags — `-from-store`,
+`-from-profile`, `-from-password`, `-from-s3-*`, `-from-b2-*`,
+`-from-store-sftp-*`, `-from-kms-*` and so on — mirroring every flag that
+locates or unlocks a repository.
+
+**The `-from-*` flags read no environment variables.** `CLOUDSTIC_PASSWORD` and
+friends configure the destination only, so one ambient value can never silently
+unlock both repositories. For non-interactive use, name the source with
+`-from-profile`; a profile entry may carry `env://` secret references like any
+other. The source must always be named explicitly — unlike `-store`, it has no
+default.
+
+Nothing is written to the source, so read-only source credentials are enough.
+
+| Flag | Description |
+|------|-------------|
+| `-from-store <uri>` | Source repository URI |
+| `-from-profile <name>` | Source repository from a profile |
+| `-dry-run` | Report what would be copied, write nothing |
+| `-source <uri>` | Copy only snapshots of this source |
+| `-account <id>` | Copy only snapshots of this account |
+| `-tag <tag>` | Copy only snapshots with this tag (repeatable) |
+| `-since <time>` | Copy only snapshots created at or after this time |
+| `-allow-copied` | Allow copying snapshots that were themselves copied |
+
+Both repositories are named before anything is written, since a mistyped
+destination is the one mistake a rerun cannot undo:
+
+```text
+copying from local:/tmp/cloudstic-src
+            to s3:dest-bucket/prod
+
+snapshot 410b18a2 of [local:/Users/ada/Documents] at 2026-04-01 18:15:03 +0000
+snapshot a1b2c3d4 saved
+
+copied 1 snapshot, skipped 0 snapshots (read 4.2 GiB, wrote 1.1 GiB) in 1m32s
+```
+
+**What is preserved.** Creation time, tags, source identity, path lineage and
+file metadata all carry over — a copy is history, not a re-backup. Sequence
+numbers are reassigned, because they record write order within a repository
+rather than being part of a snapshot's identity.
+
+**Rerunning is safe.** Each copied snapshot records where it came from, so a
+second run skips what it already copied without re-reading the source. This also
+makes an interrupted copy cheap to resume: rerun it and only the unfinished work
+is repeated.
+
+**Cost.** Copying is far more expensive than an incremental backup. Object names
+are derived from each repository's own encryption key, so nothing can be moved
+verbatim: every object in the selected snapshots is read and decrypted through
+the source, then re-encrypted and written to the destination. Data the
+destination already holds is still recognised and skipped, so copying into a
+repository that shares content with the source is much cheaper than copying into
+an empty one.
+
+**Retention.** A copy re-imports any selected snapshot the destination does not
+currently have — including one the destination deliberately forgot. For a
+scheduled copy, pass `-since` with the previous run's start time so that
+destination retention is not undone on the next run.
+
+The source and destination need not share a password, key slots, or encryption
+at all. Copying between an encrypted and an unencrypted repository works in
+either direction.
 
 ---
 

--- a/internal/engine/copy.go
+++ b/internal/engine/copy.go
@@ -1,0 +1,967 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cloudstic/cli/internal/core"
+	"github.com/cloudstic/cli/internal/hamt"
+	"github.com/cloudstic/cli/internal/logger"
+	"github.com/cloudstic/cli/internal/ui"
+	"github.com/cloudstic/cli/pkg/crypto"
+	"github.com/cloudstic/cli/pkg/store"
+)
+
+var defaultCopyLog = logger.New("copy", logger.ColorCyan)
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+// CopyOption configures a copy run.
+type CopyOption func(*copyConfig)
+
+type copyConfig struct {
+	snapshotIDs []string
+	filter      snapshotFilter
+	since       time.Time
+	hasSince    bool
+	dryRun      bool
+	allowCopied bool
+}
+
+// WithCopySnapshotIDs restricts the copy to the named source snapshots. The
+// filters still apply on top, narrowing this set further.
+func WithCopySnapshotIDs(ids ...string) CopyOption {
+	return func(cfg *copyConfig) { cfg.snapshotIDs = append(cfg.snapshotIDs, ids...) }
+}
+
+// WithCopyFilterSource restricts the copy to snapshots of the given source type.
+func WithCopyFilterSource(source string) CopyOption {
+	return func(cfg *copyConfig) { cfg.filter.source = source }
+}
+
+// WithCopyFilterPath restricts the copy to snapshots of the given source path.
+func WithCopyFilterPath(path string) CopyOption {
+	return func(cfg *copyConfig) { cfg.filter.path = path }
+}
+
+// WithCopyFilterAccount restricts the copy to snapshots of the given account.
+func WithCopyFilterAccount(account string) CopyOption {
+	return func(cfg *copyConfig) { cfg.filter.account = account }
+}
+
+// WithCopyFilterTag restricts the copy to snapshots carrying the given tag.
+// Repeating it requires all the named tags.
+func WithCopyFilterTag(tag string) CopyOption {
+	return func(cfg *copyConfig) { cfg.filter.tags = append(cfg.filter.tags, tag) }
+}
+
+// WithCopySince restricts the copy to snapshots created at or after t.
+//
+// This is the composable answer to destination retention: a scheduled copy
+// passes its previous run's start time, so snapshots the destination has since
+// forgotten are not resurrected on the next run (RFC 0017 §7).
+func WithCopySince(t time.Time) CopyOption {
+	return func(cfg *copyConfig) { cfg.since, cfg.hasSince = t, true }
+}
+
+// WithCopyDryRun resolves and reports the selection without writing anything.
+func WithCopyDryRun() CopyOption {
+	return func(cfg *copyConfig) { cfg.dryRun = true }
+}
+
+// WithCopyAllowCopied permits copying snapshots that already carry provenance
+// from an earlier copy, re-stamping them with the immediate source.
+func WithCopyAllowCopied() CopyOption {
+	return func(cfg *copyConfig) { cfg.allowCopied = true }
+}
+
+// ---------------------------------------------------------------------------
+// Results
+// ---------------------------------------------------------------------------
+
+// CopiedSnapshot records one snapshot transferred into the destination.
+type CopiedSnapshot struct {
+	SourceRef string           `json:"source_ref"`
+	DestRef   string           `json:"dest_ref"`
+	Created   string           `json:"created"`
+	Source    *core.SourceInfo `json:"source,omitempty"`
+}
+
+// SkippedSnapshot records one snapshot the destination already had.
+type SkippedSnapshot struct {
+	SourceRef string           `json:"source_ref"`
+	DestRef   string           `json:"dest_ref"`
+	Created   string           `json:"created"`
+	Reason    string           `json:"reason"`
+	Source    *core.SourceInfo `json:"source,omitempty"`
+}
+
+// CopyResult reports what a copy run did.
+type CopyResult struct {
+	Copied       []CopiedSnapshot  `json:"copied"`
+	Skipped      []SkippedSnapshot `json:"skipped"`
+	BytesRead    int64             `json:"bytes_read"`
+	BytesWritten int64             `json:"bytes_written"`
+	DryRun       bool              `json:"dry_run"`
+	SourceRepoID string            `json:"source_repo_id,omitempty"`
+	DestRepoID   string            `json:"dest_repo_id,omitempty"`
+	Duration     time.Duration     `json:"duration"`
+}
+
+// ---------------------------------------------------------------------------
+// Manager
+// ---------------------------------------------------------------------------
+
+// CopySide describes the repository a copy reads from.
+//
+// RepoID may be empty: a repository written before RepoConfig.ID existed has
+// none, and one whose marker was rewritten by an older build has lost it. That
+// is handled by CopyProvenance.Matches rather than treated as an error.
+type CopySide struct {
+	Store  store.ObjectStore
+	RepoID string
+}
+
+// CopyManager transfers snapshots from one repository into another.
+//
+// The transfer is a rebuild, not a copy of bytes. Every object reference in a
+// repository is derived from that repository's master key — chunk and content
+// refs through an HMAC of the plaintext, filemeta and node refs through hashes
+// that embed them — so an object written to the destination necessarily has a
+// different name than it had in the source. The graph is therefore reassembled
+// bottom-up, remapping each level's references as it goes (RFC 0017 §4).
+type CopyManager struct {
+	src     CopySide
+	dst     store.ObjectStore
+	dstHMAC []byte
+	dstID   string
+
+	reporter ui.Reporter
+	log      *logger.Logger
+	snapLog  *logger.Logger
+
+	srcTree *hamt.Tree
+	dstTree *hamt.Tree
+
+	// The remap tables live for the whole run rather than per snapshot.
+	//
+	// Consecutive snapshots of one source share the overwhelming majority of
+	// their graph, so a per-snapshot table re-reads every file that appears in
+	// more than one snapshot. Measured on a 2000-file tree at eight snapshots,
+	// clearing the tables between snapshots took plaintext read from 2.2 MB to
+	// 7.1 MB and wall time from 89 ms to 198 ms.
+	//
+	// It is not the only thing keeping that bounded, which is worth knowing
+	// before trusting a benchmark: copyContent checks the destination before
+	// reading anything, so bulk data is not re-read even with no table at all.
+	// What the tables save is the metadata read and the destination round trip
+	// per file per snapshot.
+	chunkRefs   map[string]string
+	contentRefs map[string]string
+	metaRefs    map[string]copiedMeta
+
+	// lastCopied remembers, per lineage, the source tree most recently copied
+	// in this run and the destination tree it produced. Holding both is what
+	// lets the next snapshot of that lineage be applied as a diff: the pair is
+	// a proven translation, so changes between two source roots map exactly
+	// onto changes against that destination root.
+	lastCopied map[string]copiedTree
+
+	// bytesRead accumulates plaintext read from the source. The copy loop is
+	// sequential, so this needs no synchronisation.
+	bytesRead int64
+}
+
+// copiedMeta is what the remap table remembers about a filemeta already
+// rebuilt in the destination.
+//
+// The affinity key is stored alongside the ref because reconstructing it needs
+// the file's parent, which is only in the metadata object. Keeping it here is
+// what lets a cache hit skip the source read entirely — and a hit is the common
+// case, since a file that did not change between two snapshots appears in both.
+type copiedMeta struct {
+	ref         string
+	affinityKey string
+}
+
+// copiedTree pairs a source tree with the destination tree copy produced from
+// it, so the next snapshot of the same lineage can be applied incrementally.
+type copiedTree struct {
+	sourceRoot string
+	destRoot   string
+}
+
+// NewCopyManager builds a manager that reads from src and writes to dst.
+//
+// dstHMAC is the destination's dedup key, and is what every rewritten
+// reference is computed under; pass nil for an unencrypted destination.
+func NewCopyManager(
+	src CopySide,
+	dst store.ObjectStore,
+	dstHMAC []byte,
+	dstRepoID string,
+	reporter ui.Reporter,
+	logWriter io.Writer,
+) *CopyManager {
+	return &CopyManager{
+		src:         src,
+		dst:         dst,
+		dstHMAC:     dstHMAC,
+		dstID:       dstRepoID,
+		reporter:    reporter,
+		log:         defaultCopyLog.To(logWriter),
+		snapLog:     SnapshotLogger(logWriter),
+		srcTree:     hamt.NewTree(src.Store, hamt.WithLogger(logWriter)),
+		dstTree:     hamt.NewTree(dst, hamt.WithLogger(logWriter)),
+		chunkRefs:   map[string]string{},
+		contentRefs: map[string]string{},
+		metaRefs:    map[string]copiedMeta{},
+		lastCopied:  map[string]copiedTree{},
+	}
+}
+
+// Run performs the copy.
+func (cm *CopyManager) Run(ctx context.Context, opts ...CopyOption) (*CopyResult, error) {
+	started := time.Now()
+	var cfg copyConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	if cm.src.RepoID != "" && cm.src.RepoID == cm.dstID {
+		return nil, fmt.Errorf(
+			"source and destination are the same repository (%s): copying a repository into itself would duplicate its history",
+			cm.src.RepoID,
+		)
+	}
+
+	result := &CopyResult{
+		DryRun:       cfg.dryRun,
+		SourceRepoID: cm.src.RepoID,
+		DestRepoID:   cm.dstID,
+	}
+
+	sourceEntries, err := LoadSnapshotCatalog(cm.src.Store, cm.snapLog)
+	if err != nil {
+		return nil, fmt.Errorf("read source snapshot catalog: %w", err)
+	}
+	selected, err := cm.selectSnapshots(ctx, cfg, sourceEntries)
+	if err != nil {
+		return nil, err
+	}
+
+	// One read of the destination catalog serves both questions asked of it:
+	// what has already been copied, and which tree each lineage should seed
+	// from.
+	destEntries, err := LoadSnapshotCatalog(cm.dst, cm.snapLog)
+	if err != nil {
+		return nil, fmt.Errorf("read destination snapshot catalog: %w", err)
+	}
+	alreadyCopied := newProvenanceIndex(destEntries)
+	cm.primeLastCopied(destEntries, sourceEntries)
+
+	pending := make([]SnapshotEntry, 0, len(selected))
+	for _, entry := range selected {
+		prov := core.CopyProvenance{RepoID: cm.src.RepoID, SnapshotRef: entry.Ref}
+		if destRef, ok := alreadyCopied.lookup(prov); ok {
+			result.Skipped = append(result.Skipped, SkippedSnapshot{
+				SourceRef: entry.Ref,
+				DestRef:   destRef,
+				Created:   entry.Snap.Created,
+				Source:    entry.Snap.Source,
+				Reason:    "already copied",
+			})
+			continue
+		}
+		pending = append(pending, entry)
+	}
+
+	if cfg.dryRun {
+		// A dry run reports the same selection a real run would act on, with
+		// the destination refs left empty because they are only knowable once
+		// the objects they name have been written.
+		for _, entry := range pending {
+			result.Copied = append(result.Copied, CopiedSnapshot{
+				SourceRef: entry.Ref,
+				Created:   entry.Snap.Created,
+				Source:    entry.Snap.Source,
+			})
+		}
+		result.Duration = time.Since(started)
+		return result, nil
+	}
+
+	if len(pending) == 0 {
+		result.Duration = time.Since(started)
+		return result, nil
+	}
+
+	// Shared locks on both repositories, source first. Shared locks do not
+	// exclude one another, so two copies running in opposite directions
+	// between the same pair cannot deadlock on the acquisition order. What
+	// they do exclude is a concurrent prune: on the source it would collect
+	// objects out from under the walk, and on the destination it would collect
+	// objects written here but not yet reachable from any snapshot.
+	// The source lock is best-effort, and only because taking it is itself a
+	// write. Copying from a repository you can only read is a supported and
+	// useful configuration, so failing to *place* a lock there must not fail
+	// the copy — but finding one already held must, since that means a prune or
+	// forget is running and objects are being collected as we walk.
+	srcLock, lockedCtx, err := AcquireSharedLock(ctx, cm.src.Store, "copy (source)")
+	switch {
+	case err == nil:
+		defer srcLock.Release()
+		ctx = lockedCtx
+	case errors.Is(err, ErrRepoLocked):
+		return nil, fmt.Errorf("lock source repository: %w", err)
+	default:
+		cm.log.Debugf("proceeding without a source lock (%v); the source is read-only "+
+			"or otherwise refused the lock, so a concurrent prune there could remove "+
+			"objects mid-copy", err)
+	}
+
+	dstLock, dstCtx, err := AcquireSharedLock(ctx, cm.dst, "copy")
+	if err != nil {
+		return nil, fmt.Errorf("lock destination repository: %w", err)
+	}
+	defer dstLock.Release()
+	ctx = dstCtx
+
+	defer func() { _ = cm.dst.Flush(ctx) }()
+
+	seq, err := cm.nextSeq()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, entry := range pending {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if !cfg.allowCopied {
+			if _, copied := core.CopyProvenanceFromMeta(entry.Snap.Meta); copied {
+				return nil, fmt.Errorf(
+					"snapshot %s was itself produced by copy: pass -allow-copied to re-stamp its provenance to this source",
+					shortRef(entry.Ref),
+				)
+			}
+		}
+
+		destRef, err := cm.copySnapshot(ctx, entry, seq)
+		if err != nil {
+			return nil, fmt.Errorf("copy snapshot %s: %w", shortRef(entry.Ref), err)
+		}
+		seq++
+
+		result.Copied = append(result.Copied, CopiedSnapshot{
+			SourceRef: entry.Ref,
+			DestRef:   destRef,
+			Created:   entry.Snap.Created,
+			Source:    entry.Snap.Source,
+		})
+	}
+
+	if err := cm.reconcileLatest(ctx, result.Copied); err != nil {
+		return nil, err
+	}
+
+	result.BytesRead = cm.bytesRead
+	result.Duration = time.Since(started)
+	return result, nil
+}
+
+// ---------------------------------------------------------------------------
+// Selection
+// ---------------------------------------------------------------------------
+
+// selectSnapshots resolves the source snapshots to copy, in the order they
+// must be written: ascending Created, ties broken by ascending source Seq.
+//
+// The ordering is load-bearing. Destination sequence numbers are allocated in
+// write order, so copying oldest-first is what keeps the destination's Seq
+// ordering agreeing with its Created ordering (RFC 0017 §4.1).
+func (cm *CopyManager) selectSnapshots(
+	ctx context.Context, cfg copyConfig, entries []SnapshotEntry,
+) ([]SnapshotEntry, error) {
+	var err error
+	if len(cfg.snapshotIDs) > 0 {
+		entries, err = cm.resolveExplicit(ctx, entries, cfg.snapshotIDs)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	selected := make([]SnapshotEntry, 0, len(entries))
+	for _, entry := range entries {
+		if !cfg.filter.IsEmpty() && !matchesFilter(&entry.Snap, cfg.filter) {
+			continue
+		}
+		if cfg.hasSince && entry.Created.Before(cfg.since) {
+			continue
+		}
+		selected = append(selected, entry)
+	}
+
+	sort.SliceStable(selected, func(i, j int) bool {
+		if !selected[i].Created.Equal(selected[j].Created) {
+			return selected[i].Created.Before(selected[j].Created)
+		}
+		return selected[i].Snap.Seq < selected[j].Snap.Seq
+	})
+	return selected, nil
+}
+
+// resolveExplicit narrows entries to the named snapshots, resolving each
+// selector the way every other command does so that "latest" and abbreviated
+// hashes mean here what they mean elsewhere.
+func (cm *CopyManager) resolveExplicit(
+	ctx context.Context, entries []SnapshotEntry, ids []string,
+) ([]SnapshotEntry, error) {
+	byRef := make(map[string]SnapshotEntry, len(entries))
+	for _, entry := range entries {
+		byRef[entry.Ref] = entry
+	}
+
+	seen := map[string]bool{}
+	out := make([]SnapshotEntry, 0, len(ids))
+	for _, id := range ids {
+		ref, err := resolveSnapshotRef(ctx, cm.src.Store, id)
+		if err != nil {
+			return nil, err
+		}
+		if seen[ref] {
+			continue
+		}
+		entry, ok := byRef[ref]
+		if !ok {
+			return nil, snapshotNotFoundError(id)
+		}
+		seen[ref] = true
+		out = append(out, entry)
+	}
+	return out, nil
+}
+
+// ---------------------------------------------------------------------------
+// Provenance index
+// ---------------------------------------------------------------------------
+
+// provenanceIndex answers "has this source snapshot already been copied here".
+type provenanceIndex struct {
+	entries map[string]string // CopyProvenance.SnapshotRef → destination ref
+	repoIDs map[string]string // CopyProvenance.SnapshotRef → recorded source repo id
+}
+
+func (p provenanceIndex) lookup(want core.CopyProvenance) (string, bool) {
+	destRef, ok := p.entries[want.SnapshotRef]
+	if !ok {
+		return "", false
+	}
+	have := core.CopyProvenance{RepoID: p.repoIDs[want.SnapshotRef], SnapshotRef: want.SnapshotRef}
+	if !have.Matches(want) {
+		return "", false
+	}
+	return destRef, true
+}
+
+// newProvenanceIndex indexes what the destination was already copied from.
+//
+// It reads the catalog's denormalized CopiedFrom rather than fetching every
+// destination snapshot object, which is the whole reason that field exists.
+// An entry written by a build predating the field has no provenance to read;
+// that degrades to re-copying the snapshot, not to skipping one that was never
+// copied, which is the safe direction (RFC 0017 §5.3).
+func newProvenanceIndex(entries []SnapshotEntry) provenanceIndex {
+	index := provenanceIndex{
+		entries: make(map[string]string, len(entries)),
+		repoIDs: make(map[string]string, len(entries)),
+	}
+	for _, entry := range entries {
+		prov, ok := core.ParseCopyProvenance(entry.CopiedFrom)
+		if !ok {
+			continue
+		}
+		index.entries[prov.SnapshotRef] = entry.Ref
+		index.repoIDs[prov.SnapshotRef] = prov.RepoID
+	}
+	return index
+}
+
+// ---------------------------------------------------------------------------
+// Per-snapshot rebuild
+// ---------------------------------------------------------------------------
+
+func (cm *CopyManager) copySnapshot(ctx context.Context, entry SnapshotEntry, seq int) (string, error) {
+	snap, err := cm.loadSourceSnapshot(ctx, entry.Ref)
+	if err != nil {
+		return "", err
+	}
+
+	phase := cm.startPhase(entry)
+	defer phase.Done()
+
+	lineage := identityKey(snap.Source)
+	prev, incremental := cm.lastCopied[lineage]
+
+	// A tree may only be reused when the source tree it was translated from is
+	// known, because reuse is expressed as a diff and a diff is the only way to
+	// carry deletions across. Reusing a tree and merely inserting this
+	// snapshot's entries over it would leave behind every file deleted since —
+	// present in the destination's copy of a snapshot that does not contain it.
+	var txn *hamt.Txn
+	if incremental {
+		txn = cm.dstTree.Edit(prev.destRoot)
+		err = cm.applySourceDiff(ctx, txn, prev.sourceRoot, snap.Root, phase)
+	} else {
+		txn = cm.dstTree.Edit("")
+		err = cm.applyWholeTree(ctx, txn, snap.Root, phase)
+	}
+	if err != nil {
+		return "", err
+	}
+
+	root, err := txn.Commit(ctx)
+	if err != nil {
+		return "", fmt.Errorf("commit destination tree: %w", err)
+	}
+
+	ref, err := cm.writeSnapshot(ctx, snap, entry.Ref, root, seq)
+	if err != nil {
+		return "", err
+	}
+	cm.lastCopied[lineage] = copiedTree{sourceRoot: snap.Root, destRoot: root}
+	return ref, nil
+}
+
+// applyWholeTree files every entry of a source snapshot into txn. It is the
+// path taken for the first snapshot of a lineage in a run, where there is no
+// earlier source tree to compare against.
+func (cm *CopyManager) applyWholeTree(ctx context.Context, txn *hamt.Txn, root string, phase ui.Phase) error {
+	return cm.srcTree.Walk(ctx, root, func(fileID, srcMetaRef string) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		copied, err := cm.copyFileMeta(ctx, srcMetaRef)
+		if err != nil {
+			return fmt.Errorf("filemeta %s: %w", shortRef(srcMetaRef), err)
+		}
+		phase.Increment(1)
+		return txn.Insert(ctx, copied.affinityKey, fileID, copied.ref)
+	})
+}
+
+// applySourceDiff files only what changed between two consecutive source
+// snapshots of one lineage.
+//
+// Re-filing every entry instead would be correct but quadratic in a way that
+// does not show up in read volume, which is why it survived a first round of
+// measurement: the remap table already makes re-reading an unchanged file free,
+// so the cost hides in the destination tree. Txn.Insert rewrites a leaf entry
+// unconditionally, so re-inserting an identical value still dirties the whole
+// spine, and Commit then re-serializes and rewrites the tree. Copying 64
+// snapshots of a 2000-file tree that way wrote 14.8 MB where the tree itself is
+// 3.5 MB — one full rewrite per snapshot, to record a single changed file.
+//
+// Walking the diff instead makes a run of snapshots cost one tree plus the
+// changes between them, which is what backup already does for the same reason.
+func (cm *CopyManager) applySourceDiff(
+	ctx context.Context, txn *hamt.Txn, oldRoot, newRoot string, phase ui.Phase,
+) error {
+	return cm.srcTree.Diff(ctx, oldRoot, newRoot, func(entry hamt.DiffEntry) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		phase.Increment(1)
+
+		if entry.NewValue == "" {
+			// Removed. The routing key has to come from the metadata the entry
+			// used to point at, which the source still holds — every object is
+			// content-addressed, so nothing was deleted there.
+			key, err := cm.affinityKeyFor(ctx, entry.OldValue)
+			if err != nil {
+				return fmt.Errorf("filemeta %s: %w", shortRef(entry.OldValue), err)
+			}
+			return txn.Delete(ctx, key, entry.Key)
+		}
+
+		copied, err := cm.copyFileMeta(ctx, entry.NewValue)
+		if err != nil {
+			return fmt.Errorf("filemeta %s: %w", shortRef(entry.NewValue), err)
+		}
+		return txn.Insert(ctx, copied.affinityKey, entry.Key, copied.ref)
+	})
+}
+
+// affinityKeyFor returns the routing key an existing source filemeta was filed
+// under, without copying it. A ref already copied in this run is answered from
+// the remap table.
+func (cm *CopyManager) affinityKeyFor(ctx context.Context, srcMetaRef string) (string, error) {
+	if cached, ok := cm.metaRefs[srcMetaRef]; ok {
+		return cached.affinityKey, nil
+	}
+	data, err := cm.get(ctx, srcMetaRef)
+	if err != nil {
+		return "", err
+	}
+	var meta core.FileMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return "", fmt.Errorf("parse filemeta: %w", err)
+	}
+	return AffinityKey(primaryParentID(&meta), meta.FileID), nil
+}
+
+// primeLastCopied recovers, per lineage, a source tree the destination already
+// holds a translation of — so the first snapshot of a run can be applied as a
+// diff instead of rebuilding a whole tree.
+//
+// The pairing comes from provenance the destination already records: a copied
+// snapshot names the source snapshot it was made from, and the source catalog
+// still knows that snapshot's root. Without this, every run would rebuild one
+// full tree before it could go incremental, which is the entire cost of a
+// scheduled copy that has a single new snapshot to bring over.
+//
+// A destination snapshot that was not produced by copy has no provenance and is
+// skipped: its tree is not a translation of anything, so no diff against it
+// would be meaningful. So is one whose recorded source repository is not the
+// one being copied from, or whose source snapshot has since been forgotten.
+func (cm *CopyManager) primeLastCopied(destEntries, sourceEntries []SnapshotEntry) {
+	sourceRoots := make(map[string]string, len(sourceEntries))
+	for _, entry := range sourceEntries {
+		sourceRoots[entry.Ref] = entry.Snap.Root
+	}
+
+	best := map[string]int{}
+	for _, entry := range destEntries {
+		prov, ok := core.ParseCopyProvenance(entry.CopiedFrom)
+		if !ok {
+			continue
+		}
+		if !prov.Matches(core.CopyProvenance{RepoID: cm.src.RepoID, SnapshotRef: prov.SnapshotRef}) {
+			continue
+		}
+		sourceRoot, ok := sourceRoots[prov.SnapshotRef]
+		if !ok {
+			continue
+		}
+		lineage := identityKey(entry.Snap.Source)
+		if seq, seen := best[lineage]; seen && seq >= entry.Snap.Seq {
+			continue
+		}
+		best[lineage] = entry.Snap.Seq
+		cm.lastCopied[lineage] = copiedTree{sourceRoot: sourceRoot, destRoot: entry.Snap.Root}
+	}
+}
+
+// identityKey collapses a SourceInfo to the lineage it belongs to, preferring
+// the stable identity fields and falling back to the display ones for snapshots
+// written before those existed.
+func identityKey(info *core.SourceInfo) string {
+	if info == nil {
+		return ""
+	}
+	container := info.Identity
+	if container == "" {
+		container = info.Account
+	}
+	path := info.PathID
+	if path == "" {
+		path = info.Path
+	}
+	return info.Type + "\x00" + container + "\x00" + path
+}
+
+// writeSnapshot persists the destination snapshot object and catalogs it.
+func (cm *CopyManager) writeSnapshot(
+	ctx context.Context, srcSnap *core.Snapshot, srcRef, root string, seq int,
+) (string, error) {
+	prov := core.CopyProvenance{RepoID: cm.src.RepoID, SnapshotRef: srcRef}
+
+	dest := *srcSnap
+	dest.Root = root
+	// Seq is a global write counter allocated at write time, not part of a
+	// snapshot's identity, so it cannot be carried over: the source's value
+	// would collide with destination history. See RFC 0017 §4.5.
+	dest.Seq = seq
+	dest.Meta = prov.ApplyTo(srcSnap.Meta)
+
+	hash, data, err := core.ComputeJSONHash(&dest)
+	if err != nil {
+		return "", err
+	}
+	ref := "snapshot/" + hash
+	if err := cm.dst.Put(ctx, ref, data); err != nil {
+		return "", fmt.Errorf("write snapshot: %w", err)
+	}
+	AppendSnapshotCatalog(cm.dst, snapshotToSummary(ref, dest), cm.snapLog)
+	return ref, nil
+}
+
+// ---------------------------------------------------------------------------
+// Object rebuild
+// ---------------------------------------------------------------------------
+
+// copyFileMeta rewrites one file's metadata for the destination and returns its
+// destination ref together with the routing key it must be filed under. Only
+// the content reference changes; every other field is carried over byte for
+// byte, which is what preserves names, timestamps, ownership and xattrs.
+//
+// The cache is consulted before the source is read, so a file unchanged across
+// a run of snapshots is fetched once no matter how many snapshots contain it.
+func (cm *CopyManager) copyFileMeta(ctx context.Context, srcRef string) (copiedMeta, error) {
+	if cached, ok := cm.metaRefs[srcRef]; ok {
+		return cached, nil
+	}
+
+	data, err := cm.get(ctx, srcRef)
+	if err != nil {
+		return copiedMeta{}, err
+	}
+	var meta core.FileMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return copiedMeta{}, fmt.Errorf("parse filemeta: %w", err)
+	}
+
+	// A folder carries no content, and backup clears its ContentHash rather
+	// than recording one for an empty stream.
+	if meta.ContentHash != "" && meta.Type != core.FileTypeFolder {
+		contentRef, err := cm.copyContent(ctx, &meta)
+		if err != nil {
+			return copiedMeta{}, err
+		}
+		meta.ContentRef = contentRef
+	}
+
+	destRef, encoded, err := core.FileMetaRef(&meta)
+	if err != nil {
+		return copiedMeta{}, err
+	}
+	if err := cm.putIfMissing(ctx, destRef, encoded); err != nil {
+		return copiedMeta{}, err
+	}
+
+	copied := copiedMeta{ref: destRef, affinityKey: AffinityKey(primaryParentID(&meta), meta.FileID)}
+	cm.metaRefs[srcRef] = copied
+	return copied, nil
+}
+
+// copyContent rebuilds one content manifest and returns its destination
+// reference (the bare hex ref, as stored on FileMeta.ContentRef).
+//
+// The destination reference is derived from the plaintext content hash the
+// filemeta already records, so it does not have to be recomputed from the
+// stream. What does have to be rebuilt is the manifest body: it lists chunk
+// refs, and those are named under the destination's key.
+func (cm *CopyManager) copyContent(ctx context.Context, meta *core.FileMeta) (string, error) {
+	destContentRef := meta.ContentHash
+	if len(cm.dstHMAC) > 0 {
+		destContentRef = crypto.ComputeHMAC(cm.dstHMAC, []byte(meta.ContentHash))
+	}
+
+	srcKey := "content/" + meta.ContentRef
+	if meta.ContentRef == "" {
+		srcKey = "content/" + meta.ContentHash
+	}
+	if _, done := cm.contentRefs[srcKey]; done {
+		return destContentRef, nil
+	}
+
+	destKey := "content/" + destContentRef
+	exists, err := cm.dst.Exists(ctx, destKey)
+	if err != nil {
+		return "", err
+	}
+	if exists {
+		// Already present, either from an interrupted earlier run or because
+		// the destination independently holds this exact content. Either way
+		// its chunks are present too, so there is nothing to transfer.
+		cm.contentRefs[srcKey] = destContentRef
+		return destContentRef, nil
+	}
+
+	raw, err := cm.get(ctx, srcKey)
+	if err != nil {
+		return "", err
+	}
+	var content core.Content
+	if err := json.Unmarshal(raw, &content); err != nil {
+		return "", fmt.Errorf("parse content %s: %w", shortRef(srcKey), err)
+	}
+
+	if len(content.Chunks) > 0 {
+		rebuilt := make([]string, len(content.Chunks))
+		for i, chunkRef := range content.Chunks {
+			destChunkRef, err := cm.copyChunk(ctx, chunkRef)
+			if err != nil {
+				return "", err
+			}
+			rebuilt[i] = destChunkRef
+		}
+		content.Chunks = rebuilt
+	}
+
+	encoded, err := json.Marshal(content)
+	if err != nil {
+		return "", err
+	}
+	if err := cm.dst.Put(ctx, destKey, encoded); err != nil {
+		return "", err
+	}
+	cm.contentRefs[srcKey] = destContentRef
+	return destContentRef, nil
+}
+
+// copyChunk transfers one chunk, re-addressing it under the destination's key.
+//
+// Chunk boundaries are reused rather than recomputed. FastCDC here is
+// parameterised by fixed constants with no key-derived seed, so re-running the
+// chunker over the same plaintext is guaranteed to reproduce the split the
+// source already recorded — and identical plaintext therefore lands on the same
+// destination ref as data backed up directly, which is what lets a copy
+// deduplicate against content the destination already holds (RFC 0017 §4.3).
+func (cm *CopyManager) copyChunk(ctx context.Context, srcRef string) (string, error) {
+	if cached, ok := cm.chunkRefs[srcRef]; ok {
+		return cached, nil
+	}
+
+	data, err := cm.get(ctx, srcRef)
+	if err != nil {
+		return "", fmt.Errorf("read chunk %s: %w", shortRef(srcRef), err)
+	}
+
+	destRef := "chunk/" + core.ComputeHash(data)
+	if len(cm.dstHMAC) > 0 {
+		destRef = "chunk/" + crypto.ComputeHMAC(cm.dstHMAC, data)
+	}
+	if err := cm.putIfMissing(ctx, destRef, data); err != nil {
+		return "", err
+	}
+	cm.chunkRefs[srcRef] = destRef
+	return destRef, nil
+}
+
+// ---------------------------------------------------------------------------
+// index/latest
+// ---------------------------------------------------------------------------
+
+// reconcileLatest points index/latest at the newest copied snapshot, but only
+// when that is newer than what the destination already considered latest.
+//
+// This is the one place copy departs from the repository's "highest Seq wins"
+// rule, and it has to. Copied snapshots are allocated sequence numbers in write
+// order, so the last one written always holds the highest Seq — which under the
+// ordinary rule would make a copy of old history silently displace a live head
+// that is years newer.
+func (cm *CopyManager) reconcileLatest(ctx context.Context, copied []CopiedSnapshot) error {
+	if len(copied) == 0 {
+		return nil
+	}
+	newest := copied[len(copied)-1]
+	newestAt, err := time.Parse(time.RFC3339, newest.Created)
+	if err != nil {
+		// An unparseable timestamp is not a reason to fail a completed copy,
+		// but it is a reason not to move a pointer based on it.
+		cm.log.Debugf("not moving index/latest: unparseable created %q", newest.Created)
+		return nil
+	}
+
+	currentRef, _, err := resolveLatestContext(ctx, cm.dst)
+	if err != nil {
+		return err
+	}
+	if currentRef != "" && currentRef != newest.DestRef {
+		current, err := loadSnapshotByRef(ctx, cm.dst, currentRef)
+		if err != nil {
+			return err
+		}
+		if at, err := time.Parse(time.RFC3339, current.Created); err == nil && !newestAt.After(at) {
+			cm.log.Debugf("leaving index/latest at %s: newer than every copied snapshot", shortRef(currentRef))
+			return nil
+		}
+	}
+
+	destSnap, err := loadSnapshotByRef(ctx, cm.dst, newest.DestRef)
+	if err != nil {
+		return err
+	}
+	return updateLatest(cm.dst, newest.DestRef, destSnap.Seq)
+}
+
+// nextSeq returns the sequence number the first copied snapshot should take.
+func (cm *CopyManager) nextSeq() (int, error) {
+	_, seq, err := resolveLatest(cm.dst)
+	if err != nil {
+		return 0, err
+	}
+	return seq + 1, nil
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func (cm *CopyManager) get(ctx context.Context, key string) ([]byte, error) {
+	data, err := cm.src.Store.Get(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	cm.bytesRead += int64(len(data))
+	return data, nil
+}
+
+// putIfMissing writes key only when the destination does not already hold it.
+//
+// The Exists check is what makes an interrupted copy cheap to retry: every
+// object below the snapshot is content-addressed, so a rerun derives the same
+// destination refs and finds most of its work already done.
+func (cm *CopyManager) putIfMissing(ctx context.Context, key string, data []byte) error {
+	exists, err := cm.dst.Exists(ctx, key)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+	return cm.dst.Put(ctx, key, data)
+}
+
+func (cm *CopyManager) loadSourceSnapshot(ctx context.Context, ref string) (*core.Snapshot, error) {
+	data, err := cm.get(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	var snap core.Snapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return nil, fmt.Errorf("parse snapshot %s: %w", shortRef(ref), err)
+	}
+	return &snap, nil
+}
+
+func (cm *CopyManager) startPhase(entry SnapshotEntry) ui.Phase {
+	if cm.reporter == nil {
+		cm.reporter = ui.NewNoOpReporter()
+	}
+	label := fmt.Sprintf("Copying snapshot %s", shortRef(entry.Ref))
+	if entry.Snap.Source != nil && entry.Snap.Source.Path != "" {
+		label = fmt.Sprintf("Copying %s (%s)", shortRef(entry.Ref), entry.Snap.Source.Path)
+	}
+	return cm.reporter.StartPhase(label, 0, false)
+}
+
+func shortRef(ref string) string {
+	hash := ref
+	if i := strings.LastIndex(ref, "/"); i >= 0 {
+		hash = ref[i+1:]
+	}
+	if len(hash) > 8 {
+		return hash[:8]
+	}
+	return hash
+}

--- a/rfcs/0017-snapshot-copy-between-repositories.md
+++ b/rfcs/0017-snapshot-copy-between-repositories.md
@@ -275,10 +275,41 @@ For each selected source snapshot, in order:
 
 **The remap table is per-run, not per-snapshot**, and is keyed on source refs at
 the filemeta, content and chunk levels. Snapshots in one run share the
-overwhelming majority of their graph; a per-snapshot table would re-read and
-re-encrypt every unchanged file once per snapshot. This is the difference
-between a copy that is proportional to the repository and one that is
-proportional to (repository × snapshots).
+overwhelming majority of their graph; a per-snapshot table would re-read every
+file that appears in more than one snapshot.
+
+**Snapshots after the first of a lineage are applied as a diff**, not as a full
+re-walk. `Tree.Diff` between the previous source root and this one yields just
+the added, modified and removed entries, which are applied to the destination
+tree the previous snapshot produced. Re-filing every entry instead is correct
+but expensive in a way that read volume does not reveal: `Txn.Insert` rewrites a
+leaf entry unconditionally, so re-inserting an identical value still dirties the
+spine and `Commit` rewrites the tree — one full tree rewrite per snapshot.
+
+A diff is also the only way to carry **deletions** across. A tree reused and
+merely inserted over keeps every file deleted since, so the destination's copy
+of a snapshot would contain files that snapshot does not. Reuse and diffing are
+therefore the same decision: a destination tree may only be reused when the
+source tree it was translated from is known.
+
+That pairing is recovered across runs from provenance the destination already
+records — a copied snapshot names its source snapshot, and the source catalog
+still knows that snapshot's root — so a scheduled copy does not rebuild a whole
+tree before it can go incremental.
+
+Measured on a 2000-file tree (`copy_bench_test.go`):
+
+| Change | Effect |
+|--------|--------|
+| Per-snapshot instead of per-run remap tables | 2.2 MB → 7.1 MB read, 89 ms → 198 ms, at 8 snapshots |
+| Full re-walk instead of a source diff | 4.1 MB → 14.8 MB written, 115 ms → 370 ms, at 64 snapshots |
+| No cross-run pairing (scheduled catch-up of one snapshot) | 1.6 KB → 707 KB read, 7.6 KB → 217 KB written |
+
+Note that bulk data is protected independently of all this: `copyContent`
+checks the destination before reading anything, so chunk data is never re-read
+even with no table at all. What these optimisations govern is metadata reads,
+destination round trips, and tree rewrites — which is exactly the part that a
+benchmark measuring bytes transferred would miss.
 
 #### 4.3 Chunk and content rebuild
 
@@ -319,6 +350,15 @@ parameters against this RFC.
 Copy acquires a **shared** repository lock on the source, then a shared lock on
 the destination (`internal/engine/repolock.go`), and holds both for the
 duration.
+
+**The source lock is best-effort, and only because taking one is itself a
+write.** This RFC lists read-only source credentials as supported, and placing a
+lock contradicts that — so a source that refuses the write is copied from
+anyway, with the loss of protection logged. Finding a lock *already held* is
+different and still fatal: it means a `prune` or `forget` is running and objects
+are being collected as the walk proceeds. The distinction is available because
+`ErrRepoLocked` is wrapped into "held by another operation" and not into an I/O
+failure.
 
 - The source lock stops a concurrent `prune`/`forget` from collecting objects
   out from under an in-flight walk.
@@ -707,8 +747,26 @@ what would be copied without writing.
 
 ### 11. Guards
 
-- **Same repository.** If source and destination resolve to the same repository
-  id (or, for legacy repositories, the same store URI and prefix), copy refuses.
+- **Same repository.** Copy refuses. This matters more than it sounds: a
+  self-copy is not a no-op, because each source snapshot is rewritten as a *new*
+  snapshot object carrying provenance. No data is duplicated — every object
+  re-addresses to the ref it already has — but the history doubles, and
+  retention grouping, `latest` and every count are wrong afterwards.
+
+  Repository ids settle it when both sides have one. When either does not, the
+  two stores are **probed**: a uniquely named object is written to the
+  destination and looked for through the source. Cheaper tests were tried and
+  are not sufficient — comparing store URIs misses `local:/srv/repo` against
+  `local:/srv/repo/.`, a symlink, a bind mount, or one bucket reachable under
+  two endpoints; comparing the stored markers collides in practice, because
+  once the id is stripped two repositories created in the same second are
+  byte-identical, which refuses legitimate copies between distinct id-less
+  repositories. The probe writes only to the destination and removes what it
+  wrote, so read-only source credentials remain sufficient.
+
+  The CLI additionally compares the two resolved store URIs, which catches the
+  common slip before either repository is opened and so before any credential
+  prompt. That check is an early convenience, not the guarantee.
 - **Uninitialized destination.** Refuse, pointing at `cloudstic init`.
 - **Empty selection.** Exit 0 with an explicit "no snapshots selected" line, not
   silently.


### PR DESCRIPTION
## Summary

- Add `cloudstic copy`, which transfers snapshot history from one repository into another — for seeding a new repository, migrating between backends, or promoting local snapshots into a remote one.
- Rebuild the destination graph bottom-up with a reference remap at each level. Nothing transfers verbatim: object names are derived from each repository's master key, so a copy is a rebuild. Timestamps, tags, source identity and file metadata carry over; `Seq` is reassigned, since it records write order within a repository rather than snapshot identity.
- Derive the source repository's `-from-*` flags from the existing flag groups instead of restating them, so the two sets cannot drift. This needed one preparatory refactor: `flagSpec.bind` now takes the name to register under rather than closing over it.
- Add `Client.CopyFrom(ctx, src *Client, opts...)`, taking the source as a client so no caller ever composes the `storelayer` chain and the source is format-gated by `NewClient`.

Part of RFC 0017. Follows #420.

## Reviewer notes

**The `-from-*` flags read no environment variables.** `CLOUDSTIC_PASSWORD` means "the repository I am operating on"; letting one ambient value bind to both sides of a two-repository command is how an operator unlocks the wrong one, or believes they did. The source also has no default — `-store` defaults to a local path, and inheriting that would make a bare `cloudstic copy` read whatever sits in `./backup_store`. A test caught that one.

**A performance pass changed the design and found a correctness bug.** Reads were flat from the start, which is why it initially looked fine, but writes grew linearly with snapshot count — 64 snapshots of a 2000-file tree wrote 14.8 MB where the tree is 3.5 MB, one full tree rewrite per snapshot to record a single changed file. Snapshots are now applied as a `Tree.Diff` against the previous source snapshot.

That fix exposed a bug that predated it: the old path seeded the destination tree and only *inserted*, so **files deleted in the source were never removed from copied snapshots**. Deleted files reappeared, silently. Reuse and diffing turn out to be the same decision — a destination tree may only be reused when the source tree it was translated from is known, because a diff is the only way to carry deletions. That pairing is now also recovered across runs from provenance already in the destination catalog.

Measured on a 2000-file tree (`copy_bench_test.go`):

| | before | after |
|---|---|---|
| 64 snapshots, bytes written | 14.8 MB | 4.1 MB |
| 64 snapshots, wall | 370 ms | 115 ms |
| scheduled catch-up of 1 snapshot, read | 707 KB | 1.6 KB |
| scheduled catch-up, written | 217 KB | 7.6 KB |

Worth knowing before trusting any of this: bulk data was never at risk, because `copyContent` checks the destination before reading. A benchmark measuring bytes transferred would have shown all of the above as fine. The costs were in metadata reads, round trips and tree rewrites.

**Self-copy is refused by probe, not by comparison.** Copying a repository into itself doubles its history. Repository ids settle it when both sides have one; otherwise a uniquely named object is written to the destination and looked for through the source. Comparing URIs misses symlinks, bind mounts and one bucket under two endpoints; comparing markers collides for repositories created in the same second once the id is stripped, which refuses legitimate copies — a test caught that too.

**The source lock is best-effort**, because taking a lock is a write and copying from a read-only repository is supported. Finding one already *held* is still fatal, since that means a prune is collecting objects as the walk proceeds. This resolves a contradiction in the RFC, which listed read-only sources as supported while requiring a source lock.

**Not a regression here:** the HAMT is history-independent for insertion but not for deletion, so the diff and whole-tree paths are compared semantically rather than by root hash. Filed separately as #421.

## Verification

- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./...`
- `env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./ ./internal/engine ./internal/hamt`
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./...`
- `npx markdownlint-cli2 rfcs/0017-snapshot-copy-between-repositories.md docs/user-guide.md`
- Manual end-to-end between two local repositories sharing no key: `check -read-data` clean on the destination, restore byte-exact, and `diff` between two copied snapshots reporting only the changed file.