### PR TITLE
fix: give repositories that predate RepoConfig.ID one by using them

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cloudstic/cli/internal/core"
 	"github.com/cloudstic/cli/internal/engine"
+	"github.com/cloudstic/cli/internal/repoconfig"
 	"github.com/cloudstic/cli/internal/storelayer"
 	"github.com/cloudstic/cli/pkg/secretref"
 	"github.com/cloudstic/cli/pkg/source"
@@ -85,6 +86,91 @@ func (c *Client) stampWriteFormat(ctx context.Context) {
 	if err := c.raiseRepoFormat(ctx); err != nil {
 		c.log.Debugf("could not stamp repository format: %v", err)
 	}
+	c.ensureRepoID(ctx)
+}
+
+// ensureRepoID gives a repository an identifier if it has none, so that one
+// written before RepoConfig.ID existed — or one whose marker an older build
+// rewrote, dropping the field — acquires one by being used rather than by the
+// operator knowing to re-run `init`.
+//
+// It runs on mutations only, following the same rule as the format stamp: a
+// read that quietly rewrote the marker would be a surprising side effect of
+// listing snapshots, and would fail against the read-only credentials that
+// reading a repository is meant to need.
+//
+// Best-effort, deliberately. An identifier only makes `copy` cheaper and more
+// precise — provenance falls back to matching on the source snapshot ref
+// without one — so it is never worth failing a completed mutation over. The
+// format stamp is fatal before a backup for a reason that does not apply here:
+// it decides how bytes are written, and this decides nothing.
+//
+// Two machines mutating one repository at the same moment can each mint an
+// identifier, and the later write wins. The cost is bounded and self-correcting:
+// snapshots copied under the losing identifier recorded it, a later copy
+// computes the winner, CopyProvenance.Matches declines to match two known and
+// different repositories, and that history is imported once more before
+// settling. That is the same failure this design already accepts from an older
+// build stripping the field, which is why matching treats an absent identifier
+// as unknown rather than as a distinguishing value.
+func (c *Client) ensureRepoID(ctx context.Context) {
+	if c.base == nil {
+		return
+	}
+	if cached := c.repoIDCache.Load(); cached != nil && *cached != "" {
+		return
+	}
+
+	// Re-read rather than trusting the cache's empty value. The marker is read
+	// immediately before it is written, so a peer that assigned an identifier
+	// since this client opened is seen and left alone.
+	raw, err := fetchRepoConfigBytes(ctx, c.base)
+	if err != nil {
+		c.log.Debugf("could not read repository config to assign an id: %v", err)
+		return
+	}
+	if raw == nil {
+		return // not initialized; init assigns the identifier
+	}
+
+	// Assigning an identifier must change nothing else about the repository,
+	// and for a marker that is plaintext on an encrypted repository it cannot:
+	// writing it back would seal it, and a sealed marker cannot be read by
+	// builds that predate sealing. That is a version-gated decision about who
+	// can still open the repository, which belongs to the format stamp and not
+	// to this. Such a marker acquires an identifier once something else seals
+	// it; until then `copy` matches provenance on the snapshot ref alone, which
+	// is the documented fallback.
+	if !repoconfig.IsSealed(raw) && len(c.encryptionKey) > 0 {
+		cfg, decErr := repoconfig.Decode(raw, nil)
+		if decErr == nil && cfg.Encrypted {
+			c.log.Debugf("leaving the plaintext marker of an encrypted repository alone rather than sealing it to assign an id")
+			return
+		}
+	}
+
+	cfg, err := repoconfig.Decode(raw, c.encryptionKey)
+	if err != nil {
+		c.log.Debugf("could not decode repository config to assign an id: %v", err)
+		return
+	}
+	if cfg.ID != "" {
+		c.repoIDCache.Store(&cfg.ID)
+		return
+	}
+
+	id, err := core.NewRepoID()
+	if err != nil {
+		c.log.Debugf("could not generate a repository id: %v", err)
+		return
+	}
+	cfg.ID = id
+	if err := putRepoConfig(ctx, c.base, *cfg, c.encryptionKey); err != nil {
+		c.log.Debugf("could not assign a repository id: %v", err)
+		return
+	}
+	c.repoIDCache.Store(&id)
+	c.log.Debugf("assigned repository id %s", id)
 }
 
 func (c *Client) Backup(ctx context.Context, src source.Source, opts ...BackupOption) (*BackupResult, error) {
@@ -111,6 +197,13 @@ func (c *Client) Backup(ctx context.Context, src source.Source, opts ...BackupOp
 	result, err := mgr.Run(ctx)
 	if err != nil {
 		return nil, err
+	}
+
+	// Backup stamps the format before writing rather than after, so it does not
+	// pass through stampWriteFormat and has to ask for the identifier itself.
+	// A dry run wrote nothing and must not start here.
+	if !result.DryRun {
+		c.ensureRepoID(ctx)
 	}
 
 	result.BytesAddedRaw = rawMeter.BytesWritten()

--- a/client.go
+++ b/client.go
@@ -82,7 +82,16 @@ type Client struct {
 	// openCfg is the config NewClient read, held so the first raiseRepoFormat
 	// of this client does not immediately re-read it. It is consumed on first
 	// use (swapped for the noRepoConfig sentinel) and never consulted again.
-	openCfg        atomic.Pointer[RepoConfig]
+	openCfg atomic.Pointer[RepoConfig]
+	// repoIDCache holds the repository identifier NewClient read, including the
+	// empty string for a repository that has none — nil means "not read yet",
+	// which is why this is a pointer rather than a string.
+	//
+	// It exists so that ensureRepoID costs nothing on the overwhelmingly common
+	// path where an identifier is already present. Without it, every backup,
+	// prune and forget would fetch the marker again purely to learn there was
+	// nothing to do.
+	repoIDCache    atomic.Pointer[string]
 	storedMeter    *storelayer.MeteredStore
 	encryptionKey  []byte
 	hmacKey        []byte
@@ -167,6 +176,8 @@ func NewClient(ctx context.Context, base store.ObjectStore, opts ...ClientOption
 	if cfg != nil {
 		c.repoFormat.Store(int64(cfg.Version))
 		c.openCfg.Store(cfg)
+		id := cfg.ID
+		c.repoIDCache.Store(&id)
 	}
 	c.store = storelayer.NewCompressedStore(inner, storelayer.WithFrameGate(c.framingEnabled))
 	c.storedMeter = storedMeter

--- a/copy.go
+++ b/copy.go
@@ -164,7 +164,15 @@ func sameRepository(ctx context.Context, src, dst *Client, srcID, dstID string) 
 // repoID returns this repository's identifier, or "" for a repository written
 // before the marker carried one — including one whose marker an older build
 // has since rewritten, dropping the field.
+//
+// A cached non-empty value is authoritative: an identifier is assigned once and
+// never changed, so it cannot go stale. An empty one is re-read, because a peer
+// may have assigned one since this client opened, and copying against a stale
+// "no identifier" would fall back to probing for no reason.
 func (c *Client) repoID(ctx context.Context) (string, error) {
+	if cached := c.repoIDCache.Load(); cached != nil && *cached != "" {
+		return *cached, nil
+	}
 	cfg, _, err := c.openRepoConfig(ctx, c.base)
 	if err != nil {
 		return "", err
@@ -172,5 +180,6 @@ func (c *Client) repoID(ctx context.Context) (string, error) {
 	if cfg == nil {
 		return "", fmt.Errorf("repository not initialized")
 	}
+	c.repoIDCache.Store(&cfg.ID)
 	return cfg.ID, nil
 }

--- a/repoid_test.go
+++ b/repoid_test.go
@@ -1,0 +1,264 @@
+package cloudstic
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cloudstic/cli/internal/repoconfig"
+	localsource "github.com/cloudstic/cli/pkg/source/local"
+	localstore "github.com/cloudstic/cli/pkg/store/local"
+)
+
+// Every repository that existed before RepoConfig.ID did has no identifier, and
+// so does any whose marker an older build rewrote. `init` is not something an
+// operator re-runs on a working repository, so an identifier that only `init`
+// could assign would never reach them. These cover the healing path that closes
+// that gap, and the two rules it has to respect: mutations only, never fatal.
+
+// markerID reads the identifier out of an unencrypted repository's marker.
+func markerID(t *testing.T, dir string) string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(dir, "config"))
+	if err != nil {
+		t.Fatalf("read marker: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("parse marker: %v", err)
+	}
+	id, _ := cfg["id"].(string)
+	return id
+}
+
+// legacyRepo returns a client for a repository whose marker carries no
+// identifier, as one written before the field existed does.
+func legacyRepo(t *testing.T, dir string) *Client {
+	t.Helper()
+	openRepo(t, dir, "")
+	stripRepoID(t, dir)
+	if markerID(t, dir) != "" {
+		t.Fatal("failed to strip the identifier from the marker")
+	}
+	// Reopen so the client's cached view matches what is on disk.
+	backend, err := localstore.New(dir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	reopened, err := NewClient(context.Background(), backend)
+	if err != nil {
+		t.Fatalf("reopen client: %v", err)
+	}
+	return reopened
+}
+
+func TestBackupAssignsAMissingRepositoryID(t *testing.T) {
+	dir := t.TempDir()
+	client := legacyRepo(t, dir)
+
+	backupTree(t, client, map[string]string{"a.txt": "payload"})
+
+	if markerID(t, dir) == "" {
+		t.Error("a repository with no identifier still has none after a backup")
+	}
+}
+
+func TestPruneAndForgetAssignAMissingRepositoryID(t *testing.T) {
+	for name, mutate := range map[string]func(*testing.T, *Client){
+		"prune": func(t *testing.T, c *Client) {
+			if _, err := c.Prune(context.Background()); err != nil {
+				t.Fatalf("prune: %v", err)
+			}
+		},
+		"forget": func(t *testing.T, c *Client) {
+			if _, err := c.ForgetPolicy(context.Background(), WithKeepLast(1)); err != nil {
+				t.Fatalf("forget: %v", err)
+			}
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			client := openRepo(t, dir, "")
+			backupTree(t, client, map[string]string{"a.txt": "payload"})
+
+			stripRepoID(t, dir)
+			backend, err := localstore.New(dir)
+			if err != nil {
+				t.Fatalf("open store: %v", err)
+			}
+			reopened, err := NewClient(context.Background(), backend)
+			if err != nil {
+				t.Fatalf("reopen: %v", err)
+			}
+
+			mutate(t, reopened)
+
+			if markerID(t, dir) == "" {
+				t.Errorf("%s did not assign a missing repository identifier", name)
+			}
+		})
+	}
+}
+
+// A read must not rewrite the marker. Doing so would be a surprising side
+// effect of listing snapshots, and would fail against the read-only credentials
+// that reading a repository is supposed to need.
+func TestReadsDoNotAssignARepositoryID(t *testing.T) {
+	dir := t.TempDir()
+	client := openRepo(t, dir, "")
+	backupTree(t, client, map[string]string{"a.txt": "payload"})
+
+	stripRepoID(t, dir)
+	backend, err := localstore.New(dir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	reopened, err := NewClient(context.Background(), backend)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+
+	ctx := context.Background()
+	if _, err := reopened.List(ctx); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if _, err := reopened.Check(ctx); err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if _, err := reopened.LsSnapshot(ctx, "latest"); err != nil {
+		t.Fatalf("ls: %v", err)
+	}
+
+	if id := markerID(t, dir); id != "" {
+		t.Errorf("a read assigned the repository identifier %q", id)
+	}
+}
+
+// A dry run wrote nothing and must not start by writing the marker.
+func TestDryRunDoesNotAssignARepositoryID(t *testing.T) {
+	dir := t.TempDir()
+	client := legacyRepo(t, dir)
+
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "a.txt"), []byte("payload"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := client.Backup(context.Background(), localsource.New(src), WithBackupDryRun()); err != nil {
+		t.Fatalf("dry-run backup: %v", err)
+	}
+
+	if id := markerID(t, dir); id != "" {
+		t.Errorf("a dry run assigned the repository identifier %q", id)
+	}
+}
+
+// An identifier is assigned once. A second mutation must not mint another, or
+// provenance recorded under the first would stop matching.
+func TestRepositoryIDIsStableAcrossMutations(t *testing.T) {
+	dir := t.TempDir()
+	client := legacyRepo(t, dir)
+
+	backupTree(t, client, map[string]string{"a.txt": "one"})
+	first := markerID(t, dir)
+	if first == "" {
+		t.Fatal("no identifier was assigned")
+	}
+
+	backupTree(t, client, map[string]string{"b.txt": "two"})
+	if _, err := client.Prune(context.Background()); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if second := markerID(t, dir); second != first {
+		t.Errorf("identifier changed across mutations: %q -> %q", first, second)
+	}
+}
+
+// A repository that already has one must not be rewritten, and the client must
+// not fetch the marker to discover that.
+func TestExistingRepositoryIDIsLeftAlone(t *testing.T) {
+	dir := t.TempDir()
+	client := openRepo(t, dir, "")
+	before := markerID(t, dir)
+	if before == "" {
+		t.Fatal("init did not assign an identifier")
+	}
+
+	backupTree(t, client, map[string]string{"a.txt": "payload"})
+
+	if after := markerID(t, dir); after != before {
+		t.Errorf("identifier was rewritten: %q -> %q", before, after)
+	}
+}
+
+// Assigning an identifier must not change anything else about the repository.
+//
+// The case that matters is a marker that is plaintext on an encrypted
+// repository, which is what builds predating marker sealing left behind.
+// Writing it back would seal it, and a sealed marker cannot be opened by those
+// builds at all — so an identifier, which only makes `copy` cheaper, would have
+// silently withdrawn the repository from every older client that could still
+// read it. That trade belongs to the version gate, not here.
+func TestAssigningARepositoryIDNeverSealsAPlaintextMarker(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	// A repository as a build predating sealing left it: encrypted, but with a
+	// plaintext marker, and no identifier.
+	base, err := localstore.New(dir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	legacy := RepoConfig{Version: 1, Created: "2026-01-01T00:00:00Z", Encrypted: true}
+	raw, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := base.Put(ctx, "config", raw); err != nil {
+		t.Fatalf("seed marker: %v", err)
+	}
+
+	client, err := NewClient(ctx, base, WithEncryptionKey(make([]byte, 32)))
+	if err != nil {
+		t.Fatalf("open client: %v", err)
+	}
+	client.ensureRepoID(ctx)
+
+	after, err := base.Get(ctx, "config")
+	if err != nil {
+		t.Fatalf("read marker: %v", err)
+	}
+	if repoconfig.IsSealed(after) {
+		t.Error("assigning an identifier sealed a marker that was plaintext, " +
+			"withdrawing the repository from builds that predate sealing")
+	}
+}
+
+// Once healed, copy takes the identifier path rather than probing, and the two
+// repositories are correctly told apart.
+func TestHealedRepositoryIDIsUsedByCopy(t *testing.T) {
+	ctx := context.Background()
+	srcDir, dstDir := t.TempDir(), t.TempDir()
+	src := legacyRepo(t, srcDir)
+	dst := legacyRepo(t, dstDir)
+
+	backupTree(t, src, map[string]string{"a.txt": "payload"})
+	if markerID(t, srcDir) == "" {
+		t.Fatal("the source was not healed by its backup")
+	}
+
+	res, err := dst.CopyFrom(ctx, src)
+	if err != nil {
+		t.Fatalf("CopyFrom: %v", err)
+	}
+	if len(res.Copied) != 1 {
+		t.Fatalf("copied %d snapshots, want 1", len(res.Copied))
+	}
+	if res.SourceRepoID == "" {
+		t.Error("the copy did not record the source repository identifier")
+	}
+	if res.SourceRepoID == res.DestRepoID {
+		t.Errorf("both repositories reported the identifier %q", res.SourceRepoID)
+	}
+}


### PR DESCRIPTION
## Summary

- Assign `RepoConfig.ID` to a repository that has none, during a mutation, so existing repositories acquire one by being used rather than by the operator knowing to re-run `init`.
- Cache the identifier the client read at open, so the common path — one is already present — costs no extra round trip.

## The gap

`init` was the **only** writer of the identifier. `UpgradeRepoFormat` preserves one it finds but never assigns one, and returns early when the version is already current, so it does not even rewrite the marker. Verified before changing anything, against a marker with the field stripped:

```
marker: {"version":2,"created":"…","encrypted":false}
after backup: …unchanged
after prune:  …unchanged
after forget: …unchanged
```

So every repository created before the field existed, and every one whose marker an older build rewrote, would have kept no identifier forever. Re-running `init` does assign one, but that is not something an operator does to a working repository.

Without one, `copy` still works but pays twice: provenance falls back to matching on the source snapshot ref alone, and same-repository detection falls back to probing both stores on every run.

## Rules it respects

- **Mutations only.** A read that quietly rewrote the marker would be a surprising side effect of listing snapshots, and would fail against the read-only credentials that reading a repository is meant to need. Same rule as the format stamp.
- **Never fatal.** An identifier only makes `copy` cheaper and more precise, so it is not worth failing a completed mutation over. The format stamp is fatal before a backup because it decides how bytes are written; this decides nothing.
- **Not on a dry run**, which wrote nothing.

## What the existing tests caught

An early version of this **sealed a marker that was plaintext**, and `TestClient_CatConfigStaysReadableUnderTheGate` and `TestBackupThatSealsStampsTheFormat` failed on it.

A plaintext marker on an encrypted repository is what builds predating marker sealing left behind. Writing it back seals it, and a sealed marker cannot be opened by those builds *at all* — so an identifier, which only makes `copy` cheaper, would have silently withdrawn the repository from every older client that could still read it. That trade belongs to the version gate, not here. Such a marker is now left alone until something else seals it, and `TestAssigningARepositoryIDNeverSealsAPlaintextMarker` pins it — verified by removing the guard and watching it fail.

## Known limit

Two machines mutating one repository at the same moment can each mint an identifier; the later write wins. The cost is one extra import of the affected history, after which it settles. That is the same failure already accepted from an older build stripping the field, and the reason `CopyProvenance.Matches` treats an absent identifier as *unknown* rather than as a distinguishing value. Stated in the code rather than papered over.

## Verification

- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./...`
- `env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./`
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./...`
- Manual runs confirming a dry run and read-only operations leave the marker untouched, a real backup/prune/forget heals it, the identifier is stable across later mutations, and an encrypted repository's sealed marker round-trips.