### PR TITLE
perf(engine): order the restore tree instead of copying it

### DIFF
--- a/internal/engine/restore.go
+++ b/internal/engine/restore.go
@@ -34,9 +34,16 @@ type restoreConfig struct {
 	noVerify   bool
 }
 
+// restorePlan is what a restore walks. byID owns the metadata; sorted is an
+// ordering over it, naming entries by FileID rather than repeating them.
+//
+// The two used to be independent copies of the same tree. A core.FileMeta is 216
+// bytes, so a snapshot's metadata was held twice over before a byte was written.
+// An ordering of IDs costs one string header each and shares the ID already
+// stored as byID's key.
 type restorePlan struct {
 	cfg         restoreConfig
-	sorted      []core.FileMeta
+	sorted      []string
 	byID        map[string]core.FileMeta
 	snapshotRef string
 	root        string
@@ -211,7 +218,8 @@ func (rm *RestoreManager) runWithWriter(ctx context.Context, plan restorePlan, w
 		}
 	}
 
-	for _, meta := range plan.sorted {
+	for _, id := range plan.sorted {
+		meta := plan.byID[id]
 		rel := buildRestorePath(meta, plan.byID)
 
 		if meta.Type == core.FileTypeFolder {
@@ -581,13 +589,14 @@ func checkSymlinkPath(p string) error {
 	return nil
 }
 
-func (rm *RestoreManager) dryRunRestore(sorted []core.FileMeta, byID map[string]core.FileMeta, snapshotRef, root string) *RestoreResult {
+func (rm *RestoreManager) dryRunRestore(sorted []string, byID map[string]core.FileMeta, snapshotRef, root string) *RestoreResult {
 	result := &RestoreResult{
 		SnapshotRef: snapshotRef,
 		Root:        root,
 		DryRun:      true,
 	}
-	for _, meta := range sorted {
+	for _, id := range sorted {
+		meta := byID[id]
 		if meta.Type == core.FileTypeFolder {
 			result.DirsWritten++
 		} else if meta.ContentHash != "" {
@@ -661,33 +670,30 @@ func buildRestorePath(meta core.FileMeta, byID map[string]core.FileMeta) string 
 // If the filter ends with "/", it matches all entries under that subtree.
 // Otherwise it matches only the entry with the exact path.
 // Ancestor directories of matched entries are always included.
-func filterByPath(sorted []core.FileMeta, byID map[string]core.FileMeta, pathFilter string) []core.FileMeta {
+func filterByPath(sorted []string, byID map[string]core.FileMeta, pathFilter string) []string {
 	isSubtree := strings.HasSuffix(pathFilter, "/")
 	prefix := pathFilter
 	if isSubtree {
 		prefix = strings.TrimSuffix(pathFilter, "/")
 	}
 
-	// Build a set of restore paths for each entry.
-	restorePaths := make(map[string]string, len(sorted))
-	for _, meta := range sorted {
-		restorePaths[meta.FileID] = buildRestorePath(meta, byID)
-	}
-
-	// Determine which entries are matched.
+	// Determine which entries are matched. The path is built once per entry and
+	// tested immediately rather than being kept in a map for a second pass: the
+	// only thing the second pass needed was the path, and nothing after this
+	// reads it.
 	matched := make(map[string]bool)
-	for _, meta := range sorted {
-		p := restorePaths[meta.FileID]
+	for _, id := range sorted {
+		p := buildRestorePath(byID[id], byID)
 		if isSubtree {
 			// Match the directory itself and anything under it.
 			if p == prefix || strings.HasPrefix(p, prefix+"/") {
-				matched[meta.FileID] = true
+				matched[id] = true
 			}
 		} else {
 			// Exact match, or — when the target is a folder — include
 			// everything under it so the user doesn't need a trailing "/".
 			if p == pathFilter || strings.HasPrefix(p, pathFilter+"/") {
-				matched[meta.FileID] = true
+				matched[id] = true
 			}
 		}
 	}
@@ -710,16 +716,16 @@ func filterByPath(sorted []core.FileMeta, byID map[string]core.FileMeta, pathFil
 			}
 		}
 	}
-	for _, meta := range sorted {
-		if matched[meta.FileID] {
-			walkAncestors(meta.FileID)
+	for _, id := range sorted {
+		if matched[id] {
+			walkAncestors(id)
 		}
 	}
 
-	var filtered []core.FileMeta
-	for _, meta := range sorted {
-		if matched[meta.FileID] {
-			filtered = append(filtered, meta)
+	var filtered []string
+	for _, id := range sorted {
+		if matched[id] {
+			filtered = append(filtered, id)
 		}
 	}
 	return filtered
@@ -792,10 +798,14 @@ func (rm *RestoreManager) collectMetadata(ctx context.Context, root string) (map
 // Ordering
 // ---------------------------------------------------------------------------
 
-// topoSort returns entries in parent-before-child order so that directories
-// are created before the files they contain. Parents contain FileIDs.
-func topoSort(byID map[string]core.FileMeta) []core.FileMeta {
-	var out []core.FileMeta
+// topoSort returns FileIDs in parent-before-child order so that directories are
+// created before the files they contain. Parents contain FileIDs.
+//
+// It orders byID rather than copying out of it: the caller already holds every
+// entry, and a second slice of core.FileMeta doubled a snapshot's metadata for
+// the sake of sequencing it.
+func topoSort(byID map[string]core.FileMeta) []string {
+	out := make([]string, 0, len(byID))
 	visited := make(map[string]bool, len(byID))
 
 	var visit func(core.FileMeta)
@@ -803,13 +813,16 @@ func topoSort(byID map[string]core.FileMeta) []core.FileMeta {
 		if visited[meta.FileID] {
 			return
 		}
+		// Marked before recursing, not after: a parent cycle would otherwise
+		// revisit this entry forever. Marking first makes a cycle terminate with
+		// the entry emitted once, in an order the cycle itself does not define.
+		visited[meta.FileID] = true
 		for _, parentID := range meta.Parents {
 			if parent, ok := byID[parentID]; ok {
 				visit(parent)
 			}
 		}
-		visited[meta.FileID] = true
-		out = append(out, meta)
+		out = append(out, meta.FileID)
 	}
 
 	for _, meta := range byID {

--- a/internal/engine/restore_ordering_test.go
+++ b/internal/engine/restore_ordering_test.go
@@ -1,0 +1,96 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cloudstic/cli/internal/core"
+)
+
+// indexOf reports where id lands in the ordering, or -1.
+func indexOf(order []string, id string) int {
+	for i, got := range order {
+		if got == id {
+			return i
+		}
+	}
+	return -1
+}
+
+// topoSort's contract is parent-before-child. It returns FileIDs, so the caller
+// keeps one copy of each entry rather than two.
+func TestTopoSort_OrdersParentsBeforeChildren(t *testing.T) {
+	byID := map[string]core.FileMeta{
+		"root":  {FileID: "root", Type: core.FileTypeFolder},
+		"a":     {FileID: "a", Type: core.FileTypeFolder, Parents: []string{"root"}},
+		"b":     {FileID: "b", Type: core.FileTypeFolder, Parents: []string{"a"}},
+		"leaf":  {FileID: "leaf", Parents: []string{"b"}},
+		"other": {FileID: "other", Parents: []string{"root"}},
+	}
+
+	order := topoSort(byID)
+	if len(order) != len(byID) {
+		t.Fatalf("ordering has %d entries, want %d", len(order), len(byID))
+	}
+
+	seen := make(map[string]bool, len(order))
+	for _, id := range order {
+		if seen[id] {
+			t.Fatalf("%s appears twice in the ordering", id)
+		}
+		seen[id] = true
+	}
+
+	for _, child := range []struct{ child, parent string }{
+		{"a", "root"}, {"b", "a"}, {"leaf", "b"}, {"other", "root"},
+	} {
+		if indexOf(order, child.parent) > indexOf(order, child.child) {
+			t.Errorf("%s (parent) is ordered after %s (child)", child.parent, child.child)
+		}
+	}
+}
+
+// A parent cycle is not reachable from a repository this code wrote, but it is
+// reachable from a corrupt or hostile one. Marking an entry visited before
+// recursing makes the walk terminate and emit each entry once; marking after
+// recursing, as it did before, recurses until the stack is exhausted.
+func TestTopoSort_TerminatesOnAParentCycle(t *testing.T) {
+	byID := map[string]core.FileMeta{
+		"x": {FileID: "x", Type: core.FileTypeFolder, Parents: []string{"y"}},
+		"y": {FileID: "y", Type: core.FileTypeFolder, Parents: []string{"x"}},
+		"z": {FileID: "z", Parents: []string{"x"}},
+	}
+
+	done := make(chan []string, 1)
+	go func() { done <- topoSort(byID) }()
+
+	order := <-done
+	if len(order) != len(byID) {
+		t.Fatalf("ordering has %d entries, want %d", len(order), len(byID))
+	}
+	seen := make(map[string]bool, len(order))
+	for _, id := range order {
+		if seen[id] {
+			t.Fatalf("%s appears twice in the ordering", id)
+		}
+		seen[id] = true
+	}
+	for id := range byID {
+		if !seen[id] {
+			t.Errorf("%s is missing from the ordering", id)
+		}
+	}
+}
+
+// An entry naming a parent that is not in the snapshot must still be ordered,
+// not dropped. Restore relies on that: a filtered or partial tree has entries
+// whose parents were never loaded.
+func TestTopoSort_KeepsEntriesWithUnknownParents(t *testing.T) {
+	byID := map[string]core.FileMeta{
+		"orphan": {FileID: "orphan", Parents: []string{"missing"}},
+	}
+
+	order := topoSort(byID)
+	if len(order) != 1 || order[0] != "orphan" {
+		t.Fatalf("order = %v, want [orphan]", order)
+	}
+}

--- a/internal/engine/restore_pipeline_test.go
+++ b/internal/engine/restore_pipeline_test.go
@@ -216,7 +216,8 @@ func TestRunWithWriter_RestoresFilesConcurrently(t *testing.T) {
 		t.Fatalf("prepareRestore: %v", err)
 	}
 	files := 0
-	for _, m := range plan.sorted {
+	for _, id := range plan.sorted {
+		m := plan.byID[id]
 		if m.Type != core.FileTypeFolder && m.ContentHash != "" {
 			files++
 		}


### PR DESCRIPTION
## Summary

- `topoSort` returns FileIDs and `restorePlan.sorted` carries that ordering, so `byID` is the only copy of the snapshot's metadata
- `filterByPath` works in IDs and drops the `restorePaths` map it built only to read each path once in the following loop
- `topoSort` marks an entry visited before recursing into its parents rather than after, so a parent cycle terminates instead of exhausting the stack

`prepareRestore` held the tree twice: `byID` mapped every FileID to a
`core.FileMeta`, and `topoSort` built a second slice of the same 216-byte structs
purely to sequence them.

Closes #439

## Measurements

With packfiles disabled, so the pack catalog term (#440) does not mask the
change. Peak RSS, three runs each, on the same tree:

| | 5 000 files | 50 000 files |
|---|---|---|
| `main` @ `ac7c4ae` | 156 156 156 MB | 189 187 186 MB |
| this branch | 155 156 155 MB | 156 155 156 MB |

Restore's own growth with tree size is now flat. Live heap at 50k drops from
99.8 MB to 86.5 MB, and `topoSort` leaves the heap profile entirely.

**With packfiles enabled there is no measurable change** — the catalog dominates
peak RSS and the run-to-run noise band is around ±60 MB, wider than this saving.
That is #440's ground, not this change's.

## The cycle change

Not strictly required by #439, and called out so it can be dropped if you'd
rather keep the PR to one thing. `visited` was set after recursing into parents,
so a filemeta whose parent chain forms a cycle recursed until the stack was
exhausted:

```
runtime: goroutine stack exceeds 1000000000-byte limit
fatal error: stack overflow
```

Reproduced by reverting just that line under `TestTopoSort_TerminatesOnAParentCycle`.
Such a cycle is not reachable from a repository this code wrote, but it is
reachable from a corrupt or hostile one, and the entries here come straight off
the store. For acyclic input the emitted order is identical either way.

## Verification

```bash
env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./internal/... .
```

```bash
env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./internal/engine/...
```

Both pass; lint reports 0 issues. New tests cover parent-before-child ordering,
cycle termination, and entries whose parents are absent from the snapshot.
