### PR TITLE
fix(store): heal a pack index that lists nothing

### DIFF
--- a/internal/storelayer/pack.go
+++ b/internal/storelayer/pack.go
@@ -529,21 +529,27 @@ func (s *PackStore) loadCatalogLocked(ctx context.Context) (err error) {
 	// The monolithic catalog is the pre-shard layout. It is still read so that
 	// repositories written before sharding stay readable, but nothing writes it
 	// any more; compaction folds it into a shard and removes it.
-	legacyFound, err := s.loadLegacyCatalogLocked(ctx, refs)
+	legacyEntries, err := s.loadLegacyCatalogLocked(ctx, refs)
 	if err != nil {
 		return err
 	}
-	shardCount, err := s.loadShardsLocked(ctx, refs)
+	shardEntries, err := s.loadShardsLocked(ctx, refs)
 	if err != nil {
 		return err
 	}
 
-	// No stored index found. On a fresh repository that is correct; on one that
-	// has packfiles it means the index was lost, so rebuild from the packs' own
-	// footers rather than proceeding as though nothing were packed. The decision
-	// must not use len(s.catalog): auto-flush can populate it with local entries
-	// before the remote catalog has ever been loaded.
-	if !legacyFound && shardCount == 0 {
+	// The stored index described nothing. On a fresh repository that is correct;
+	// on one that has packfiles it means the index was lost, so rebuild from the
+	// packs' own footers rather than proceeding as though nothing were packed.
+	//
+	// The test is on entries the stored index yielded, which is neither of the
+	// two things it is tempting to use. len(s.catalog) is wrong because Put's
+	// auto-flush populates it with local entries before the index is ever read,
+	// so a genuinely lost index stops being detected mid-run. The mere existence
+	// of index/packs or a shard is wrong because an object that lists nothing
+	// leaves the repository exactly as unindexed as a missing one, and reading it
+	// as authoritative turns a recoverable loss into objects reported missing.
+	if legacyEntries+shardEntries == 0 {
 		if err := s.healMissingCatalogLocked(ctx); err != nil {
 			return err
 		}
@@ -568,18 +574,23 @@ func (s *PackStore) resetCatalogAfterLoadFailureLocked() {
 }
 
 // loadLegacyCatalogLocked merges the pre-shard monolithic catalog, if the
-// repository still has one, and reports whether it was found. mu must be held.
-func (s *PackStore) loadLegacyCatalogLocked(ctx context.Context, refs packRefInterner) (bool, error) {
+// repository still has one, and reports how many entries it described. mu must
+// be held.
+//
+// The count, rather than a found/not-found flag, is what loadCatalogLocked needs:
+// a catalog object that exists and lists nothing leaves the repository just as
+// unindexed as one that was deleted.
+func (s *PackStore) loadLegacyCatalogLocked(ctx context.Context, refs packRefInterner) (int, error) {
 	// A fresh repository legitimately has no catalog. Establish that up front so
 	// a missing object is never conflated with an unreadable one; backends do
 	// not expose a typed not-found error, so an existence check is the only
 	// reliable way to tell the two apart.
 	exists, err := s.ObjectStore.Exists(ctx, indexPacksKey)
 	if err != nil {
-		return false, fmt.Errorf("check pack catalog %s: %w", indexPacksKey, err)
+		return 0, fmt.Errorf("check pack catalog %s: %w", indexPacksKey, err)
 	}
 	if !exists {
-		return false, nil
+		return 0, nil
 	}
 
 	data, err := s.ObjectStore.Get(ctx, indexPacksKey)
@@ -587,24 +598,25 @@ func (s *PackStore) loadLegacyCatalogLocked(ctx context.Context, refs packRefInt
 		// Tolerate a backend that reports absence only on read (or that raced
 		// with a concurrent write), but treat every other error as fatal.
 		if isNotFoundErr(err) {
-			return false, nil
+			return 0, nil
 		}
-		return false, fmt.Errorf("load pack catalog %s: %w", indexPacksKey, err)
+		return 0, fmt.Errorf("load pack catalog %s: %w", indexPacksKey, err)
 	}
 
 	// A catalog written before sealing, or by a repository without encryption,
 	// is plaintext and passes through unchanged.
 	data, err = openIndex(data, s.indexKey)
 	if err != nil {
-		return false, fmt.Errorf("open pack catalog %s: %w", indexPacksKey, err)
+		return 0, fmt.Errorf("open pack catalog %s: %w", indexPacksKey, err)
 	}
 
-	if err := mergePackIndex(data, s.catalog, refs); err != nil {
-		return false, fmt.Errorf("unmarshal packs catalog: %w", err)
+	decoded, err := mergePackIndex(data, s.catalog, refs)
+	if err != nil {
+		return 0, fmt.Errorf("unmarshal packs catalog: %w", err)
 	}
 	s.mergedIndex[indexPacksKey] = true
-	s.debugf("merged %d entries from the legacy catalog", len(s.catalog))
-	return true, nil
+	s.debugf("merged %d entries from the legacy catalog", decoded)
+	return decoded, nil
 }
 
 // isNotFoundErr reports whether err indicates a missing object. Backends do not

--- a/internal/storelayer/pack_heal_trigger_test.go
+++ b/internal/storelayer/pack_heal_trigger_test.go
@@ -1,0 +1,198 @@
+package storelayer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cloudstic/cli/internal/core"
+	"github.com/cloudstic/cli/pkg/store/storetest"
+)
+
+// seedPackedObject writes one small object through a PackStore and flushes it,
+// leaving a real packfile with a footer on mem. It returns the object's key and
+// its bytes.
+func seedPackedObject(t *testing.T, ctx context.Context, mem *storetest.MemStore) (string, []byte) {
+	t.Helper()
+
+	seed, err := NewPackStore(mem)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := "filemeta/" + core.ComputeHash([]byte("recoverable"))
+	payload := []byte("payload-bytes")
+	if err := seed.Put(ctx, key, payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := seed.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+	return key, payload
+}
+
+// dropShards removes every shard the seeding flush wrote, simulating a lost
+// index while the packs themselves survive.
+func dropShards(t *testing.T, ctx context.Context, mem *storetest.MemStore) {
+	t.Helper()
+
+	shards, err := mem.List(ctx, shardPrefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range shards {
+		if err := mem.Delete(ctx, key); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// An index object that exists and lists nothing leaves the repository exactly as
+// unindexed as a missing one. Keying the heal on whether index/packs exists read
+// the empty object as authoritative, so a packed object came back as not found
+// even though its pack — and its footer — were intact.
+func TestPackStore_HealsWhenLegacyCatalogIsEmpty(t *testing.T) {
+	ctx := context.Background()
+	mem := storetest.NewMemStore()
+
+	key, payload := seedPackedObject(t, ctx, mem)
+	dropShards(t, ctx, mem)
+	if err := mem.Put(ctx, indexPacksKey, []byte("{}")); err != nil {
+		t.Fatal(err)
+	}
+
+	fresh, err := NewPackStore(mem)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := fresh.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get failed instead of healing from the pack footer: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("got %q, want %q", got, payload)
+	}
+}
+
+// The same hole, reached through a shard rather than the legacy catalog.
+func TestPackStore_HealsWhenShardsDescribeNothing(t *testing.T) {
+	ctx := context.Background()
+	mem := storetest.NewMemStore()
+
+	key, payload := seedPackedObject(t, ctx, mem)
+	dropShards(t, ctx, mem)
+	if err := mem.Put(ctx, shardPrefix+"empty", []byte("{}")); err != nil {
+		t.Fatal(err)
+	}
+
+	fresh, err := NewPackStore(mem)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := fresh.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get failed instead of healing from the pack footer: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("got %q, want %q", got, payload)
+	}
+}
+
+// The case the entry count exists to distinguish from an empty index: a healthy
+// index whose keys are all already in the catalog because Put's auto-flush put
+// them there. Counting insertions rather than decoded entries would read this as
+// an empty index and heal a repository that never lost anything.
+func TestPackStore_DoesNotHealWhenIndexEntriesAreAlreadyKnown(t *testing.T) {
+	ctx := context.Background()
+	mem := storetest.NewMemStore()
+
+	key, payload := seedPackedObject(t, ctx, mem)
+
+	// Strip the footers so a heal, if one were triggered, could not quietly
+	// succeed and hide the misfire. A footerless pack makes healMissingCatalog
+	// fail loudly instead.
+	packs, err := mem.List(ctx, packPrefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(packs) == 0 {
+		t.Fatal("expected at least one pack")
+	}
+	for _, ref := range packs {
+		data, err := mem.Get(ctx, ref)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := mem.Put(ctx, ref, data[:len(data)/2]); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	fresh, err := NewPackStore(mem)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Pre-populate the catalog the way an auto-flush would, so every entry the
+	// stored shard names is already present and none of them is inserted.
+	entry, err := shardEntryFor(ctx, mem, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fresh.mu.Lock()
+	fresh.catalog[key] = entry
+	fresh.pendingShard[key] = entry
+	fresh.mu.Unlock()
+
+	if _, err := fresh.Get(ctx, key); err != nil {
+		t.Fatalf("Get healed (and failed) on a repository whose index was intact: %v", err)
+	}
+	_ = payload
+}
+
+// shardEntryFor reads the stored shards and returns the entry recorded for key,
+// so a test can seed the catalog with exactly what the index already says.
+func shardEntryFor(ctx context.Context, mem *storetest.MemStore, key string) (PackEntry, error) {
+	keys, err := mem.List(ctx, shardPrefix)
+	if err != nil {
+		return PackEntry{}, err
+	}
+	catalog := make(map[string]PackEntry)
+	for _, k := range keys {
+		data, err := mem.Get(ctx, k)
+		if err != nil {
+			return PackEntry{}, err
+		}
+		if _, err := mergePackIndex(data, catalog, newPackRefInterner(catalog)); err != nil {
+			return PackEntry{}, err
+		}
+	}
+	return catalog[key], nil
+}
+
+// mergePackIndex reports what the object described, not what it inserted. The
+// difference is the whole basis of the heal decision.
+func TestMergePackIndex_CountsDecodedEntriesNotInsertions(t *testing.T) {
+	shard := []byte(`{"filemeta/a":{"p":"packs/one","o":0,"l":1},"filemeta/b":{"p":"packs/one","o":1,"l":1}}`)
+
+	catalog := make(map[string]PackEntry)
+	decoded, err := mergePackIndex(shard, catalog, newPackRefInterner(catalog))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decoded != 2 {
+		t.Fatalf("decoded = %d, want 2", decoded)
+	}
+
+	// Same object into a catalog that already holds both keys: nothing is
+	// inserted, but the object still described two entries.
+	again, err := mergePackIndex(shard, catalog, newPackRefInterner(catalog))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again != 2 {
+		t.Fatalf("decoded on re-merge = %d, want 2 (insertions would be 0)", again)
+	}
+
+	empty := make(map[string]PackEntry)
+	if n, err := mergePackIndex([]byte("{}"), empty, newPackRefInterner(empty)); err != nil || n != 0 {
+		t.Fatalf("empty object: got (%d, %v), want (0, nil)", n, err)
+	}
+}

--- a/internal/storelayer/pack_heal_trigger_test.go
+++ b/internal/storelayer/pack_heal_trigger_test.go
@@ -2,9 +2,11 @@ package storelayer
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/cloudstic/cli/internal/core"
+	"github.com/cloudstic/cli/pkg/store"
 	"github.com/cloudstic/cli/pkg/store/storetest"
 )
 
@@ -96,6 +98,34 @@ func TestPackStore_HealsWhenShardsDescribeNothing(t *testing.T) {
 	}
 }
 
+// listSpyStore records the prefixes listed through it. Whether the heal ran is
+// otherwise invisible from outside: it is the only thing in a plain Get that
+// lists packPrefix, and on a repository whose packs are intact it would repair
+// nothing and return no error, so its effect cannot be observed in the result.
+type listSpyStore struct {
+	store.ObjectStore
+	mu       sync.Mutex
+	prefixes []string
+}
+
+func (s *listSpyStore) List(ctx context.Context, prefix string) ([]string, error) {
+	s.mu.Lock()
+	s.prefixes = append(s.prefixes, prefix)
+	s.mu.Unlock()
+	return s.ObjectStore.List(ctx, prefix)
+}
+
+func (s *listSpyStore) listed(prefix string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, p := range s.prefixes {
+		if p == prefix {
+			return true
+		}
+	}
+	return false
+}
+
 // The case the entry count exists to distinguish from an empty index: a healthy
 // index whose keys are all already in the catalog because Put's auto-flush put
 // them there. Counting insertions rather than decoded entries would read this as
@@ -105,66 +135,75 @@ func TestPackStore_DoesNotHealWhenIndexEntriesAreAlreadyKnown(t *testing.T) {
 	mem := storetest.NewMemStore()
 
 	key, payload := seedPackedObject(t, ctx, mem)
+	entry := shardEntryFor(t, ctx, mem, key)
 
-	// Strip the footers so a heal, if one were triggered, could not quietly
-	// succeed and hide the misfire. A footerless pack makes healMissingCatalog
-	// fail loudly instead.
-	packs, err := mem.List(ctx, packPrefix)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(packs) == 0 {
-		t.Fatal("expected at least one pack")
-	}
-	for _, ref := range packs {
-		data, err := mem.Get(ctx, ref)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := mem.Put(ctx, ref, data[:len(data)/2]); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	fresh, err := NewPackStore(mem)
+	spy := &listSpyStore{ObjectStore: mem}
+	fresh, err := NewPackStore(spy)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// Pre-populate the catalog the way an auto-flush would, so every entry the
 	// stored shard names is already present and none of them is inserted.
-	entry, err := shardEntryFor(ctx, mem, key)
-	if err != nil {
-		t.Fatal(err)
-	}
 	fresh.mu.Lock()
 	fresh.catalog[key] = entry
 	fresh.pendingShard[key] = entry
 	fresh.mu.Unlock()
 
-	if _, err := fresh.Get(ctx, key); err != nil {
-		t.Fatalf("Get healed (and failed) on a repository whose index was intact: %v", err)
+	// Read a key the catalog does not hold, so the load actually runs rather
+	// than being short-circuited by the seeded entry.
+	if _, err := fresh.Get(ctx, "filemeta/"+core.ComputeHash([]byte("absent"))); err == nil {
+		t.Fatal("expected a miss for an object that was never stored")
 	}
-	_ = payload
+
+	if spy.listed(packPrefix) {
+		t.Errorf("the heal ran on a repository whose index was intact: listed %q", packPrefix)
+	}
+
+	fresh.mu.RLock()
+	loaded := fresh.catalogLoaded
+	fresh.mu.RUnlock()
+	if !loaded {
+		t.Error("catalog did not finish loading")
+	}
+
+	got, err := fresh.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get on the indexed key failed: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("got %q, want %q", got, payload)
+	}
 }
 
 // shardEntryFor reads the stored shards and returns the entry recorded for key,
 // so a test can seed the catalog with exactly what the index already says.
-func shardEntryFor(ctx context.Context, mem *storetest.MemStore, key string) (PackEntry, error) {
+//
+// It fails the test directly rather than returning an error, matching the other
+// helpers here: every caller could only pass the error to t.Fatal, and naming
+// the shard at the point of failure is what makes a broken fixture diagnosable.
+func shardEntryFor(t *testing.T, ctx context.Context, mem *storetest.MemStore, key string) PackEntry {
+	t.Helper()
+
 	keys, err := mem.List(ctx, shardPrefix)
 	if err != nil {
-		return PackEntry{}, err
+		t.Fatalf("list pack index shards under %s: %v", shardPrefix, err)
 	}
 	catalog := make(map[string]PackEntry)
 	for _, k := range keys {
 		data, err := mem.Get(ctx, k)
 		if err != nil {
-			return PackEntry{}, err
+			t.Fatalf("read pack index shard %s: %v", k, err)
 		}
 		if _, err := mergePackIndex(data, catalog, newPackRefInterner(catalog)); err != nil {
-			return PackEntry{}, err
+			t.Fatalf("merge pack index shard %s: %v", k, err)
 		}
 	}
-	return catalog[key], nil
+
+	entry, ok := catalog[key]
+	if !ok {
+		t.Fatalf("no shard records an entry for %s; the fixture never indexed it", key)
+	}
+	return entry
 }
 
 // mergePackIndex reports what the object described, not what it inserted. The

--- a/internal/storelayer/packshard.go
+++ b/internal/storelayer/packshard.go
@@ -62,30 +62,38 @@ func (i packRefInterner) intern(ref string) string {
 // mergePackIndex decodes one JSON index object directly into catalog. Decoding
 // an entry before deciding whether to insert it keeps duplicate keys harmless,
 // while avoiding an intermediate map proportional to the whole shard.
-func mergePackIndex(data []byte, catalog map[string]PackEntry, refs packRefInterner) error {
+//
+// It reports how many entries the object contained, not how many were inserted.
+// The two differ whenever a key is already present, and the caller's question —
+// did the stored index describe anything — is answered by the former. Counting
+// insertions instead would read a healthy index as empty whenever the entries it
+// names were already in the catalog, which is what auto-flush leaves behind.
+func mergePackIndex(data []byte, catalog map[string]PackEntry, refs packRefInterner) (int, error) {
 	dec := json.NewDecoder(bytes.NewReader(data))
 	start, err := dec.Token()
 	if err != nil {
-		return err
+		return 0, err
 	}
 	if start != json.Delim('{') {
-		return fmt.Errorf("pack index must be a JSON object")
+		return 0, fmt.Errorf("pack index must be a JSON object")
 	}
 
+	decoded := 0
 	for dec.More() {
 		keyToken, err := dec.Token()
 		if err != nil {
-			return err
+			return decoded, err
 		}
 		key, ok := keyToken.(string)
 		if !ok {
-			return fmt.Errorf("pack index key is not a string")
+			return decoded, fmt.Errorf("pack index key is not a string")
 		}
 
 		var entry PackEntry
 		if err := dec.Decode(&entry); err != nil {
-			return err
+			return decoded, err
 		}
+		decoded++
 		if _, exists := catalog[key]; exists {
 			continue
 		}
@@ -95,21 +103,21 @@ func mergePackIndex(data []byte, catalog map[string]PackEntry, refs packRefInter
 
 	end, err := dec.Token()
 	if err != nil {
-		return err
+		return decoded, err
 	}
 	if end != json.Delim('}') {
-		return fmt.Errorf("pack index is missing its closing object delimiter")
+		return decoded, fmt.Errorf("pack index is missing its closing object delimiter")
 	}
 
 	// json.Unmarshal rejects trailing values, so retain that validation while
 	// using the streaming decoder.
 	if err := dec.Decode(&struct{}{}); err != io.EOF {
 		if err == nil {
-			return fmt.Errorf("pack index has trailing data")
+			return decoded, fmt.Errorf("pack index has trailing data")
 		}
-		return err
+		return decoded, err
 	}
-	return nil
+	return decoded, nil
 }
 
 // writeShard persists entries as a new immutable shard, named by the hash of
@@ -140,7 +148,11 @@ func (s *PackStore) writeShard(ctx context.Context, entries map[string]PackEntry
 }
 
 // loadShardsLocked merges every shard into the in-memory catalog and returns
-// how many were read. mu must be held.
+// how many entries those shards described. mu must be held.
+//
+// The count is of entries rather than of shards because it feeds the decision in
+// loadCatalogLocked about whether the stored index is lost. A shard that exists
+// and describes nothing leaves the catalog exactly as empty as no shard at all.
 //
 // A shard that cannot be read fails the caller. Continuing with a partial merge
 // would produce a catalog that looks complete and is not, which is how a prune
@@ -151,6 +163,7 @@ func (s *PackStore) loadShardsLocked(ctx context.Context, refs packRefInterner) 
 		return 0, fmt.Errorf("list pack index shards: %w", err)
 	}
 
+	entries := 0
 	for _, key := range keys {
 		data, err := s.ObjectStore.Get(ctx, key)
 		if err != nil {
@@ -161,16 +174,18 @@ func (s *PackStore) loadShardsLocked(ctx context.Context, refs packRefInterner) 
 			return 0, fmt.Errorf("open pack index shard %s: %w", key, err)
 		}
 
-		if err := mergePackIndex(plain, s.catalog, refs); err != nil {
+		decoded, err := mergePackIndex(plain, s.catalog, refs)
+		if err != nil {
 			return 0, fmt.Errorf("unmarshal pack index shard %s: %w", key, err)
 		}
+		entries += decoded
 		s.mergedIndex[key] = true
 	}
 
 	if len(keys) > 0 {
-		s.debugf("pack: merged %d shards", len(keys))
+		s.debugf("pack: merged %d entries from %d shards", entries, len(keys))
 	}
-	return len(keys), nil
+	return entries, nil
 }
 
 // CompactCatalog folds every shard, and the legacy monolithic catalog, into a

--- a/internal/storelayer/packshard_test.go
+++ b/internal/storelayer/packshard_test.go
@@ -67,7 +67,7 @@ func TestMergePackIndex_IsFirstWriterWinsOrderIndependentAndIdempotent(t *testin
 		catalog := make(map[string]PackEntry)
 		refs := newPackRefInterner(catalog)
 		for _, part := range parts {
-			if err := mergePackIndex(part, catalog, refs); err != nil {
+			if _, err := mergePackIndex(part, catalog, refs); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -85,7 +85,7 @@ func TestMergePackIndex_IsFirstWriterWinsOrderIndependentAndIdempotent(t *testin
 
 	winner := PackEntry{PackRef: "packs/winner", Offset: 7, Length: 9}
 	catalog := map[string]PackEntry{"filemeta/shared": winner}
-	if err := mergePackIndex(first, catalog, newPackRefInterner(catalog)); err != nil {
+	if _, err := mergePackIndex(first, catalog, newPackRefInterner(catalog)); err != nil {
 		t.Fatal(err)
 	}
 	if got := catalog["filemeta/shared"]; got != winner {
@@ -105,7 +105,7 @@ func TestMergePackIndex_RejectsMalformedInput(t *testing.T) {
 	for name, input := range tests {
 		t.Run(name, func(t *testing.T) {
 			catalog := make(map[string]PackEntry)
-			if err := mergePackIndex([]byte(input), catalog, newPackRefInterner(catalog)); err == nil {
+			if _, err := mergePackIndex([]byte(input), catalog, newPackRefInterner(catalog)); err == nil {
 				t.Fatal("merge succeeded for malformed input")
 			}
 		})


### PR DESCRIPTION
## Summary

- Decide the footer heal on how many entries the stored pack index yielded, not on whether `index/packs` or a shard exists
- `mergePackIndex` now reports entries decoded rather than inserted, so a healthy index whose keys are already in the catalog is not mistaken for an empty one
- `loadLegacyCatalogLocked` and `loadShardsLocked` return entry counts, and the legacy loader's debug line now reports its own contribution instead of the whole catalog's size

#444 replaced `len(s.catalog) == 0` with an existence test because auto-flush
populates the catalog before the index is read, which made the old trigger stop
firing mid-run. Existence is wrong the other way: an index object that lists
nothing leaves the repository exactly as unindexed as a missing one, so a
present-but-empty `index/packs` beside intact packfiles suppressed the heal and a
packed object came back as `not found`. Counting what the index described covers
both cases with one signal.

Closes #445

## Verification

- `TestPackStore_HealsWhenLegacyCatalogIsEmpty` and `TestPackStore_HealsWhenShardsDescribeNothing` fail on `main` at `8ca8005` and pass here
- `TestPackStore_DoesNotHealWhenIndexEntriesAreAlreadyKnown` guards the auto-flush case #444 fixed, by stripping pack footers so a misfired heal fails loudly rather than quietly succeeding

```bash
env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./internal/storelayer/... ./internal/engine/... .
```

```bash
env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./internal/storelayer/...
```

Both pass; lint reports 0 issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pack store catalog recovery now properly triggers when legacy catalogs or shards are empty.
  * Improved recovery from missing or empty catalog data using surviving pack information.
  * Prevented unnecessary recovery when existing index entries are already available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->