### PR TITLE
test(benchmark): measure peak memory across repository sizes

### DIFF
--- a/.github/workflows/memory.yml
+++ b/.github/workflows/memory.yml
@@ -1,0 +1,87 @@
+name: Memory scaling
+
+# Peak memory as a function of repository size.
+#
+# Deliberately not part of the ordinary CI run: it builds several synthetic
+# trees and backs each one up, which costs minutes rather than seconds. Two ways
+# in — dispatch it by hand against any ref, or put the `benchmark` label on a
+# pull request when a change could plausibly move memory.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref to measure (branch, tag, or refs/pull/<number>/head)
+        required: false
+        default: main
+        type: string
+      sizes:
+        description: Space-separated tree sizes to measure
+        required: false
+        default: "5000 20000 50000"
+        type: string
+  pull_request:
+    types: [labeled, synchronize]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: memory-${{ github.event.inputs.ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  memory:
+    # On a pull request this runs only while the `benchmark` label is on it, so
+    # an unrelated label does not start a ten-minute job, and pushing more
+    # commits to an already-labelled PR re-measures without another click.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'benchmark')
+    name: Peak RSS vs repository size
+    runs-on: macos-latest
+    steps:
+      - name: Checkout target ref
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - name: Measure
+        shell: bash
+        env:
+          SIZES: ${{ github.event.inputs.sizes || '5000 20000 50000' }}
+        run: |
+          set -euo pipefail
+          mkdir -p benchmark-results
+          ./scripts/benchmark/memory.sh | tee benchmark-results/memory.log
+
+      - name: Publish summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          ./scripts/benchmark/render-memory.sh benchmark-results/memory.csv >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo ""
+            echo "<details><summary>Run log</summary>"
+            echo ""
+            echo '```text'
+            cat benchmark-results/memory.log
+            echo '```'
+            echo ""
+            echo "</details>"
+            echo ""
+            echo "Ref \`${{ github.event.inputs.ref || github.ref }}\` on \`${{ runner.os }}\`."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload results
+        uses: actions/upload-artifact@v7
+        with:
+          name: memory-scaling
+          path: |
+            benchmark-results/memory.csv
+            benchmark-results/memory.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,32 @@ golangci-lint run ./...
 
 # Format
 go fmt ./...
+
+# Peak memory as a function of repository size (minutes, not seconds)
+SIZES="5000 20000" ./scripts/benchmark/memory.sh
 ```
+
+### Performance measurement
+
+Three layers, in cost order:
+
+- **Go benchmarks** (`*_bench_test.go`) — allocation and time per operation.
+  Compare runs with `benchstat`; `-benchmem` reports `B/op`, which measures
+  allocation *volume* and cannot distinguish memory that is freed from memory
+  that is retained.
+- **`scripts/benchmark/run.sh`** — the real binary against other tools
+  (restic, borg, duplicacy), reporting time, peak RSS and repository size at
+  one dataset size.
+- **`scripts/benchmark/memory.sh`** — peak RSS for each operation across
+  several tree sizes. This is the one that answers "does this grow with the
+  repository", which a single measurement cannot: an operation holding a fixed
+  working set is fine at any scale, one holding a per-entry structure
+  eventually meets a repository it cannot open. `render-memory.sh` turns its
+  CSV into a Markdown table and charts for a job summary; the `Memory scaling`
+  workflow runs both on demand or on a pull request labelled `benchmark`.
+
+Retention bugs are invisible to `B/op` — see `docs/caching.md` for a worked
+example where the allocation delta understated the cost roughly fivefold.
 
 ### E2E Test Modes
 

--- a/scripts/benchmark/memory.sh
+++ b/scripts/benchmark/memory.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+#
+# Peak memory as a function of repository size.
+#
+# scripts/benchmark/run.sh already reports peak RSS, but at one dataset size,
+# and a single point cannot distinguish memory that is constant from memory
+# that grows with the repository. That difference is the whole question: an
+# operation holding a fixed working set is fine at any scale, one holding a
+# per-file structure eventually meets a repository it cannot open. Telling them
+# apart needs the same operation measured at several sizes.
+#
+# The dataset is therefore many small files rather than run.sh's gigabyte of
+# large ones: the independent variable is the number of entries, and file size
+# is held down so throughput does not drown out per-entry cost.
+#
+# Usage:
+#   scripts/benchmark/memory.sh                   # default sizes
+#   SIZES="1000 5000" scripts/benchmark/memory.sh # override
+#   OUT=/tmp/mem.csv scripts/benchmark/memory.sh
+
+set -euo pipefail
+
+SIZES=${SIZES:-"5000 20000 50000"}
+OUT=${OUT:-benchmark-results/memory.csv}
+KEEP=${KEEP:-0} # keep scratch dirs for inspection
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+CLOUDSTIC_BIN="$REPO_ROOT/bin/cloudstic"
+PASSWORD=${BENCH_REPO_PASSWORD:-benchmark-password}
+
+WORK=$(mktemp -d -t cloudstic-mem-XXXXXX)
+cleanup() { [ "$KEEP" = "1" ] || rm -rf "$WORK"; }
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Peak RSS, portably
+# ---------------------------------------------------------------------------
+
+# time(1) reports maximum resident set size in different units and under
+# different labels per platform: BSD/macOS `-l` gives bytes, GNU `-v` gives
+# kilobytes. Normalising here keeps the CSV in one unit.
+detect_time() {
+    if /usr/bin/time -l true >/dev/null 2>&1; then
+        echo "bsd"
+    elif /usr/bin/time -v true >/dev/null 2>&1; then
+        echo "gnu"
+    else
+        echo "none"
+    fi
+}
+TIME_FLAVOUR=$(detect_time)
+
+if [ "$TIME_FLAVOUR" = "none" ]; then
+    echo "Error: need BSD (/usr/bin/time -l) or GNU (/usr/bin/time -v) time." >&2
+    echo "On Debian/Ubuntu: apt-get install time" >&2
+    exit 1
+fi
+
+# measure <operation> <files> <command...>
+#
+# Appends one CSV row. A failing command is fatal: a partial run would produce
+# a curve with a hole in it, which is worse than no curve at all.
+measure() {
+    local op=$1 files=$2
+    shift 2
+    local err out
+    err=$(mktemp)
+    out=$(mktemp)
+
+    local seconds peak_kb peak_mb
+    if [ "$TIME_FLAVOUR" = "bsd" ]; then
+        /usr/bin/time -l "$@" >"$out" 2>"$err" || { cat "$err" >&2; exit 1; }
+        peak_kb=$(( $(grep "maximum resident set size" "$err" | awk '{print $1}') / 1024 ))
+        seconds=$(grep -E "real" "$err" | tail -1 | awk '{print $1}')
+    else
+        /usr/bin/time -v "$@" >"$out" 2>"$err" || { cat "$err" >&2; exit 1; }
+        peak_kb=$(grep "Maximum resident set size" "$err" | awk '{print $NF}')
+        # GNU prints h:mm:ss or m:ss.ss; normalise to seconds.
+        seconds=$(grep "Elapsed (wall clock)" "$err" | awk '{print $NF}' | awk -F: '
+            {  if (NF == 3) print $1 * 3600 + $2 * 60 + $3;
+               else if (NF == 2) print $1 * 60 + $2;
+               else print $1 }')
+    fi
+    peak_mb=$(echo "scale=1; $peak_kb / 1024" | bc)
+
+    printf '%s,%d,%s,%s\n' "$op" "$files" "$peak_mb" "$seconds" >>"$OUT"
+    printf '  %-22s %8d files  %8s MB  %8ss\n' "$op" "$files" "$peak_mb" "$seconds"
+
+    rm -f "$err" "$out"
+}
+
+# ---------------------------------------------------------------------------
+# Dataset
+# ---------------------------------------------------------------------------
+
+# generate_tree <root> <count>
+#
+# One folder per 100 files, so the folder count scales with the tree rather
+# than every entry landing in one enormous directory. Contents are unique per
+# file: identical bytes would deduplicate to a single content object and make
+# the store side of the measurement unrepresentative.
+#
+# The loop uses only builtins — no forks — which is what keeps 50k files a
+# few seconds rather than a few minutes.
+generate_tree() {
+    local root=$1 count=$2 per_dir=100
+    local dirs=$(( (count + per_dir - 1) / per_dir ))
+
+    for (( d = 0; d < dirs; d++ )); do
+        mkdir -p "$root/dir-$d"
+    done
+    for (( i = 0; i < count; i++ )); do
+        printf 'cloudstic benchmark entry %d\n' "$i" > "$root/dir-$(( i / per_dir ))/file-$i.txt"
+    done
+}
+
+# touch_fraction <root> <count> <denominator>
+#
+# Rewrites every Nth file so the follow-up backup has real work to do. An
+# incremental over an unchanged tree measures the scan path only; changing a
+# slice exercises upload and the HAMT rewrite too.
+touch_fraction() {
+    local root=$1 count=$2 denom=$3
+    for (( i = 0; i < count; i += denom )); do
+        printf 'cloudstic benchmark entry %d modified\n' "$i" > "$root/dir-$(( i / 100 ))/file-$i.txt"
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+
+echo "Building cloudstic..."
+( cd "$REPO_ROOT" && go build -o bin/cloudstic ./cmd/cloudstic )
+
+mkdir -p "$(dirname "$OUT")"
+echo "operation,files,peak_mb,seconds" >"$OUT"
+
+echo ""
+echo "=== Peak memory vs repository size ==="
+echo "time(1): $TIME_FLAVOUR   sizes: $SIZES"
+echo ""
+
+export CLOUDSTIC_PASSWORD="$PASSWORD"
+
+for size in $SIZES; do
+    echo "--- $size files ---"
+    data="$WORK/data-$size"
+    repo="$WORK/repo-$size"
+    restore="$WORK/restore-$size"
+    mkdir -p "$data" "$repo" "$restore"
+
+    printf '  generating %d files... ' "$size"
+    generate_tree "$data" "$size"
+    echo "done"
+
+    store_flags=(-store "local:$repo")
+    source_flags=(-source "local:$data")
+
+    "$CLOUDSTIC_BIN" init "${store_flags[@]}" -quiet >/dev/null
+
+    measure backup-initial "$size" \
+        "$CLOUDSTIC_BIN" backup "${store_flags[@]}" "${source_flags[@]}" -quiet
+
+    touch_fraction "$data" "$size" 20
+
+    measure backup-incremental "$size" \
+        "$CLOUDSTIC_BIN" backup "${store_flags[@]}" "${source_flags[@]}" -quiet
+
+    # diff needs two explicit refs, and list reports newest first. Written
+    # without mapfile or a negative array index: macOS still ships bash 3.2,
+    # where both are syntax errors rather than graceful failures.
+    refs=$("$CLOUDSTIC_BIN" list "${store_flags[@]}" -json 2>/dev/null \
+        | grep -o 'snapshot/[a-f0-9]\{64\}')
+    newest=$(printf '%s\n' "$refs" | head -1)
+    oldest=$(printf '%s\n' "$refs" | tail -1)
+    measure diff "$size" \
+        "$CLOUDSTIC_BIN" diff "${store_flags[@]}" "$oldest" "$newest" -quiet
+
+    measure check "$size" \
+        "$CLOUDSTIC_BIN" check "${store_flags[@]}" -quiet
+
+    measure restore "$size" \
+        "$CLOUDSTIC_BIN" restore "${store_flags[@]}" -output "$restore" latest -quiet
+
+    measure prune "$size" \
+        "$CLOUDSTIC_BIN" prune "${store_flags[@]}" -quiet
+
+    # Reclaim before the next size so the scratch dir does not grow without
+    # bound over the sweep; each size is independent anyway.
+    rm -rf "$data" "$repo" "$restore"
+    echo ""
+done
+
+echo "Wrote $OUT"

--- a/scripts/benchmark/render-memory.sh
+++ b/scripts/benchmark/render-memory.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Render memory.sh's CSV as Markdown for a GitHub job summary.
+#
+# Emits a table first and the charts after it. That order is deliberate: the
+# table is the record, the charts are the reading aid. GitHub renders mermaid in
+# job summaries, but `xychart-beta` needs a recent enough Mermaid, and a
+# renderer that does not know the directive shows the block as plain text — so
+# the numbers must already be on the page by then.
+#
+# One chart per operation, single series. Mermaid's xychart has no legend, so a
+# multi-series chart would be unreadable; a chart titled with its operation
+# needs no legend at all.
+#
+# Usage: scripts/benchmark/render-memory.sh benchmark-results/memory.csv
+
+set -euo pipefail
+
+CSV=${1:-benchmark-results/memory.csv}
+
+if [ ! -f "$CSV" ]; then
+    echo "Error: $CSV not found" >&2
+    exit 1
+fi
+
+operations=$(awk -F, 'NR > 1 { print $1 }' "$CSV" | awk '!seen[$0]++')
+sizes=$(awk -F, 'NR > 1 { print $2 }' "$CSV" | sort -n | awk '!seen[$0]++')
+
+# ---------------------------------------------------------------------------
+# Table
+# ---------------------------------------------------------------------------
+
+printf '## Peak memory vs repository size\n\n'
+printf 'Peak resident set size of the real binary, per operation, at each tree size.\n'
+printf 'An operation whose row stays flat holds a working set; one that tracks the\n'
+printf 'file count holds a per-entry structure and will eventually meet a repository\n'
+printf 'it cannot open.\n\n'
+
+printf '| Operation |'
+for s in $sizes; do printf ' %s files |' "$s"; done
+printf ' Growth |\n|---|'
+for _ in $sizes; do printf '%s' '---:|'; done
+printf '%s\n' '---:|'
+
+for op in $operations; do
+    printf '| `%s` |' "$op"
+    first=""
+    last=""
+    for s in $sizes; do
+        mb=$(awk -F, -v o="$op" -v f="$s" '$1 == o && $2 == f { print $3 }' "$CSV")
+        [ -n "$mb" ] || mb="-"
+        [ -n "$first" ] || first=$mb
+        last=$mb
+        printf ' %s MB |' "$mb"
+    done
+    if [ "$first" != "-" ] && [ "$last" != "-" ] && [ "$first" != "0" ]; then
+        printf ' %sx |\n' "$(echo "scale=2; $last / $first" | bc)"
+    else
+        printf ' - |\n'
+    fi
+done
+
+printf '\nWall time is recorded in the CSV artifact; this table is memory only, since\n'
+printf 'timing on a shared runner is too noisy to read as a trend.\n'
+
+# ---------------------------------------------------------------------------
+# Charts
+# ---------------------------------------------------------------------------
+
+printf '\n### Charts\n'
+
+# y-axis is shared across every chart so the panels are visually comparable —
+# a per-chart axis would make a flat operation and a climbing one look alike.
+ymax=$(awk -F, 'NR > 1 { if ($3 + 0 > m) m = $3 + 0 } END { printf "%d", (m * 1.15) + 1 }' "$CSV")
+
+xaxis=$(printf '%s, ' $sizes | sed 's/, $//')
+
+for op in $operations; do
+    series=$(for s in $sizes; do
+        awk -F, -v o="$op" -v f="$s" '$1 == o && $2 == f { printf "%s, ", $3 }' "$CSV"
+    done | sed 's/, $//')
+
+    printf '\n```mermaid\n'
+    printf 'xychart-beta\n'
+    printf '    title "%s — peak RSS (MB)"\n' "$op"
+    printf '    x-axis "files in tree" [%s]\n' "$xaxis"
+    printf '    y-axis "peak RSS (MB)" 0 --> %s\n' "$ymax"
+    printf '    line [%s]\n' "$series"
+    printf '```\n'
+done


### PR DESCRIPTION
## Summary

`scripts/benchmark/run.sh` already reports peak RSS — but at one dataset size. A single point cannot separate memory that is constant from memory that grows with the repository, and that is the distinction worth guarding: an operation holding a fixed working set is fine at any scale; one holding a per-entry structure eventually meets a repository it cannot open.

- **`scripts/benchmark/memory.sh`** measures backup, incremental backup, diff, check, restore and prune across several tree sizes, writing a CSV. The dataset is many small files rather than `run.sh`'s gigabyte of large ones, because the independent variable is entry count, not bytes.
- **`scripts/benchmark/render-memory.sh`** turns the CSV into a Markdown table plus one mermaid chart per operation.
- **`.github/workflows/memory.yml`** runs both and writes the result to the job summary.

## A first run already found something

At 2k / 10k / 30k files on an M-series laptop:

| Operation | 2,000 | 10,000 | 30,000 | Growth |
|---|---:|---:|---:|---:|
| `backup-initial` | 127.2 MB | 149.6 MB | 246.1 MB | 1.93x |
| `backup-incremental` | 118.4 MB | 154.3 MB | 167.6 MB | 1.41x |
| `diff` | 105.5 MB | 154.6 MB | 158.3 MB | 1.50x |
| `check` | 110.7 MB | 154.8 MB | 158.3 MB | 1.42x |
| `restore` | 120.8 MB | 155.7 MB | **306.0 MB** | **2.53x** |
| `prune` | 117.7 MB | 154.2 MB | 244.0 MB | 2.07x |

`restore` is the steepest of the six. That is not necessarily a bug — `RestoreManager.collectMetadata` retains every entry by design, since restore writes every file, and `topoSort` needs the whole set to order parents before children. But it is the operation most likely to meet a repository it cannot open, and now there is a number for it rather than an intuition.

Note the ~90–100 MB floor at small sizes: that is the Go runtime and its arena, not the workload. Growth ratios therefore understate per-entry cost.

## Design notes for review

- **The table is emitted before the charts, always.** `xychart-beta` needs a recent Mermaid, and a renderer that does not know the directive shows the block as source text. The numbers have to already be on the page when that happens. **I could not verify from here whether GitHub's summary renderer supports `xychart-beta`** — the syntax is valid, but that is a different renderer. If the charts come through as raw text on the first run, the table still carries the result and only the chart block needs replacing.
- **One chart per operation**, not one chart with six lines: mermaid's xychart has no legend, so a multi-series chart is unreadable, while a chart titled with its operation needs no legend at all.
- **Written for bash 3.2**, which is what macOS and the runner still ship. No `mapfile`, no negative array indices — both are syntax errors there rather than graceful failures. Verified with `/bin/bash -n` under 3.2.57.
- **Elapsed time comes from `time(1)`, not `date(1)`** — one-second resolution rounded most operations to `0s`.
- **Peak RSS parsing handles both** BSD `time -l` (bytes) and GNU `time -v` (kilobytes), so the script is useful locally on Linux, not only on the macOS runner.

## The label

The PR trigger is gated on a `benchmark` label so a ten-minute job is opt-in per PR rather than charged to every one. **I created that label** (`gh label create benchmark`) — without it the PR-triggered half of the workflow is inert. Flagging it because it is a repo-level change rather than something in this diff. The `synchronize` trigger means pushing to an already-labelled PR re-measures without another click.

## Not included

No regression gating. This run is informational — I would rather see the shape across a few real PRs before picking thresholds, since a hard fail on runner noise is worse than no gate. Allocation counts and peak RSS are considerably more stable than `ns/op`, so gating is realistic later; it just needs a baseline first.

## Verification

- `SIZES="2000 10000 30000" ./scripts/benchmark/memory.sh` — full sweep, all six operations, output above
- `/bin/bash -n` on both scripts under bash 3.2.57
- `./scripts/benchmark/render-memory.sh` against real CSV output
- `go build ./... && go test ./cmd/cloudstic` passes
- `npx markdownlint-cli2 '**/*.md'` — 0 issues