### PR TITLE
refactor(benchmark): split the comparative harness from the CI one

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,6 +6,10 @@ name: Benchmark
 # four tools and may change for that reason, which would silently move the
 # numbers tracked here. See scripts/benchmark/cloudstic.sh.
 
+# Two ways in, matching the Memory scaling workflow: dispatch it by hand
+# against any ref, or put the `benchmark` label on a pull request. The same
+# label drives both workflows, so labelling a PR once asks for the whole
+# performance picture rather than half of it.
 on:
   workflow_dispatch:
     inputs:
@@ -14,6 +18,8 @@ on:
         required: false
         default: main
         type: string
+  pull_request:
+    types: [labeled, synchronize]
 
 permissions:
   contents: read
@@ -24,6 +30,12 @@ concurrency:
 
 jobs:
   benchmark:
+    # On a pull request this runs only while the `benchmark` label is on it, so
+    # an unrelated label does not start the job, and pushing more commits to an
+    # already-labelled PR re-measures without another click.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'benchmark')
     name: Cloudstic local benchmark
     runs-on: macos-latest
     steps:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,5 +1,11 @@
 name: Benchmark
 
+# Cloudstic measured on its own terms, on a mixed dataset.
+#
+# Deliberately not compare.sh: that script's dataset exists to be fair across
+# four tools and may change for that reason, which would silently move the
+# numbers tracked here. See scripts/benchmark/cloudstic.sh.
+
 on:
   workflow_dispatch:
     inputs:
@@ -18,7 +24,7 @@ concurrency:
 
 jobs:
   benchmark:
-    name: Cloudstic local/local benchmark
+    name: Cloudstic local benchmark
     runs-on: macos-latest
     steps:
       - name: Checkout target ref
@@ -36,21 +42,21 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p benchmark-results
-          ./scripts/benchmark/run.sh local local cloudstic | tee benchmark-results/local-local-cloudstic.txt
+          ./scripts/benchmark/cloudstic.sh local | tee benchmark-results/cloudstic.log
 
       - name: Publish summary
         shell: bash
         run: |
           set -euo pipefail
           go run ./internal/cmd/benchreport render \
-            -in benchmark-results/run.csv \
-            -title "Local benchmark" >> "$GITHUB_STEP_SUMMARY"
+            -in benchmark-results/cloudstic.csv \
+            -title "Cloudstic benchmark" >> "$GITHUB_STEP_SUMMARY"
           {
             echo ""
             echo "<details><summary>Run log</summary>"
             echo ""
             echo '```text'
-            cat benchmark-results/local-local-cloudstic.txt
+            cat benchmark-results/cloudstic.log
             echo '```'
             echo ""
             echo "</details>"
@@ -61,7 +67,7 @@ jobs:
       - name: Upload benchmark artifact
         uses: actions/upload-artifact@v7
         with:
-          name: local-local-cloudstic-benchmark
+          name: cloudstic-benchmark
           path: |
-            benchmark-results/local-local-cloudstic.txt
-            benchmark-results/run.csv
+            benchmark-results/cloudstic.log
+            benchmark-results/cloudstic.csv

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,9 +39,18 @@ Three layers, in cost order:
   Compare runs with `benchstat`; `-benchmem` reports `B/op`, which measures
   allocation *volume* and cannot distinguish memory that is freed from memory
   that is retained.
-- **`scripts/benchmark/run.sh`** — the real binary against other tools
-  (restic, borg, duplicacy), reporting time, peak RSS and repository size at
-  one dataset size.
+- **`scripts/benchmark/cloudstic.sh`** — this product on its own terms, over a
+  mixed dataset: throughput, incremental cost at one and at a thousand changed
+  files, deduplication, and the stored-to-logical ratio. What the `Benchmark`
+  workflow runs.
+- **`scripts/benchmark/compare.sh`** — the same binary against restic, borg and
+  duplicacy. Manual, and needs those tools installed.
+
+  CI does **not** use `compare.sh`, and the split is not cosmetic. Its dataset
+  exists to be fair across four tools and may legitimately change for that
+  reason — which would silently move numbers a trend line is built on. The two
+  share `lib.sh` for measurement mechanics and nothing else; in particular
+  their datasets are separate, which is the whole point.
 - **`scripts/benchmark/memory.sh`** — peak RSS for each operation across
   several tree sizes. This is the one that answers "does this grow with the
   repository", which a single measurement cannot: an operation holding a fixed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,8 +55,14 @@ Three layers, in cost order:
   several tree sizes. This is the one that answers "does this grow with the
   repository", which a single measurement cannot: an operation holding a fixed
   working set is fine at any scale, one holding a per-entry structure
-  eventually meets a repository it cannot open. The `Memory scaling` workflow
-  runs it on demand or on a pull request labelled `benchmark`.
+  eventually meets a repository it cannot open. What the `Memory scaling`
+  workflow runs.
+
+Both workflows trigger the same two ways: dispatched by hand against any ref,
+or by putting the `benchmark` label on a pull request. One label asks for the
+whole performance picture rather than half of it, and `synchronize` means
+pushing to an already-labelled PR re-measures without another click. Neither
+runs unlabelled, because both cost minutes rather than seconds.
 
 Both scripts write the same CSV schema and render through
 `internal/cmd/benchreport`, which is where the analysis lives:

--- a/internal/benchreport/render.go
+++ b/internal/benchreport/render.go
@@ -26,9 +26,15 @@ func Render(w io.Writer, rep *Report, title string) error {
 			"cannot open.\n\n")
 		renderScalingTable(b, rep)
 	case KindComparison:
-		b.WriteString("Each tool over the same dataset. Times on a shared runner carry several\n" +
-			"percent of noise, so read the column for its order of magnitude rather than\n" +
-			"its last digit.\n\n")
+		if len(rep.Tools()) > 1 {
+			b.WriteString("Each tool over the same dataset. Times on a shared runner carry several\n" +
+				"percent of noise, so read the column for its order of magnitude rather than\n" +
+				"its last digit.\n\n")
+		} else {
+			b.WriteString("One pass over a mixed dataset. Times on a shared runner carry several\n" +
+				"percent of noise, so read them for their order of magnitude rather than\n" +
+				"their last digit; the bytes added are exact.\n\n")
+		}
 		renderComparisonTable(b, rep)
 	}
 
