### PR TITLE
docs: list the perf label in the issue type vocabulary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -462,7 +462,7 @@ One or two sentences on the desired end state.
 
 **Labels** — apply exactly one *type* label plus one or more `area/*` labels:
 
-- Type (pick one): `bug`, `enhancement`, `refactor`, `tech debt`, `chore`, `test`, `documentation`, `rfc`, `tracking`
+- Type (pick one): `bug`, `enhancement`, `refactor`, `tech debt`, `chore`, `test`, `documentation`, `perf`, `rfc`, `tracking`
 - Area: `area/cli`, `area/core`, `area/tui`, `area/completion`, `area/onboarding`, `area/ci`
 
 **Titles** — see Naming Conventions above. In short: no conventional-commit prefix (the label carries the type), lead with an imperative verb or an `Area:` scanning prefix, no trailing period.


### PR DESCRIPTION
## Summary

- Add `perf` to the issue type-label list in `AGENTS.md`

`perf` was already listed as a valid Conventional Commit type in the Naming
Conventions section and is used by existing commits, but the "Creating GitHub
Issues" label list omitted it. Since that section also says not to invent new
labels, performance work had nowhere accurate to land. The label now exists on
the repository, so this records it.

## Verification

- Documentation only; no code paths touched.
- `markdownlint-cli2` conventions preserved (single-line list item, unchanged surrounding structure).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated issue labeling guidance to include `enhancement` as an available label type for better issue categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->