### PR TITLE
refactor(engine): unify manager deps, logging and filemeta loading

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -193,7 +193,12 @@ func (c *Client) Backup(ctx context.Context, src source.Source, opts ...BackupOp
 	rawMeter := storelayer.NewMeteredStore(c.store)
 	c.storedMeter.Reset()
 
-	mgr := engine.NewBackupManager(src, rawMeter, c.reporter, c.hmacKey, c.logWriter, opts...)
+	// Backup writes through its own meter so the run's raw byte count is
+	// separable from the client-wide stored-bytes total.
+	deps := c.engineDeps()
+	deps.Store = rawMeter
+
+	mgr := engine.NewBackupManager(deps, src, opts...)
 	result, err := mgr.Run(ctx)
 	if err != nil {
 		return nil, err

--- a/check.go
+++ b/check.go
@@ -24,6 +24,6 @@ var (
 // and checking that every referenced object can be read.
 // With WithReadData(), chunk data is re-hashed for byte-level verification.
 func (c *Client) Check(ctx context.Context, opts ...CheckOption) (*CheckResult, error) {
-	mgr := engine.NewCheckManager(c.store, c.reporter, c.hmacKey)
+	mgr := engine.NewCheckManager(c.engineDeps())
 	return mgr.Run(ctx, opts...)
 }

--- a/client.go
+++ b/client.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 
 	"github.com/cloudstic/cli/internal/core"
+	"github.com/cloudstic/cli/internal/engine"
 	"github.com/cloudstic/cli/internal/logger"
 	"github.com/cloudstic/cli/internal/repoconfig"
 	"github.com/cloudstic/cli/internal/storelayer"
@@ -103,6 +104,18 @@ type Client struct {
 	// one. An unbound logger falls back to the process-wide writer.
 	log       *logger.Logger
 	logWriter io.Writer
+}
+
+// engineDeps is the dependency set the engine managers are built from, as this
+// client is configured. An operation that works against a different store —
+// backup, which meters its own — overrides Store on the returned value.
+func (c *Client) engineDeps() engine.Deps {
+	return engine.Deps{
+		Store:    c.store,
+		Reporter: c.reporter,
+		LogSink:  c.logWriter,
+		HMACKey:  c.hmacKey,
+	}
 }
 
 func NewClient(ctx context.Context, base store.ObjectStore, opts ...ClientOption) (*Client, error) {

--- a/copy.go
+++ b/copy.go
@@ -86,14 +86,7 @@ func (c *Client) CopyFrom(ctx context.Context, src *Client, opts ...CopyOption) 
 		)
 	}
 
-	mgr := engine.NewCopyManager(
-		engine.CopySide{Store: src.store, RepoID: srcID},
-		c.store,
-		c.hmacKey,
-		dstID,
-		c.reporter,
-		c.logWriter,
-	)
+	mgr := engine.NewCopyManager(c.engineDeps(), engine.CopySide{Store: src.store, RepoID: srcID}, dstID)
 
 	// Bytes written are metered as they land in the backend — after compression
 	// and encryption — which is the number that matches what the destination is

--- a/internal/engine/backup.go
+++ b/internal/engine/backup.go
@@ -2,12 +2,10 @@ package engine
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"sort"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -129,8 +127,7 @@ type BackupManager struct {
 	cfg        backupConfig
 
 	newMetas     map[string]core.FileMeta
-	metaCacheMu  sync.RWMutex
-	metaCache    map[string]core.FileMeta
+	metas        *metaLoader
 	pendingMetas map[string][]byte // deferred filemeta PUTs (ref → JSON)
 	parentIndex  map[string]string // fileID → primary parent fileID (for AffinityKey lookups)
 	hmacKey      []byte
@@ -158,7 +155,7 @@ func NewBackupManager(src source.Source, dest store.ObjectStore, reporter ui.Rep
 		sourceInfo:   sourceInfo,
 		cfg:          cfg,
 		newMetas:     make(map[string]core.FileMeta),
-		metaCache:    make(map[string]core.FileMeta),
+		metas:        newMetaLoader(keyCache),
 		pendingMetas: make(map[string][]byte),
 		parentIndex:  make(map[string]string),
 		hmacKey:      hmacKey,
@@ -456,25 +453,4 @@ func (bm *BackupManager) writeSnapshotObject(ctx context.Context, root string, s
 
 func (bm *BackupManager) trackFileMeta(ref string, fm core.FileMeta) {
 	bm.newMetas[ref] = fm
-}
-
-func (bm *BackupManager) loadMeta(ctx context.Context, ref string) (*core.FileMeta, error) {
-	bm.metaCacheMu.RLock()
-	fm, ok := bm.metaCache[ref]
-	bm.metaCacheMu.RUnlock()
-	if ok {
-		return &fm, nil
-	}
-
-	data, err := getVerified(ctx, bm.store, ref)
-	if err != nil {
-		return nil, err
-	}
-	if err := json.Unmarshal(data, &fm); err != nil {
-		return nil, err
-	}
-	bm.metaCacheMu.Lock()
-	bm.metaCache[ref] = fm
-	bm.metaCacheMu.Unlock()
-	return &fm, nil
 }

--- a/internal/engine/backup.go
+++ b/internal/engine/backup.go
@@ -112,10 +112,9 @@ func WithExcludeHash(hash string) BackupOption {
 // BackupManager orchestrates a backup: scanning a source for changes, uploading
 // new or modified files, and persisting a snapshot backed by a Merkle-HAMT.
 type BackupManager struct {
-	// log is this manager's debug sink, and snapLog the snapshot-catalog one
-	// it passes to the free functions in snapshots.go.
+	// log is this manager's debug sink; the snapshot catalog carries its own.
 	log     *logger.Logger
-	snapLog *logger.Logger
+	catalog snapshotCatalog
 	source  source.Source
 	// store is the key-cached view of the destination, and the only store this
 	// manager writes through. It is held at its concrete type so PreloadKeys
@@ -150,7 +149,7 @@ func NewBackupManager(src source.Source, dest store.ObjectStore, reporter ui.Rep
 	keyCache := storelayer.NewKeyCacheStore(dest)
 	return &BackupManager{
 		log:          defaultBackupLog.To(logWriter),
-		snapLog:      SnapshotLogger(logWriter),
+		catalog:      newSnapshotCatalog(keyCache, logWriter),
 		source:       src,
 		store:        keyCache,
 		tree:         hamt.NewTree(keyCache, hamt.WithLogger(logWriter)),
@@ -334,7 +333,7 @@ func (bm *BackupManager) Run(ctx context.Context) (*RunResult, error) {
 	}
 
 	// Update snapshot catalog (best-effort).
-	AppendSnapshotCatalog(bm.store, snapshotToSummary(snapRef, snap), bm.snapLog)
+	bm.catalog.add(snapshotToSummary(snapRef, snap))
 
 	r := bm.buildResult()
 	r.SnapshotHash = snapHash
@@ -373,7 +372,7 @@ func (bm *BackupManager) loadLatestSeq() (int, error) {
 // silently downgrade an incremental backup to a full rescan and reset the
 // sequence number.
 func (bm *BackupManager) findPreviousSnapshot(info core.SourceInfo) (*core.Snapshot, error) {
-	entries, err := LoadSnapshotCatalog(bm.store, bm.snapLog)
+	entries, err := bm.catalog.load()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/engine/backup.go
+++ b/internal/engine/backup.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"context"
 	"fmt"
-	"io"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -17,7 +16,6 @@ import (
 	"github.com/cloudstic/cli/internal/storelayer"
 	"github.com/cloudstic/cli/internal/ui"
 	"github.com/cloudstic/cli/pkg/source"
-	"github.com/cloudstic/cli/pkg/store"
 )
 
 var defaultBackupLog = logger.New("backup", logger.ColorGreen)
@@ -133,7 +131,7 @@ type BackupManager struct {
 	hmacKey      []byte
 }
 
-func NewBackupManager(src source.Source, dest store.ObjectStore, reporter ui.Reporter, hmacKey []byte, logWriter io.Writer, opts ...BackupOption) *BackupManager {
+func NewBackupManager(d Deps, src source.Source, opts ...BackupOption) *BackupManager {
 	cfg := backupConfig{
 		generator: "cloudstic-cli",
 		meta:      map[string]string{},
@@ -143,22 +141,22 @@ func NewBackupManager(src source.Source, dest store.ObjectStore, reporter ui.Rep
 	}
 
 	sourceInfo := src.Info()
-	keyCache := storelayer.NewKeyCacheStore(dest)
+	keyCache := storelayer.NewKeyCacheStore(d.Store)
 	return &BackupManager{
-		log:          defaultBackupLog.To(logWriter),
-		catalog:      newSnapshotCatalog(keyCache, logWriter),
+		log:          defaultBackupLog.To(d.LogSink),
+		catalog:      newSnapshotCatalog(keyCache, d.LogSink),
 		source:       src,
 		store:        keyCache,
-		tree:         hamt.NewTree(keyCache, hamt.WithLogger(logWriter)),
-		chunker:      NewChunker(keyCache, hmacKey),
-		reporter:     reporter,
+		tree:         hamt.NewTree(keyCache, hamt.WithLogger(d.LogSink)),
+		chunker:      NewChunker(keyCache, d.HMACKey),
+		reporter:     d.Reporter,
 		sourceInfo:   sourceInfo,
 		cfg:          cfg,
 		newMetas:     make(map[string]core.FileMeta),
 		metas:        newMetaLoader(keyCache),
 		pendingMetas: make(map[string][]byte),
 		parentIndex:  make(map[string]string),
-		hmacKey:      hmacKey,
+		hmacKey:      d.HMACKey,
 	}
 }
 

--- a/internal/engine/backup.go
+++ b/internal/engine/backup.go
@@ -114,11 +114,13 @@ func WithExcludeHash(hash string) BackupOption {
 type BackupManager struct {
 	// log is this manager's debug sink, and snapLog the snapshot-catalog one
 	// it passes to the free functions in snapshots.go.
-	log        *logger.Logger
-	snapLog    *logger.Logger
-	source     source.Source
-	store      store.ObjectStore
-	keyCache   *storelayer.KeyCacheStore
+	log     *logger.Logger
+	snapLog *logger.Logger
+	source  source.Source
+	// store is the key-cached view of the destination, and the only store this
+	// manager writes through. It is held at its concrete type so PreloadKeys
+	// stays reachable; every other use goes through store.ObjectStore.
+	store      *storelayer.KeyCacheStore
 	tree       *hamt.Tree
 	txn        *hamt.Txn // working tree; opened by scanSource, written by Commit
 	chunker    *Chunker
@@ -151,7 +153,6 @@ func NewBackupManager(src source.Source, dest store.ObjectStore, reporter ui.Rep
 		snapLog:      SnapshotLogger(logWriter),
 		source:       src,
 		store:        keyCache,
-		keyCache:     keyCache,
 		tree:         hamt.NewTree(keyCache, hamt.WithLogger(logWriter)),
 		chunker:      NewChunker(keyCache, hmacKey),
 		reporter:     reporter,
@@ -282,7 +283,7 @@ func (bm *BackupManager) Run(ctx context.Context) (*RunResult, error) {
 	}
 
 	// Wait for key cache to finish preloading from inner lists.
-	if err := bm.keyCache.PreloadKeys(ctx, "chunk/", "content/", "node/"); err != nil {
+	if err := bm.store.PreloadKeys(ctx, "chunk/", "content/", "node/"); err != nil {
 		return nil, fmt.Errorf("preload key cache: %w", err)
 	}
 

--- a/internal/engine/backup_scan.go
+++ b/internal/engine/backup_scan.go
@@ -153,7 +153,7 @@ func (bm *BackupManager) lookupDeleteParentID(ctx context.Context, fileID string
 		return "", nil
 	}
 
-	oldMeta, err := bm.loadMeta(ctx, ref)
+	oldMeta, err := bm.metas.load(ctx, ref)
 	if err != nil {
 		return "", fmt.Errorf("load old file metadata for delete %s: %w", fileID, err)
 	}
@@ -175,7 +175,7 @@ func (bm *BackupManager) detectChange(ctx context.Context, oldRoot string, meta 
 		return true, "", nil
 	}
 
-	oldMeta, err := bm.loadMeta(ctx, oldRef)
+	oldMeta, err := bm.metas.load(ctx, oldRef)
 	if err != nil {
 		return false, "", err
 	}
@@ -272,10 +272,7 @@ func (bm *BackupManager) insertFolder(ctx context.Context, meta *core.FileMeta, 
 	if err != nil {
 		return err
 	}
-	bm.metaCacheMu.RLock()
-	_, inCache := bm.metaCache[metaRef]
-	bm.metaCacheMu.RUnlock()
-	if !inCache {
+	if !bm.metas.cached(metaRef) {
 		bm.pendingMetas[metaRef] = metaData
 	}
 	bm.trackFileMeta(metaRef, *meta)
@@ -375,7 +372,7 @@ func (bm *BackupManager) lookupMetaByFileID(ctx context.Context, fileID string) 
 	if fm, ok := bm.newMetas[ref]; ok {
 		return &fm
 	}
-	fm, err := bm.loadMeta(ctx, ref)
+	fm, err := bm.metas.load(ctx, ref)
 	if err != nil {
 		return nil
 	}
@@ -390,7 +387,7 @@ func (bm *BackupManager) countRemoved(ctx context.Context, oldRoot string) error
 	}
 	return bm.txn.DiffFrom(ctx, oldRoot, func(d hamt.DiffEntry) error {
 		if d.OldValue != "" && d.NewValue == "" {
-			meta, err := bm.loadMeta(ctx, d.OldValue)
+			meta, err := bm.metas.load(ctx, d.OldValue)
 			if err != nil {
 				return err
 			}

--- a/internal/engine/backup_scan_test.go
+++ b/internal/engine/backup_scan_test.go
@@ -57,7 +57,7 @@ func TestDetectChange_NativeFileFastPath(t *testing.T) {
 		Content: []byte("exported docx content"),
 	}
 
-	mgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
+	mgr := NewBackupManager(Deps{Store: dest, Reporter: ui.NewNoOpReporter()}, src)
 	result1, err := mgr.Run(ctx)
 	if err != nil {
 		t.Fatalf("First backup failed: %v", err)
@@ -72,7 +72,7 @@ func TestDetectChange_NativeFileFastPath(t *testing.T) {
 	}
 
 	// Second backup: same headRevisionId → should detect as unchanged.
-	mgr2 := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
+	mgr2 := NewBackupManager(Deps{Store: dest, Reporter: ui.NewNoOpReporter()}, src)
 	result2, err := mgr2.Run(ctx)
 	if err != nil {
 		t.Fatalf("Second backup failed: %v", err)
@@ -102,7 +102,7 @@ func TestDetectChange_NativeFileFastPath(t *testing.T) {
 		Content: []byte("new exported docx content"),
 	}
 
-	mgr3 := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
+	mgr3 := NewBackupManager(Deps{Store: dest, Reporter: ui.NewNoOpReporter()}, src)
 	result3, err := mgr3.Run(ctx)
 	if err != nil {
 		t.Fatalf("Third backup failed: %v", err)
@@ -143,7 +143,7 @@ func TestDetectChange_NativeFileEmptyRevID(t *testing.T) {
 		Content: []byte("exported docx content"),
 	}
 
-	mgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
+	mgr := NewBackupManager(Deps{Store: dest, Reporter: ui.NewNoOpReporter()}, src)
 	result1, err := mgr.Run(ctx)
 	if err != nil {
 		t.Fatalf("First backup failed: %v", err)
@@ -153,7 +153,7 @@ func TestDetectChange_NativeFileEmptyRevID(t *testing.T) {
 	}
 
 	// Second backup: still no headRevisionId → should be treated as changed.
-	mgr2 := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
+	mgr2 := NewBackupManager(Deps{Store: dest, Reporter: ui.NewNoOpReporter()}, src)
 	result2, err := mgr2.Run(ctx)
 	if err != nil {
 		t.Fatalf("Second backup failed: %v", err)
@@ -182,7 +182,7 @@ func TestDetectChange_NativeFileCarriesForwardMetadata(t *testing.T) {
 		Content: []byte("content"),
 	}
 
-	mgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
+	mgr := NewBackupManager(Deps{Store: dest, Reporter: ui.NewNoOpReporter()}, src)
 	result1, err := mgr.Run(ctx)
 	if err != nil {
 		t.Fatalf("First backup failed: %v", err)
@@ -211,7 +211,7 @@ func TestDetectChange_NativeFileCarriesForwardMetadata(t *testing.T) {
 
 	// Second backup with same revID: the unchanged path should carry forward
 	// ContentHash and Size from the first backup.
-	mgr2 := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
+	mgr2 := NewBackupManager(Deps{Store: dest, Reporter: ui.NewNoOpReporter()}, src)
 	result2, err := mgr2.Run(ctx)
 	if err != nil {
 		t.Fatalf("Second backup failed: %v", err)
@@ -272,7 +272,7 @@ func TestScanIncremental_DeleteWithoutParentUsesExistingMetadataParent(t *testin
 	}
 
 	dest := NewMockStore()
-	mgr := NewBackupManager(inc, dest, ui.NewNoOpReporter(), nil, nil)
+	mgr := NewBackupManager(Deps{Store: dest, Reporter: ui.NewNoOpReporter()}, inc)
 	_, err := mgr.Run(ctx)
 	if err != nil {
 		t.Fatalf("first backup failed: %v", err)
@@ -285,7 +285,7 @@ func TestScanIncremental_DeleteWithoutParentUsesExistingMetadataParent(t *testin
 	inc.changes = deleteOnly
 	delete(base.Files, "FILE_1")
 
-	mgr2 := NewBackupManager(inc, dest, ui.NewNoOpReporter(), nil, nil)
+	mgr2 := NewBackupManager(Deps{Store: dest, Reporter: ui.NewNoOpReporter()}, inc)
 	second, err := mgr2.Run(ctx)
 	if err != nil {
 		t.Fatalf("second backup failed: %v", err)

--- a/internal/engine/backup_test.go
+++ b/internal/engine/backup_test.go
@@ -53,7 +53,7 @@ func TestBackupManager_ResolvesPathsForOpaqueIDs(t *testing.T) {
 		Content: []byte("jpeg"),
 	}
 
-	mgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
+	mgr := NewBackupManager(Deps{Store: dest, Reporter: ui.NewNoOpReporter()}, src)
 	result, err := mgr.Run(ctx)
 	if err != nil {
 		t.Fatalf("Backup failed: %v", err)
@@ -96,7 +96,7 @@ func TestBackupManager_Run(t *testing.T) {
 	src.AddFile("file1.txt", "id1", []byte("hello world"))
 	src.AddFile("file2.txt", "id2", []byte("another file"))
 
-	mgr := NewBackupManager(src, dest, reporter, nil, nil)
+	mgr := NewBackupManager(Deps{Store: dest, Reporter: reporter}, src)
 
 	// Read store wraps dest with CompressedStore so we can read back
 	// the compressed data written by the BackupManager.
@@ -231,7 +231,7 @@ func TestBackupManager_IgnoreEmptySnapshot(t *testing.T) {
 
 	src.AddFile("file1.txt", "id1", []byte("hello world"))
 
-	first := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
+	first := NewBackupManager(Deps{Store: dest, Reporter: ui.NewNoOpReporter()}, src)
 	firstResult, err := first.Run(ctx)
 	if err != nil {
 		t.Fatalf("first backup failed: %v", err)
@@ -248,7 +248,7 @@ func TestBackupManager_IgnoreEmptySnapshot(t *testing.T) {
 	}
 	firstLatest := idx.LatestSnapshot
 
-	second := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil, WithIgnoreEmptySnapshot())
+	second := NewBackupManager(Deps{Store: dest, Reporter: ui.NewNoOpReporter()}, src, WithIgnoreEmptySnapshot())
 	result, err := second.Run(ctx)
 	if err != nil {
 		t.Fatalf("second backup failed: %v", err)
@@ -343,7 +343,7 @@ func TestFindPreviousSnapshot_Identity(t *testing.T) {
 	})
 
 	src := NewMockSource()
-	bm := NewBackupManager(src, s, ui.NewNoOpReporter(), nil, nil)
+	bm := NewBackupManager(Deps{Store: s, Reporter: ui.NewNoOpReporter()}, src)
 
 	// Search from the Mac with same identity and same selected-root path.
 	info := core.SourceInfo{
@@ -387,7 +387,7 @@ func TestFindPreviousSnapshot_LegacyFallback(t *testing.T) {
 	})
 
 	src := NewMockSource()
-	bm := NewBackupManager(src, s, ui.NewNoOpReporter(), nil, nil)
+	bm := NewBackupManager(Deps{Store: s, Reporter: ui.NewNoOpReporter()}, src)
 
 	// Search without VolumeUUID — should fall back to account+path.
 	info := core.SourceInfo{
@@ -446,7 +446,7 @@ func TestFindPreviousSnapshot_IdentityPreferredOverLegacy(t *testing.T) {
 	})
 
 	src := NewMockSource()
-	bm := NewBackupManager(src, s, ui.NewNoOpReporter(), nil, nil)
+	bm := NewBackupManager(Deps{Store: s, Reporter: ui.NewNoOpReporter()}, src)
 
 	// Search with identity — should find the identity-matched snapshot first.
 	info := core.SourceInfo{
@@ -491,7 +491,7 @@ func TestFindPreviousSnapshot_IdentityDifferentSubdirs(t *testing.T) {
 	})
 
 	src := NewMockSource()
-	bm := NewBackupManager(src, s, ui.NewNoOpReporter(), nil, nil)
+	bm := NewBackupManager(Deps{Store: s, Reporter: ui.NewNoOpReporter()}, src)
 
 	// Search for Documents on the same drive — should NOT match Photos.
 	info := core.SourceInfo{
@@ -522,7 +522,7 @@ func TestBackupManager_Run_PropagatesLatestIndexError(t *testing.T) {
 	src := NewMockSource()
 	src.AddFile("file1.txt", "id1", []byte("hello"))
 
-	mgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
+	mgr := NewBackupManager(Deps{Store: dest, Reporter: ui.NewNoOpReporter()}, src)
 	_, err := mgr.Run(ctx)
 	if err == nil {
 		t.Fatal("expected Run to fail when index/latest cannot be read")
@@ -552,7 +552,7 @@ func TestBackupManager_Run_FlushesPacksBeforeUpdatingIndexLatest(t *testing.T) {
 	src := NewMockSource()
 	src.AddFile("file1.txt", "id1", []byte("hello world"))
 
-	mgr := NewBackupManager(src, packed, ui.NewNoOpReporter(), nil, nil)
+	mgr := NewBackupManager(Deps{Store: packed, Reporter: ui.NewNoOpReporter()}, src)
 	if _, err := mgr.Run(ctx); err != nil {
 		t.Fatalf("Run: %v", err)
 	}

--- a/internal/engine/check.go
+++ b/internal/engine/check.go
@@ -69,12 +69,12 @@ type CheckManager struct {
 }
 
 // NewCheckManager creates a CheckManager.
-func NewCheckManager(s store.ObjectStore, reporter ui.Reporter, hmacKey []byte) *CheckManager {
+func NewCheckManager(d Deps) *CheckManager {
 	return &CheckManager{
-		store:    s,
-		tree:     hamt.NewTree(s),
-		reporter: reporter,
-		hmacKey:  hmacKey,
+		store:    d.Store,
+		tree:     hamt.NewTree(d.Store),
+		reporter: d.Reporter,
+		hmacKey:  d.HMACKey,
 	}
 }
 

--- a/internal/engine/check_test.go
+++ b/internal/engine/check_test.go
@@ -72,7 +72,7 @@ func TestCheckManager_HealthyRepo(t *testing.T) {
 	mockStore := NewMockStore()
 	buildTestRepo(t, mockStore)
 
-	cm := NewCheckManager(mockStore, ui.NewNoOpReporter(), nil)
+	cm := NewCheckManager(Deps{Store: mockStore, Reporter: ui.NewNoOpReporter()})
 	result, err := cm.Run(ctx)
 	if err != nil {
 		t.Fatalf("Check failed: %v", err)
@@ -93,7 +93,7 @@ func TestCheckManager_HealthyRepoWithReadData(t *testing.T) {
 	mockStore := NewMockStore()
 	buildTestRepo(t, mockStore)
 
-	cm := NewCheckManager(mockStore, ui.NewNoOpReporter(), nil)
+	cm := NewCheckManager(Deps{Store: mockStore, Reporter: ui.NewNoOpReporter()})
 	result, err := cm.Run(ctx, WithReadData())
 	if err != nil {
 		t.Fatalf("Check failed: %v", err)
@@ -111,7 +111,7 @@ func TestCheckManager_MissingChunk(t *testing.T) {
 	// Delete the chunk
 	_ = mockStore.Delete(ctx, chunkRef)
 
-	cm := NewCheckManager(mockStore, ui.NewNoOpReporter(), nil)
+	cm := NewCheckManager(Deps{Store: mockStore, Reporter: ui.NewNoOpReporter()})
 	result, err := cm.Run(ctx)
 	if err != nil {
 		t.Fatalf("Check failed: %v", err)
@@ -134,7 +134,7 @@ func TestCheckManager_MissingContent(t *testing.T) {
 
 	_ = mockStore.Delete(ctx, contentRef)
 
-	cm := NewCheckManager(mockStore, ui.NewNoOpReporter(), nil)
+	cm := NewCheckManager(Deps{Store: mockStore, Reporter: ui.NewNoOpReporter()})
 	result, err := cm.Run(ctx)
 	if err != nil {
 		t.Fatalf("Check failed: %v", err)
@@ -157,7 +157,7 @@ func TestCheckManager_MissingFileMeta(t *testing.T) {
 
 	_ = mockStore.Delete(ctx, metaRef)
 
-	cm := NewCheckManager(mockStore, ui.NewNoOpReporter(), nil)
+	cm := NewCheckManager(Deps{Store: mockStore, Reporter: ui.NewNoOpReporter()})
 	result, err := cm.Run(ctx)
 	if err != nil {
 		t.Fatalf("Check failed: %v", err)
@@ -177,7 +177,7 @@ func TestCheckManager_MissingHAMTNode(t *testing.T) {
 
 	_ = mockStore.Delete(ctx, rootRef)
 
-	cm := NewCheckManager(mockStore, ui.NewNoOpReporter(), nil)
+	cm := NewCheckManager(Deps{Store: mockStore, Reporter: ui.NewNoOpReporter()})
 	result, err := cm.Run(ctx)
 	if err != nil {
 		t.Fatalf("Check failed: %v", err)
@@ -207,7 +207,7 @@ func TestCheckManager_CorruptChunk_ReadData(t *testing.T) {
 	// Corrupt the chunk data
 	_ = mockStore.Put(ctx, chunkRef, []byte("corrupted data"))
 
-	cm := NewCheckManager(mockStore, ui.NewNoOpReporter(), nil)
+	cm := NewCheckManager(Deps{Store: mockStore, Reporter: ui.NewNoOpReporter()})
 	result, err := cm.Run(ctx, WithReadData())
 	if err != nil {
 		t.Fatalf("Check failed: %v", err)
@@ -238,7 +238,7 @@ func TestCheckManager_CorruptChunk_WithoutReadData(t *testing.T) {
 	// Corrupt the chunk data — should NOT be detected without --read-data
 	_ = mockStore.Put(ctx, chunkRef, []byte("corrupted data"))
 
-	cm := NewCheckManager(mockStore, ui.NewNoOpReporter(), nil)
+	cm := NewCheckManager(Deps{Store: mockStore, Reporter: ui.NewNoOpReporter()})
 	result, err := cm.Run(ctx)
 	if err != nil {
 		t.Fatalf("Check failed: %v", err)
@@ -253,7 +253,7 @@ func TestCheckManager_SingleSnapshot(t *testing.T) {
 	mockStore := NewMockStore()
 	snapRef, _, _, _, _ := buildTestRepo(t, mockStore)
 
-	cm := NewCheckManager(mockStore, ui.NewNoOpReporter(), nil)
+	cm := NewCheckManager(Deps{Store: mockStore, Reporter: ui.NewNoOpReporter()})
 	result, err := cm.Run(ctx, WithSnapshotRef(snapRef))
 	if err != nil {
 		t.Fatalf("Check failed: %v", err)
@@ -271,7 +271,7 @@ func TestCheckManager_SnapshotLatestAlias(t *testing.T) {
 	mockStore := NewMockStore()
 	buildTestRepo(t, mockStore)
 
-	cm := NewCheckManager(mockStore, ui.NewNoOpReporter(), nil)
+	cm := NewCheckManager(Deps{Store: mockStore, Reporter: ui.NewNoOpReporter()})
 	result, err := cm.Run(ctx, WithSnapshotRef("latest"))
 	if err != nil {
 		t.Fatalf("Check failed: %v", err)
@@ -329,7 +329,7 @@ func TestCheckManager_ContentRef_HMACPath(t *testing.T) {
 	idxData, _ := json.Marshal(idx)
 	_ = mockStore.Put(ctx, "index/latest", idxData)
 
-	cm := NewCheckManager(mockStore, ui.NewNoOpReporter(), hmacKey)
+	cm := NewCheckManager(Deps{Store: mockStore, Reporter: ui.NewNoOpReporter(), HMACKey: hmacKey})
 	result, err := cm.Run(ctx)
 	if err != nil {
 		t.Fatalf("Check failed: %v", err)
@@ -386,7 +386,7 @@ func TestCheckManager_CorruptChunk_HMACReadData(t *testing.T) {
 	// Now corrupt the chunk
 	_ = mockStore.Put(ctx, chunkRef, []byte("corrupted!"))
 
-	cm := NewCheckManager(mockStore, ui.NewNoOpReporter(), hmacKey)
+	cm := NewCheckManager(Deps{Store: mockStore, Reporter: ui.NewNoOpReporter(), HMACKey: hmacKey})
 	result, err := cm.Run(ctx, WithReadData())
 	if err != nil {
 		t.Fatalf("Check failed: %v", err)

--- a/internal/engine/copy.go
+++ b/internal/engine/copy.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"sort"
 	"strings"
 	"time"
@@ -207,25 +206,18 @@ type copiedTree struct {
 //
 // dstHMAC is the destination's dedup key, and is what every rewritten
 // reference is computed under; pass nil for an unencrypted destination.
-func NewCopyManager(
-	src CopySide,
-	dst store.ObjectStore,
-	dstHMAC []byte,
-	dstRepoID string,
-	reporter ui.Reporter,
-	logWriter io.Writer,
-) *CopyManager {
+func NewCopyManager(d Deps, src CopySide, dstRepoID string) *CopyManager {
 	return &CopyManager{
 		src:         src,
-		dst:         dst,
-		dstHMAC:     dstHMAC,
+		dst:         d.Store,
+		dstHMAC:     d.HMACKey,
 		dstID:       dstRepoID,
-		reporter:    reporter,
-		log:         defaultCopyLog.To(logWriter),
-		srcCatalog:  newSnapshotCatalog(src.Store, logWriter),
-		dstCatalog:  newSnapshotCatalog(dst, logWriter),
-		srcTree:     hamt.NewTree(src.Store, hamt.WithLogger(logWriter)),
-		dstTree:     hamt.NewTree(dst, hamt.WithLogger(logWriter)),
+		reporter:    d.Reporter,
+		log:         defaultCopyLog.To(d.LogSink),
+		srcCatalog:  newSnapshotCatalog(src.Store, d.LogSink),
+		dstCatalog:  newSnapshotCatalog(d.Store, d.LogSink),
+		srcTree:     hamt.NewTree(src.Store, hamt.WithLogger(d.LogSink)),
+		dstTree:     hamt.NewTree(d.Store, hamt.WithLogger(d.LogSink)),
 		chunkRefs:   map[string]string{},
 		contentRefs: map[string]string{},
 		metaRefs:    map[string]copiedMeta{},

--- a/internal/engine/copy.go
+++ b/internal/engine/copy.go
@@ -146,7 +146,11 @@ type CopyManager struct {
 
 	reporter ui.Reporter
 	log      *logger.Logger
-	snapLog  *logger.Logger
+
+	// A copy reads one repository's catalog and writes another's, so it binds
+	// one per side rather than passing a store per call.
+	srcCatalog snapshotCatalog
+	dstCatalog snapshotCatalog
 
 	srcTree *hamt.Tree
 	dstTree *hamt.Tree
@@ -218,7 +222,8 @@ func NewCopyManager(
 		dstID:       dstRepoID,
 		reporter:    reporter,
 		log:         defaultCopyLog.To(logWriter),
-		snapLog:     SnapshotLogger(logWriter),
+		srcCatalog:  newSnapshotCatalog(src.Store, logWriter),
+		dstCatalog:  newSnapshotCatalog(dst, logWriter),
 		srcTree:     hamt.NewTree(src.Store, hamt.WithLogger(logWriter)),
 		dstTree:     hamt.NewTree(dst, hamt.WithLogger(logWriter)),
 		chunkRefs:   map[string]string{},
@@ -249,7 +254,7 @@ func (cm *CopyManager) Run(ctx context.Context, opts ...CopyOption) (*CopyResult
 		DestRepoID:   cm.dstID,
 	}
 
-	sourceEntries, err := LoadSnapshotCatalog(cm.src.Store, cm.snapLog)
+	sourceEntries, err := cm.srcCatalog.load()
 	if err != nil {
 		return nil, fmt.Errorf("read source snapshot catalog: %w", err)
 	}
@@ -261,7 +266,7 @@ func (cm *CopyManager) Run(ctx context.Context, opts ...CopyOption) (*CopyResult
 	// One read of the destination catalog serves both questions asked of it:
 	// what has already been copied, and which tree each lineage should seed
 	// from.
-	destEntries, err := LoadSnapshotCatalog(cm.dst, cm.snapLog)
+	destEntries, err := cm.dstCatalog.load()
 	if err != nil {
 		return nil, fmt.Errorf("read destination snapshot catalog: %w", err)
 	}
@@ -700,7 +705,7 @@ func (cm *CopyManager) writeSnapshot(
 	if err := cm.dst.Put(ctx, ref, data); err != nil {
 		return "", fmt.Errorf("write snapshot: %w", err)
 	}
-	AppendSnapshotCatalog(cm.dst, snapshotToSummary(ref, dest), cm.snapLog)
+	cm.dstCatalog.add(snapshotToSummary(ref, dest))
 	return ref, nil
 }
 

--- a/internal/engine/deps.go
+++ b/internal/engine/deps.go
@@ -1,0 +1,39 @@
+package engine
+
+import (
+	"io"
+
+	"github.com/cloudstic/cli/internal/ui"
+	"github.com/cloudstic/cli/pkg/store"
+)
+
+// Deps is the ambient dependency set every engine manager is built from: the
+// repository it works against, where progress is reported, where debug output
+// goes, and the key content addressing is computed under.
+//
+// It is one value rather than a positional parameter each because those four
+// appeared in five different orders across the constructors, and Reporter and
+// LogSink are both "somewhere output goes" — a transposition the compiler
+// cannot catch. Passing them by name also stopped three managers from silently
+// having no debug sink at all: restore, check and prune took no log writer,
+// which read as an omission rather than a decision.
+//
+// Not every manager uses every field. A manager that does not report progress
+// ignores Reporter, and one that does not content-address ignores HMACKey.
+type Deps struct {
+	// Store is the repository this manager reads and writes. Required.
+	Store store.ObjectStore
+
+	// Reporter receives phase and progress updates. The long-running
+	// operations — backup, restore, check, prune, forget, copy — call into it
+	// unconditionally, so pass ui.NewNoOpReporter() rather than nil.
+	Reporter ui.Reporter
+
+	// LogSink receives component-prefixed debug output. A nil sink discards,
+	// so a caller with nowhere to send it can leave this zero.
+	LogSink io.Writer
+
+	// HMACKey is the dedup key that content refs are derived under. Nil for a
+	// repository with no encryption.
+	HMACKey []byte
+}

--- a/internal/engine/diff.go
+++ b/internal/engine/diff.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"context"
-	"io"
 	"sort"
 
 	"github.com/cloudstic/cli/internal/core"
@@ -52,12 +51,12 @@ type DiffManager struct {
 	log *logger.Logger
 }
 
-func NewDiffManager(s store.ObjectStore, logWriter io.Writer) *DiffManager {
+func NewDiffManager(d Deps) *DiffManager {
 	return &DiffManager{
-		log:   defaultDiffLog.To(logWriter),
-		store: s,
-		tree:  hamt.NewTree(s),
-		metas: newMetaLoader(s),
+		log:   defaultDiffLog.To(d.LogSink),
+		store: d.Store,
+		tree:  hamt.NewTree(d.Store),
+		metas: newMetaLoader(d.Store),
 	}
 }
 

--- a/internal/engine/diff.go
+++ b/internal/engine/diff.go
@@ -98,8 +98,8 @@ func (dm *DiffManager) Run(ctx context.Context, snapID1, snapID2 string, opts ..
 		case ChangeModified:
 			modified++
 		}
-		dm.log.Debugf("Found %d changes: %d added, %d removed, %d modified", len(changes), added, removed, modified)
 	}
+	dm.log.Debugf("Found %d changes: %d added, %d removed, %d modified", len(changes), added, removed, modified)
 
 	return &DiffResult{Ref1: ref1, Ref2: ref2, Changes: changes}, nil
 }

--- a/internal/engine/diff.go
+++ b/internal/engine/diff.go
@@ -12,6 +12,8 @@ import (
 	"github.com/cloudstic/cli/pkg/store"
 )
 
+var defaultDiffLog = logger.New("diff", logger.ColorCyan)
+
 // ChangeType describes how a file differs between two snapshots.
 type ChangeType string
 
@@ -53,7 +55,7 @@ type DiffManager struct {
 
 func NewDiffManager(s store.ObjectStore, logWriter io.Writer) *DiffManager {
 	return &DiffManager{
-		log:   SnapshotLogger(logWriter),
+		log:   defaultDiffLog.To(logWriter),
 		store: s,
 		tree:  hamt.NewTree(s),
 	}

--- a/internal/engine/diff.go
+++ b/internal/engine/diff.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"context"
-	"encoding/json"
 	"io"
 	"sort"
 
@@ -45,9 +44,9 @@ type DiffResult struct {
 
 // DiffManager compares two snapshots and reports file-level changes.
 type DiffManager struct {
-	store     store.ObjectStore
-	tree      *hamt.Tree
-	metaCache map[string]core.FileMeta
+	store store.ObjectStore
+	tree  *hamt.Tree
+	metas *metaLoader
 	// log is where progress detail goes. It used to be written straight to
 	// os.Stderr, which a library caller could neither capture nor silence.
 	log *logger.Logger
@@ -58,6 +57,7 @@ func NewDiffManager(s store.ObjectStore, logWriter io.Writer) *DiffManager {
 		log:   defaultDiffLog.To(logWriter),
 		store: s,
 		tree:  hamt.NewTree(s),
+		metas: newMetaLoader(s),
 	}
 }
 
@@ -67,8 +67,6 @@ func (dm *DiffManager) Run(ctx context.Context, snapID1, snapID2 string, opts ..
 	for _, opt := range opts {
 		opt(&cfg)
 	}
-
-	dm.metaCache = make(map[string]core.FileMeta)
 
 	dm.log.Debugf("Resolving snapshot %q...", snapID1)
 	root1, ref1, err := dm.loadRoot(ctx, snapID1)
@@ -162,7 +160,7 @@ func (dm *DiffManager) diffRoots(ctx context.Context, root1, root2 string) ([]Fi
 func (dm *DiffManager) toFileChange(ctx context.Context, d hamt.DiffEntry, oldByID, newByID map[string]core.FileMeta) (FileChange, error) {
 	ct, metaRef := classifyEntry(d)
 
-	meta, err := dm.loadMeta(ctx, metaRef)
+	meta, err := dm.metas.load(ctx, metaRef)
 	if err != nil {
 		return FileChange{}, err
 	}
@@ -191,29 +189,10 @@ func classifyEntry(d hamt.DiffEntry) (ChangeType, string) {
 	}
 }
 
-func (dm *DiffManager) loadMeta(ctx context.Context, ref string) (*core.FileMeta, error) {
-	if dm.metaCache == nil {
-		dm.metaCache = make(map[string]core.FileMeta)
-	}
-	if fm, ok := dm.metaCache[ref]; ok {
-		return &fm, nil
-	}
-	data, err := getVerified(ctx, dm.store, ref)
-	if err != nil {
-		return nil, err
-	}
-	var fm core.FileMeta
-	if err := json.Unmarshal(data, &fm); err != nil {
-		return nil, err
-	}
-	dm.metaCache[ref] = fm
-	return &fm, nil
-}
-
 func (dm *DiffManager) collectMetadata(ctx context.Context, root string) (map[string]core.FileMeta, error) {
 	byID := make(map[string]core.FileMeta)
 	err := dm.tree.Walk(ctx, root, func(_, valueRef string) error {
-		fm, err := dm.loadMeta(ctx, valueRef)
+		fm, err := dm.metas.load(ctx, valueRef)
 		if err != nil {
 			return err
 		}

--- a/internal/engine/diff_test.go
+++ b/internal/engine/diff_test.go
@@ -24,7 +24,7 @@ func TestDiffManager_Run(t *testing.T) {
 	snap2Ref := saveSnapshotRef(ctx, store, root2, 2)
 	_ = store.Put(ctx, "index/latest", createIndex(snap2Ref, 2))
 
-	dm := NewDiffManager(store, nil)
+	dm := NewDiffManager(Deps{Store: store})
 
 	changes, err := dm.diffRoots(ctx, root1, root2)
 	if err != nil {
@@ -93,7 +93,7 @@ func TestDiffManager_DerivesPathsFromParentsWithoutPersistedPaths(t *testing.T) 
 	root1 := createHamt(ctx, t, store, []string{"dir", "file"}, []string{rootDir, oldFile})
 	root2 := createHamt(ctx, t, store, []string{"dir", "file"}, []string{rootDir, newFile})
 
-	dm := NewDiffManager(store, nil)
+	dm := NewDiffManager(Deps{Store: store})
 	changes, err := dm.diffRoots(ctx, root1, root2)
 	if err != nil {
 		t.Fatalf("Diff failed: %v", err)

--- a/internal/engine/find.go
+++ b/internal/engine/find.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"context"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/cloudstic/cli/internal/core"
@@ -231,15 +230,15 @@ type FindManager struct {
 	log *logger.Logger
 }
 
-func NewFindManager(s store.ObjectStore, logWriter io.Writer) *FindManager {
+func NewFindManager(d Deps) *FindManager {
 	// One Tree serves every snapshot root and shares a single node cache
 	// between them, which is what makes the delta scan's structural sharing
 	// pay off rather than re-reading the same nodes per snapshot.
 	return &FindManager{
-		store:   s,
-		tree:    hamt.NewTree(s),
-		catalog: newSnapshotCatalog(s, logWriter),
-		log:     defaultFindLog.To(logWriter),
+		store:   d.Store,
+		tree:    hamt.NewTree(d.Store),
+		catalog: newSnapshotCatalog(d.Store, d.LogSink),
+		log:     defaultFindLog.To(d.LogSink),
 	}
 }
 

--- a/internal/engine/find.go
+++ b/internal/engine/find.go
@@ -1,18 +1,18 @@
 package engine
 
 import (
-	"io"
-
 	"context"
 	"fmt"
+	"io"
 	"time"
-
-	"github.com/cloudstic/cli/internal/logger"
 
 	"github.com/cloudstic/cli/internal/core"
 	"github.com/cloudstic/cli/internal/hamt"
+	"github.com/cloudstic/cli/internal/logger"
 	"github.com/cloudstic/cli/pkg/store"
 )
+
+var defaultFindLog = logger.New("find", logger.ColorCyan)
 
 // defaultFindMaxResults bounds how many distinct files one query reports.
 // Scanning continues past the cap so the counters stay accurate; only
@@ -223,10 +223,11 @@ func (q *FindQuery) SetPattern(pattern string) {
 // It is a pure read path: no lock is taken, nothing is written, and the
 // repository format is not stamped.
 type FindManager struct {
-	store store.ObjectStore
-	tree  *hamt.Tree
-	// log is the snapshot-catalog sink this manager passes to the free
-	// functions in snapshots.go.
+	store   store.ObjectStore
+	tree    *hamt.Tree
+	catalog snapshotCatalog
+	// log is this manager's own debug sink, handed to the scanner for its
+	// progress reporting.
 	log *logger.Logger
 }
 
@@ -234,7 +235,12 @@ func NewFindManager(s store.ObjectStore, logWriter io.Writer) *FindManager {
 	// One Tree serves every snapshot root and shares a single node cache
 	// between them, which is what makes the delta scan's structural sharing
 	// pay off rather than re-reading the same nodes per snapshot.
-	return &FindManager{store: s, tree: hamt.NewTree(s), log: SnapshotLogger(logWriter)}
+	return &FindManager{
+		store:   s,
+		tree:    hamt.NewTree(s),
+		catalog: newSnapshotCatalog(s, logWriter),
+		log:     defaultFindLog.To(logWriter),
+	}
 }
 
 // Run executes the query.
@@ -255,7 +261,7 @@ func (fm *FindManager) Run(ctx context.Context, q FindQuery) (*FindResult, error
 
 	start := time.Now()
 	fm.log.Debugf("Loading snapshot catalog...")
-	catalog, err := LoadSnapshotCatalog(fm.store, fm.log)
+	catalog, err := fm.catalog.load()
 	if err != nil {
 		return nil, fmt.Errorf("load snapshot catalog: %w", err)
 	}

--- a/internal/engine/find_scan.go
+++ b/internal/engine/find_scan.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -29,6 +28,11 @@ type findScanner struct {
 	tree  *hamt.Tree
 	pred  *findPredicate
 	out   *findCollector
+	// metas reads through on every call rather than memoizing: a full scan
+	// crosses every snapshot in the repository, and holding each filemeta it
+	// decodes would grow without bound. The evaluated map below is the bounded
+	// memo that makes the repeats cheap instead.
+	metas *metaLoader
 	// log receives the scan heartbeat. It replaced a verbose flag writing
 	// straight to os.Stderr, which no library caller could redirect.
 	log *logger.Logger
@@ -97,6 +101,7 @@ func newFindScanner(s store.ObjectStore, tree *hamt.Tree, pred *findPredicate, o
 		pred:      pred,
 		out:       out,
 		log:       log,
+		metas:     newUncachedMetaLoader(s),
 		evaluated: make(map[[16]byte]findRefEval),
 	}
 }
@@ -366,19 +371,15 @@ func (s *findScanner) eval(ctx context.Context, ref string) (findRefEval, error)
 }
 
 func (s *findScanner) loadMeta(ctx context.Context, ref string) (*core.FileMeta, error) {
-	data, err := getVerified(ctx, s.store, ref)
+	meta, err := s.metas.load(ctx, ref)
 	if err != nil {
-		return nil, fmt.Errorf("load %s: %w", ref, err)
+		return nil, err
 	}
 	s.metaFetched++
 	if s.metaFetched%10000 == 0 {
 		s.log.Debugf("  read %d metadata objects", s.metaFetched)
 	}
-	var meta core.FileMeta
-	if err := json.Unmarshal(data, &meta); err != nil {
-		return nil, fmt.Errorf("decode %s: %w", ref, err)
-	}
-	return &meta, nil
+	return meta, nil
 }
 
 func resolveCandidatePaths(state *lineageState, meta core.FileMeta) []string {

--- a/internal/engine/find_test.go
+++ b/internal/engine/find_test.go
@@ -147,11 +147,11 @@ func (r *findRepo) runFind(q FindQuery) *FindResult {
 	r.t.Helper()
 	ctx := context.Background()
 
-	delta, err := NewFindManager(r.store, nil).Run(ctx, q)
+	delta, err := NewFindManager(Deps{Store: r.store}).Run(ctx, q)
 	if err != nil {
 		r.t.Fatalf("find (delta): %v", err)
 	}
-	full, err := NewFindManager(r.store, nil).Run(ctx, withNoDelta(q))
+	full, err := NewFindManager(Deps{Store: r.store}).Run(ctx, withNoDelta(q))
 	if err != nil {
 		r.t.Fatalf("find (no-delta): %v", err)
 	}
@@ -658,7 +658,7 @@ func TestFind_SnapshotSelectors(t *testing.T) {
 	})
 
 	t.Run("unknown snapshot is an error", func(t *testing.T) {
-		_, err := NewFindManager(r.store, nil).Run(context.Background(),
+		_, err := NewFindManager(Deps{Store: r.store}).Run(context.Background(),
 			FindQuery{Name: "notes.txt", Snapshots: []string{"deadbeef"}})
 		if err == nil {
 			t.Fatal("want an error for an unknown snapshot")
@@ -716,7 +716,7 @@ func TestFind_MaxResultsTruncatesButKeepsCountersAccurate(t *testing.T) {
 
 func TestFind_EmptyQueryIsRejected(t *testing.T) {
 	r := newFindRepo(t)
-	if _, err := NewFindManager(r.store, nil).Run(context.Background(), FindQuery{}); err == nil {
+	if _, err := NewFindManager(Deps{Store: r.store}).Run(context.Background(), FindQuery{}); err == nil {
 		t.Fatal("a query with no predicate must be refused rather than dumping the repository")
 	}
 }
@@ -729,7 +729,7 @@ func TestFind_InvalidPatternsFailBeforeScanning(t *testing.T) {
 		{Type: "symlink"},
 		{Newer: "not-a-time"},
 	} {
-		if _, err := NewFindManager(r.store, nil).Run(context.Background(), q); err == nil {
+		if _, err := NewFindManager(Deps{Store: r.store}).Run(context.Background(), q); err == nil {
 			t.Error("want a compile error before the scan starts")
 		}
 	}
@@ -761,7 +761,7 @@ func TestFind_MissingMetadataObjectIsAnError(t *testing.T) {
 			break
 		}
 	}
-	if _, err := NewFindManager(r.store, nil).Run(context.Background(), patternQuery("*.txt")); err == nil {
+	if _, err := NewFindManager(Deps{Store: r.store}).Run(context.Background(), patternQuery("*.txt")); err == nil {
 		t.Fatal("want an error when a referenced filemeta cannot be read")
 	}
 }
@@ -791,11 +791,11 @@ func TestFind_DeltaScanReadsFarFewerObjectsThanFullScan(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	delta, err := NewFindManager(r.store, nil).Run(ctx, patternQuery("*.txt"))
+	delta, err := NewFindManager(Deps{Store: r.store}).Run(ctx, patternQuery("*.txt"))
 	if err != nil {
 		t.Fatalf("delta: %v", err)
 	}
-	full, err := NewFindManager(r.store, nil).Run(ctx, withNoDelta(patternQuery("*.txt")))
+	full, err := NewFindManager(Deps{Store: r.store}).Run(ctx, withNoDelta(patternQuery("*.txt")))
 	if err != nil {
 		t.Fatalf("full: %v", err)
 	}

--- a/internal/engine/forget.go
+++ b/internal/engine/forget.go
@@ -3,11 +3,9 @@ package engine
 import (
 	"context"
 	"fmt"
-	"io"
 	"sort"
 	"strings"
 
-	"github.com/cloudstic/cli/internal/storelayer"
 	"github.com/cloudstic/cli/internal/ui"
 	"github.com/cloudstic/cli/pkg/store"
 )
@@ -113,12 +111,13 @@ type ForgetManager struct {
 	catalog  snapshotCatalog
 }
 
-func NewForgetManager(s store.ObjectStore, reporter ui.Reporter, logWriter io.Writer) *ForgetManager {
+func NewForgetManager(d Deps) *ForgetManager {
 	return &ForgetManager{
-		store:    s,
-		reporter: reporter,
-		catalog:  newSnapshotCatalog(s, logWriter),
-		pruner:   NewPruneManager(storelayer.NewMeteredStore(s), reporter),
+		store:    d.Store,
+		reporter: d.Reporter,
+		catalog:  newSnapshotCatalog(d.Store, d.LogSink),
+		// NewPruneManager meters the store itself, so d is handed over as-is.
+		pruner: NewPruneManager(d),
 	}
 }
 

--- a/internal/engine/forget.go
+++ b/internal/engine/forget.go
@@ -1,14 +1,11 @@
 package engine
 
 import (
-	"io"
-
 	"context"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
-
-	"github.com/cloudstic/cli/internal/logger"
 
 	"github.com/cloudstic/cli/internal/storelayer"
 	"github.com/cloudstic/cli/internal/ui"
@@ -113,16 +110,14 @@ type ForgetManager struct {
 	store    store.ObjectStore
 	reporter ui.Reporter
 	pruner   *PruneManager
-	// log is the snapshot-catalog sink this manager passes to the free
-	// functions in snapshots.go.
-	log *logger.Logger
+	catalog  snapshotCatalog
 }
 
 func NewForgetManager(s store.ObjectStore, reporter ui.Reporter, logWriter io.Writer) *ForgetManager {
 	return &ForgetManager{
 		store:    s,
 		reporter: reporter,
-		log:      SnapshotLogger(logWriter),
+		catalog:  newSnapshotCatalog(s, logWriter),
 		pruner:   NewPruneManager(storelayer.NewMeteredStore(s), reporter),
 	}
 }
@@ -159,7 +154,7 @@ func (fm *ForgetManager) Run(ctx context.Context, snapshotID string, opts ...For
 	}
 
 	// Update snapshot catalog (best-effort).
-	RemoveFromSnapshotCatalog(fm.store, fm.log, targetRef)
+	fm.catalog.remove(targetRef)
 
 	if err := fm.fixupLatest(targetRef); err != nil {
 		phase.Error()
@@ -221,7 +216,7 @@ func (fm *ForgetManager) fixupLatest(deletedRef string) error {
 		return nil
 	}
 
-	entries, err := LoadSnapshotCatalog(fm.store, fm.log)
+	entries, err := fm.catalog.load()
 	if err != nil {
 		return err
 	}
@@ -271,7 +266,7 @@ func (fm *ForgetManager) RunPolicy(ctx context.Context, opts ...ForgetOption) (*
 		return nil, fmt.Errorf("empty policy: specify at least one -keep-* option or a tag/source/account/path filter")
 	}
 
-	entries, err := LoadSnapshotCatalog(fm.store, fm.log)
+	entries, err := fm.catalog.load()
 	if err != nil {
 		return nil, err
 	}
@@ -352,10 +347,10 @@ func (fm *ForgetManager) forgetBatch(ctx context.Context, entries []SnapshotEntr
 	}
 
 	// Update snapshot catalog (best-effort).
-	RemoveFromSnapshotCatalog(fm.store, fm.log, removedRefs...)
+	fm.catalog.remove(removedRefs...)
 
 	// Elect new latest from the remaining snapshots.
-	remaining, err := LoadSnapshotCatalog(fm.store, fm.log)
+	remaining, err := fm.catalog.load()
 	if err != nil {
 		return err
 	}

--- a/internal/engine/forget_test.go
+++ b/internal/engine/forget_test.go
@@ -26,7 +26,7 @@ func TestForgetManager_Run(t *testing.T) {
 
 	_ = store.Put(ctx, "index/latest", createIndex(snap3Ref, 3))
 
-	fm := NewForgetManager(store, ui.NewNoOpReporter(), nil)
+	fm := NewForgetManager(Deps{Store: store, Reporter: ui.NewNoOpReporter()})
 
 	// Test 1: Forget intermediate snapshot (snap2) -- latest should not change.
 	if _, err := fm.Run(context.Background(), snap2Ref); err != nil {
@@ -71,7 +71,7 @@ func TestForgetManager_Run(t *testing.T) {
 func TestForgetManager_ResolveSnapshot_PropagatesLatestError(t *testing.T) {
 	backendErr := errors.New("simulated network error")
 	s := newErrorOnGetStore(NewMockStore(), backendErr, "index/latest")
-	fm := NewForgetManager(s, ui.NewNoOpReporter(), nil)
+	fm := NewForgetManager(Deps{Store: s, Reporter: ui.NewNoOpReporter()})
 
 	_, err := fm.resolveSnapshot("latest")
 	if err == nil {
@@ -95,7 +95,7 @@ func TestForgetManager_FixupLatest_PropagatesError(t *testing.T) {
 	_ = inner.Put(ctx, "index/latest", createIndex(ref, 1))
 
 	s := newErrorOnGetStore(inner, backendErr, "index/latest")
-	fm := NewForgetManager(s, ui.NewNoOpReporter(), nil)
+	fm := NewForgetManager(Deps{Store: s, Reporter: ui.NewNoOpReporter()})
 
 	err := fm.fixupLatest(ref)
 	if err == nil {
@@ -120,7 +120,7 @@ func createIndex(ref string, seq int) []byte {
 }
 
 func TestForgetManager_RunPolicy_RequiresPolicyOrFilter(t *testing.T) {
-	fm := NewForgetManager(NewMockStore(), ui.NewNoOpReporter(), nil)
+	fm := NewForgetManager(Deps{Store: NewMockStore(), Reporter: ui.NewNoOpReporter()})
 
 	_, err := fm.RunPolicy(context.Background())
 	if err == nil {
@@ -134,7 +134,7 @@ func TestForgetManager_RunPolicy_RequiresPolicyOrFilter(t *testing.T) {
 func TestForgetManager_RunPolicy_FilterOnlyAllowed(t *testing.T) {
 	ctx := context.Background()
 	store := NewMockStore()
-	fm := NewForgetManager(store, ui.NewNoOpReporter(), nil)
+	fm := NewForgetManager(Deps{Store: store, Reporter: ui.NewNoOpReporter()})
 
 	snap := core.Snapshot{
 		Seq:     1,
@@ -171,7 +171,7 @@ func TestForgetManager_DryRunRemovesNothing(t *testing.T) {
 	snapRef := saveSnapshot(ctx, s, &snap)
 	_ = s.Put(ctx, "index/latest", createIndex(snapRef, 1))
 
-	fm := NewForgetManager(s, ui.NewNoOpReporter(), nil)
+	fm := NewForgetManager(Deps{Store: s, Reporter: ui.NewNoOpReporter()})
 	result, err := fm.Run(ctx, snapRef, WithForgetDryRun())
 	if err != nil {
 		t.Fatalf("dry run: %v", err)

--- a/internal/engine/init.go
+++ b/internal/engine/init.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/cloudstic/cli/internal/core"
@@ -63,8 +62,8 @@ type InitManager struct {
 
 // NewInitManager creates an InitManager that operates on the raw (undecorated)
 // object store.
-func NewInitManager(s store.ObjectStore, logWriter io.Writer) *InitManager {
-	return &InitManager{store: s, log: defaultInitLog.To(logWriter)}
+func NewInitManager(d Deps) *InitManager {
+	return &InitManager{store: d.Store, log: defaultInitLog.To(d.LogSink)}
 }
 
 const configKey = "config"

--- a/internal/engine/init_test.go
+++ b/internal/engine/init_test.go
@@ -39,7 +39,7 @@ var _ crypto.KMSClient = (*mockKMS)(nil)
 
 func TestInitManager_UnencryptedRepo(t *testing.T) {
 	s := NewMockStore()
-	mgr := NewInitManager(s, nil)
+	mgr := NewInitManager(Deps{Store: s})
 
 	result, err := mgr.Run(context.Background(), WithInitNoEncryption())
 	if err != nil {
@@ -68,7 +68,7 @@ func TestInitManager_UnencryptedRepo(t *testing.T) {
 
 func TestInitManager_EncryptedWithPassword(t *testing.T) {
 	s := NewMockStore()
-	mgr := NewInitManager(s, nil)
+	mgr := NewInitManager(Deps{Store: s})
 
 	result, err := mgr.Run(context.Background(), WithInitCredentials(keychain.Chain{keychain.WithPassword("test-password")}))
 	if err != nil {
@@ -107,7 +107,7 @@ func TestInitManager_EncryptedWithPassword(t *testing.T) {
 
 func TestInitManager_EncryptedWithPlatformKey(t *testing.T) {
 	s := NewMockStore()
-	mgr := NewInitManager(s, nil)
+	mgr := NewInitManager(Deps{Store: s})
 
 	platformKey := make([]byte, 32)
 	for i := range platformKey {
@@ -133,7 +133,7 @@ func TestInitManager_EncryptedWithPlatformKey(t *testing.T) {
 
 func TestInitManager_AlreadyInitialized(t *testing.T) {
 	s := NewMockStore()
-	mgr := NewInitManager(s, nil)
+	mgr := NewInitManager(Deps{Store: s})
 
 	// First init.
 	if _, err := mgr.Run(context.Background(), WithInitNoEncryption()); err != nil {
@@ -154,7 +154,7 @@ func TestInitManager_AlreadyInitialized(t *testing.T) {
 func TestInitManager_Run_PropagatesConfigCheckError(t *testing.T) {
 	backendErr := errors.New("simulated network error")
 	s := newErrorOnGetStore(NewMockStore(), backendErr, configKey)
-	mgr := NewInitManager(s, nil)
+	mgr := NewInitManager(Deps{Store: s})
 
 	_, err := mgr.Run(context.Background(), WithInitNoEncryption())
 	if err == nil {
@@ -171,7 +171,7 @@ func TestInitManager_Run_PropagatesConfigCheckError(t *testing.T) {
 func TestInitManager_WriteRepoConfig_PropagatesReadError(t *testing.T) {
 	backendErr := errors.New("simulated network error")
 	s := newErrorOnGetStore(NewMockStore(), backendErr, configKey)
-	mgr := NewInitManager(s, nil)
+	mgr := NewInitManager(Deps{Store: s})
 
 	err := mgr.writeRepoConfig(context.Background(), false, nil)
 	if err == nil {
@@ -194,7 +194,7 @@ func TestInitManager_AdoptsExistingSlots(t *testing.T) {
 	slot, _ := keychain.CreatePlatformSlot(masterKey, platformKey)
 	_ = keychain.WriteKeySlot(context.Background(), s, slot)
 
-	mgr := NewInitManager(s, nil)
+	mgr := NewInitManager(Deps{Store: s})
 	result, err := mgr.Run(context.Background(), WithInitCredentials(keychain.Chain{keychain.WithPlatformKey(platformKey)}))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -222,7 +222,7 @@ func TestInitManager_AdoptExistingSlots_WrongCredential(t *testing.T) {
 		wrongKey[i] = byte(i + 100)
 	}
 
-	mgr := NewInitManager(s, nil)
+	mgr := NewInitManager(Deps{Store: s})
 	_, err := mgr.Run(context.Background(), WithInitCredentials(keychain.Chain{keychain.WithPlatformKey(wrongKey)}))
 	if err == nil {
 		t.Fatal("expected error when adopting slots with wrong key")
@@ -231,7 +231,7 @@ func TestInitManager_AdoptExistingSlots_WrongCredential(t *testing.T) {
 
 func TestInitManager_WithRecoveryKey(t *testing.T) {
 	s := NewMockStore()
-	mgr := NewInitManager(s, nil)
+	mgr := NewInitManager(Deps{Store: s})
 
 	result, err := mgr.Run(context.Background(),
 		WithInitCredentials(keychain.Chain{keychain.WithPassword("test-password")}),
@@ -274,7 +274,7 @@ func TestInitManager_WithRecoveryKey(t *testing.T) {
 
 func TestInitManager_EncryptedWithKMS(t *testing.T) {
 	s := NewMockStore()
-	mgr := NewInitManager(s, nil)
+	mgr := NewInitManager(Deps{Store: s})
 	kms := &mockKMS{xorByte: 0x42}
 
 	result, err := mgr.Run(context.Background(),
@@ -324,7 +324,7 @@ func TestInitManager_EncryptedWithKMS(t *testing.T) {
 
 func TestInitManager_KMSWithPasswordSlots(t *testing.T) {
 	s := NewMockStore()
-	mgr := NewInitManager(s, nil)
+	mgr := NewInitManager(Deps{Store: s})
 	kms := &mockKMS{xorByte: 0x42}
 
 	// Init with both KMS and password — should create both slot types.
@@ -373,7 +373,7 @@ func TestInitManager_KMSWithPasswordSlots(t *testing.T) {
 
 func TestInitManager_KMSWithRecovery(t *testing.T) {
 	s := NewMockStore()
-	mgr := NewInitManager(s, nil)
+	mgr := NewInitManager(Deps{Store: s})
 	kms := &mockKMS{xorByte: 0x42}
 
 	result, err := mgr.Run(context.Background(),
@@ -404,7 +404,7 @@ func TestInitManager_KMSWithRecovery(t *testing.T) {
 
 func TestInitManager_NoEncryptionOverridesCreds(t *testing.T) {
 	s := NewMockStore()
-	mgr := NewInitManager(s, nil)
+	mgr := NewInitManager(Deps{Store: s})
 
 	// Passing both a password and --no-encryption should result in unencrypted repo.
 	result, err := mgr.Run(context.Background(),
@@ -429,7 +429,7 @@ func TestInitManager_NoEncryptionOverridesCreds(t *testing.T) {
 }
 func TestInitManager_AdoptAddsNewSlots(t *testing.T) {
 	s := NewMockStore()
-	mgr := NewInitManager(s, nil)
+	mgr := NewInitManager(Deps{Store: s})
 	ctx := context.Background()
 
 	// 1. Pre-create a password slot
@@ -511,7 +511,7 @@ func TestInitManager_AdoptRefusesEncryptingPopulatedRepo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mgr := NewInitManager(s, nil)
+	mgr := NewInitManager(Deps{Store: s})
 	_, err = mgr.Run(ctx,
 		WithInitCredentials(keychain.Chain{keychain.WithPassword("newpw")}),
 		WithInitAdoptSlots(),
@@ -550,7 +550,7 @@ func TestInitManager_AdoptAllowsEncryptingEmptyRepo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mgr := NewInitManager(s, nil)
+	mgr := NewInitManager(Deps{Store: s})
 	result, err := mgr.Run(ctx,
 		WithInitCredentials(keychain.Chain{keychain.WithPassword("newpw")}),
 		WithInitAdoptSlots(),
@@ -593,7 +593,7 @@ func TestInitManager_AdoptEncryptedRepoUnaffectedByGuard(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mgr := NewInitManager(s, nil)
+	mgr := NewInitManager(Deps{Store: s})
 	result, err := mgr.Run(ctx,
 		WithInitCredentials(keychain.Chain{keychain.WithPassword("p1")}),
 		WithInitAdoptSlots(),

--- a/internal/engine/list.go
+++ b/internal/engine/list.go
@@ -51,8 +51,11 @@ func (lm *ListManager) Run(ctx context.Context, opts ...ListOption) (*ListResult
 					source += fmt.Sprintf(" path_id=%s", e.Snap.Source.PathID)
 				}
 			}
-			lm.catalog.debugf("  %s seq=%d created=%s%s", e.Ref, e.Snap.Seq, e.Snap.Created, source)
 		}
+		// Logged for every snapshot, not only those carrying source info: the
+		// suffix is what varies, and skipping the line entirely made a listing
+		// that silently omitted rows the caller had just been handed.
+		lm.catalog.debugf("  %s seq=%d created=%s%s", e.Ref, e.Snap.Seq, e.Snap.Created, source)
 	}
 	return &ListResult{Snapshots: entries}, nil
 }

--- a/internal/engine/list.go
+++ b/internal/engine/list.go
@@ -3,9 +3,6 @@ package engine
 import (
 	"context"
 	"fmt"
-	"io"
-
-	"github.com/cloudstic/cli/pkg/store"
 )
 
 // ListOption configures a list operation.
@@ -24,8 +21,8 @@ type ListManager struct {
 	catalog snapshotCatalog
 }
 
-func NewListManager(s store.ObjectStore, logWriter io.Writer) *ListManager {
-	return &ListManager{catalog: newSnapshotCatalog(s, logWriter)}
+func NewListManager(d Deps) *ListManager {
+	return &ListManager{catalog: newSnapshotCatalog(d.Store, d.LogSink)}
 }
 
 // Run lists every snapshot in the store.

--- a/internal/engine/list.go
+++ b/internal/engine/list.go
@@ -1,12 +1,9 @@
 package engine
 
 import (
-	"io"
-
 	"context"
 	"fmt"
-
-	"github.com/cloudstic/cli/internal/logger"
+	"io"
 
 	"github.com/cloudstic/cli/pkg/store"
 )
@@ -24,14 +21,11 @@ type ListResult struct {
 
 // ListManager enumerates all available snapshots.
 type ListManager struct {
-	store store.ObjectStore
-	// log is the snapshot-catalog sink this manager passes to the free
-	// functions in snapshots.go.
-	log *logger.Logger
+	catalog snapshotCatalog
 }
 
 func NewListManager(s store.ObjectStore, logWriter io.Writer) *ListManager {
-	return &ListManager{store: s, log: SnapshotLogger(logWriter)}
+	return &ListManager{catalog: newSnapshotCatalog(s, logWriter)}
 }
 
 // Run lists every snapshot in the store.
@@ -41,12 +35,12 @@ func (lm *ListManager) Run(ctx context.Context, opts ...ListOption) (*ListResult
 		opt(&cfg)
 	}
 
-	lm.log.Debugf("Loading snapshot catalog...")
-	entries, err := LoadSnapshotCatalog(lm.store, lm.log)
+	lm.catalog.debugf("Loading snapshot catalog...")
+	entries, err := lm.catalog.load()
 	if err != nil {
 		return nil, err
 	}
-	lm.log.Debugf("Found %d snapshots", len(entries))
+	lm.catalog.debugf("Found %d snapshots", len(entries))
 	for _, e := range entries {
 		source := ""
 		if e.Snap.Source != nil {
@@ -60,7 +54,7 @@ func (lm *ListManager) Run(ctx context.Context, opts ...ListOption) (*ListResult
 					source += fmt.Sprintf(" path_id=%s", e.Snap.Source.PathID)
 				}
 			}
-			lm.log.Debugf("  %s seq=%d created=%s%s", e.Ref, e.Snap.Seq, e.Snap.Created, source)
+			lm.catalog.debugf("  %s seq=%d created=%s%s", e.Ref, e.Snap.Seq, e.Snap.Created, source)
 		}
 	}
 	return &ListResult{Snapshots: entries}, nil

--- a/internal/engine/ls_snapshot.go
+++ b/internal/engine/ls_snapshot.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"context"
-	"encoding/json"
 	"io"
 	"sort"
 
@@ -31,13 +30,14 @@ type LsSnapshotResult struct {
 
 // LsSnapshotManager lists the file tree of a single snapshot.
 //
-// Unlike DiffManager and PruneManager it holds no filemeta cache, because it
-// cannot benefit from one: a HAMT key is derived from meta.FileID, which is
+// Unlike DiffManager and PruneManager its loader does not memoize, because it
+// could never get a hit: a HAMT key is derived from meta.FileID, which is
 // itself a FileMeta field, so no two keys share a filemeta ref. Walking a
 // single root therefore reaches every ref exactly once.
 type LsSnapshotManager struct {
 	store store.ObjectStore
 	tree  *hamt.Tree
+	metas *metaLoader
 	// log is where progress detail goes; see DiffManager.log.
 	log *logger.Logger
 }
@@ -47,6 +47,7 @@ func NewLsSnapshotManager(s store.ObjectStore, logWriter io.Writer) *LsSnapshotM
 		store: s,
 		log:   defaultLsLog.To(logWriter),
 		tree:  hamt.NewTree(s),
+		metas: newUncachedMetaLoader(s),
 	}
 }
 
@@ -113,7 +114,7 @@ func (lm *LsSnapshotManager) resolveSnapshot(ctx context.Context, id string) (*c
 func (lm *LsSnapshotManager) collectMeta(ctx context.Context, root string) (map[string]core.FileMeta, error) {
 	refToMeta := make(map[string]core.FileMeta)
 	err := lm.tree.Walk(ctx, root, func(_, valueRef string) error {
-		fm, err := lm.loadMeta(ctx, valueRef)
+		fm, err := lm.metas.load(ctx, valueRef)
 		if err != nil {
 			return err
 		}
@@ -121,18 +122,6 @@ func (lm *LsSnapshotManager) collectMeta(ctx context.Context, root string) (map[
 		return nil
 	})
 	return refToMeta, err
-}
-
-func (lm *LsSnapshotManager) loadMeta(ctx context.Context, ref string) (*core.FileMeta, error) {
-	data, err := getVerified(ctx, lm.store, ref)
-	if err != nil {
-		return nil, err
-	}
-	var fm core.FileMeta
-	if err := json.Unmarshal(data, &fm); err != nil {
-		return nil, err
-	}
-	return &fm, nil
 }
 
 // buildHierarchy returns sorted root refs and a parent->children map.

--- a/internal/engine/ls_snapshot.go
+++ b/internal/engine/ls_snapshot.go
@@ -12,6 +12,8 @@ import (
 	"github.com/cloudstic/cli/pkg/store"
 )
 
+var defaultLsLog = logger.New("ls", logger.ColorCyan)
+
 // LsSnapshotOption configures an ls-snapshot operation.
 type LsSnapshotOption func(*lsSnapshotConfig)
 
@@ -43,7 +45,7 @@ type LsSnapshotManager struct {
 func NewLsSnapshotManager(s store.ObjectStore, logWriter io.Writer) *LsSnapshotManager {
 	return &LsSnapshotManager{
 		store: s,
-		log:   SnapshotLogger(logWriter),
+		log:   defaultLsLog.To(logWriter),
 		tree:  hamt.NewTree(s),
 	}
 }

--- a/internal/engine/ls_snapshot.go
+++ b/internal/engine/ls_snapshot.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"context"
-	"io"
 	"sort"
 
 	"github.com/cloudstic/cli/internal/core"
@@ -42,12 +41,12 @@ type LsSnapshotManager struct {
 	log *logger.Logger
 }
 
-func NewLsSnapshotManager(s store.ObjectStore, logWriter io.Writer) *LsSnapshotManager {
+func NewLsSnapshotManager(d Deps) *LsSnapshotManager {
 	return &LsSnapshotManager{
-		store: s,
-		log:   defaultLsLog.To(logWriter),
-		tree:  hamt.NewTree(s),
-		metas: newUncachedMetaLoader(s),
+		store: d.Store,
+		log:   defaultLsLog.To(d.LogSink),
+		tree:  hamt.NewTree(d.Store),
+		metas: newUncachedMetaLoader(d.Store),
 	}
 }
 

--- a/internal/engine/ls_snapshot.go
+++ b/internal/engine/ls_snapshot.go
@@ -28,10 +28,14 @@ type LsSnapshotResult struct {
 }
 
 // LsSnapshotManager lists the file tree of a single snapshot.
+//
+// Unlike DiffManager and PruneManager it holds no filemeta cache, because it
+// cannot benefit from one: a HAMT key is derived from meta.FileID, which is
+// itself a FileMeta field, so no two keys share a filemeta ref. Walking a
+// single root therefore reaches every ref exactly once.
 type LsSnapshotManager struct {
-	store     store.ObjectStore
-	tree      *hamt.Tree
-	metaCache map[string]core.FileMeta
+	store store.ObjectStore
+	tree  *hamt.Tree
 	// log is where progress detail goes; see DiffManager.log.
 	log *logger.Logger
 }
@@ -51,8 +55,6 @@ func (lm *LsSnapshotManager) Run(ctx context.Context, snapshotID string, opts ..
 		opt(&cfg)
 	}
 
-	lm.metaCache = make(map[string]core.FileMeta)
-
 	lm.log.Debugf("Resolving snapshot %q...", snapshotID)
 	snap, ref, err := lm.resolveSnapshot(ctx, snapshotID)
 	if err != nil {
@@ -71,8 +73,8 @@ func (lm *LsSnapshotManager) Run(ctx context.Context, snapshotID string, opts ..
 		} else {
 			files++
 		}
-		lm.log.Debugf("Collected %d files, %d directories", files, dirs)
 	}
+	lm.log.Debugf("Collected %d files, %d directories", files, dirs)
 
 	roots, children := lm.buildHierarchy(refToMeta)
 
@@ -120,9 +122,6 @@ func (lm *LsSnapshotManager) collectMeta(ctx context.Context, root string) (map[
 }
 
 func (lm *LsSnapshotManager) loadMeta(ctx context.Context, ref string) (*core.FileMeta, error) {
-	if fm, ok := lm.metaCache[ref]; ok {
-		return &fm, nil
-	}
 	data, err := getVerified(ctx, lm.store, ref)
 	if err != nil {
 		return nil, err

--- a/internal/engine/metaloader.go
+++ b/internal/engine/metaloader.go
@@ -1,0 +1,83 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/cloudstic/cli/internal/core"
+	"github.com/cloudstic/cli/pkg/store"
+)
+
+// metaLoader reads and decodes the filemeta objects an operation walks over.
+//
+// Whether a loader memoizes is a property of the traversal, not of the call
+// site. An operation that visits several snapshots — diff, prune, backup's
+// change detection — meets the same ref repeatedly, because a file that did not
+// change keeps its filemeta from one snapshot to the next. An operation that
+// walks a single root meets every ref exactly once: a HAMT key derives from
+// meta.FileID, which is itself a FileMeta field, so no two keys can share a
+// filemeta ref. A cache there is pure overhead, which is what newUncached is
+// for.
+type metaLoader struct {
+	store store.ObjectStore
+
+	// mu guards cache, and is taken even by the single-threaded callers. An
+	// uncontended RWMutex is a few nanoseconds against a store read, and paying
+	// it unconditionally means no caller has to establish whether it is allowed
+	// to share a loader before doing so.
+	mu sync.RWMutex
+	// cache is nil for a read-through loader, which is what distinguishes the
+	// two kinds — a nil map reads as empty, so load simply never finds a hit.
+	cache map[string]core.FileMeta
+}
+
+// newMetaLoader returns a loader that remembers every filemeta it reads.
+func newMetaLoader(s store.ObjectStore) *metaLoader {
+	return &metaLoader{store: s, cache: make(map[string]core.FileMeta)}
+}
+
+// newUncachedMetaLoader returns a loader that reads through on every call, for
+// traversals that cannot get a hit or cannot afford to hold the whole tree.
+func newUncachedMetaLoader(s store.ObjectStore) *metaLoader {
+	return &metaLoader{store: s}
+}
+
+// load returns the filemeta stored at ref.
+//
+// The bytes are content-verified before decoding: ref names a SHA-256 of them,
+// so a substituted or rotted object is refused here rather than decoded into a
+// plausible-looking tree. See getVerified.
+func (l *metaLoader) load(ctx context.Context, ref string) (*core.FileMeta, error) {
+	l.mu.RLock()
+	fm, ok := l.cache[ref]
+	l.mu.RUnlock()
+	if ok {
+		return &fm, nil
+	}
+
+	data, err := getVerified(ctx, l.store, ref)
+	if err != nil {
+		return nil, fmt.Errorf("load filemeta %s: %w", ref, err)
+	}
+	if err := json.Unmarshal(data, &fm); err != nil {
+		return nil, fmt.Errorf("decode filemeta %s: %w", ref, err)
+	}
+
+	l.mu.Lock()
+	if l.cache != nil {
+		l.cache[ref] = fm
+	}
+	l.mu.Unlock()
+	return &fm, nil
+}
+
+// cached reports whether ref has already been read through this loader. Backup
+// uses it to skip re-queueing a filemeta it has already written this run.
+func (l *metaLoader) cached(ref string) bool {
+	l.mu.RLock()
+	_, ok := l.cache[ref]
+	l.mu.RUnlock()
+	return ok
+}

--- a/internal/engine/provenance_test.go
+++ b/internal/engine/provenance_test.go
@@ -40,7 +40,7 @@ func TestSnapshotToSummary_LeavesProvenanceEmptyForOrdinarySnapshots(t *testing.
 // field when it reconciles. The value must come back from the snapshot object's
 // Meta on the next rebuild rather than staying lost — otherwise a single run of
 // an older binary would make copy re-import the whole history.
-func TestLoadSnapshotCatalog_RebuildsProvenanceFromSnapshotMeta(t *testing.T) {
+func TestSnapshotCatalogLoad_RebuildsProvenanceFromSnapshotMeta(t *testing.T) {
 	s := NewMockStore()
 	prov := core.CopyProvenance{RepoID: "9f2c1a", SnapshotRef: "snapshot/source123"}
 	ref := putSnapshot(t, s, copiedSnapshot("2026-01-01T00:00:00Z", prov))
@@ -54,9 +54,9 @@ func TestLoadSnapshotCatalog_RebuildsProvenanceFromSnapshotMeta(t *testing.T) {
 		Root:    "node/" + strings.Repeat("a", 8),
 	}})
 
-	entries, err := LoadSnapshotCatalog(s, nil)
+	entries, err := newSnapshotCatalog(s, nil).load()
 	if err != nil {
-		t.Fatalf("LoadSnapshotCatalog: %v", err)
+		t.Fatalf("catalog load: %v", err)
 	}
 	if len(entries) != 1 {
 		t.Fatalf("got %d entries, want 1", len(entries))
@@ -72,14 +72,14 @@ func TestLoadSnapshotCatalog_RebuildsProvenanceFromSnapshotMeta(t *testing.T) {
 
 // A snapshot written by backup lands in the catalog through the same funnel, so
 // an ordinary backup must not start claiming provenance.
-func TestAppendSnapshotCatalog_RoundTripsProvenance(t *testing.T) {
+func TestSnapshotCatalogAdd_RoundTripsProvenance(t *testing.T) {
 	s := NewMockStore()
 	prov := core.CopyProvenance{RepoID: "9f2c1a", SnapshotRef: "snapshot/source123"}
 
-	AppendSnapshotCatalog(s, snapshotToSummary("snapshot/dest456", *copiedSnapshot("2026-01-01T00:00:00Z", prov)), nil)
-	AppendSnapshotCatalog(s, snapshotToSummary("snapshot/plain", core.Snapshot{
+	newSnapshotCatalog(s, nil).add(snapshotToSummary("snapshot/dest456", *copiedSnapshot("2026-01-01T00:00:00Z", prov)))
+	newSnapshotCatalog(s, nil).add(snapshotToSummary("snapshot/plain", core.Snapshot{
 		Version: 1, Created: "2026-01-02T00:00:00Z", Seq: 2,
-	}), nil)
+	}))
 
 	catalog := readCatalog(t, s)
 	byRef := map[string]core.SnapshotSummary{}

--- a/internal/engine/provenance_test.go
+++ b/internal/engine/provenance_test.go
@@ -100,10 +100,7 @@ func TestSnapshotCatalogAdd_RoundTripsProvenance(t *testing.T) {
 // is therefore closed at the point user metadata enters.
 func TestBackup_RejectsReservedMetadataKeys(t *testing.T) {
 	src := NewMockSource()
-	mgr := NewBackupManager(src, NewMockStore(), ui.NewNoOpReporter(), nil, nil,
-		WithMeta("host", "laptop"),
-		WithMeta(core.MetaKeyCopyFromSnapshot, "snapshot/forged"),
-	)
+	mgr := NewBackupManager(Deps{Store: NewMockStore(), Reporter: ui.NewNoOpReporter()}, src, WithMeta("host", "laptop"), WithMeta(core.MetaKeyCopyFromSnapshot, "snapshot/forged"))
 
 	_, err := mgr.Run(context.Background())
 	if err == nil {
@@ -119,10 +116,7 @@ func TestBackup_RejectsReservedMetadataKeys(t *testing.T) {
 
 func TestBackup_AllowsOrdinaryMetadataKeys(t *testing.T) {
 	src := NewMockSource()
-	mgr := NewBackupManager(src, NewMockStore(), ui.NewNoOpReporter(), nil, nil,
-		WithMeta("host", "laptop"),
-		WithMeta("cloudstic", "not-the-prefix"),
-	)
+	mgr := NewBackupManager(Deps{Store: NewMockStore(), Reporter: ui.NewNoOpReporter()}, src, WithMeta("host", "laptop"), WithMeta("cloudstic", "not-the-prefix"))
 
 	if _, err := mgr.Run(context.Background()); err != nil {
 		t.Fatalf("backup rejected ordinary metadata: %v", err)

--- a/internal/engine/prune.go
+++ b/internal/engine/prune.go
@@ -33,10 +33,10 @@ var objectPrefixes = []string{"chunk/", "content/", "filemeta/", "node/", "snaps
 
 // PruneManager implements mark-and-sweep garbage collection over the object store.
 type PruneManager struct {
-	store     *storelayer.MeteredStore
-	tree      *hamt.Tree
-	reporter  ui.Reporter
-	metaCache map[string]core.FileMeta
+	store    *storelayer.MeteredStore
+	tree     *hamt.Tree
+	reporter ui.Reporter
+	metas    *metaLoader
 }
 
 func NewPruneManager(s store.ObjectStore, reporter ui.Reporter) *PruneManager {
@@ -45,6 +45,7 @@ func NewPruneManager(s store.ObjectStore, reporter ui.Reporter) *PruneManager {
 		store:    meteredStore,
 		tree:     hamt.NewTree(meteredStore),
 		reporter: reporter,
+		metas:    newMetaLoader(meteredStore),
 	}
 }
 
@@ -62,8 +63,6 @@ func (pm *PruneManager) Run(ctx context.Context, opts ...PruneOption) (*PruneRes
 		defer lock.Release()
 		ctx = lockedCtx
 	}
-
-	pm.metaCache = make(map[string]core.FileMeta)
 
 	markPhase := pm.reporter.StartPhase("Marking reachable objects", 0, false)
 	reachable, err := pm.mark(ctx, markPhase)
@@ -231,7 +230,7 @@ func (pm *PruneManager) markFileMeta(ctx context.Context, ref string, reachable 
 	}
 	reachable[ref] = true
 
-	meta, err := pm.loadMeta(ctx, ref)
+	meta, err := pm.metas.load(ctx, ref)
 	if err != nil {
 		return err
 	}
@@ -328,20 +327,4 @@ func (pm *PruneManager) loadSnapshot(ctx context.Context, ref string) (*core.Sna
 		return nil, err
 	}
 	return &s, nil
-}
-
-func (pm *PruneManager) loadMeta(ctx context.Context, ref string) (*core.FileMeta, error) {
-	if fm, ok := pm.metaCache[ref]; ok {
-		return &fm, nil
-	}
-	data, err := getVerified(ctx, pm.store, ref)
-	if err != nil {
-		return nil, fmt.Errorf("get filemeta %s: %w", ref, err)
-	}
-	var fm core.FileMeta
-	if err := json.Unmarshal(data, &fm); err != nil {
-		return nil, err
-	}
-	pm.metaCache[ref] = fm
-	return &fm, nil
 }

--- a/internal/engine/prune.go
+++ b/internal/engine/prune.go
@@ -39,12 +39,12 @@ type PruneManager struct {
 	metas    *metaLoader
 }
 
-func NewPruneManager(s store.ObjectStore, reporter ui.Reporter) *PruneManager {
-	meteredStore := storelayer.NewMeteredStore(s)
+func NewPruneManager(d Deps) *PruneManager {
+	meteredStore := storelayer.NewMeteredStore(d.Store)
 	return &PruneManager{
 		store:    meteredStore,
 		tree:     hamt.NewTree(meteredStore),
-		reporter: reporter,
+		reporter: d.Reporter,
 		metas:    newMetaLoader(meteredStore),
 	}
 }

--- a/internal/engine/prune_guard_test.go
+++ b/internal/engine/prune_guard_test.go
@@ -37,7 +37,7 @@ func TestPruneManager_AbortsWhenSnapshotsVanishButObjectsRemain(t *testing.T) {
 	}
 
 	metered := storelayer.NewMeteredStore(&hiddenSnapshotStore{ObjectStore: mockStore})
-	pm := NewPruneManager(metered, ui.NewNoOpReporter())
+	pm := NewPruneManager(Deps{Store: metered, Reporter: ui.NewNoOpReporter()})
 
 	result, err := pm.Run(ctx)
 	if err == nil {
@@ -57,7 +57,7 @@ func TestPruneManager_EmptyRepositorySucceeds(t *testing.T) {
 	mockStore := NewMockStore()
 
 	metered := storelayer.NewMeteredStore(mockStore)
-	pm := NewPruneManager(metered, ui.NewNoOpReporter())
+	pm := NewPruneManager(Deps{Store: metered, Reporter: ui.NewNoOpReporter()})
 
 	result, err := pm.Run(ctx)
 	if err != nil {

--- a/internal/engine/prune_test.go
+++ b/internal/engine/prune_test.go
@@ -55,7 +55,7 @@ func TestPruneManager_Run(t *testing.T) {
 
 	// 3. Run Prune
 	metered := storelayer.NewMeteredStore(mockStore)
-	pm := NewPruneManager(metered, ui.NewNoOpReporter())
+	pm := NewPruneManager(Deps{Store: metered, Reporter: ui.NewNoOpReporter()})
 	result, err := pm.Run(ctx)
 	if err != nil {
 		t.Fatalf("Prune failed: %v", err)

--- a/internal/engine/repoid_test.go
+++ b/internal/engine/repoid_test.go
@@ -25,11 +25,11 @@ func loadMarker(t *testing.T, s *MockStore, encryptionKey []byte) *core.RepoConf
 
 func TestInitManager_AssignsRepositoryID(t *testing.T) {
 	first := NewMockStore()
-	if _, err := NewInitManager(first, nil).Run(context.Background(), WithInitNoEncryption()); err != nil {
+	if _, err := NewInitManager(Deps{Store: first}).Run(context.Background(), WithInitNoEncryption()); err != nil {
 		t.Fatalf("init: %v", err)
 	}
 	second := NewMockStore()
-	if _, err := NewInitManager(second, nil).Run(context.Background(), WithInitNoEncryption()); err != nil {
+	if _, err := NewInitManager(Deps{Store: second}).Run(context.Background(), WithInitNoEncryption()); err != nil {
 		t.Fatalf("init: %v", err)
 	}
 
@@ -49,7 +49,7 @@ func TestInitManager_AssignsRepositoryIDToEncryptedRepo(t *testing.T) {
 	// survive a seal/unseal round trip rather than only a plain marshal.
 	s := NewMockStore()
 	chain := keychain.Chain{keychain.WithPassword("test-password")}
-	if _, err := NewInitManager(s, nil).Run(context.Background(), WithInitCredentials(chain)); err != nil {
+	if _, err := NewInitManager(Deps{Store: s}).Run(context.Background(), WithInitCredentials(chain)); err != nil {
 		t.Fatalf("init: %v", err)
 	}
 
@@ -78,12 +78,12 @@ func TestInitManager_AdoptPreservesRepositoryID(t *testing.T) {
 	// out of it elsewhere record the old id as provenance, and a new one would
 	// make the next `copy` import the entire history again.
 	s := NewMockStore()
-	if _, err := NewInitManager(s, nil).Run(context.Background(), WithInitNoEncryption()); err != nil {
+	if _, err := NewInitManager(Deps{Store: s}).Run(context.Background(), WithInitNoEncryption()); err != nil {
 		t.Fatalf("init: %v", err)
 	}
 	original := loadMarker(t, s, nil).ID
 
-	if _, err := NewInitManager(s, nil).Run(
+	if _, err := NewInitManager(Deps{Store: s}).Run(
 		context.Background(), WithInitNoEncryption(), WithInitAdoptSlots(),
 	); err != nil {
 		t.Fatalf("re-init: %v", err)
@@ -107,7 +107,7 @@ func TestInitManager_AdoptAssignsIDToLegacyRepository(t *testing.T) {
 		t.Fatalf("seed legacy marker: %v", err)
 	}
 
-	if _, err := NewInitManager(s, nil).Run(
+	if _, err := NewInitManager(Deps{Store: s}).Run(
 		context.Background(), WithInitNoEncryption(), WithInitAdoptSlots(),
 	); err != nil {
 		t.Fatalf("adopt: %v", err)

--- a/internal/engine/repolock_test.go
+++ b/internal/engine/repolock_test.go
@@ -353,7 +353,7 @@ func TestPruneDryRun_NoLock(t *testing.T) {
 	s := NewMockStore()
 
 	metered := storelayer.NewMeteredStore(s)
-	pm := NewPruneManager(metered, ui.NewNoOpReporter())
+	pm := NewPruneManager(Deps{Store: metered, Reporter: ui.NewNoOpReporter()})
 	_, err := pm.Run(ctx, WithPruneDryRun())
 	if err != nil {
 		t.Fatalf("dry run should succeed: %v", err)
@@ -370,7 +370,7 @@ func TestBackupDryRun_NoLock(t *testing.T) {
 	s := NewMockStore()
 	src := NewMockSource()
 
-	bm := NewBackupManager(src, s, ui.NewNoOpReporter(), nil, nil, WithBackupDryRun())
+	bm := NewBackupManager(Deps{Store: s, Reporter: ui.NewNoOpReporter()}, src, WithBackupDryRun())
 	_, err := bm.Run(ctx)
 	if err != nil {
 		t.Fatalf("dry run should succeed: %v", err)

--- a/internal/engine/restore.go
+++ b/internal/engine/restore.go
@@ -111,12 +111,12 @@ type RestoreManager struct {
 	memBudget *semaphore.Weighted
 }
 
-func NewRestoreManager(s store.ObjectStore, reporter ui.Reporter) *RestoreManager {
+func NewRestoreManager(d Deps) *RestoreManager {
 	return &RestoreManager{
-		store:     s,
-		tree:      hamt.NewTree(s),
-		metas:     newUncachedMetaLoader(s),
-		reporter:  reporter,
+		store:     d.Store,
+		tree:      hamt.NewTree(d.Store),
+		metas:     newUncachedMetaLoader(d.Store),
+		reporter:  d.Reporter,
 		memBudget: semaphore.NewWeighted(restoreMemoryBudget),
 	}
 }

--- a/internal/engine/restore.go
+++ b/internal/engine/restore.go
@@ -106,6 +106,7 @@ const restoreMemoryBudget = 128 * 1024 * 1024
 type RestoreManager struct {
 	store     store.ObjectStore
 	tree      *hamt.Tree
+	metas     *metaLoader
 	reporter  ui.Reporter
 	memBudget *semaphore.Weighted
 }
@@ -114,6 +115,7 @@ func NewRestoreManager(s store.ObjectStore, reporter ui.Reporter) *RestoreManage
 	return &RestoreManager{
 		store:     s,
 		tree:      hamt.NewTree(s),
+		metas:     newUncachedMetaLoader(s),
 		reporter:  reporter,
 		memBudget: semaphore.NewWeighted(restoreMemoryBudget),
 	}
@@ -767,7 +769,7 @@ func (rm *RestoreManager) collectMetadata(ctx context.Context, root string) (map
 	g.SetLimit(store.GetConcurrencyHint(rm.store, 10))
 	for _, ref := range refs {
 		g.Go(func() error {
-			fm, err := rm.loadMeta(gCtx, ref)
+			fm, err := rm.metas.load(gCtx, ref)
 			if err != nil {
 				return err
 			}
@@ -784,18 +786,6 @@ func (rm *RestoreManager) collectMetadata(ctx context.Context, root string) (map
 	}
 	phase.Done()
 	return byID, nil
-}
-
-func (rm *RestoreManager) loadMeta(ctx context.Context, ref string) (*core.FileMeta, error) {
-	data, err := getVerified(ctx, rm.store, ref)
-	if err != nil {
-		return nil, err
-	}
-	var fm core.FileMeta
-	if err := json.Unmarshal(data, &fm); err != nil {
-		return nil, err
-	}
-	return &fm, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/restore_parallel_test.go
+++ b/internal/engine/restore_parallel_test.go
@@ -19,7 +19,7 @@ import (
 func TestRestoreManager_WriteChunks_PreservesOrder(t *testing.T) {
 	ctx := context.Background()
 	s := NewMockStore()
-	rm := NewRestoreManager(s, ui.NewNoOpReporter())
+	rm := NewRestoreManager(Deps{Store: s, Reporter: ui.NewNoOpReporter()})
 
 	const n = 37 // more than one batch at the default concurrency hint (10)
 	refs := make([]string, n)
@@ -49,7 +49,7 @@ func TestRestoreManager_WriteChunks_FetchesConcurrently(t *testing.T) {
 	ctx := context.Background()
 	inner := NewMockStore()
 	tracker := &concurrencyTrackingStore{ObjectStore: inner}
-	rm := NewRestoreManager(tracker, ui.NewNoOpReporter())
+	rm := NewRestoreManager(Deps{Store: tracker, Reporter: ui.NewNoOpReporter()})
 
 	const n = 8
 	refs := make([]string, n)
@@ -79,7 +79,7 @@ func TestRestoreManager_CollectMetadata_FetchesConcurrently(t *testing.T) {
 	dest := setupBackupForRestore(t)
 
 	tracker := &concurrencyTrackingStore{ObjectStore: dest}
-	rsMgr := NewRestoreManager(tracker, ui.NewNoOpReporter())
+	rsMgr := NewRestoreManager(Deps{Store: tracker, Reporter: ui.NewNoOpReporter()})
 
 	snap, _, err := rsMgr.resolveSnapshot(ctx, "")
 	if err != nil {
@@ -117,13 +117,13 @@ func TestRestoreManager_MultiChunkFile_RoundTrips(t *testing.T) {
 	src.AddFile("big.bin", "id1", content)
 
 	raw := NewMockStore()
-	bkMgr := NewBackupManager(src, raw, ui.NewNoOpReporter(), nil, nil)
+	bkMgr := NewBackupManager(Deps{Store: raw, Reporter: ui.NewNoOpReporter()}, src)
 	if _, err := bkMgr.Run(ctx); err != nil {
 		t.Fatalf("backup: %v", err)
 	}
 
 	tracker := &concurrencyTrackingStore{ObjectStore: storelayer.NewCompressedStore(raw)}
-	rsMgr := NewRestoreManager(tracker, ui.NewNoOpReporter())
+	rsMgr := NewRestoreManager(Deps{Store: tracker, Reporter: ui.NewNoOpReporter()})
 
 	var buf bytes.Buffer
 	if _, err := rsMgr.Run(ctx, NewZipRestoreWriter(&buf), ""); err != nil {

--- a/internal/engine/restore_pipeline_test.go
+++ b/internal/engine/restore_pipeline_test.go
@@ -126,7 +126,7 @@ func TestWriteChunks_KeepsFetchesInFlightWhileWriting(t *testing.T) {
 		gate:        newFetchGate(),
 		hold:        func(key string) bool { return key != refs[0] },
 	}
-	rm := NewRestoreManager(bs, ui.NewNoOpReporter())
+	rm := NewRestoreManager(Deps{Store: bs, Reporter: ui.NewNoOpReporter()})
 
 	const wantInFlight = 2
 	w := &handshakeWriter{inFlight: &bs.inFlight, gate: bs.gate, want: wantInFlight}
@@ -205,7 +205,7 @@ func TestRunWithWriter_RestoresFilesConcurrently(t *testing.T) {
 	dest := setupBackupForRestore(t)
 
 	bs := &blockingStore{ObjectStore: dest, delay: 5 * time.Millisecond}
-	rm := NewRestoreManager(bs, ui.NewNoOpReporter())
+	rm := NewRestoreManager(Deps{Store: bs, Reporter: ui.NewNoOpReporter()})
 
 	// Plan and write are driven separately so the peak can be reset in
 	// between. prepareRestore fetches file metadata concurrently on its own,

--- a/internal/engine/restore_test.go
+++ b/internal/engine/restore_test.go
@@ -68,7 +68,7 @@ func setupBackupForRestore(t *testing.T) *MockStore {
 		Content: []byte("deep content"),
 	}
 
-	bkMgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
+	bkMgr := NewBackupManager(Deps{Store: dest, Reporter: ui.NewNoOpReporter()}, src)
 	if _, err := bkMgr.Run(context.Background()); err != nil {
 		t.Fatalf("Backup setup failed: %v", err)
 	}
@@ -120,12 +120,12 @@ func TestRestoreManager_Run(t *testing.T) {
 		Content: []byte("nested content"),
 	}
 
-	bkMgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
+	bkMgr := NewBackupManager(Deps{Store: dest, Reporter: ui.NewNoOpReporter()}, src)
 	if _, err := bkMgr.Run(context.Background()); err != nil {
 		t.Fatalf("Backup setup failed: %v", err)
 	}
 
-	rsMgr := NewRestoreManager(storelayer.NewCompressedStore(dest), ui.NewNoOpReporter())
+	rsMgr := NewRestoreManager(Deps{Store: storelayer.NewCompressedStore(dest), Reporter: ui.NewNoOpReporter()})
 
 	var buf bytes.Buffer
 	result, err := rsMgr.Run(context.Background(), NewZipRestoreWriter(&buf), "")
@@ -175,7 +175,7 @@ func TestRestoreManager_Run(t *testing.T) {
 
 func TestRestoreManager_PathFilter_SingleFile(t *testing.T) {
 	dest := setupBackupForRestore(t)
-	rsMgr := NewRestoreManager(storelayer.NewCompressedStore(dest), ui.NewNoOpReporter())
+	rsMgr := NewRestoreManager(Deps{Store: storelayer.NewCompressedStore(dest), Reporter: ui.NewNoOpReporter()})
 
 	var buf bytes.Buffer
 	result, err := rsMgr.Run(context.Background(), NewZipRestoreWriter(&buf), "", WithRestorePath("subdir/nested.txt"))
@@ -211,7 +211,7 @@ func TestRestoreManager_PathFilter_SingleFile(t *testing.T) {
 
 func TestRestoreManager_RunToDir(t *testing.T) {
 	dest := setupBackupForRestore(t)
-	rsMgr := NewRestoreManager(storelayer.NewCompressedStore(dest), ui.NewNoOpReporter())
+	rsMgr := NewRestoreManager(Deps{Store: storelayer.NewCompressedStore(dest), Reporter: ui.NewNoOpReporter()})
 
 	outDir := filepath.Join(t.TempDir(), "restored")
 	writer, err := NewFSRestoreWriter(outDir)
@@ -249,7 +249,7 @@ func TestRestoreManager_RunToDir(t *testing.T) {
 
 func TestRestoreManager_RunToDir_PathFilter(t *testing.T) {
 	dest := setupBackupForRestore(t)
-	rsMgr := NewRestoreManager(storelayer.NewCompressedStore(dest), ui.NewNoOpReporter())
+	rsMgr := NewRestoreManager(Deps{Store: storelayer.NewCompressedStore(dest), Reporter: ui.NewNoOpReporter()})
 
 	outDir := filepath.Join(t.TempDir(), "restored")
 	writer, err := NewFSRestoreWriter(outDir)
@@ -274,7 +274,7 @@ func TestRestoreManager_RunToDir_PathFilter(t *testing.T) {
 
 func TestRestoreManager_RunToDir_SkipsExistingFiles(t *testing.T) {
 	dest := setupBackupForRestore(t)
-	rsMgr := NewRestoreManager(storelayer.NewCompressedStore(dest), ui.NewNoOpReporter())
+	rsMgr := NewRestoreManager(Deps{Store: storelayer.NewCompressedStore(dest), Reporter: ui.NewNoOpReporter()})
 
 	outDir := filepath.Join(t.TempDir(), "restored")
 	if err := os.MkdirAll(filepath.Join(outDir, "subdir"), 0o755); err != nil {
@@ -331,7 +331,7 @@ func TestFSRestoreWriter_WarnDedupf(t *testing.T) {
 
 func TestRestoreManager_RunToDir_DryRun_NoWrites(t *testing.T) {
 	dest := setupBackupForRestore(t)
-	rsMgr := NewRestoreManager(storelayer.NewCompressedStore(dest), ui.NewNoOpReporter())
+	rsMgr := NewRestoreManager(Deps{Store: storelayer.NewCompressedStore(dest), Reporter: ui.NewNoOpReporter()})
 
 	outDir := filepath.Join(t.TempDir(), "dry-run-out")
 	writer, err := NewFSRestoreWriter(outDir)
@@ -352,7 +352,7 @@ func TestRestoreManager_RunToDir_DryRun_NoWrites(t *testing.T) {
 
 func TestRestoreManager_Run_NilWriter(t *testing.T) {
 	dest := setupBackupForRestore(t)
-	rsMgr := NewRestoreManager(storelayer.NewCompressedStore(dest), ui.NewNoOpReporter())
+	rsMgr := NewRestoreManager(Deps{Store: storelayer.NewCompressedStore(dest), Reporter: ui.NewNoOpReporter()})
 
 	if _, err := rsMgr.Run(context.Background(), nil, ""); err == nil {
 		t.Fatal("expected error for nil writer")
@@ -411,7 +411,7 @@ func TestSecureRestorePath(t *testing.T) {
 
 func TestRestoreManager_PathFilter_Subtree(t *testing.T) {
 	dest := setupBackupForRestore(t)
-	rsMgr := NewRestoreManager(storelayer.NewCompressedStore(dest), ui.NewNoOpReporter())
+	rsMgr := NewRestoreManager(Deps{Store: storelayer.NewCompressedStore(dest), Reporter: ui.NewNoOpReporter()})
 
 	var buf bytes.Buffer
 	result, err := rsMgr.Run(context.Background(), NewZipRestoreWriter(&buf), "", WithRestorePath("subdir/"))
@@ -447,7 +447,7 @@ func TestRestoreManager_PathFilter_Subtree(t *testing.T) {
 
 func TestRestoreManager_PathFilter_NoMatch(t *testing.T) {
 	dest := setupBackupForRestore(t)
-	rsMgr := NewRestoreManager(storelayer.NewCompressedStore(dest), ui.NewNoOpReporter())
+	rsMgr := NewRestoreManager(Deps{Store: storelayer.NewCompressedStore(dest), Reporter: ui.NewNoOpReporter()})
 
 	var buf bytes.Buffer
 	result, err := rsMgr.Run(context.Background(), NewZipRestoreWriter(&buf), "", WithRestorePath("nonexistent.txt"))
@@ -468,7 +468,7 @@ func TestRestoreManager_PathFilter_NoMatch(t *testing.T) {
 // the immediate parent.
 func TestRestoreManager_PathFilter_DeepSingleFile(t *testing.T) {
 	dest := setupBackupForRestore(t)
-	rsMgr := NewRestoreManager(storelayer.NewCompressedStore(dest), ui.NewNoOpReporter())
+	rsMgr := NewRestoreManager(Deps{Store: storelayer.NewCompressedStore(dest), Reporter: ui.NewNoOpReporter()})
 
 	var buf bytes.Buffer
 	result, err := rsMgr.Run(context.Background(), NewZipRestoreWriter(&buf), "", WithRestorePath("subdir/deep/file.txt"))
@@ -576,13 +576,13 @@ func TestRestoreManager_PathFilter_CloudLikeIDs(t *testing.T) {
 		Content: []byte("mp3-data"),
 	}
 
-	bkMgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
+	bkMgr := NewBackupManager(Deps{Store: dest, Reporter: ui.NewNoOpReporter()}, src)
 	if _, err := bkMgr.Run(context.Background()); err != nil {
 		t.Fatalf("Backup failed: %v", err)
 	}
 
 	t.Run("subtree filter", func(t *testing.T) {
-		rsMgr := NewRestoreManager(storelayer.NewCompressedStore(dest), ui.NewNoOpReporter())
+		rsMgr := NewRestoreManager(Deps{Store: storelayer.NewCompressedStore(dest), Reporter: ui.NewNoOpReporter()})
 		var buf bytes.Buffer
 		result, err := rsMgr.Run(context.Background(), NewZipRestoreWriter(&buf), "", WithRestorePath("My Documents/"))
 		if err != nil {
@@ -606,7 +606,7 @@ func TestRestoreManager_PathFilter_CloudLikeIDs(t *testing.T) {
 	})
 
 	t.Run("single deep file", func(t *testing.T) {
-		rsMgr := NewRestoreManager(storelayer.NewCompressedStore(dest), ui.NewNoOpReporter())
+		rsMgr := NewRestoreManager(Deps{Store: storelayer.NewCompressedStore(dest), Reporter: ui.NewNoOpReporter()})
 		var buf bytes.Buffer
 		result, err := rsMgr.Run(context.Background(), NewZipRestoreWriter(&buf), "", WithRestorePath("My Documents/Photos/img.jpg"))
 		if err != nil {
@@ -637,7 +637,7 @@ func TestRestoreManager_PathFilter_CloudLikeIDs(t *testing.T) {
 
 func TestRestoreManager_PathFilter_DryRun(t *testing.T) {
 	dest := setupBackupForRestore(t)
-	rsMgr := NewRestoreManager(storelayer.NewCompressedStore(dest), ui.NewNoOpReporter())
+	rsMgr := NewRestoreManager(Deps{Store: storelayer.NewCompressedStore(dest), Reporter: ui.NewNoOpReporter()})
 
 	var buf bytes.Buffer
 	result, err := rsMgr.Run(context.Background(), NewZipRestoreWriter(&buf), "", WithRestorePath("subdir/"), WithRestoreDryRun())
@@ -727,7 +727,7 @@ func TestRestoreManager_PathFilter_MixedLegacyAndNormalizedFileMeta(t *testing.T
 		t.Fatalf("put latest index: %v", err)
 	}
 
-	rsMgr := NewRestoreManager(dest, ui.NewNoOpReporter())
+	rsMgr := NewRestoreManager(Deps{Store: dest, Reporter: ui.NewNoOpReporter()})
 	var buf bytes.Buffer
 	result, err := rsMgr.Run(ctx, NewZipRestoreWriter(&buf), "latest", WithRestorePath("docs/guide.txt"))
 	if err != nil {

--- a/internal/engine/restore_verify_test.go
+++ b/internal/engine/restore_verify_test.go
@@ -28,7 +28,7 @@ func setupBackupForRestoreLarge(t *testing.T) *MockStore {
 	}
 	src.AddFile("big.txt", "id_big", content)
 
-	bkMgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
+	bkMgr := NewBackupManager(Deps{Store: dest, Reporter: ui.NewNoOpReporter()}, src)
 	if _, err := bkMgr.Run(context.Background()); err != nil {
 		t.Fatalf("Backup setup failed: %v", err)
 	}
@@ -60,7 +60,7 @@ func TestRestore_RejectsTamperedChunk(t *testing.T) {
 	dest := setupBackupForRestoreLarge(t)
 	tamperChunk(t, dest, []byte("attacker controlled content"))
 
-	rsMgr := NewRestoreManager(storelayer.NewCompressedStore(dest), ui.NewNoOpReporter())
+	rsMgr := NewRestoreManager(Deps{Store: storelayer.NewCompressedStore(dest), Reporter: ui.NewNoOpReporter()})
 	outDir := filepath.Join(t.TempDir(), "restored")
 	writer, err := NewFSRestoreWriter(outDir)
 	if err != nil {
@@ -91,7 +91,7 @@ func TestRestore_NoVerifyStillWritesTamperedChunk(t *testing.T) {
 	dest := setupBackupForRestoreLarge(t)
 	tamperChunk(t, dest, []byte("attacker controlled content"))
 
-	rsMgr := NewRestoreManager(storelayer.NewCompressedStore(dest), ui.NewNoOpReporter())
+	rsMgr := NewRestoreManager(Deps{Store: storelayer.NewCompressedStore(dest), Reporter: ui.NewNoOpReporter()})
 	outDir := filepath.Join(t.TempDir(), "restored")
 	writer, err := NewFSRestoreWriter(outDir)
 	if err != nil {
@@ -117,7 +117,7 @@ func TestRestore_NoVerifyStillWritesTamperedChunk(t *testing.T) {
 // Verification must not fire on healthy data.
 func TestRestore_VerifiesCleanRestore(t *testing.T) {
 	dest := setupBackupForRestore(t)
-	rsMgr := NewRestoreManager(storelayer.NewCompressedStore(dest), ui.NewNoOpReporter())
+	rsMgr := NewRestoreManager(Deps{Store: storelayer.NewCompressedStore(dest), Reporter: ui.NewNoOpReporter()})
 
 	outDir := filepath.Join(t.TempDir(), "restored")
 	writer, err := NewFSRestoreWriter(outDir)
@@ -179,7 +179,7 @@ func TestRestore_VerifiesInlineContent(t *testing.T) {
 	dest.Data[contentKey] = tampered
 	dest.mu.Unlock()
 
-	rsMgr := NewRestoreManager(storelayer.NewCompressedStore(dest), ui.NewNoOpReporter())
+	rsMgr := NewRestoreManager(Deps{Store: storelayer.NewCompressedStore(dest), Reporter: ui.NewNoOpReporter()})
 	outDir := filepath.Join(t.TempDir(), "restored")
 	writer, err := NewFSRestoreWriter(outDir)
 	if err != nil {

--- a/internal/engine/restore_xattrs_unix_test.go
+++ b/internal/engine/restore_xattrs_unix_test.go
@@ -109,7 +109,7 @@ func TestRestoreManager_RunToDir_ReplaysXattrs(t *testing.T) {
 		Meta:    core.FileMeta{FileID: "id_file", Name: "file.txt", Parents: []string{"id_dir"}, Xattrs: map[string][]byte{"user.file": []byte("f")}},
 		Content: []byte("content"),
 	}
-	bkMgr := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
+	bkMgr := NewBackupManager(Deps{Store: dest, Reporter: ui.NewNoOpReporter()}, src)
 	if _, err := bkMgr.Run(t.Context()); err != nil {
 		t.Fatalf("backup setup failed: %v", err)
 	}
@@ -119,7 +119,7 @@ func TestRestoreManager_RunToDir_ReplaysXattrs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewFSRestoreWriter: %v", err)
 	}
-	rsMgr := NewRestoreManager(storelayer.NewCompressedStore(dest), ui.NewNoOpReporter())
+	rsMgr := NewRestoreManager(Deps{Store: storelayer.NewCompressedStore(dest), Reporter: ui.NewNoOpReporter()})
 	if _, err := rsMgr.Run(t.Context(), writer, ""); err != nil {
 		t.Fatalf("Run: %v", err)
 	}

--- a/internal/engine/snapshot_resolution_test.go
+++ b/internal/engine/snapshot_resolution_test.go
@@ -33,21 +33,21 @@ func TestSnapshotReadersDoNotListForFullHash(t *testing.T) {
 		{
 			name: "restore",
 			resolve: func(selector string) error {
-				_, _, err := NewRestoreManager(s, ui.NewNoOpReporter()).resolveSnapshot(ctx, selector)
+				_, _, err := NewRestoreManager(Deps{Store: s, Reporter: ui.NewNoOpReporter()}).resolveSnapshot(ctx, selector)
 				return err
 			},
 		},
 		{
 			name: "ls",
 			resolve: func(selector string) error {
-				_, _, err := NewLsSnapshotManager(s, nil).resolveSnapshot(ctx, selector)
+				_, _, err := NewLsSnapshotManager(Deps{Store: s}).resolveSnapshot(ctx, selector)
 				return err
 			},
 		},
 		{
 			name: "diff",
 			resolve: func(selector string) error {
-				_, err := NewDiffManager(s, nil).resolveSnapshot(ctx, selector)
+				_, err := NewDiffManager(Deps{Store: s}).resolveSnapshot(ctx, selector)
 				return err
 			},
 		},
@@ -84,21 +84,21 @@ func TestSnapshotReadersResolveUniqueHashPrefix(t *testing.T) {
 		{
 			name: "restore",
 			resolve: func(selector string) (string, error) {
-				_, resolved, err := NewRestoreManager(s, ui.NewNoOpReporter()).resolveSnapshot(ctx, selector)
+				_, resolved, err := NewRestoreManager(Deps{Store: s, Reporter: ui.NewNoOpReporter()}).resolveSnapshot(ctx, selector)
 				return resolved, err
 			},
 		},
 		{
 			name: "ls",
 			resolve: func(selector string) (string, error) {
-				_, resolved, err := NewLsSnapshotManager(s, nil).resolveSnapshot(ctx, selector)
+				_, resolved, err := NewLsSnapshotManager(Deps{Store: s}).resolveSnapshot(ctx, selector)
 				return resolved, err
 			},
 		},
 		{
 			name: "diff",
 			resolve: func(selector string) (string, error) {
-				return NewDiffManager(s, nil).resolveSnapshot(ctx, selector)
+				return NewDiffManager(Deps{Store: s}).resolveSnapshot(ctx, selector)
 			},
 		},
 	}
@@ -138,21 +138,21 @@ func TestSnapshotReadersRejectAmbiguousHashPrefix(t *testing.T) {
 		{
 			name: "restore",
 			resolve: func(selector string) error {
-				_, _, err := NewRestoreManager(s, ui.NewNoOpReporter()).resolveSnapshot(ctx, selector)
+				_, _, err := NewRestoreManager(Deps{Store: s, Reporter: ui.NewNoOpReporter()}).resolveSnapshot(ctx, selector)
 				return err
 			},
 		},
 		{
 			name: "ls",
 			resolve: func(selector string) error {
-				_, _, err := NewLsSnapshotManager(s, nil).resolveSnapshot(ctx, selector)
+				_, _, err := NewLsSnapshotManager(Deps{Store: s}).resolveSnapshot(ctx, selector)
 				return err
 			},
 		},
 		{
 			name: "diff",
 			resolve: func(selector string) error {
-				_, err := NewDiffManager(s, nil).resolveSnapshot(ctx, selector)
+				_, err := NewDiffManager(Deps{Store: s}).resolveSnapshot(ctx, selector)
 				return err
 			},
 		},
@@ -185,21 +185,21 @@ func TestSnapshotReadersReturnNotFoundSentinel(t *testing.T) {
 		{
 			name: "restore",
 			resolve: func(selector string) error {
-				_, _, err := NewRestoreManager(s, ui.NewNoOpReporter()).resolveSnapshot(ctx, selector)
+				_, _, err := NewRestoreManager(Deps{Store: s, Reporter: ui.NewNoOpReporter()}).resolveSnapshot(ctx, selector)
 				return err
 			},
 		},
 		{
 			name: "ls",
 			resolve: func(selector string) error {
-				_, _, err := NewLsSnapshotManager(s, nil).resolveSnapshot(ctx, selector)
+				_, _, err := NewLsSnapshotManager(Deps{Store: s}).resolveSnapshot(ctx, selector)
 				return err
 			},
 		},
 		{
 			name: "diff",
 			resolve: func(selector string) error {
-				_, _, err := NewDiffManager(s, nil).loadRoot(ctx, selector)
+				_, _, err := NewDiffManager(Deps{Store: s}).loadRoot(ctx, selector)
 				return err
 			},
 		},

--- a/internal/engine/snapshots.go
+++ b/internal/engine/snapshots.go
@@ -18,15 +18,35 @@ import (
 )
 
 // defaultSnapLog is the prefix and colour for snapshot-catalog diagnostics.
-// The functions below take a *logger.Logger rather than reading a package
-// variable, because they are free functions with no receiver to carry a sink
-// — see RFC 0022 §8. A nil logger is tolerated and simply logs nothing.
 var defaultSnapLog = logger.New("snapshots", logger.ColorCyan)
 
-// SnapshotLogger returns a snapshot-catalog logger writing to w.
-func SnapshotLogger(w io.Writer) *logger.Logger { return defaultSnapLog.To(w) }
-
 const snapshotCatalogKey = "index/snapshots"
+
+// snapshotCatalog is the index/snapshots catalog: the store holding it, paired
+// with the sink its best-effort failures are reported to.
+//
+// Every operation needs both, so they are bound once here rather than
+// re-passed on each call. That pairing is what keeps a manager down to a
+// single logger of its own: while these were free functions taking a store and
+// a *logger.Logger, every manager that so much as read the catalog had to
+// carry a second, snapshot-prefixed logger purely to hand back down.
+//
+// A nil sink is tolerated and simply logs nothing (RFC 0022 §8).
+type snapshotCatalog struct {
+	store store.ObjectStore
+	log   *logger.Logger
+}
+
+// newSnapshotCatalog binds the catalog living in s to the debug sink w.
+func newSnapshotCatalog(s store.ObjectStore, w io.Writer) snapshotCatalog {
+	return snapshotCatalog{store: s, log: defaultSnapLog.To(w)}
+}
+
+// debugf reports catalog progress to the bound sink, so a caller whose whole
+// job is the catalog can narrate it without reaching through to c.log.
+func (c snapshotCatalog) debugf(format string, args ...any) {
+	c.log.Debugf(format, args...)
+}
 
 var (
 	// ErrSnapshotNotFound means no snapshot matched a requested reference.
@@ -39,22 +59,22 @@ var (
 // Snapshot catalog (index/snapshots)
 // ---------------------------------------------------------------------------
 
-// LoadSnapshotCatalog returns all snapshots, using the catalog index when
-// available and falling back to individual GETs only for snapshots that are
-// missing from the catalog. The catalog is automatically rebuilt/updated
-// whenever a mismatch with the live snapshot keys is detected.
+// load returns all snapshots, using the catalog index when available and
+// falling back to individual GETs only for snapshots that are missing from the
+// catalog. The catalog is automatically rebuilt/updated whenever a mismatch
+// with the live snapshot keys is detected.
 // Results are sorted newest-first by Created time.
-func LoadSnapshotCatalog(s store.ObjectStore, log *logger.Logger) ([]SnapshotEntry, error) {
+func (c snapshotCatalog) load() ([]SnapshotEntry, error) {
 	ctx := context.Background()
 
 	// 1. Load catalog (best-effort).
 	var catalog []core.SnapshotSummary
-	if data, err := s.Get(ctx, snapshotCatalogKey); err == nil {
+	if data, err := c.store.Get(ctx, snapshotCatalogKey); err == nil {
 		_ = json.Unmarshal(data, &catalog)
 	}
 
 	// 2. List live snapshot keys for reconciliation.
-	liveKeys, err := s.List(ctx, "snapshot/")
+	liveKeys, err := c.store.List(ctx, "snapshot/")
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +112,7 @@ func LoadSnapshotCatalog(s store.ObjectStore, log *logger.Logger) ([]SnapshotEnt
 
 	// 5. Fetch missing snapshot objects concurrently.
 	if len(missing) > 0 {
-		fetched, err := fetchSnapshots(s, missing)
+		fetched, err := fetchSnapshots(c.store, missing)
 		if err != nil {
 			return nil, fmt.Errorf("load snapshot catalog: %w", err)
 		}
@@ -140,32 +160,31 @@ func LoadSnapshotCatalog(s store.ObjectStore, log *logger.Logger) ([]SnapshotEnt
 
 	// 7. Persist rebuilt catalog (best-effort).
 	if needRebuild {
-		if err := SaveSnapshotCatalog(s, updatedCatalog); err != nil {
-			log.Debugf("failed to persist snapshot catalog: %v", err)
+		if err := c.save(updatedCatalog); err != nil {
+			c.log.Debugf("failed to persist snapshot catalog: %v", err)
 		}
 	}
 
 	return entries, nil
 }
 
-// SaveSnapshotCatalog persists the full catalog to the store.
-func SaveSnapshotCatalog(s store.ObjectStore, catalog []core.SnapshotSummary) error {
+// save persists the full catalog to the store.
+func (c snapshotCatalog) save(catalog []core.SnapshotSummary) error {
 	data, err := json.Marshal(catalog)
 	if err != nil {
 		return err
 	}
-	return s.Put(context.Background(), snapshotCatalogKey, data)
+	return c.store.Put(context.Background(), snapshotCatalogKey, data)
 }
 
-// loadCatalogForUpdate reads the current catalog for AppendSnapshotCatalog and
-// RemoveFromSnapshotCatalog. ok is false when the read failed for a real
-// reason (not simply "no catalog yet"): callers must not treat that as an
-// empty catalog, since persisting one would clobber every existing entry with
-// a base that just happens to be wrong rather than absent. The self-heal in
-// LoadSnapshotCatalog recovers a merely stale catalog on the next read; it
-// cannot recover one that was overwritten with fabricated emptiness.
-func loadCatalogForUpdate(s store.ObjectStore) (catalog []core.SnapshotSummary, ok bool) {
-	data, err := s.Get(context.Background(), snapshotCatalogKey)
+// loadForUpdate reads the current catalog for add and remove. ok is false when
+// the read failed for a real reason (not simply "no catalog yet"): callers
+// must not treat that as an empty catalog, since persisting one would clobber
+// every existing entry with a base that just happens to be wrong rather than
+// absent. The self-heal in load recovers a merely stale catalog on the next
+// read; it cannot recover one that was overwritten with fabricated emptiness.
+func (c snapshotCatalog) loadForUpdate() (catalog []core.SnapshotSummary, ok bool) {
+	data, err := c.store.Get(context.Background(), snapshotCatalogKey)
 	switch {
 	case err == nil:
 		_ = json.Unmarshal(data, &catalog)
@@ -177,26 +196,26 @@ func loadCatalogForUpdate(s store.ObjectStore) (catalog []core.SnapshotSummary, 
 	}
 }
 
-// AppendSnapshotCatalog loads the current catalog, appends a new summary, and
-// persists it. This is best-effort; errors are logged but not propagated.
-func AppendSnapshotCatalog(s store.ObjectStore, summary core.SnapshotSummary, log *logger.Logger) {
-	catalog, ok := loadCatalogForUpdate(s)
+// add loads the current catalog, appends a new summary, and persists it. This
+// is best-effort; errors are logged but not propagated.
+func (c snapshotCatalog) add(summary core.SnapshotSummary) {
+	catalog, ok := c.loadForUpdate()
 	if !ok {
-		log.Debugf("failed to append snapshot catalog: could not read existing catalog")
+		c.log.Debugf("failed to append snapshot catalog: could not read existing catalog")
 		return
 	}
 	catalog = append(catalog, summary)
-	if err := SaveSnapshotCatalog(s, catalog); err != nil {
-		log.Debugf("failed to append snapshot catalog: %v", err)
+	if err := c.save(catalog); err != nil {
+		c.log.Debugf("failed to append snapshot catalog: %v", err)
 	}
 }
 
-// RemoveFromSnapshotCatalog loads the current catalog, removes entries whose
-// refs match, and persists the result. This is best-effort.
-func RemoveFromSnapshotCatalog(s store.ObjectStore, log *logger.Logger, refs ...string) {
-	catalog, ok := loadCatalogForUpdate(s)
+// remove loads the current catalog, drops entries whose refs match, and
+// persists the result. This is best-effort.
+func (c snapshotCatalog) remove(refs ...string) {
+	catalog, ok := c.loadForUpdate()
 	if !ok {
-		log.Debugf("failed to update snapshot catalog after removal: could not read existing catalog")
+		c.log.Debugf("failed to update snapshot catalog after removal: could not read existing catalog")
 		return
 	}
 	if len(catalog) == 0 {
@@ -212,8 +231,8 @@ func RemoveFromSnapshotCatalog(s store.ObjectStore, log *logger.Logger, refs ...
 			filtered = append(filtered, cs)
 		}
 	}
-	if err := SaveSnapshotCatalog(s, filtered); err != nil {
-		log.Debugf("failed to update snapshot catalog after removal: %v", err)
+	if err := c.save(filtered); err != nil {
+		c.log.Debugf("failed to update snapshot catalog after removal: %v", err)
 	}
 }
 

--- a/internal/engine/snapshots_test.go
+++ b/internal/engine/snapshots_test.go
@@ -51,7 +51,7 @@ func readCatalog(t *testing.T, s *MockStore) []core.SnapshotSummary {
 	return catalog
 }
 
-func TestLoadSnapshotCatalog_NoCatalog(t *testing.T) {
+func TestSnapshotCatalogLoad_NoCatalog(t *testing.T) {
 	s := NewMockStore()
 	now := time.Now()
 
@@ -60,9 +60,9 @@ func TestLoadSnapshotCatalog_NoCatalog(t *testing.T) {
 	ref1 := putSnapshot(t, s, snap1)
 	ref2 := putSnapshot(t, s, snap2)
 
-	entries, err := LoadSnapshotCatalog(s, nil)
+	entries, err := newSnapshotCatalog(s, nil).load()
 	if err != nil {
-		t.Fatalf("LoadSnapshotCatalog: %v", err)
+		t.Fatalf("catalog load: %v", err)
 	}
 
 	if len(entries) != 2 {
@@ -84,7 +84,7 @@ func TestLoadSnapshotCatalog_NoCatalog(t *testing.T) {
 	}
 }
 
-func TestLoadSnapshotCatalog_WithValidCatalog(t *testing.T) {
+func TestSnapshotCatalogLoad_WithValidCatalog(t *testing.T) {
 	s := NewMockStore()
 	now := time.Now()
 
@@ -97,9 +97,9 @@ func TestLoadSnapshotCatalog_WithValidCatalog(t *testing.T) {
 		snapshotToSummary(ref1, *snap1),
 	})
 
-	entries, err := LoadSnapshotCatalog(s, nil)
+	entries, err := newSnapshotCatalog(s, nil).load()
 	if err != nil {
-		t.Fatalf("LoadSnapshotCatalog: %v", err)
+		t.Fatalf("catalog load: %v", err)
 	}
 
 	if len(entries) != 1 {
@@ -110,7 +110,7 @@ func TestLoadSnapshotCatalog_WithValidCatalog(t *testing.T) {
 	}
 }
 
-func TestLoadSnapshotCatalog_ReconcilesMissingEntries(t *testing.T) {
+func TestSnapshotCatalogLoad_ReconcilesMissingEntries(t *testing.T) {
 	s := NewMockStore()
 	now := time.Now()
 
@@ -124,9 +124,9 @@ func TestLoadSnapshotCatalog_ReconcilesMissingEntries(t *testing.T) {
 		snapshotToSummary(ref1, *snap1),
 	})
 
-	entries, err := LoadSnapshotCatalog(s, nil)
+	entries, err := newSnapshotCatalog(s, nil).load()
 	if err != nil {
-		t.Fatalf("LoadSnapshotCatalog: %v", err)
+		t.Fatalf("catalog load: %v", err)
 	}
 
 	if len(entries) != 2 {
@@ -142,7 +142,7 @@ func TestLoadSnapshotCatalog_ReconcilesMissingEntries(t *testing.T) {
 	_ = ref2
 }
 
-func TestLoadSnapshotCatalog_RemovesStaleEntries(t *testing.T) {
+func TestSnapshotCatalogLoad_RemovesStaleEntries(t *testing.T) {
 	s := NewMockStore()
 	now := time.Now()
 
@@ -155,9 +155,9 @@ func TestLoadSnapshotCatalog_RemovesStaleEntries(t *testing.T) {
 		{Ref: "snapshot/deleted", Seq: 99, Created: now.Format(time.RFC3339), Root: "node/gone"},
 	})
 
-	entries, err := LoadSnapshotCatalog(s, nil)
+	entries, err := newSnapshotCatalog(s, nil).load()
 	if err != nil {
-		t.Fatalf("LoadSnapshotCatalog: %v", err)
+		t.Fatalf("catalog load: %v", err)
 	}
 
 	if len(entries) != 1 {
@@ -173,14 +173,14 @@ func TestLoadSnapshotCatalog_RemovesStaleEntries(t *testing.T) {
 	}
 }
 
-func TestAppendSnapshotCatalog(t *testing.T) {
+func TestSnapshotCatalogAdd(t *testing.T) {
 	s := NewMockStore()
 	now := time.Now()
 
 	snap1 := &core.Snapshot{Seq: 1, Created: now.Format(time.RFC3339), Root: "node/a"}
 
 	// Start with empty catalog.
-	AppendSnapshotCatalog(s, snapshotToSummary("snapshot/abc", *snap1), nil)
+	newSnapshotCatalog(s, nil).add(snapshotToSummary("snapshot/abc", *snap1))
 
 	catalog := readCatalog(t, s)
 	if len(catalog) != 1 {
@@ -192,7 +192,7 @@ func TestAppendSnapshotCatalog(t *testing.T) {
 
 	// Append a second.
 	snap2 := &core.Snapshot{Seq: 2, Created: now.Format(time.RFC3339), Root: "node/b"}
-	AppendSnapshotCatalog(s, snapshotToSummary("snapshot/def", *snap2), nil)
+	newSnapshotCatalog(s, nil).add(snapshotToSummary("snapshot/def", *snap2))
 
 	catalog = readCatalog(t, s)
 	if len(catalog) != 2 {
@@ -200,7 +200,7 @@ func TestAppendSnapshotCatalog(t *testing.T) {
 	}
 }
 
-func TestRemoveFromSnapshotCatalog(t *testing.T) {
+func TestSnapshotCatalogRemove(t *testing.T) {
 	s := NewMockStore()
 	now := time.Now()
 
@@ -210,7 +210,7 @@ func TestRemoveFromSnapshotCatalog(t *testing.T) {
 		{Ref: "snapshot/ccc", Seq: 3, Created: now.Format(time.RFC3339)},
 	})
 
-	RemoveFromSnapshotCatalog(s, nil, "snapshot/aaa", "snapshot/ccc")
+	newSnapshotCatalog(s, nil).remove("snapshot/aaa", "snapshot/ccc")
 
 	catalog := readCatalog(t, s)
 	if len(catalog) != 1 {
@@ -221,11 +221,11 @@ func TestRemoveFromSnapshotCatalog(t *testing.T) {
 	}
 }
 
-func TestRemoveFromSnapshotCatalog_NoCatalog(t *testing.T) {
+func TestSnapshotCatalogRemove_NoCatalog(t *testing.T) {
 	s := NewMockStore()
 
 	// Should not panic when catalog doesn't exist.
-	RemoveFromSnapshotCatalog(s, nil, "snapshot/xxx")
+	newSnapshotCatalog(s, nil).remove("snapshot/xxx")
 }
 
 func TestSnapshotToSummary(t *testing.T) {
@@ -262,12 +262,12 @@ func TestSnapshotToSummary(t *testing.T) {
 	}
 }
 
-func TestLoadSnapshotCatalog_EmptyRepo(t *testing.T) {
+func TestSnapshotCatalogLoad_EmptyRepo(t *testing.T) {
 	s := NewMockStore()
 
-	entries, err := LoadSnapshotCatalog(s, nil)
+	entries, err := newSnapshotCatalog(s, nil).load()
 	if err != nil {
-		t.Fatalf("LoadSnapshotCatalog: %v", err)
+		t.Fatalf("catalog load: %v", err)
 	}
 	if len(entries) != 0 {
 		t.Errorf("expected 0 entries, got %d", len(entries))
@@ -339,29 +339,29 @@ func TestFetchSnapshots_PropagatesRealError(t *testing.T) {
 	}
 }
 
-// LoadSnapshotCatalog must not persist a catalog that silently omits a
+// Loading the catalog must not persist a catalog that silently omits a
 // snapshot it failed to fetch for a real (non-not-found) reason.
-func TestLoadSnapshotCatalog_PropagatesFetchError(t *testing.T) {
+func TestSnapshotCatalogLoad_PropagatesFetchError(t *testing.T) {
 	backendErr := errors.New("simulated network error")
 	inner := NewMockStore()
 	snap := &core.Snapshot{Seq: 1, Root: "node/a"}
 	ref := putSnapshot(t, inner, snap)
-	// No catalog yet, so LoadSnapshotCatalog must fetch ref individually.
+	// No catalog yet, so load must fetch ref individually.
 	s := newErrorOnGetStore(inner, backendErr, ref)
 
-	_, err := LoadSnapshotCatalog(s, nil)
+	_, err := newSnapshotCatalog(s, nil).load()
 	if err == nil {
-		t.Fatal("expected LoadSnapshotCatalog to propagate a real fetch error")
+		t.Fatal("expected catalog load to propagate a real fetch error")
 	}
 	if !errors.Is(err, backendErr) {
-		t.Errorf("LoadSnapshotCatalog error = %v, want it to wrap %v", err, backendErr)
+		t.Errorf("catalog load error = %v, want it to wrap %v", err, backendErr)
 	}
 }
 
-// A real read failure on index/snapshots must not cause AppendSnapshotCatalog
+// A real read failure on index/snapshots must not cause a catalog add
 // to silently overwrite the existing catalog with one containing only the
 // new entry.
-func TestAppendSnapshotCatalog_DoesNotClobberOnReadError(t *testing.T) {
+func TestSnapshotCatalogAdd_DoesNotClobberOnReadError(t *testing.T) {
 	backendErr := errors.New("simulated network error")
 	inner := NewMockStore()
 	putCatalog(t, inner, []core.SnapshotSummary{
@@ -369,7 +369,7 @@ func TestAppendSnapshotCatalog_DoesNotClobberOnReadError(t *testing.T) {
 	})
 	s := newErrorOnGetStore(inner, backendErr, snapshotCatalogKey)
 
-	AppendSnapshotCatalog(s, core.SnapshotSummary{Ref: "snapshot/new", Seq: 2}, nil)
+	newSnapshotCatalog(s, nil).add(core.SnapshotSummary{Ref: "snapshot/new", Seq: 2})
 
 	catalog := readCatalog(t, inner)
 	if len(catalog) != 1 || catalog[0].Ref != "snapshot/existing" {
@@ -377,7 +377,7 @@ func TestAppendSnapshotCatalog_DoesNotClobberOnReadError(t *testing.T) {
 	}
 }
 
-func TestRemoveFromSnapshotCatalog_DoesNotClobberOnReadError(t *testing.T) {
+func TestSnapshotCatalogRemove_DoesNotClobberOnReadError(t *testing.T) {
 	backendErr := errors.New("simulated network error")
 	inner := NewMockStore()
 	putCatalog(t, inner, []core.SnapshotSummary{
@@ -385,7 +385,7 @@ func TestRemoveFromSnapshotCatalog_DoesNotClobberOnReadError(t *testing.T) {
 	})
 	s := newErrorOnGetStore(inner, backendErr, snapshotCatalogKey)
 
-	RemoveFromSnapshotCatalog(s, nil, "snapshot/existing")
+	newSnapshotCatalog(s, nil).remove("snapshot/existing")
 
 	catalog := readCatalog(t, inner)
 	if len(catalog) != 1 || catalog[0].Ref != "snapshot/existing" {

--- a/internal/engine/tamper_test.go
+++ b/internal/engine/tamper_test.go
@@ -87,7 +87,7 @@ func TestRestoreRejectsTamperedFileMeta(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new writer: %v", err)
 	}
-	rm := NewRestoreManager(dest, ui.NewNoOpReporter())
+	rm := NewRestoreManager(Deps{Store: dest, Reporter: ui.NewNoOpReporter()})
 	_, err = rm.Run(context.Background(), writer, "latest")
 
 	if err == nil {
@@ -131,7 +131,7 @@ func TestRestoreRejectsTamperedSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new writer: %v", err)
 	}
-	rm := NewRestoreManager(dest, ui.NewNoOpReporter())
+	rm := NewRestoreManager(Deps{Store: dest, Reporter: ui.NewNoOpReporter()})
 	if _, err := rm.Run(ctx, writer, "latest"); err == nil {
 		t.Fatal("restore accepted a snapshot that does not hash to its key")
 	} else if !strings.Contains(err.Error(), "integrity check") {
@@ -148,7 +148,7 @@ func TestCheckReportsTamperedFileMeta(t *testing.T) {
 		fm.Size = 999999
 	})
 
-	cm := NewCheckManager(dest, ui.NewNoOpReporter(), nil)
+	cm := NewCheckManager(Deps{Store: dest, Reporter: ui.NewNoOpReporter()})
 	res, err := cm.Run(context.Background(), WithReadData())
 	if err != nil {
 		t.Fatalf("check: %v", err)
@@ -171,7 +171,7 @@ func TestCheckReportsTamperedInlineContent(t *testing.T) {
 	dest := NewMockStore()
 	src.AddFile("small.txt", "id1", []byte("small enough to store inline"))
 
-	bm := NewBackupManager(src, dest, ui.NewNoOpReporter(), nil, nil)
+	bm := NewBackupManager(Deps{Store: dest, Reporter: ui.NewNoOpReporter()}, src)
 	if _, err := bm.Run(context.Background()); err != nil {
 		t.Fatalf("backup: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestCheckReportsTamperedInlineContent(t *testing.T) {
 		t.Fatalf("put forged content: %v", err)
 	}
 
-	cm := NewCheckManager(dest, ui.NewNoOpReporter(), nil)
+	cm := NewCheckManager(Deps{Store: dest, Reporter: ui.NewNoOpReporter()})
 	res, err := cm.Run(ctx, WithReadData())
 	if err != nil {
 		t.Fatalf("check: %v", err)

--- a/internal/engine/verbose_test.go
+++ b/internal/engine/verbose_test.go
@@ -118,6 +118,36 @@ func TestLsSnapshotManager_LogsProgressToTheCallersWriter(t *testing.T) {
 	}
 }
 
+// The collected-entries line summarises the whole walk, so it belongs after the
+// counting loop rather than inside it. Emitting it per entry turned a one-line
+// summary into one line per file, which on a real snapshot buries every other
+// diagnostic in the debug log.
+func TestLsSnapshotManager_LogsTheCollectedSummaryOnce(t *testing.T) {
+	ctx := context.Background()
+	s := NewMockStore()
+
+	metas := []string{
+		createMeta(ctx, s, "file1.txt", 100),
+		createMeta(ctx, s, "file2.txt", 200),
+		createMeta(ctx, s, "file3.txt", 300),
+	}
+	root := createHamt(ctx, t, s, []string{"file1", "file2", "file3"}, metas)
+	snap := core.Snapshot{Seq: 1, Root: root, Created: "2025-01-01T00:00:00Z"}
+	ref := saveSnapshot(ctx, s, &snap)
+
+	var log bytes.Buffer
+	if _, err := NewLsSnapshotManager(s, &log).Run(ctx, ref); err != nil {
+		t.Fatalf("LsSnapshot: %v", err)
+	}
+
+	if got := strings.Count(log.String(), "Collected "); got != 1 {
+		t.Errorf("collected summary logged %d times, want 1; got:\n%s", got, log.String())
+	}
+	if !strings.Contains(log.String(), "Collected 3 files, 0 directories") {
+		t.Errorf("summary does not report the final totals; got:\n%s", log.String())
+	}
+}
+
 func TestDiffManager_LogsProgressToTheCallersWriter(t *testing.T) {
 	ctx := context.Background()
 	s := NewMockStore()

--- a/internal/engine/verbose_test.go
+++ b/internal/engine/verbose_test.go
@@ -167,3 +167,61 @@ func TestDiffManager_LogsProgressToTheCallersWriter(t *testing.T) {
 		t.Errorf("log does not mention resolving the snapshots; got:\n%s", log.String())
 	}
 }
+
+// Like ls, diff's change summary describes the whole comparison and belongs
+// after the counting loop rather than inside it.
+func TestDiffManager_LogsTheChangeSummaryOnce(t *testing.T) {
+	ctx := context.Background()
+	s := NewMockStore()
+
+	m1 := createMeta(ctx, s, "file1.txt", 100)
+	m2 := createMeta(ctx, s, "file2.txt", 200)
+	m3 := createMeta(ctx, s, "file3.txt", 300)
+
+	// file1 is unchanged between the two, so the diff is exactly two additions.
+	before := createHamt(ctx, t, s, []string{"file1"}, []string{m1})
+	after := createHamt(ctx, t, s, []string{"file1", "file2", "file3"}, []string{m1, m2, m3})
+	ref1 := saveSnapshot(ctx, s, &core.Snapshot{Seq: 1, Root: before, Created: "2025-01-01T00:00:00Z"})
+	ref2 := saveSnapshot(ctx, s, &core.Snapshot{Seq: 2, Root: after, Created: "2025-01-02T00:00:00Z"})
+
+	var log bytes.Buffer
+	res, err := NewDiffManager(Deps{Store: s, LogSink: &log}).Run(ctx, ref1, ref2)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if len(res.Changes) != 2 {
+		t.Fatalf("got %d changes, want 2", len(res.Changes))
+	}
+	if got := strings.Count(log.String(), "Found "); got != 1 {
+		t.Errorf("change summary logged %d times, want 1; got:\n%s", got, log.String())
+	}
+	if !strings.Contains(log.String(), "Found 2 changes: 2 added, 0 removed, 0 modified") {
+		t.Errorf("summary does not report the final totals; got:\n%s", log.String())
+	}
+}
+
+// A snapshot with no source info is still a snapshot the caller was handed, so
+// it must appear in the debug listing. The per-entry line used to sit inside
+// the branch that formats the source suffix, so those rows vanished.
+func TestListManager_LogsSnapshotsWithoutSourceInfo(t *testing.T) {
+	ctx := context.Background()
+	s := NewMockStore()
+
+	withSource := core.Snapshot{
+		Seq: 1, Root: "node/1", Created: "2025-01-01T00:00:00Z",
+		Source: &core.SourceInfo{Type: "local", Account: "acct", Path: "/data"},
+	}
+	withoutSource := core.Snapshot{Seq: 2, Root: "node/2", Created: "2025-01-02T00:00:00Z"}
+	ref1 := saveSnapshot(ctx, s, &withSource)
+	ref2 := saveSnapshot(ctx, s, &withoutSource)
+
+	var log bytes.Buffer
+	if _, err := NewListManager(Deps{Store: s, LogSink: &log}).Run(ctx); err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	for _, ref := range []string{ref1, ref2} {
+		if !strings.Contains(log.String(), ref) {
+			t.Errorf("log omits snapshot %s; got:\n%s", ref, log.String())
+		}
+	}
+}

--- a/internal/engine/verbose_test.go
+++ b/internal/engine/verbose_test.go
@@ -61,7 +61,7 @@ func TestListManager_LogsProgressToTheCallersWriter(t *testing.T) {
 	}))
 
 	var log bytes.Buffer
-	mgr := NewListManager(s, &log)
+	mgr := NewListManager(Deps{Store: s, LogSink: &log})
 	result, err := mgr.Run(ctx)
 	if err != nil {
 		t.Fatalf("List: %v", err)
@@ -90,7 +90,7 @@ func TestListManager_NoWriterMeansNoOutput(t *testing.T) {
 	}))
 
 	out := captureStderr(t, func() {
-		if _, err := NewListManager(s, nil).Run(ctx); err != nil {
+		if _, err := NewListManager(Deps{Store: s}).Run(ctx); err != nil {
 			t.Fatalf("List: %v", err)
 		}
 	})
@@ -110,7 +110,7 @@ func TestLsSnapshotManager_LogsProgressToTheCallersWriter(t *testing.T) {
 	_ = s.Put(ctx, "index/latest", createIndex(ref, 1))
 
 	var log bytes.Buffer
-	if _, err := NewLsSnapshotManager(s, &log).Run(ctx, ref); err != nil {
+	if _, err := NewLsSnapshotManager(Deps{Store: s, LogSink: &log}).Run(ctx, ref); err != nil {
 		t.Fatalf("LsSnapshot: %v", err)
 	}
 	if !strings.Contains(log.String(), "Resolving snapshot") {
@@ -136,7 +136,7 @@ func TestLsSnapshotManager_LogsTheCollectedSummaryOnce(t *testing.T) {
 	ref := saveSnapshot(ctx, s, &snap)
 
 	var log bytes.Buffer
-	if _, err := NewLsSnapshotManager(s, &log).Run(ctx, ref); err != nil {
+	if _, err := NewLsSnapshotManager(Deps{Store: s, LogSink: &log}).Run(ctx, ref); err != nil {
 		t.Fatalf("LsSnapshot: %v", err)
 	}
 
@@ -160,7 +160,7 @@ func TestDiffManager_LogsProgressToTheCallersWriter(t *testing.T) {
 	ref2 := saveSnapshot(ctx, s, &snap2)
 
 	var log bytes.Buffer
-	if _, err := NewDiffManager(s, &log).Run(ctx, ref1, ref2); err != nil {
+	if _, err := NewDiffManager(Deps{Store: s, LogSink: &log}).Run(ctx, ref1, ref2); err != nil {
 		t.Fatalf("Diff: %v", err)
 	}
 	if !strings.Contains(log.String(), "Resolving snapshot") {

--- a/query.go
+++ b/query.go
@@ -15,7 +15,7 @@ type ListOption = engine.ListOption
 type ListResult = engine.ListResult
 
 func (c *Client) List(ctx context.Context, opts ...ListOption) (*ListResult, error) {
-	mgr := engine.NewListManager(c.store, c.logWriter)
+	mgr := engine.NewListManager(c.engineDeps())
 	return mgr.Run(ctx, opts...)
 }
 
@@ -29,7 +29,7 @@ type LsSnapshotResult = engine.LsSnapshotResult
 // LsSnapshot lists a snapshot selected by latest, full hash, or unambiguous
 // hash prefix. An ambiguous prefix is rejected.
 func (c *Client) LsSnapshot(ctx context.Context, snapshotID string, opts ...LsSnapshotOption) (*LsSnapshotResult, error) {
-	mgr := engine.NewLsSnapshotManager(c.store, c.logWriter)
+	mgr := engine.NewLsSnapshotManager(c.engineDeps())
 	return mgr.Run(ctx, snapshotID, opts...)
 }
 
@@ -73,7 +73,7 @@ var (
 // storable, loggable, sendable — which a closure over a private struct is not.
 // Use FindQuery.SetPattern for a positional pattern, which routes by shape.
 func (c *Client) Find(ctx context.Context, q FindQuery) (*FindResult, error) {
-	mgr := engine.NewFindManager(c.store, c.logWriter)
+	mgr := engine.NewFindManager(c.engineDeps())
 	return mgr.Run(ctx, q)
 }
 
@@ -99,7 +99,7 @@ const (
 // Diff compares snapshots selected by latest, full hashes, or unambiguous hash
 // prefixes. An ambiguous prefix is rejected.
 func (c *Client) Diff(ctx context.Context, snap1, snap2 string, opts ...DiffOption) (*DiffResult, error) {
-	mgr := engine.NewDiffManager(c.store, c.logWriter)
+	mgr := engine.NewDiffManager(c.engineDeps())
 	return mgr.Run(ctx, snap1, snap2, opts...)
 }
 

--- a/repo.go
+++ b/repo.go
@@ -32,7 +32,7 @@ var (
 func InitRepo(ctx context.Context, rawStore store.ObjectStore, opts ...InitOption) (*InitResult, error) {
 	// No client exists here to carry a sink, so init's one debug line goes to
 	// the process-wide fallback. See RFC 0022 §8.
-	mgr := engine.NewInitManager(rawStore, nil)
+	mgr := engine.NewInitManager(engine.Deps{Store: rawStore})
 	return mgr.Run(ctx, opts...)
 }
 

--- a/restore.go
+++ b/restore.go
@@ -29,7 +29,7 @@ var (
 // snapshotRef can be "", "latest", a bare hash or unambiguous hash prefix, or
 // "snapshot/<hash-or-prefix>". An ambiguous prefix is rejected.
 func (c *Client) Restore(ctx context.Context, w io.Writer, snapshotRef string, opts ...RestoreOption) (*RestoreResult, error) {
-	mgr := engine.NewRestoreManager(c.store, c.reporter)
+	mgr := engine.NewRestoreManager(c.engineDeps())
 	return mgr.Run(ctx, engine.NewZipRestoreWriter(w), snapshotRef, opts...)
 }
 
@@ -37,7 +37,7 @@ func (c *Client) Restore(ctx context.Context, w io.Writer, snapshotRef string, o
 // snapshotRef can be "", "latest", a bare hash or unambiguous hash prefix, or
 // "snapshot/<hash-or-prefix>". An ambiguous prefix is rejected.
 func (c *Client) RestoreToDir(ctx context.Context, outputDir, snapshotRef string, opts ...RestoreOption) (*RestoreResult, error) {
-	mgr := engine.NewRestoreManager(c.store, c.reporter)
+	mgr := engine.NewRestoreManager(c.engineDeps())
 	writer, err := engine.NewFSRestoreWriter(outputDir)
 	if err != nil {
 		return nil, err

--- a/retention.go
+++ b/retention.go
@@ -19,7 +19,7 @@ var (
 )
 
 func (c *Client) Prune(ctx context.Context, opts ...PruneOption) (*PruneResult, error) {
-	mgr := engine.NewPruneManager(c.store, c.reporter)
+	mgr := engine.NewPruneManager(c.engineDeps())
 	result, err := mgr.Run(ctx, opts...)
 	if err != nil {
 		return nil, err
@@ -70,7 +70,7 @@ type KeepReason = engine.KeepReason
 type SnapshotEntry = engine.SnapshotEntry
 
 func (c *Client) Forget(ctx context.Context, snapshotID string, opts ...ForgetOption) (*ForgetResult, error) {
-	mgr := engine.NewForgetManager(c.store, c.reporter, c.logWriter)
+	mgr := engine.NewForgetManager(c.engineDeps())
 	result, err := mgr.Run(ctx, snapshotID, opts...)
 	if err != nil {
 		return nil, err
@@ -82,7 +82,7 @@ func (c *Client) Forget(ctx context.Context, snapshotID string, opts ...ForgetOp
 }
 
 func (c *Client) ForgetPolicy(ctx context.Context, opts ...ForgetOption) (*PolicyResult, error) {
-	mgr := engine.NewForgetManager(c.store, c.reporter, c.logWriter)
+	mgr := engine.NewForgetManager(c.engineDeps())
 	result, err := mgr.RunPolicy(ctx, opts...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Cleanup pass over `internal/engine`, landed as six atomic commits — each verified green before the next, and each purely structural or purely behavioural, never both.

**The duplicate store was literal.** `NewBackupManager` assigned the same `KeyCacheStore` pointer to both `store` and `keyCache`; the second field existed only so one `PreloadKeys` call could reach the concrete type. One field now, held concrete — the capability assertions in `store.GetConcurrencyHint` see the same dynamic value either way.

**The two loggers were a symptom.** The snapshot catalog was three free functions that each re-took a store *and* a `*logger.Logger`, so every manager touching it carried a second, snapshot-prefixed logger purely to hand back down. Binding the pair once in a `snapshotCatalog` value leaves each manager with one logger. That also surfaced that `DiffManager` and `LsSnapshotManager` had a `log` field documented as "the snapshot-catalog sink" while never calling a catalog function — they were borrowing the `[snapshots]` prefix, and now have their own, as does `find`. Copy's single `snapLog` was used against two different stores; it is now an explicit `srcCatalog`/`dstCatalog`. The four catalog symbols had no callers outside the package and are unexported.

**`loadMeta` was written six times** — backup, diff, prune, ls, restore, find scanner — and the copies had drifted: backup guarded its cache with an RWMutex, diff lazily allocated one, prune wrapped its error while others returned it bare, ls and restore had none. One `metaLoader` now, with memoization as a constructor choice rather than an accident: it is a property of the traversal, not the call site.

**Eleven constructors took the same four dependencies in five different orders**, and `Reporter`/`LogSink` are both "somewhere output goes" — a transposition the compiler cannot catch. `engine.Deps` fixes the order and gives restore, check and prune a debug sink they had simply never been passed. `Client.engineDeps()` supplies the set; backup is the only caller that overrides it, swapping in its own meter. Forget also stopped double-wrapping the store in a `MeteredStore` before handing it to `NewPruneManager`, which wraps one itself — the inner meter was created inline, never referenced, and counted the same writes.

### Defects found along the way

Each fixed in its own commit with a regression test, kept separate from the structural work:

- `ls` allocated a filemeta cache it never wrote to. **Note:** this was *not* costing re-fetches — a HAMT key derives from `meta.FileID`, itself a `FileMeta` field, so no two keys share a filemeta ref and a single-root walk reaches each exactly once. The cache could never hit, so it is deleted rather than populated. The caches in `diff` and `prune` do earn their keep; those walk several snapshots, where unchanged files share a ref.
- `diff`'s change summary sat inside the counting loop, printing once per change with running totals instead of once with the final ones.
- `list`'s per-snapshot line sat inside the branch formatting the source suffix, so a snapshot with no source info was silently absent from a listing the caller had just been handed.

### Reviewer notes

- No public API change. `engine.Deps` is exported because the root package constructs it, but it appears in no exported signature there, so it needs no alias — `internal/apicheck` passes.
- Nothing here touches the on-disk format: no object encoding, key layout, or version gate is affected, so `docs/compatibility.md` needs no new baseline.
- Filemeta error wrapping is now uniform. No caller inspects these errors, and `%w` leaves `errors.Is` unaffected.
- Debug output changes: `diff`, `ls` and `find` now carry their own component prefixes instead of `[snapshots]`.
- The branch name predates the work and does not follow the repo's `<type>/<kebab-slug>` convention; the PR title does, and the squash subject is what lands.

## Verification

- `env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./...` passes (full module, including `internal/apicheck`)
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./...` — 0 issues

Docker-backed e2e tests (MinIO store, SFTP source/store) skipped locally for want of `/var/run/docker.sock`, so those paths were not exercised here and rely on CI.