### PR TITLE
perf(engine): release scan filemetas before the upload phase

### DIFF
--- a/internal/engine/backup.go
+++ b/internal/engine/backup.go
@@ -124,6 +124,10 @@ type BackupManager struct {
 	sourceInfo core.SourceInfo
 	cfg        backupConfig
 
+	// newMetas holds filemetas produced by the current scan, whose bytes are
+	// still queued in pendingMetas and so cannot be read back through metas.
+	// It is scan-phase only: Run releases it once scanSource returns, so
+	// nothing after that point may read or write it.
 	newMetas     map[string]core.FileMeta
 	metas        *metaLoader
 	pendingMetas map[string][]byte // deferred filemeta PUTs (ref → JSON)
@@ -253,6 +257,17 @@ func (bm *BackupManager) Run(ctx context.Context) (*RunResult, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// newMetas exists to answer parent lookups for entries whose filemeta has
+	// not been written yet, which only happens while scanning. Its last reader
+	// returned with scanSource, so it is released here rather than carried
+	// through upload — the longest and most allocation-heavy phase, where it
+	// would hold a core.FileMeta per scanned file for nothing.
+	//
+	// Releasing by nilling is deliberate: a nil map still reads as empty, but a
+	// write to one panics, so a lookup reintroduced below this line fails
+	// loudly instead of quietly repopulating a map nothing consumes.
+	bm.newMetas = nil
 
 	if bm.cfg.dryRun {
 		if usedFullScan {

--- a/internal/engine/backup_test.go
+++ b/internal/engine/backup_test.go
@@ -87,6 +87,50 @@ func TestBackupManager_ResolvesPathsForOpaqueIDs(t *testing.T) {
 	checkNoStoredPath("FOLDER_B", "FILE_C")
 }
 
+// newMetas answers parent lookups for filemetas whose bytes are still queued in
+// pendingMetas, which only happens while scanning. It used to be carried
+// through upload — and written to there — holding a core.FileMeta per scanned
+// file for a map nothing read, across the longest phase of a backup.
+//
+// TestBackupManager_ResolvesPathsForOpaqueIDs covers the other side of this:
+// releasing the map too early breaks parent resolution for a tree whose entries
+// carry no Paths.
+func TestBackupManager_ReleasesScanFilemetasBeforeUpload(t *testing.T) {
+	newSrc := func() *MockSource {
+		src := NewMockSource()
+		src.Files["FOLDER_A"] = MockFile{Meta: core.FileMeta{
+			FileID: "FOLDER_A", Name: "Documents", Type: core.FileTypeFolder,
+		}}
+		src.Files["FILE_B"] = MockFile{
+			Meta:    core.FileMeta{FileID: "FILE_B", Name: "notes.txt", Parents: []string{"FOLDER_A"}},
+			Content: []byte("hello"),
+		}
+		return src
+	}
+
+	for _, tc := range []struct {
+		name string
+		opts []BackupOption
+	}{
+		{name: "full"},
+		{name: "dry-run", opts: []BackupOption{WithBackupDryRun()}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mgr := NewBackupManager(
+				Deps{Store: NewMockStore(), Reporter: ui.NewNoOpReporter()},
+				newSrc(), tc.opts...,
+			)
+			if _, err := mgr.Run(context.Background()); err != nil {
+				t.Fatalf("Backup failed: %v", err)
+			}
+			if mgr.newMetas != nil {
+				t.Errorf("newMetas still holds %d entries after Run; it is scan-phase only",
+					len(mgr.newMetas))
+			}
+		})
+	}
+}
+
 func TestBackupManager_Run(t *testing.T) {
 	ctx := context.Background()
 	src := NewMockSource()

--- a/internal/engine/backup_upload.go
+++ b/internal/engine/backup_upload.go
@@ -29,11 +29,16 @@ var inlineBufferPool = sync.Pool{
 	},
 }
 
+// uploadResult is what one worker reports back about a single file.
+//
+// It carries no core.FileMeta. The upload phase has no reader for one — the
+// paths built during the scan are already persisted, and newMetas is released
+// before upload begins — so returning a 216-byte struct by value through the
+// results channel would cost memory for every file to no end.
 type uploadResult struct {
 	fileID        string
 	parentID      string // primary parent's raw fileID (for the affinity routing key)
 	ref           string
-	meta          core.FileMeta
 	contentRef    string   // content key to cache (empty when dedup'd)
 	contentChunks []string // chunk refs for the content entry (nil for inline)
 	err           error
@@ -97,7 +102,6 @@ func (bm *BackupManager) upload(ctx context.Context, pending []core.FileMeta, to
 			phase.Error()
 			return fmt.Errorf("hamt insert: %w", err)
 		}
-		bm.newMetas[res.ref] = res.meta
 	}
 
 	phase.Done()
@@ -130,7 +134,6 @@ func (bm *BackupManager) processFile(ctx context.Context, meta core.FileMeta, ph
 		fileID:        meta.FileID,
 		parentID:      primaryParentID(&meta),
 		ref:           metaRef,
-		meta:          meta,
 		contentRef:    contentRef,
 		contentChunks: contentChunks,
 	}


### PR DESCRIPTION
## Summary

`BackupManager.newMetas` answers parent lookups for filemetas whose bytes are still queued in `pendingMetas` — a case that only arises while scanning. Its one reader is `lookupMetaByFileID`, reached from `buildPathFromTree` during `scanSource`. The upload phase nevertheless kept writing to it, and the map stayed live for the whole run.

Nothing read those writes. A minimal `core.FileMeta` measures ~456 bytes in a map (216 B shallow, and real ones also carry `Paths`, `Extra` and `Xattrs`), so a million-file backup carried roughly half a gigabyte of ballast through its longest and most allocation-heavy phase.

- `Run` releases the map once `scanSource` returns. That covers the dry-run path too, since it returns before upload.
- `uploadResult` loses its `core.FileMeta` field along with the dead write, so each result travels 216 bytes lighter through the buffered `results` channel.

Nilling rather than clearing is deliberate: a nil map still reads as empty but **panics on write**, so a lookup reintroduced below that line fails loudly instead of quietly repopulating a map nothing consumes.

Closes #428

## Verification

Both directions are covered, which is what makes the placement safe rather than plausible:

- `TestBackupManager_ResolvesPathsForOpaqueIDs` (pre-existing) covers releasing **too early**. I confirmed it by moving `bm.newMetas = nil` above `scanSource` — it fails, because parent resolution for a tree carrying no `Paths` depends on the map being live through the scan.
- `TestBackupManager_ReleasesScanFilemetasBeforeUpload` (new) covers releasing **not at all**, asserting the map is nil after `Run` on both the full and dry-run paths, so the upload-phase write cannot creep back.

Commands run:

- `env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./...` passes (full module)
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./...` — 0 issues

Docker-backed e2e tests (MinIO, SFTP) skipped locally for want of `/var/run/docker.sock`, so those paths rely on CI.

## Reviewer notes

- No behaviour change: the removed write had no reader, and the release point is after the last one.
- No public API change; `uploadResult` is unexported.
- This is the first of the four caching follow-ups from #427 — the unambiguous one. #429 (bound `metaLoader` like `NodeStore`), #430 (`KeyCacheStore` raw-hash keys) and #431 (pin the two filemeta path routes agree) are still open and deliberately gated behind benchmarks or a test-first step.