### PR TITLE
fix(e2e): give each child process its own coverage directory

### DIFF
--- a/e2e/harness_test.go
+++ b/e2e/harness_test.go
@@ -14,12 +14,14 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	cloudstic "github.com/cloudstic/cli"
 )
 
-// TestMain sets up a shared GOCOVERDIR for coverage tracking.
+// TestMain sets up the coverage directory tree. Each child process gets its own
+// directory beneath it — see cleanEnv for why sharing one is not safe.
 func TestMain(m *testing.M) {
 	coverDir := os.Getenv("GOCOVERDIR")
 	ownsDir := coverDir == ""
@@ -30,16 +32,13 @@ func TestMain(m *testing.M) {
 			fmt.Fprintf(os.Stderr, "e2e: failed to create GOCOVERDIR: %v\n", err)
 			os.Exit(1)
 		}
-		if err := os.Setenv("GOCOVERDIR", coverDir); err != nil {
-			fmt.Fprintf(os.Stderr, "e2e: failed to set GOCOVERDIR: %v\n", err)
-			os.Exit(1)
-		}
 	}
+	coverBase = coverDir
 
 	code := m.Run()
 
 	if outFile := os.Getenv("E2E_COVERAGE_OUT"); outFile != "" {
-		cmd := exec.Command("go", "tool", "covdata", "textfmt", "-i="+coverDir, "-o="+outFile)
+		cmd := exec.Command("go", "tool", "covdata", "textfmt", "-i="+coverInputs(coverDir), "-o="+outFile)
 		if out, err := cmd.CombinedOutput(); err != nil {
 			fmt.Fprintf(os.Stderr, "e2e: coverage conversion failed: %v\n%s\n", err, out)
 		}
@@ -90,14 +89,81 @@ func buildBinary(t *testing.T) string {
 	return buildPath
 }
 
+// coverBase is the directory the per-process coverage directories live under,
+// and coverSeq names them apart. Both are set by TestMain.
+var (
+	coverBase string
+	coverSeq  atomic.Int64
+)
+
+// cleanEnv builds the environment for a child cloudstic process: the test
+// process's own, minus anything that would leak configuration into it, plus a
+// coverage directory belonging to that child alone.
+//
+// The private coverage directory is what stops a Go runtime race from failing
+// unrelated tests. A -cover binary rewrites covmeta.<hash> on every exit —
+// it does not skip the write when the file is already there — via a temporary
+// file named for the meta hash and the clock, with no pid in it. macOS
+// quantizes UnixNano to microseconds, so two of these processes exiting in the
+// same microsecond choose the same temporary path; one renames it away and the
+// other fails:
+//
+//	coverage meta-data emit failed: ... rename ...: no such file or directory
+//
+// The binary writes that to stderr, and the run helpers fold stderr into the
+// string a test asserts on, so it surfaced as an unrelated assertion failing
+// with output the command never produced — a diff test reporting a coverage
+// error. It reproduced in 5 of 25 attempts at 24 concurrent processes sharing
+// one directory, and CI runs e2e with -parallel 8.
+//
+// Giving each process its own directory removes the shared path the race needs.
+//
+// Only the failure goes away, not a gap in the data: counter files are named
+// with the pid and never collided, and every process writes identical meta
+// content, so one winner was always enough. Measured before and after, the
+// suite reports the same 38.4%.
 func cleanEnv() []string {
 	var env []string
 	for _, e := range os.Environ() {
-		if !strings.HasPrefix(e, "CLOUDSTIC_") {
-			env = append(env, e)
+		if strings.HasPrefix(e, "CLOUDSTIC_") || strings.HasPrefix(e, "GOCOVERDIR=") {
+			continue
+		}
+		env = append(env, e)
+	}
+	if coverBase == "" {
+		return env
+	}
+	dir := filepath.Join(coverBase, strconv.FormatInt(coverSeq.Add(1), 10))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		// Coverage is reporting, not correctness: a test must not fail because
+		// its counters could not be placed.
+		return env
+	}
+	return append(env, "GOCOVERDIR="+dir)
+}
+
+// coverInputs lists the per-process directories for `go tool covdata`, which
+// takes a comma-separated set rather than a tree to walk.
+//
+// A full run produces around 400 of them: roughly 74 KB of argument, against an
+// ARG_MAX near 1 MB, and about 50 MB of temporary files that TestMain removes.
+// Both have an order of magnitude of headroom; past that this would need to
+// merge in batches rather than pass every directory at once.
+func coverInputs(base string) string {
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		return base
+	}
+	dirs := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			dirs = append(dirs, filepath.Join(base, e.Name()))
 		}
 	}
-	return env
+	if len(dirs) == 0 {
+		return base
+	}
+	return strings.Join(dirs, ",")
 }
 
 func run(t *testing.T, bin string, args ...string) string {


### PR DESCRIPTION
## Summary

Give each child `cloudstic` process its own `GOCOVERDIR`, so concurrent e2e tests stop tripping a Go runtime race that fails unrelated assertions.

## The failure

```
--- FAIL: TestCLI_Feature_DiffSameSnapshot/diff_same_snapshot/local_to_local
    expected diff output to contain no changes, got:
        error: coverage meta-data emit failed: ... rename ...: no such file or directory

        Diffing snapshot/41eb… vs snapshot/41eb…
```

The diff was correct — the coverage error was prepended to it. `run()` uses `CombinedOutput()`, so a child's stderr becomes part of the string under test.

## Cause

A `-cover` binary rewrites `covmeta.<hash>` on **every** exit. It does not skip when the file already exists — confirmed by the inode changing on each run — and it does so via a temporary file named for the meta hash and the clock, with **no pid**. macOS quantizes `UnixNano` to microseconds (every emitted filename ends in `000`), so two processes exiting in the same microsecond choose the same temporary path: one renames it away, the other's rename gets `ENOENT`.

Reproduced at **5 of 25** attempts with 24 concurrent processes sharing one directory. CI runs e2e with `-parallel 8`, so this was a live flake, not a local curiosity.

## What I tried first, and why it failed

A single serial warm-up run before the parallel tests, on the theory that a process skips the meta write when the file is already present. **It does not skip**, and the reproduction rate was unchanged at 5 of 25. The race window is permanent, not confined to an empty directory — which is what forced the per-process fix.

## No coverage was actually being lost

Despite what the error suggests. Counter files carry the pid and never collided, and every process writes identical meta content, so one winner was always sufficient. Measured before and after, the suite reports the same **38.4%**. What changes is only that the run stops failing — I checked rather than assuming, because "fixes a coverage error" invites the assumption that coverage improves.

## Cost

A full run creates ~411 per-process directories: about 74 KB of argument against an `ARG_MAX` near 1 MB, and ~50 MB of temporary files that `TestMain` already removes. Both have an order of magnitude of headroom, noted in the code so that a future tenfold growth is recognised as needing batched merging rather than discovered as a mysterious `E2BIG`.

## Verification

- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./...`
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./...`
- `E2E_COVERAGE_OUT=… go test -shuffle=on -parallel 8 -count=1 ./e2e/` — passes, and produces a profile that `go tool cover -func` reads (9772 lines, 38.4%), confirming the comma-separated multi-directory conversion works.
- The 25-round reproduction harness, before and after.