### PR TITLE
perf(store): load pack catalog without duplicate entries

### DIFF
--- a/internal/storelayer/pack.go
+++ b/internal/storelayer/pack.go
@@ -310,18 +310,26 @@ func (s *PackStore) Get(ctx context.Context, key string) ([]byte, error) {
 		return data, nil
 	}
 
+	// 2. Is it in our catalog?
+	entry, inCatalog := s.catalog[key]
 	s.mu.RUnlock()
 
-	// 2. Is it in our catalog? A failed streaming decode may have inserted
-	// entries before encountering the error, so catalogEntry never exposes the
-	// map until the complete catalog has loaded successfully.
-	entry, inCatalog, err := s.catalogEntry(ctx, key)
-	if err != nil {
-		return nil, err
-	}
+	// If not in catalog, wait: we might need to load the catalog from the remote store first,
+	// or it's just a normal large object.
 	if !inCatalog {
-		// It's a large object or an object not in a packfile; get it directly.
-		return s.ObjectStore.Get(ctx, key)
+		if key != indexPacksKey && !strings.HasPrefix(key, packPrefix) {
+			if err := s.ensureCatalogLoaded(ctx); err != nil {
+				return nil, err
+			}
+			s.mu.RLock()
+			entry, inCatalog = s.catalog[key]
+			s.mu.RUnlock()
+		}
+
+		if !inCatalog {
+			// It's a large object or an object not in a packfile; get it directly.
+			return s.ObjectStore.Get(ctx, key)
+		}
 	}
 
 	// 3. We know it's in a pack. Do we have the pack in the LRU cache?
@@ -360,11 +368,12 @@ func (s *PackStore) Exists(ctx context.Context, key string) (bool, error) {
 		s.mu.RUnlock()
 		return true, nil
 	}
+	if _, ok := s.catalog[key]; ok {
+		s.mu.RUnlock()
+		return true, nil
+	}
 	s.mu.RUnlock()
 
-	if _, ok, err := s.catalogEntry(ctx, key); err != nil || ok {
-		return ok, err
-	}
 	return s.ObjectStore.Exists(ctx, key)
 }
 