@@ -88,26 +94,46 @@ func renderScalingTable(b *strings.Builder, rep *Report) {
 
 func renderComparisonTable(b *strings.Builder, rep *Report) {
 	tools := rep.Tools()
+	scale := rep.Scales()[0]
+
+	// Repository growth is only shown for a single-tool run. Across tools it
+	// would invite a comparison the number cannot support — each writes a
+	// different format, so "bytes added" is not measuring the same thing twice.
+	withDelta := len(tools) == 1 && rep.hasRepoDelta()
 
 	b.WriteString("| Operation |")
 	for _, t := range tools {
 		fmt.Fprintf(b, " %s |", t)
 	}
+	if withDelta {
+		b.WriteString(" Repo added |")
+	}
 	b.WriteString("\n|---|")
 	for range tools {
+		b.WriteString("---:|")
+	}
+	if withDelta {
 		b.WriteString("---:|")
 	}
 	b.WriteString("\n")
 
 	for _, op := range rep.Operations() {
 		fmt.Fprintf(b, "| `%s` |", op)
+		var delta string
 		for _, t := range tools {
-			row, ok := rep.find(t, op, rep.Scales()[0])
+			row, ok := rep.find(t, op, scale)
 			if !ok {
 				b.WriteString(" - |")
 				continue
 			}
 			fmt.Fprintf(b, " %ss · %s MB |", trim(row.Seconds), trim(row.PeakMB))
+			delta = row.RepoDelta
+		}
+		if withDelta {
+			if delta == "" {
+				delta = "-"
+			}
+			fmt.Fprintf(b, " %s |", delta)
 		}
 		b.WriteString("\n")
 	}

--- a/internal/benchreport/report.go
+++ b/internal/benchreport/report.go
@@ -172,6 +172,17 @@ func (r *Report) find(tool, op string, scale int) (Row, bool) {
 	return Row{}, false
 }
 
+// hasRepoDelta reports whether any row measured repository growth. The memory
+// sweep does not, so its table must not grow an empty column.
+func (r *Report) hasRepoDelta() bool {
+	for _, row := range r.Rows {
+		if row.RepoDelta != "" && row.RepoDelta != "-" {
+			return true
+		}
+	}
+	return false
+}
+
 // Metric selects which measurement a table or chart reports.
 type Metric struct {
 	Name  string // column heading

--- a/internal/benchreport/report_test.go
+++ b/internal/benchreport/report_test.go
@@ -224,6 +224,59 @@ func TestAppendRowOmitsZeroScale(t *testing.T) {
 	}
 }
 
+// A single-tool run is a self-benchmark, not a comparison, and its prose has to
+// say so — "each tool over the same dataset" reads as a missing column.
+func TestSingleToolRunIsNotDescribedAsAComparison(t *testing.T) {
+	csv := "tool,operation,scale,seconds,peak_mb,repo_delta\ncloudstic,Initial Backup,,0.70,534.4,344.0 MB\n"
+	var b strings.Builder
+	if err := Render(&b, parse(t, csv), "T"); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if strings.Contains(b.String(), "Each tool") {
+		t.Errorf("one tool described as a cross-tool comparison:\n%s", b.String())
+	}
+}
+
+// Repository growth is the column that shows deduplication working, so a
+// self-benchmark must surface it.
+func TestSingleToolTableShowsRepoGrowth(t *testing.T) {
+	csv := "tool,operation,scale,seconds,peak_mb,repo_delta\n" +
+		"cloudstic,Deduplicated Backup,,0.54,343.4,40 KB\n"
+	var b strings.Builder
+	if err := Render(&b, parse(t, csv), "T"); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := b.String()
+	if !strings.Contains(out, "Repo added") || !strings.Contains(out, "40 KB") {
+		t.Errorf("repository growth missing from a single-tool table:\n%s", out)
+	}
+}
+
+// Across tools the same column would invite a comparison it cannot support:
+// each writes a different format, so "bytes added" is not the same measurement
+// twice.
+func TestComparisonTableOmitsRepoGrowth(t *testing.T) {
+	var b strings.Builder
+	if err := Render(&b, parse(t, comparisonCSV), "T"); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if strings.Contains(b.String(), "Repo added") {
+		t.Errorf("repository growth shown across tools, which compares different formats:\n%s", b.String())
+	}
+}
+
+// The memory sweep records no repository growth; its table must not grow an
+// empty column because of it.
+func TestScalingTableHasNoRepoColumn(t *testing.T) {
+	var b strings.Builder
+	if err := Render(&b, parse(t, scalingCSV), "T"); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if strings.Contains(b.String(), "Repo added") {
+		t.Errorf("scaling table grew a column it has no data for:\n%s", b.String())
+	}
+}
+
 func lineContaining(t *testing.T, s, want string) string {
 	t.Helper()
 	for _, line := range strings.Split(s, "\n") {

--- a/scripts/benchmark/cloudstic.sh
+++ b/scripts/benchmark/cloudstic.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#
+# Cloudstic on its own terms.
+#
+# This is what CI runs, and it is deliberately not compare.sh with a tool
+# filter. The two answer different questions and the answers pull in different
+# directions: compare.sh needs a dataset that is *fair across four tools* and
+# can only measure what all of them expose, while this one is free to stress
+# what this design actually claims — deduplication, compressibility,
+# incremental cost — and to report numbers no other tool has.
+#
+# Keeping them apart is what lets a trend line survive. A dataset tweak made so
+# borg is not unfairly penalised must not move the numbers CI has been tracking
+# for months.
+#
+# Usage:
+#   scripts/benchmark/cloudstic.sh              # local store
+#   scripts/benchmark/cloudstic.sh s3           # S3 store
+#   BENCH_CSV=/tmp/x.csv scripts/benchmark/cloudstic.sh
+
+set -euo pipefail
+
+STORE=${1:-local}
+if [ "$STORE" != "local" ] && [ "$STORE" != "s3" ]; then
+    echo "Usage: $0 [local|s3]" >&2
+    exit 1
+fi
+
+S3_BUCKET=${S3_BUCKET:-cloudstic-benchmark-734836384094-us-east-1}
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+PASSWORD=${BENCH_REPO_PASSWORD:-benchmark-password}
+
+# shellcheck source=scripts/benchmark/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+WORK=$(mktemp -d -t cloudstic-bench-XXXXXX)
+cleanup() {
+    rm -rf "$WORK" "$RESTORE_DIR"
+}
+trap cleanup EXIT
+
+# A pre-set variable in an operator's shell must not change what is measured.
+# CLOUDSTIC_KMS_KEY_ARN in particular would send a local/local run to AWS KMS.
+unset CLOUDSTIC_KMS_KEY_ARN CLOUDSTIC_KMS_REGION CLOUDSTIC_KMS_ENDPOINT
+unset CLOUDSTIC_PROFILE CLOUDSTIC_PROFILES_FILE
+unset CLOUDSTIC_STORE CLOUDSTIC_SOURCE
+export CLOUDSTIC_PASSWORD="$PASSWORD"
+
+echo "Building cloudstic..."
+( cd "$REPO_ROOT" && go build -o /tmp/cloudstic ./cmd/cloudstic )
+CLOUDSTIC_BIN="/tmp/cloudstic"
+
+bench_init "${BENCH_CSV:-benchmark-results/cloudstic.csv}"
+
+# ---------------------------------------------------------------------------
+# Dataset
+# ---------------------------------------------------------------------------
+#
+# Mixed on purpose, because the operations below stress different parts of it:
+# incompressible bulk exercises chunking and upload, a compressible file
+# exercises zstd, and a few thousand small files exercise the metadata path
+# that dominates a real home directory.
+#
+# This dataset belongs to this script. compare.sh has its own, and neither may
+# be changed to suit the other.
+
+DATA="$WORK/data"
+mkdir -p "$DATA/docs" "$DATA/config"
+
+echo "Generating dataset..."
+dd if=/dev/urandom of="$DATA/random.dat" bs=1m count=300 status=none
+dd if=/dev/zero    of="$DATA/zero.dat"   bs=1m count=300 status=none
+for i in $(seq 1 40); do
+    dd if=/dev/urandom of="$DATA/docs/doc_$i.bin" bs=1m count=1 status=none
+done
+for (( i = 0; i < 3000; i++ )); do
+    printf 'cloudstic benchmark config entry %d\n' "$i" > "$DATA/config/setting_$i.cfg"
+done
+echo "Dataset: $(du -sh "$DATA" | cut -f1 | xargs)"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Store
+# ---------------------------------------------------------------------------
+
+if [ "$STORE" = "s3" ]; then
+    eval "$(aws configure export-credentials --format env 2>/dev/null)" || true
+    BENCH_S3_PREFIX="s3://$S3_BUCKET/cloudstic-self/"
+    STORE_FLAGS="-store s3:$S3_BUCKET/cloudstic-self/"
+    aws s3 rm "$BENCH_S3_PREFIX" --recursive >/dev/null 2>&1 || true
+else
+    BENCH_REPO_DIR="$WORK/repo"
+    mkdir -p "$BENCH_REPO_DIR"
+    STORE_FLAGS="-store local:$BENCH_REPO_DIR"
+fi
+
+# shellcheck disable=SC2086 # STORE_FLAGS is intentionally word-split
+$CLOUDSTIC_BIN init $STORE_FLAGS -quiet >/dev/null
+
+SOURCE_FLAGS="-source local:$DATA"
+
+echo "### Cloudstic ($STORE store)"
+print_table_header
+
+# shellcheck disable=SC2086
+backup() { run_bench "$1" $CLOUDSTIC_BIN backup $STORE_FLAGS $SOURCE_FLAGS -quiet; }
+
+backup "Initial Backup"
+backup "Incremental (No Changes)"
+
+echo "modified" >> "$DATA/config/setting_1.cfg"
+backup "Incremental (1 File Changed)"
+
+# A thousand changed files is the case a per-file cost would show up in, where
+# a single changed file cannot.
+for (( i = 0; i < 1000; i++ )); do
+    printf 'cloudstic benchmark config entry %d modified\n' "$i" > "$DATA/config/setting_$i.cfg"
+done
+backup "Incremental (1000 Changed)"
+
+mkdir -p "$DATA/new_data"
+dd if=/dev/urandom of="$DATA/new_data/extra.dat" bs=1m count=200 status=none
+backup "Add 200MB New Data"
+
+# Copies of data already stored. Repo Added is the number that matters here:
+# content addressing should make this close to free, and the column says so
+# directly rather than leaving it inferred from elapsed time.
+cp -r "$DATA/docs" "$DATA/docs_copy"
+cp "$DATA/random.dat" "$DATA/random_copy.dat"
+backup "Deduplicated Backup"
+
+# shellcheck disable=SC2086
+run_bench "Check" $CLOUDSTIC_BIN check $STORE_FLAGS -quiet
+# shellcheck disable=SC2086
+run_bench "Full Restore" $CLOUDSTIC_BIN restore $STORE_FLAGS \
+    -output "$(fresh_restore_target)" -format dir -quiet
+# Restore without the per-file content-hash check, which separates what
+# verification costs from what fetching and writing cost.
+# shellcheck disable=SC2086
+run_bench "Full Restore (-no-verify)" $CLOUDSTIC_BIN restore $STORE_FLAGS \
+    -output "$(fresh_restore_target)" -format dir -no-verify -quiet
+# shellcheck disable=SC2086
+run_bench "Prune" $CLOUDSTIC_BIN prune $STORE_FLAGS -quiet
+
+print_repo_size
+
+# The stored-to-logical ratio is this product's headline claim and no other
+# tool reports it comparably, so it belongs here rather than in compare.sh.
+logical_kb=$(du -sk "$DATA" | awk '{print $1}')
+stored_kb=$(get_repo_size_kb)
+if [ "$stored_kb" -gt 0 ]; then
+    printf "| %-30s | %12s | %13s | %12s |\n" "Logical / Stored" \
+        "$(format_size_kb "$logical_kb")" "$(format_size_kb "$stored_kb")" \
+        "$(echo "scale=2; $logical_kb / $stored_kb" | bc)x"
+fi
+
+echo ""
+echo "Done. CSV: $BENCH_CSV"

--- a/scripts/benchmark/compare.sh
+++ b/scripts/benchmark/compare.sh
@@ -1,4 +1,15 @@
 #!/usr/bin/env bash
+#
+# Cloudstic against the other backup tools on the same dataset.
+#
+# The dataset here exists to be *fair across four tools*, which constrains it:
+# it can only exercise what restic, borg and duplicacy all expose, and it may
+# legitimately change when one of them is being penalised unfairly. That is why
+# CI does not use this script — a change made for cross-tool fairness would
+# silently move the numbers a trend line is built on. scripts/benchmark/cloudstic.sh
+# measures this product on its own terms and is what the Benchmark workflow runs.
+#
+# Usage: scripts/benchmark/compare.sh [local|gdrive] [local|s3] [cloudstic|restic|borg|duplicacy|all] [--debug]
 
 set -e
 
@@ -61,19 +72,6 @@ echo "Building cloudstic binary..."
 go build -o /tmp/cloudstic ./cmd/cloudstic
 export CLOUDSTIC_BIN="/tmp/cloudstic"
 
-# benchreport owns the CSV schema, so the competitive run and the memory sweep
-# cannot drift into two different formats. This harness keeps its own timing:
-# it compares four tools, and a tool that is not installed has to leave a gap
-# rather than abort the comparison.
-go build -o /tmp/benchreport ./internal/cmd/benchreport
-export BENCHREPORT_BIN="/tmp/benchreport"
-BENCH_CSV=${BENCH_CSV:-benchmark-results/run.csv}
-mkdir -p "$(dirname "$BENCH_CSV")"
-rm -f "$BENCH_CSV"
-export BENCH_CSV
-
-# Which tool the next run_bench belongs to. Each benchmark_* function sets it.
-CURRENT_TOOL="cloudstic"
 
 # Ensure benchmark runs are not affected by operator shell defaults.
 # In particular, a pre-set CLOUDSTIC_KMS_KEY_ARN would make `cloudstic init`
@@ -221,110 +219,10 @@ reset_data_dir() {
     cp -a "$DATA_TEMPLATE"/ "$DATA_DIR/"
 }
 
-# Format KB into human-readable size
-format_size_kb() {
-    local kb=$1
-    if [ "$kb" -lt 1024 ]; then
-        echo "${kb} KB"
-    elif [ "$kb" -lt 1048576 ]; then
-        echo "$(echo "scale=1; $kb / 1024" | bc) MB"
-    else
-        echo "$(echo "scale=2; $kb / 1048576" | bc) GB"
-    fi
-}
-
-# Set BENCH_REPO_DIR (local) or BENCH_S3_PREFIX (s3://bucket/prefix/) to enable repo size tracking.
-BENCH_REPO_DIR=""
-BENCH_S3_PREFIX=""
-
-# Scratch directory for restore targets. Restore is measured on a fresh, empty
-# directory every time, and the result is discarded before the next step so a
-# partially-restored tree can never make a later step look faster.
-RESTORE_DIR=$(mktemp -d -t benchmark-restore-XXXXXX)
-
-fresh_restore_target() {
-    rm -rf "${RESTORE_DIR:?}"/*
-    echo "$RESTORE_DIR/out"
-}
-
-get_repo_size_kb() {
-    if [ -n "$BENCH_REPO_DIR" ] && [ -d "$BENCH_REPO_DIR" ]; then
-        du -sk "$BENCH_REPO_DIR" | awk '{print $1}'
-    elif [ -n "$BENCH_S3_PREFIX" ]; then
-        local bytes
-        bytes=$(aws s3 ls "$BENCH_S3_PREFIX" --summarize --recursive 2>/dev/null \
-            | grep "Total Size" | awk '{print $3}')
-        echo $(( ${bytes:-0} / 1024 ))
-    else
-        echo 0
-    fi
-}
-
-run_bench() {
-    local step_name="$1"
-    shift
-    local stdout_file=$(mktemp)
-    local stderr_file=$(mktemp)
-    
-    local size_before
-    size_before=$(get_repo_size_kb)
-    
-    if /usr/bin/time -l "$@" > "$stdout_file" 2> "$stderr_file"; then
-        local real_time=$(grep "real" "$stderr_file" | awk '{print $1}')
-        local mem_bytes=$(grep "maximum resident set size" "$stderr_file" | awk '{print $1}')
-        local mem_mb=$(echo "scale=2; $mem_bytes / 1024 / 1024" | bc)
-        
-        local repo_added="-"
-        local size_after
-        size_after=$(get_repo_size_kb)
-        if [ "$size_before" -gt 0 ] || [ "$size_after" -gt 0 ]; then
-            local delta_kb=$((size_after - size_before))
-            repo_added=$(format_size_kb $delta_kb)
-        fi
-        
-        printf "| %-30s | %10s s | %10.2f MB | %12s |\n" "$step_name" "$real_time" "$mem_mb" "$repo_added"
-
-        "$BENCHREPORT_BIN" row -out "$BENCH_CSV" -tool "$CURRENT_TOOL" \
-            -op "$step_name" -seconds "$real_time" -peak-mb "$mem_mb" \
-            -repo-delta "$repo_added" || true
-        
-        if [ -n "$DEBUG_FLAG" ]; then
-            echo "  [debug] $step_name stdout:" >&2
-            cat "$stdout_file" >&2
-        fi
-    else
-        echo "" >&2
-        echo "ERROR: '$step_name' failed" >&2
-        echo "Command: $*" >&2
-        echo "--- stdout ---" >&2
-        cat "$stdout_file" >&2
-        echo "--- stderr ---" >&2
-        # Filter out /usr/bin/time statistics to show only command stderr
-        grep -v -E '^\s+[0-9].*( real | user | sys |maximum resident|page reclaims|page faults|voluntary context|involuntary context|swaps|block input|block output|messages sent|messages received|signals received|instructions retired|cycles elapsed|peak memory)' "$stderr_file" >&2 || true
-        echo "---" >&2
-    fi
-    rm -f "$stdout_file" "$stderr_file"
-}
-
-print_table_header() {
-    printf "| %-30s | %12s | %13s | %12s |\n" "Operation" "Time" "Peak Mem" "Repo Added"
-    echo "|--------------------------------|--------------|---------------|--------------|"        
-}
-
-print_repo_size() {
-    local size
-    if [ -n "$BENCH_REPO_DIR" ] && [ -d "$BENCH_REPO_DIR" ]; then
-        size=$(du -sh "$BENCH_REPO_DIR" | cut -f1 | xargs)
-    elif [ -n "$BENCH_S3_PREFIX" ]; then
-        local bytes
-        bytes=$(aws s3 ls "$BENCH_S3_PREFIX" --summarize --recursive 2>/dev/null \
-            | grep "Total Size" | awk '{print $3}')
-        size=$(format_size_kb $(( ${bytes:-0} / 1024 )))
-    else
-        size="-"
-    fi
-    printf "| %-30s | %12s | %13s | %12s |\n" "Final Repo Size" "$size" "-" "-"
-}
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+# shellcheck source=scripts/benchmark/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+bench_init "${BENCH_CSV:-benchmark-results/compare.csv}"
 
 # Repository password used by all tools during benchmarks.
 # Override with: BENCH_REPO_PASSWORD='your-password' ./scripts/benchmark/run.sh ...

--- a/scripts/benchmark/lib.sh
+++ b/scripts/benchmark/lib.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# Shared measurement mechanics for the benchmark scripts.
+#
+# What lives here is deliberately limited to *how* a step is measured and
+# reported — timing, peak RSS, repository growth, the table. The datasets do
+# not, and that separation is the point: compare.sh's dataset exists to be fair
+# across four tools, cloudstic.sh's exists to stress this one. Sharing them
+# would mean a change made for cross-tool fairness silently moved the numbers
+# CI tracks over time, which is the coupling the two scripts were split to
+# avoid.
+#
+# Source this after setting REPO_ROOT. It expects bash 3.2 — still what macOS
+# and the runners ship.
+
+# BENCH_REPO_DIR (local) or BENCH_S3_PREFIX (s3://bucket/prefix/) enable
+# repository-growth tracking. A script sets whichever applies before its first
+# run_bench.
+BENCH_REPO_DIR=""
+BENCH_S3_PREFIX=""
+
+# CURRENT_TOOL labels rows in the CSV. compare.sh reassigns it per tool;
+# cloudstic.sh leaves it alone.
+CURRENT_TOOL="cloudstic"
+
+# Scratch directory for restore targets. Restore is measured on a fresh, empty
+# directory every time, and the result is discarded before the next step so a
+# partially-restored tree can never make a later step look faster.
+RESTORE_DIR=$(mktemp -d -t benchmark-restore-XXXXXX)
+
+# bench_init <csv-path>
+#
+# Builds the reporting binary and starts a fresh CSV. benchreport owns the
+# schema so the harnesses cannot drift into two different formats.
+bench_init() {
+    BENCH_CSV=$1
+    go build -o /tmp/benchreport "$REPO_ROOT/internal/cmd/benchreport"
+    BENCHREPORT_BIN="/tmp/benchreport"
+    mkdir -p "$(dirname "$BENCH_CSV")"
+    rm -f "$BENCH_CSV"
+    export BENCH_CSV BENCHREPORT_BIN
+}
+
+fresh_restore_target() {
+    rm -rf "${RESTORE_DIR:?}"/*
+    echo "$RESTORE_DIR/out"
+}
+
+format_size_kb() {
+    local kb=$1
+    if [ "$kb" -lt 1024 ]; then
+        echo "${kb} KB"
+    elif [ "$kb" -lt 1048576 ]; then
+        echo "$(echo "scale=1; $kb / 1024" | bc) MB"
+    else
+        echo "$(echo "scale=2; $kb / 1048576" | bc) GB"
+    fi
+}
+
+get_repo_size_kb() {
+    if [ -n "$BENCH_REPO_DIR" ] && [ -d "$BENCH_REPO_DIR" ]; then
+        du -sk "$BENCH_REPO_DIR" | awk '{print $1}'
+    elif [ -n "$BENCH_S3_PREFIX" ]; then
+        local bytes
+        bytes=$(aws s3 ls "$BENCH_S3_PREFIX" --summarize --recursive 2>/dev/null \
+            | grep "Total Size" | awk '{print $3}')
+        echo $(( ${bytes:-0} / 1024 ))
+    else
+        echo 0
+    fi
+}
+
+# run_bench <step name> <command...>
+#
+# A failing step is reported and the run continues. That is deliberate and is
+# why this does not use `benchreport run`, which exits: compare.sh measures four
+# tools, and one that is missing or broken has to leave a gap rather than
+# abandon the comparison.
+run_bench() {
+    local step_name="$1"
+    shift
+    local stdout_file stderr_file
+    stdout_file=$(mktemp)
+    stderr_file=$(mktemp)
+
+    local size_before
+    size_before=$(get_repo_size_kb)
+
+    if /usr/bin/time -l "$@" > "$stdout_file" 2> "$stderr_file"; then
+        local real_time mem_bytes mem_mb
+        real_time=$(grep "real" "$stderr_file" | awk '{print $1}')
+        mem_bytes=$(grep "maximum resident set size" "$stderr_file" | awk '{print $1}')
+        mem_mb=$(echo "scale=2; $mem_bytes / 1024 / 1024" | bc)
+
+        local repo_added="-"
+        local size_after
+        size_after=$(get_repo_size_kb)
+        if [ "$size_before" -gt 0 ] || [ "$size_after" -gt 0 ]; then
+            local delta_kb=$((size_after - size_before))
+            repo_added=$(format_size_kb $delta_kb)
+        fi
+
+        printf "| %-30s | %10s s | %10.2f MB | %12s |\n" "$step_name" "$real_time" "$mem_mb" "$repo_added"
+
+        "$BENCHREPORT_BIN" row -out "$BENCH_CSV" -tool "$CURRENT_TOOL" \
+            -op "$step_name" -seconds "$real_time" -peak-mb "$mem_mb" \
+            -repo-delta "$repo_added" || true
+
+        if [ -n "${DEBUG_FLAG:-}" ]; then
+            echo "  [debug] $step_name stdout:" >&2
+            cat "$stdout_file" >&2
+        fi
+    else
+        echo "" >&2
+        echo "ERROR: '$step_name' failed" >&2
+        echo "Command: $*" >&2
+        echo "--- stdout ---" >&2
+        cat "$stdout_file" >&2
+        echo "--- stderr ---" >&2
+        # Strip time(1)'s own statistics so only the command's stderr shows.
+        grep -v -E '^\s+[0-9].*( real | user | sys |maximum resident|page reclaims|page faults|voluntary context|involuntary context|swaps|block input|block output|messages sent|messages received|signals received|instructions retired|cycles elapsed|peak memory)' "$stderr_file" >&2 || true
+        echo "---" >&2
+    fi
+    rm -f "$stdout_file" "$stderr_file"
+}
+
+print_table_header() {
+    printf "| %-30s | %12s | %13s | %12s |\n" "Operation" "Time" "Peak Mem" "Repo Added"
+    echo "|--------------------------------|--------------|---------------|--------------|"
+}
+
+print_repo_size() {
+    local size
+    if [ -n "$BENCH_REPO_DIR" ] && [ -d "$BENCH_REPO_DIR" ]; then
+        size=$(du -sh "$BENCH_REPO_DIR" | cut -f1 | xargs)
+    elif [ -n "$BENCH_S3_PREFIX" ]; then
+        local bytes
+        bytes=$(aws s3 ls "$BENCH_S3_PREFIX" --summarize --recursive 2>/dev/null \
+            | grep "Total Size" | awk '{print $3}')
+        size=$(format_size_kb $(( ${bytes:-0} / 1024 )))
+    else
+        size="-"
+    fi
+    printf "| %-30s | %12s | %13s | %12s |\n" "Final Repo Size" "$size" "-" "-"
+}


### PR DESCRIPTION
## Summary

**Stacked on #435** — base is `refactor/bench-reporting-in-go`, so review that first. GitHub retargets this to `main` automatically once #435 merges. Per repo convention a stacked PR gets no CI run.

### What CI was actually doing

`benchmark.yml` invoked `run.sh local local cloudstic` — the third argument filters to cloudstic — on a runner where **restic, borg and duplicacy are not installed**. The comparison never happened in CI. It was a 615-line cross-tool harness executing 64 lines of cloudstic-specific code.

### Why that matters beyond the dead paths

The dead paths are cosmetic. The structural problem is that the two jobs have conflicting requirements:

- A **comparison** needs a dataset that is fair across four tools, and can only measure what all of them expose.
- **Tracking this product over time** needs a dataset that stresses this design, and is free to report numbers no other tool has.

Sharing one script meant a change made for cross-tool fairness — adjusting the dataset so borg is not unfairly penalised, say — would silently move the numbers a trend line is built on.

### The split

| Script | Job |
|---|---|
| `compare.sh` (was `run.sh`) | Cloudstic vs restic/borg/duplicacy. Manual only. |
| `cloudstic.sh` (new) | This product on its own terms. What the Benchmark workflow runs. |
| `lib.sh` (new) | Measurement mechanics both use. |

`lib.sh` holds `run_bench`, repo-size tracking and the table — the *how*. **The datasets deliberately stay separate**, which follows directly from the argument above: sharing them would reintroduce exactly the coupling the split removes.

`cloudstic.sh` measures things a comparison cannot, and the first run shows why they are worth having:

| Operation | Time · Peak RSS | Repo added |
|---|---:|---:|
| `Initial Backup` | 0.7s · 534.4 MB | 344.0 MB |
| `Incremental (1 File Changed)` | 0.27s · 127.3 MB | 12 KB |
| `Incremental (1000 Changed)` | 0.27s · 144.2 MB | 1.3 MB |
| `Deduplicated Backup` | 0.54s · 343.4 MB | **40 KB** |
| `Prune` | 0.13s · 153.1 MB | -320 KB |

Copying 340 MB of already-stored data adds 40 KB, and a thousand changed files costs the same wall time as one — both properties the design claims and neither previously measured. The script also reports a stored-to-logical ratio (2.18x on this dataset).

### Report changes

The table grows a **Repo added** column for single-tool runs, and the prose no longer says "each tool over the same dataset" when there is one. The column is deliberately withheld across tools, where it would invite comparing byte counts between different repository formats — that is not the same measurement twice.

## Verification

- `./scripts/benchmark/cloudstic.sh` — full run, output above
- `./scripts/benchmark/compare.sh local local cloudstic` — still works after the `lib.sh` extraction, output unchanged
- `/bin/bash -n` on all three scripts under bash 3.2.57
- `go test -race ./...` passes; `golangci-lint run ./...` — 0 issues
- `npx markdownlint-cli2 '**/*.md'` — 0 issues

## Trigger

The Benchmark workflow had fired once since April 2nd, so the split was worth roughly nothing on its own. It now also runs on a pull request carrying the `benchmark` label, matching Memory scaling.

Same label rather than a second one, deliberately: labelling a PR *is* the act of asking for performance data, and wanting the memory curve but not the throughput numbers is not a real case. `synchronize` is included so pushing to an already-labelled PR re-measures without another click, and any other label leaves both jobs skipped.