@@ -498,12 +507,21 @@ func (s *PackStore) Flush(ctx context.Context) error {
 //
 // s.catalogLoaded is set only when the catalog was read successfully or proven
 // absent, and is the invariant Flush relies on before overwriting index/packs.
-func (s *PackStore) loadCatalogLocked(ctx context.Context) error {
+func (s *PackStore) loadCatalogLocked(ctx context.Context) (err error) {
 	// If it was already loaded or proven missing (noted by dirty flag or some other state), we wouldn't be here,
 	// but we need to track if we've already attempted loading so we don't spam 404s.
 	if s.catalogLoaded {
 		return nil
 	}
+
+	// Streaming writes directly into s.catalog. If any part of the load fails,
+	// remove those uncommitted remote entries before releasing mu while keeping
+	// authoritative entries tracked in pendingShard.
+	defer func() {
+		if err != nil {
+			s.resetCatalogAfterLoadFailureLocked()
+		}
+	}()
 
 	s.debugf("loading pack catalog")
 	refs := newPackRefInterner(s.catalog)
@@ -518,17 +536,31 @@ func (s *PackStore) loadCatalogLocked(ctx context.Context) error {
 		return err
 	}
 
-	s.catalogLoaded = true
-
 	// Nothing found. On a fresh repository that is correct; on one that has
 	// packfiles it means the index was lost, so rebuild from the packs' own
 	// footers rather than proceeding as though nothing were packed.
 	if len(s.catalog) == 0 {
-		return s.healMissingCatalogLocked(ctx)
+		if err := s.healMissingCatalogLocked(ctx); err != nil {
+			return err
+		}
 	}
 
+	s.catalogLoaded = true
 	s.debugf("loaded %d entries into the pack catalog", len(s.catalog))
 	return nil
+}
+
+// resetCatalogAfterLoadFailureLocked discards entries streamed from an index
+// that did not load completely while retaining independently authoritative
+// entries in pendingShard, whether locally written or recovered from a pack
+// footer. mu must be held.
+func (s *PackStore) resetCatalogAfterLoadFailureLocked() {
+	catalog := make(map[string]PackEntry, len(s.pendingShard))
+	for key, entry := range s.pendingShard {
+		catalog[key] = entry
+	}
+	s.catalog = catalog
+	s.mergedIndex = make(map[string]bool)
 }
 
 // loadLegacyCatalogLocked merges the pre-shard monolithic catalog, if the
@@ -599,35 +631,6 @@ func (s *PackStore) ensureCatalogLoaded(ctx context.Context) error {
 	return s.loadCatalogLocked(ctx)
 }
 
-// catalogEntry returns an entry only after the entire stored catalog has been
-// loaded successfully. mergePackIndex streams directly into s.catalog to avoid
-// a shard-sized temporary map, so a decode error can leave entries in the map;
-// catalogLoaded is the commit bit that keeps that partial state invisible.
-func (s *PackStore) catalogEntry(ctx context.Context, key string) (PackEntry, bool, error) {
-	// PackStore's physical index and pack objects cannot themselves be packed.
-	// Other currently-unpacked keys still need the lookup for compatibility with
-	// repositories written before the packable-prefix restriction existed.
-	if key == indexPacksKey || strings.HasPrefix(key, packPrefix) {
-		return PackEntry{}, false, nil
-	}
-
-	s.mu.RLock()
-	loaded := s.catalogLoaded
-	entry, ok := s.catalog[key]
-	s.mu.RUnlock()
-	if loaded {
-		return entry, ok, nil
-	}
-
-	if err := s.ensureCatalogLoaded(ctx); err != nil {
-		return PackEntry{}, false, err
-	}
-	s.mu.RLock()
-	entry, ok = s.catalog[key]
-	s.mu.RUnlock()
-	return entry, ok, nil
-}
-
 // Delete removes an object. For packed objects, it just removes it from the catalog.
 // The actual packfile is not currently garbage collected.
 func (s *PackStore) Delete(ctx context.Context, key string) error {
@@ -665,13 +668,12 @@ func (s *PackStore) Size(ctx context.Context, key string) (int64, error) {
 		s.mu.RUnlock()
 		return entry.Length, nil
 	}
-	s.mu.RUnlock()
-
-	if entry, ok, err := s.catalogEntry(ctx, key); err != nil {
-		return 0, err
-	} else if ok {
+	if entry, ok := s.catalog[key]; ok {
+		s.mu.RUnlock()
 		return entry.Length, nil
 	}
+	s.mu.RUnlock()
+
 	return s.ObjectStore.Size(ctx, key)
 }
 

--- a/internal/storelayer/pack.go
+++ b/internal/storelayer/pack.go
@@ -529,17 +529,21 @@ func (s *PackStore) loadCatalogLocked(ctx context.Context) (err error) {
 	// The monolithic catalog is the pre-shard layout. It is still read so that
 	// repositories written before sharding stay readable, but nothing writes it
 	// any more; compaction folds it into a shard and removes it.
-	if err := s.loadLegacyCatalogLocked(ctx, refs); err != nil {
+	legacyFound, err := s.loadLegacyCatalogLocked(ctx, refs)
+	if err != nil {
 		return err
 	}
-	if _, err := s.loadShardsLocked(ctx, refs); err != nil {
+	shardCount, err := s.loadShardsLocked(ctx, refs)
+	if err != nil {
 		return err
 	}
 
-	// Nothing found. On a fresh repository that is correct; on one that has
-	// packfiles it means the index was lost, so rebuild from the packs' own
-	// footers rather than proceeding as though nothing were packed.
-	if len(s.catalog) == 0 {
+	// No stored index found. On a fresh repository that is correct; on one that
+	// has packfiles it means the index was lost, so rebuild from the packs' own
+	// footers rather than proceeding as though nothing were packed. The decision
+	// must not use len(s.catalog): auto-flush can populate it with local entries
+	// before the remote catalog has ever been loaded.
+	if !legacyFound && shardCount == 0 {
 		if err := s.healMissingCatalogLocked(ctx); err != nil {
 			return err
 		}
@@ -564,18 +568,18 @@ func (s *PackStore) resetCatalogAfterLoadFailureLocked() {
 }
 
 // loadLegacyCatalogLocked merges the pre-shard monolithic catalog, if the
-// repository still has one. mu must be held.
-func (s *PackStore) loadLegacyCatalogLocked(ctx context.Context, refs packRefInterner) error {
+// repository still has one, and reports whether it was found. mu must be held.
+func (s *PackStore) loadLegacyCatalogLocked(ctx context.Context, refs packRefInterner) (bool, error) {
 	// A fresh repository legitimately has no catalog. Establish that up front so
 	// a missing object is never conflated with an unreadable one; backends do
 	// not expose a typed not-found error, so an existence check is the only
 	// reliable way to tell the two apart.
 	exists, err := s.ObjectStore.Exists(ctx, indexPacksKey)
 	if err != nil {
-		return fmt.Errorf("check pack catalog %s: %w", indexPacksKey, err)
+		return false, fmt.Errorf("check pack catalog %s: %w", indexPacksKey, err)
 	}
 	if !exists {
-		return nil
+		return false, nil
 	}
 
 	data, err := s.ObjectStore.Get(ctx, indexPacksKey)
@@ -583,24 +587,24 @@ func (s *PackStore) loadLegacyCatalogLocked(ctx context.Context, refs packRefInt
 		// Tolerate a backend that reports absence only on read (or that raced
 		// with a concurrent write), but treat every other error as fatal.
 		if isNotFoundErr(err) {
-			return nil
+			return false, nil
 		}
-		return fmt.Errorf("load pack catalog %s: %w", indexPacksKey, err)
+		return false, fmt.Errorf("load pack catalog %s: %w", indexPacksKey, err)
 	}
 
 	// A catalog written before sealing, or by a repository without encryption,
 	// is plaintext and passes through unchanged.
 	data, err = openIndex(data, s.indexKey)
 	if err != nil {
-		return fmt.Errorf("open pack catalog %s: %w", indexPacksKey, err)
+		return false, fmt.Errorf("open pack catalog %s: %w", indexPacksKey, err)
 	}
 
 	if err := mergePackIndex(data, s.catalog, refs); err != nil {
-		return fmt.Errorf("unmarshal packs catalog: %w", err)
+		return false, fmt.Errorf("unmarshal packs catalog: %w", err)
 	}
 	s.mergedIndex[indexPacksKey] = true
 	s.debugf("merged %d entries from the legacy catalog", len(s.catalog))
-	return nil
+	return true, nil
 }
 
 // isNotFoundErr reports whether err indicates a missing object. Backends do not

--- a/internal/storelayer/pack.go
+++ b/internal/storelayer/pack.go
@@ -3,7 +3,6 @@ package storelayer
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -311,26 +310,18 @@ func (s *PackStore) Get(ctx context.Context, key string) ([]byte, error) {
 		return data, nil
 	}
 
-	// 2. Is it in our catalog?
-	entry, inCatalog := s.catalog[key]
 	s.mu.RUnlock()
 
-	// If not in catalog, wait: we might need to load the catalog from the remote store first,
-	// or it's just a normal large object.
+	// 2. Is it in our catalog? A failed streaming decode may have inserted
+	// entries before encountering the error, so catalogEntry never exposes the
+	// map until the complete catalog has loaded successfully.
+	entry, inCatalog, err := s.catalogEntry(ctx, key)
+	if err != nil {
+		return nil, err
+	}
 	if !inCatalog {
-		if key != indexPacksKey && !strings.HasPrefix(key, packPrefix) {
-			if err := s.ensureCatalogLoaded(ctx); err != nil {
-				return nil, err
-			}
-			s.mu.RLock()
-			entry, inCatalog = s.catalog[key]
-			s.mu.RUnlock()
-		}
-
-		if !inCatalog {
-			// It's a large object or an object not in a packfile; get it directly.
-			return s.ObjectStore.Get(ctx, key)
-		}
+		// It's a large object or an object not in a packfile; get it directly.
+		return s.ObjectStore.Get(ctx, key)
 	}
 
 	// 3. We know it's in a pack. Do we have the pack in the LRU cache?
@@ -369,12 +360,11 @@ func (s *PackStore) Exists(ctx context.Context, key string) (bool, error) {
 		s.mu.RUnlock()
 		return true, nil
 	}
-	if _, ok := s.catalog[key]; ok {
-		s.mu.RUnlock()
-		return true, nil
-	}
 	s.mu.RUnlock()
 
+	if _, ok, err := s.catalogEntry(ctx, key); err != nil || ok {
+		return ok, err
+	}
 	return s.ObjectStore.Exists(ctx, key)
 }
 
@@ -516,14 +506,15 @@ func (s *PackStore) loadCatalogLocked(ctx context.Context) error {
 	}
 
 	s.debugf("loading pack catalog")
+	refs := newPackRefInterner(s.catalog)
 
 	// The monolithic catalog is the pre-shard layout. It is still read so that
 	// repositories written before sharding stay readable, but nothing writes it
 	// any more; compaction folds it into a shard and removes it.
-	if err := s.loadLegacyCatalogLocked(ctx); err != nil {
+	if err := s.loadLegacyCatalogLocked(ctx, refs); err != nil {
 		return err
 	}
-	if _, err := s.loadShardsLocked(ctx); err != nil {
+	if _, err := s.loadShardsLocked(ctx, refs); err != nil {
 		return err
 	}
 
@@ -542,7 +533,7 @@ func (s *PackStore) loadCatalogLocked(ctx context.Context) error {
 
 // loadLegacyCatalogLocked merges the pre-shard monolithic catalog, if the
 // repository still has one. mu must be held.
-func (s *PackStore) loadLegacyCatalogLocked(ctx context.Context) error {
+func (s *PackStore) loadLegacyCatalogLocked(ctx context.Context, refs packRefInterner) error {
 	// A fresh repository legitimately has no catalog. Establish that up front so
 	// a missing object is never conflated with an unreadable one; backends do
 	// not expose a typed not-found error, so an existence check is the only
@@ -572,7 +563,7 @@ func (s *PackStore) loadLegacyCatalogLocked(ctx context.Context) error {
 		return fmt.Errorf("open pack catalog %s: %w", indexPacksKey, err)
 	}
 
-	if err := json.Unmarshal(data, &s.catalog); err != nil {
+	if err := mergePackIndex(data, s.catalog, refs); err != nil {
 		return fmt.Errorf("unmarshal packs catalog: %w", err)
 	}
 	s.mergedIndex[indexPacksKey] = true
@@ -606,6 +597,35 @@ func (s *PackStore) ensureCatalogLoaded(ctx context.Context) error {
 	defer s.mu.Unlock()
 	// Another goroutine may have loaded it while we waited for the lock.
 	return s.loadCatalogLocked(ctx)
+}
+
+// catalogEntry returns an entry only after the entire stored catalog has been
+// loaded successfully. mergePackIndex streams directly into s.catalog to avoid
+// a shard-sized temporary map, so a decode error can leave entries in the map;
+// catalogLoaded is the commit bit that keeps that partial state invisible.
+func (s *PackStore) catalogEntry(ctx context.Context, key string) (PackEntry, bool, error) {
+	// PackStore's physical index and pack objects cannot themselves be packed.
+	// Other currently-unpacked keys still need the lookup for compatibility with
+	// repositories written before the packable-prefix restriction existed.
+	if key == indexPacksKey || strings.HasPrefix(key, packPrefix) {
+		return PackEntry{}, false, nil
+	}
+
+	s.mu.RLock()
+	loaded := s.catalogLoaded
+	entry, ok := s.catalog[key]
+	s.mu.RUnlock()
+	if loaded {
+		return entry, ok, nil
+	}
+
+	if err := s.ensureCatalogLoaded(ctx); err != nil {
+		return PackEntry{}, false, err
+	}
+	s.mu.RLock()
+	entry, ok = s.catalog[key]
+	s.mu.RUnlock()
+	return entry, ok, nil
 }
 
 // Delete removes an object. For packed objects, it just removes it from the catalog.
@@ -645,12 +665,13 @@ func (s *PackStore) Size(ctx context.Context, key string) (int64, error) {
 		s.mu.RUnlock()
 		return entry.Length, nil
 	}
-	if entry, ok := s.catalog[key]; ok {
-		s.mu.RUnlock()
-		return entry.Length, nil
-	}
 	s.mu.RUnlock()
 
+	if entry, ok, err := s.catalogEntry(ctx, key); err != nil {
+		return 0, err
+	} else if ok {
+		return entry.Length, nil
+	}
 	return s.ObjectStore.Size(ctx, key)
 }
 

--- a/internal/storelayer/pack_catalog_test.go
+++ b/internal/storelayer/pack_catalog_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strconv"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/cloudstic/cli/pkg/store"
@@ -134,14 +134,14 @@ func TestPackStore_GetFailsWhenCatalogUnreadable(t *testing.T) {
 	}
 }
 
-// Streaming avoids a shard-sized temporary map, which means entries decoded
-// before malformed data remain in the private map. catalogLoaded is the commit
-// bit: concurrent readers must all fail rather than observe that partial state.
-func TestPackStore_PartialDecodeIsInvisibleToConcurrentReaders(t *testing.T) {
+// Auto-flush adds authoritative local entries before the stored catalog is
+// loaded. A later load failure must discard only streamed remote entries: the
+// local objects remain readable without depending on an unrelated bad shard.
+func TestPackStore_FailedCatalogLoadPreservesAutoFlushedEntries(t *testing.T) {
 	ctx := context.Background()
 	inner := storetest.NewMemStore()
 	malformed := []byte(`{
-		"filemeta/visible":{"p":"packs/one","o":0,"l":1},
+		"filemeta/partial":{"p":"packs/missing","o":0,"l":1},
 		"node/bad":{"p":[],"o":1,"l":1}
 	}`)
 	if err := inner.Put(ctx, shardPrefix+"malformed", malformed); err != nil {
@@ -149,58 +149,39 @@ func TestPackStore_PartialDecodeIsInvisibleToConcurrentReaders(t *testing.T) {
 	}
 
 	ps := newPackStoreT(t, inner)
-	if _, err := ps.Get(ctx, "filemeta/visible"); err == nil {
-		t.Fatal("initial Get succeeded despite the malformed shard")
-	}
-	ps.mu.RLock()
-	_, partiallyDecoded := ps.catalog["filemeta/visible"]
-	loaded := ps.catalogLoaded
-	ps.mu.RUnlock()
-	if !partiallyDecoded || loaded {
-		t.Fatalf("test setup did not leave an uncommitted entry (present=%v, loaded=%v)", partiallyDecoded, loaded)
-	}
-
-	operations := map[string]func() error{
-		"get": func() error {
-			_, err := ps.Get(ctx, "filemeta/visible")
-			return err
-		},
-		"exists": func() error {
-			_, err := ps.Exists(ctx, "filemeta/visible")
-			return err
-		},
-		"size": func() error {
-			_, err := ps.Size(ctx, "filemeta/visible")
-			return err
-		},
-		"list": func() error {
-			_, err := ps.List(ctx, "filemeta/")
-			return err
-		},
-	}
-
-	type result struct {
-		name string
-		err  error
-	}
-	results := make(chan result, len(operations))
-	var wg sync.WaitGroup
-	for name, operation := range operations {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			results <- result{name: name, err: operation()}
-		}()
-	}
-	wg.Wait()
-	close(results)
-
-	for result := range results {
-		if result.err == nil {
-			t.Errorf("%s exposed a partially decoded catalog entry", result.name)
-		} else if !strings.Contains(result.err.Error(), "unmarshal pack index shard") {
-			t.Errorf("%s returned the wrong error: %v", result.name, result.err)
+	payload := make([]byte, maxObjectSize)
+	const firstKey = "chunk/local-0"
+	for i := 0; i < maxPackSize/maxObjectSize; i++ {
+		key := "chunk/local-" + strconv.Itoa(i)
+		if err := ps.Put(ctx, key, payload); err != nil {
+			t.Fatalf("put %s: %v", key, err)
 		}
+	}
+
+	assertLocalReadable := func() {
+		t.Helper()
+		if got, err := ps.Get(ctx, firstKey); err != nil || len(got) != len(payload) {
+			t.Errorf("Get(local) = %d bytes, %v; want %d bytes, nil", len(got), err, len(payload))
+		}
+		if ok, err := ps.Exists(ctx, firstKey); err != nil || !ok {
+			t.Errorf("Exists(local) = %v, %v; want true, nil", ok, err)
+		}
+		if size, err := ps.Size(ctx, firstKey); err != nil || size != int64(len(payload)) {
+			t.Errorf("Size(local) = %d, %v; want %d, nil", size, err, len(payload))
+		}
+	}
+	assertLocalReadable()
+
+	if _, err := ps.List(ctx, "filemeta/"); err == nil {
+		t.Fatal("List succeeded despite the malformed shard")
+	}
+	assertLocalReadable()
+
+	if err := inner.Delete(ctx, shardPrefix+"malformed"); err != nil {
+		t.Fatal(err)
+	}
+	if ok, err := ps.Exists(ctx, "filemeta/partial"); err != nil || ok {
+		t.Errorf("Exists(partial) = %v, %v; want false, nil", ok, err)
 	}
 }
 

--- a/internal/storelayer/pack_catalog_test.go
+++ b/internal/storelayer/pack_catalog_test.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/cloudstic/cli/pkg/store"
 	"github.com/cloudstic/cli/pkg/store/local"
+	"github.com/cloudstic/cli/pkg/store/storetest"
 )
 
 // faultyCatalogStore fails reads of the pack catalog a bounded number of times,
@@ -129,6 +131,76 @@ func TestPackStore_GetFailsWhenCatalogUnreadable(t *testing.T) {
 
 	if _, err := ps.Get(ctx, "filemeta/a"); err == nil {
 		t.Fatal("Get succeeded; want an error when the catalog is unreadable")
+	}
+}
+
+// Streaming avoids a shard-sized temporary map, which means entries decoded
+// before malformed data remain in the private map. catalogLoaded is the commit
+// bit: concurrent readers must all fail rather than observe that partial state.
+func TestPackStore_PartialDecodeIsInvisibleToConcurrentReaders(t *testing.T) {
+	ctx := context.Background()
+	inner := storetest.NewMemStore()
+	malformed := []byte(`{
+		"filemeta/visible":{"p":"packs/one","o":0,"l":1},
+		"node/bad":{"p":[],"o":1,"l":1}
+	}`)
+	if err := inner.Put(ctx, shardPrefix+"malformed", malformed); err != nil {
+		t.Fatal(err)
+	}
+
+	ps := newPackStoreT(t, inner)
+	if _, err := ps.Get(ctx, "filemeta/visible"); err == nil {
+		t.Fatal("initial Get succeeded despite the malformed shard")
+	}
+	ps.mu.RLock()
+	_, partiallyDecoded := ps.catalog["filemeta/visible"]
+	loaded := ps.catalogLoaded
+	ps.mu.RUnlock()
+	if !partiallyDecoded || loaded {
+		t.Fatalf("test setup did not leave an uncommitted entry (present=%v, loaded=%v)", partiallyDecoded, loaded)
+	}
+
+	operations := map[string]func() error{
+		"get": func() error {
+			_, err := ps.Get(ctx, "filemeta/visible")
+			return err
+		},
+		"exists": func() error {
+			_, err := ps.Exists(ctx, "filemeta/visible")
+			return err
+		},
+		"size": func() error {
+			_, err := ps.Size(ctx, "filemeta/visible")
+			return err
+		},
+		"list": func() error {
+			_, err := ps.List(ctx, "filemeta/")
+			return err
+		},
+	}
+
+	type result struct {
+		name string
+		err  error
+	}
+	results := make(chan result, len(operations))
+	var wg sync.WaitGroup
+	for name, operation := range operations {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			results <- result{name: name, err: operation()}
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	for result := range results {
+		if result.err == nil {
+			t.Errorf("%s exposed a partially decoded catalog entry", result.name)
+		} else if !strings.Contains(result.err.Error(), "unmarshal pack index shard") {
+			t.Errorf("%s returned the wrong error: %v", result.name, result.err)
+		}
 	}
 }
 

--- a/internal/storelayer/pack_catalog_test.go
+++ b/internal/storelayer/pack_catalog_test.go
@@ -140,6 +140,9 @@ func TestPackStore_GetFailsWhenCatalogUnreadable(t *testing.T) {
 func TestPackStore_FailedCatalogLoadPreservesAutoFlushedEntries(t *testing.T) {
 	ctx := context.Background()
 	inner := storetest.NewMemStore()
+	seedPackedRepo(t, inner, "filemeta/preexisting")
+	dropIndexObjects(t, inner)
+
 	malformed := []byte(`{
 		"filemeta/partial":{"p":"packs/missing","o":0,"l":1},
 		"node/bad":{"p":[],"o":1,"l":1}
@@ -182,6 +185,13 @@ func TestPackStore_FailedCatalogLoadPreservesAutoFlushedEntries(t *testing.T) {
 	}
 	if ok, err := ps.Exists(ctx, "filemeta/partial"); err != nil || ok {
 		t.Errorf("Exists(partial) = %v, %v; want false, nil", ok, err)
+	}
+	got, err := ps.Get(ctx, "filemeta/preexisting")
+	if err != nil {
+		t.Fatalf("Get(preexisting) after index recovery: %v", err)
+	}
+	if want := "payload for filemeta/preexisting"; string(got) != want {
+		t.Errorf("Get(preexisting) = %q, want %q", got, want)
 	}
 }
 

--- a/internal/storelayer/packshard.go
+++ b/internal/storelayer/packshard.go
@@ -1,9 +1,11 @@
 package storelayer
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 
 	"github.com/cloudstic/cli/internal/core"
 )
@@ -30,6 +32,85 @@ import (
 //
 // See RFC 0018 and docs/compatibility.md.
 const shardPrefix = "index/packmap/"
+
+// packRefInterner keeps the one canonical copy of each pack name while index
+// objects are decoded. It is needed only for the duration of a catalog load:
+// the catalog entries retain the canonical strings after this map is released.
+type packRefInterner map[string]string
+
+func newPackRefInterner(catalog map[string]PackEntry) packRefInterner {
+	refs := make(packRefInterner)
+	for key, entry := range catalog {
+		if ref, ok := refs[entry.PackRef]; ok {
+			entry.PackRef = ref
+			catalog[key] = entry
+			continue
+		}
+		refs[entry.PackRef] = entry.PackRef
+	}
+	return refs
+}
+
+func (i packRefInterner) intern(ref string) string {
+	if existing, ok := i[ref]; ok {
+		return existing
+	}
+	i[ref] = ref
+	return ref
+}
+
+// mergePackIndex decodes one JSON index object directly into catalog. Decoding
+// an entry before deciding whether to insert it keeps duplicate keys harmless,
+// while avoiding an intermediate map proportional to the whole shard.
+func mergePackIndex(data []byte, catalog map[string]PackEntry, refs packRefInterner) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	start, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	if start != json.Delim('{') {
+		return fmt.Errorf("pack index must be a JSON object")
+	}
+
+	for dec.More() {
+		keyToken, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return fmt.Errorf("pack index key is not a string")
+		}
+
+		var entry PackEntry
+		if err := dec.Decode(&entry); err != nil {
+			return err
+		}
+		if _, exists := catalog[key]; exists {
+			continue
+		}
+		entry.PackRef = refs.intern(entry.PackRef)
+		catalog[key] = entry
+	}
+
+	end, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	if end != json.Delim('}') {
+		return fmt.Errorf("pack index is missing its closing object delimiter")
+	}
+
+	// json.Unmarshal rejects trailing values, so retain that validation while
+	// using the streaming decoder.
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("pack index has trailing data")
+		}
+		return err
+	}
+	return nil
+}
 
 // writeShard persists entries as a new immutable shard, named by the hash of
 // its own contents. Two runs that happen to produce identical shards write the
@@ -64,7 +145,7 @@ func (s *PackStore) writeShard(ctx context.Context, entries map[string]PackEntry
 // A shard that cannot be read fails the caller. Continuing with a partial merge
 // would produce a catalog that looks complete and is not, which is how a prune
 // deletes objects it simply could not see.
-func (s *PackStore) loadShardsLocked(ctx context.Context) (int, error) {
+func (s *PackStore) loadShardsLocked(ctx context.Context, refs packRefInterner) (int, error) {
 	keys, err := s.ObjectStore.List(ctx, shardPrefix)
 	if err != nil {
 		return 0, fmt.Errorf("list pack index shards: %w", err)
@@ -80,14 +161,8 @@ func (s *PackStore) loadShardsLocked(ctx context.Context) (int, error) {
 			return 0, fmt.Errorf("open pack index shard %s: %w", key, err)
 		}
 
-		var entries map[string]PackEntry
-		if err := json.Unmarshal(plain, &entries); err != nil {
+		if err := mergePackIndex(plain, s.catalog, refs); err != nil {
 			return 0, fmt.Errorf("unmarshal pack index shard %s: %w", key, err)
-		}
-		for k, entry := range entries {
-			if _, exists := s.catalog[k]; !exists {
-				s.catalog[k] = entry
-			}
 		}
 		s.mergedIndex[key] = true
 	}

--- a/internal/storelayer/packshard_test.go
+++ b/internal/storelayer/packshard_test.go
@@ -3,11 +3,95 @@ package storelayer
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"sync"
 	"testing"
+	"unsafe"
 
 	"github.com/cloudstic/cli/pkg/store/local"
+	"github.com/cloudstic/cli/pkg/store/storetest"
 )
+
+func TestPackStore_LoadShardsInternsPackRefs(t *testing.T) {
+	ctx := context.Background()
+	base := storetest.NewMemStore()
+
+	writer, err := NewPackStore(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.writeShard(ctx, map[string]PackEntry{
+		"filemeta/a": {PackRef: "packs/shared", Offset: 0, Length: 1},
+		"filemeta/b": {PackRef: "packs/shared", Offset: 1, Length: 1},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.writeShard(ctx, map[string]PackEntry{
+		"node/c": {PackRef: "packs/shared", Offset: 2, Length: 1},
+		"node/d": {PackRef: "packs/other", Offset: 0, Length: 1},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	reader, err := NewPackStore(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reader.ensureCatalogLoaded(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	a := reader.catalog["filemeta/a"].PackRef
+	b := reader.catalog["filemeta/b"].PackRef
+	c := reader.catalog["node/c"].PackRef
+	if unsafe.StringData(a) != unsafe.StringData(b) || unsafe.StringData(a) != unsafe.StringData(c) {
+		t.Fatal("entries sharing a pack ref retained separate string allocations")
+	}
+	if unsafe.StringData(a) == unsafe.StringData(reader.catalog["node/d"].PackRef) {
+		t.Fatal("distinct pack refs unexpectedly share storage")
+	}
+}
+
+func TestMergePackIndex_IsFirstWriterWinsOrderIndependentAndIdempotent(t *testing.T) {
+	first := []byte(`{
+		"filemeta/a":{"p":"packs/one","o":0,"l":1},
+		"filemeta/shared":{"p":"packs/one","o":1,"l":1}
+	}`)
+	second := []byte(`{
+		"node/b":{"p":"packs/two","o":0,"l":1},
+		"filemeta/shared":{"p":"packs/one","o":1,"l":1}
+	}`)
+
+	merge := func(parts ...[]byte) map[string]PackEntry {
+		t.Helper()
+		catalog := make(map[string]PackEntry)
+		refs := newPackRefInterner(catalog)
+		for _, part := range parts {
+			if err := mergePackIndex(part, catalog, refs); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return catalog
+	}
+
+	forward := merge(first, second)
+	reverse := merge(second, first)
+	if !reflect.DeepEqual(forward, reverse) {
+		t.Fatalf("merge depends on shard order:\nforward: %#v\nreverse: %#v", forward, reverse)
+	}
+	if twice := merge(first, second, first, second); !reflect.DeepEqual(forward, twice) {
+		t.Fatalf("merge is not idempotent:\nonce: %#v\ntwice: %#v", forward, twice)
+	}
+
+	winner := PackEntry{PackRef: "packs/winner", Offset: 7, Length: 9}
+	catalog := map[string]PackEntry{"filemeta/shared": winner}
+	if err := mergePackIndex(first, catalog, newPackRefInterner(catalog)); err != nil {
+		t.Fatal(err)
+	}
+	if got := catalog["filemeta/shared"]; got != winner {
+		t.Fatalf("later shard replaced the first entry: got %#v, want %#v", got, winner)
+	}
+}
 
 // The race the shard layout exists to remove: two writers sharing a repository.
 //

--- a/internal/storelayer/packshard_test.go
+++ b/internal/storelayer/packshard_test.go
@@ -93,6 +93,25 @@ func TestMergePackIndex_IsFirstWriterWinsOrderIndependentAndIdempotent(t *testin
 	}
 }
 
+func TestMergePackIndex_RejectsMalformedInput(t *testing.T) {
+	tests := map[string]string{
+		"empty":          "",
+		"not an object":  `[]`,
+		"truncated":      `{"filemeta/a":{"p":"packs/one","o":0,"l":1}`,
+		"bad entry type": `{"filemeta/a":{"p":[],"o":0,"l":1}}`,
+		"trailing value": `{} {}`,
+		"trailing junk":  `{} x`,
+	}
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			catalog := make(map[string]PackEntry)
+			if err := mergePackIndex([]byte(input), catalog, newPackRefInterner(catalog)); err == nil {
+				t.Fatal("merge succeeded for malformed input")
+			}
+		})
+	}
+}
+
 // The race the shard layout exists to remove: two writers sharing a repository.
 //
 // With a single mutable catalog both loaded the same object, appended their own


### PR DESCRIPTION
Closes #436

## Summary

- stream pack-index JSON directly into the catalog instead of allocating a whole-shard map
- intern pack references across shards and legacy catalogs so entries share one string per pack
- preserve first-writer-wins, order-independent, and idempotent merge behavior
- on a failed catalog load, discard streamed remote entries while retaining authoritative entries tracked in pendingShard, including auto-flushed local writes
- retain compatibility with legacy repositories containing keys that current versions no longer pack

## Validation

- focused race tests repeated across catalog interning, malformed input, auto-flush rollback, concurrent writers, and legacy compatibility
- go test -count=1 ./internal/storelayer
- golangci-lint run ./internal/storelayer/...
- all non-E2E Go packages passed
- mergePackIndex coverage: 90%; failed-load reset coverage: 100%
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved catalog loading reliability, including recovery from missing or malformed catalog shards.
  * Preserved locally auto-flushed entries when a later catalog load fails.
  * Prevented invalid remote entries from becoming available after failed loads.
  * Added stricter validation for malformed or duplicate catalog index data.

* **Performance**
  * Reduced memory usage while loading and merging catalog indexes through streaming processing and shared references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->