### PR TITLE
perf(store): serialize the pack catalog once when compacting

### DIFF
--- a/internal/storelayer/pack.go
+++ b/internal/storelayer/pack.go
@@ -471,7 +471,7 @@ func (s *PackStore) Flush(ctx context.Context) error {
 	}
 
 	if len(pending) > 0 {
-		if err := s.writeShard(ctx, pending); err != nil {
+		if _, err := s.writeShard(ctx, pending); err != nil {
 			s.mu.Lock()
 			for k, v := range pending {
 				s.pendingShard[k] = v

--- a/internal/storelayer/pack_compact_test.go
+++ b/internal/storelayer/pack_compact_test.go
@@ -1,0 +1,159 @@
+package storelayer
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cloudstic/cli/pkg/store/storetest"
+)
+
+// writeShard names the object it wrote. Compaction used to derive that name by
+// marshalling the same map a second time, which both doubled the cost and left
+// room for the two to disagree.
+func TestWriteShard_ReturnsTheKeyItWrote(t *testing.T) {
+	ctx := context.Background()
+	mem := storetest.NewMemStore()
+
+	s, err := NewPackStore(mem)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	key, err := s.writeShard(ctx, map[string]PackEntry{
+		"filemeta/a": {PackRef: "packs/one", Offset: 0, Length: 1},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(key, shardPrefix) {
+		t.Fatalf("key %q is not under %q", key, shardPrefix)
+	}
+	if _, err := mem.Get(ctx, key); err != nil {
+		t.Fatalf("nothing was written at the returned key %s: %v", key, err)
+	}
+
+	// Nothing to write is not an error, and names no object.
+	empty, err := s.writeShard(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if empty != "" {
+		t.Fatalf("empty shard returned key %q, want \"\"", empty)
+	}
+}
+
+// Compacting a catalog whose entries have all been deleted has no consolidated
+// shard to write, but must still remove the shards that named them -- that
+// removal is the whole reason the compaction runs. It must not claim a
+// consolidated shard exists, either, or the next load merges an absent object.
+func TestCompactCatalog_EmptiedCatalogRemovesItsShards(t *testing.T) {
+	ctx := context.Background()
+	mem := storetest.NewMemStore()
+
+	s, err := NewPackStore(mem)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keys := []string{"filemeta/a", "filemeta/b"}
+	for _, k := range keys {
+		if err := s.Put(ctx, k, []byte("v")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := s.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+	for _, k := range keys {
+		if err := s.Delete(ctx, k); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if _, err := s.CompactCatalog(ctx); err != nil {
+		t.Fatalf("CompactCatalog: %v", err)
+	}
+
+	s.mu.RLock()
+	merged := make([]string, 0, len(s.mergedIndex))
+	for k := range s.mergedIndex {
+		merged = append(merged, k)
+	}
+	s.mu.RUnlock()
+
+	for _, k := range merged {
+		if k == "" {
+			t.Error("mergedIndex records an empty key")
+			continue
+		}
+		if _, err := mem.Get(ctx, k); err != nil {
+			t.Errorf("mergedIndex names %s, which does not exist: %v", k, err)
+		}
+	}
+
+	// A fresh reader must not resurrect the deleted entries.
+	fresh, err := NewPackStore(mem)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, k := range keys {
+		if ok, err := fresh.Exists(ctx, k); err != nil {
+			t.Errorf("Exists(%s): %v", k, err)
+		} else if ok {
+			t.Errorf("%s came back after compaction removed it", k)
+		}
+	}
+}
+
+// The consolidated shard a compaction writes is the one it then refuses to
+// delete. If the key it recorded and the key it wrote could differ, compaction
+// would delete its own output and leave the catalog with nothing on the store.
+func TestCompactCatalog_KeepsTheShardItWrote(t *testing.T) {
+	ctx := context.Background()
+	mem := storetest.NewMemStore()
+
+	writer, err := NewPackStore(mem)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Two flushes, so there are two shards to consolidate.
+	for _, k := range []string{"filemeta/a", "filemeta/b"} {
+		if err := writer.Put(ctx, k, []byte("v")); err != nil {
+			t.Fatal(err)
+		}
+		if err := writer.Flush(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Compaction consolidates only shards the store has read. A store that wrote
+	// them never absorbed them, so the compaction has to run on a fresh reader.
+	s, err := NewPackStore(mem)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.CompactCatalog(ctx); err != nil {
+		t.Fatalf("CompactCatalog: %v", err)
+	}
+
+	shards, err := mem.List(ctx, shardPrefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(shards) != 1 {
+		t.Fatalf("after compaction there are %d shards, want 1: %v", len(shards), shards)
+	}
+
+	fresh, err := NewPackStore(mem)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, k := range []string{"filemeta/a", "filemeta/b"} {
+		got, err := fresh.Get(ctx, k)
+		if err != nil {
+			t.Errorf("Get(%s) after compaction: %v", k, err)
+		} else if string(got) != "v" {
+			t.Errorf("Get(%s) = %q, want %q", k, got, "v")
+		}
+	}
+}

--- a/internal/storelayer/packshard.go
+++ b/internal/storelayer/packshard.go
@@ -120,31 +120,51 @@ func mergePackIndex(data []byte, catalog map[string]PackEntry, refs packRefInter
 	return decoded, nil
 }
 
-// writeShard persists entries as a new immutable shard, named by the hash of
-// its own contents. Two runs that happen to produce identical shards write the
-// same object, which is harmless.
-func (s *PackStore) writeShard(ctx context.Context, entries map[string]PackEntry) error {
+// sealShard renders entries as the object a shard is stored as, returning the
+// key it belongs under and the bytes to write. An empty set has no shard and
+// returns an empty key.
+//
+// It performs no I/O, so a caller holding mu can seal the catalog in place and
+// release the lock before writing. That is what lets CompactCatalog avoid
+// copying the whole catalog purely to get it out from under the lock.
+func (s *PackStore) sealShard(entries map[string]PackEntry) (string, []byte, error) {
 	if len(entries) == 0 {
-		return nil
+		return "", nil, nil
 	}
 
 	plain, err := json.Marshal(entries)
 	if err != nil {
-		return fmt.Errorf("marshal pack index shard: %w", err)
+		return "", nil, fmt.Errorf("marshal pack index shard: %w", err)
 	}
 	sealed, err := sealIndex(plain, s.indexKey)
 	if err != nil {
-		return fmt.Errorf("seal pack index shard: %w", err)
+		return "", nil, fmt.Errorf("seal pack index shard: %w", err)
 	}
 
 	// Name by the plaintext hash so the key is stable regardless of the nonce a
 	// sealed shard carries.
-	key := shardPrefix + core.ComputeHash(plain)
+	return shardPrefix + core.ComputeHash(plain), sealed, nil
+}
+
+// writeShard persists entries as a new immutable shard and returns the key it
+// wrote, or an empty key when there was nothing to write. Two runs that happen
+// to produce identical shards write the same object, which is harmless.
+//
+// The key is returned rather than recomputed by the caller. Deriving it a second
+// time meant marshalling the whole map again, and a caller that derived it
+// differently — from a marshal that failed, say — would name an object that was
+// never written and then delete the shards it was meant to replace.
+func (s *PackStore) writeShard(ctx context.Context, entries map[string]PackEntry) (string, error) {
+	key, sealed, err := s.sealShard(entries)
+	if err != nil || key == "" {
+		return "", err
+	}
+
 	if err := s.ObjectStore.Put(ctx, key, sealed); err != nil {
-		return fmt.Errorf("write pack index shard %s: %w", key, err)
+		return "", fmt.Errorf("write pack index shard %s: %w", key, err)
 	}
 	s.debugf("pack: wrote shard %s with %d entries", key, len(entries))
-	return nil
+	return key, nil
 }
 
 // loadShardsLocked merges every shard into the in-memory catalog and returns
@@ -208,29 +228,45 @@ func (s *PackStore) CompactCatalog(ctx context.Context) (int, error) {
 	// Listing the prefix instead would put a shard written by someone else since
 	// we loaded into the delete set, and we would remove it without ever having
 	// read it.
+	//
+	// The catalog is sealed here, under the same lock, rather than copied out and
+	// marshalled afterwards. Sealing does no I/O, so the lock is held only for the
+	// marshal, and a repository large enough for compaction to matter is exactly
+	// the one whose catalog is expensive to duplicate.
 	s.mu.RLock()
 	absorbed := make([]string, 0, len(s.mergedIndex))
 	for key := range s.mergedIndex {
 		absorbed = append(absorbed, key)
 	}
 	pendingRemoval := s.needsCompaction
-	merged := make(map[string]PackEntry, len(s.catalog))
-	for k, v := range s.catalog {
-		merged[k] = v
+	shouldCompact := len(absorbed) > 1 || pendingRemoval
+	var consolidated string
+	var sealed []byte
+	var err error
+	if shouldCompact {
+		consolidated, sealed, err = s.sealShard(s.catalog)
 	}
 	s.mu.RUnlock()
 
 	// Consolidating a single object gains nothing — but a deletion is only
 	// durable once the index is rewritten, so a pending removal makes the
 	// rewrite necessary rather than merely useful.
-	if len(absorbed) <= 1 && !pendingRemoval {
+	if !shouldCompact {
 		return 0, nil
 	}
-
-	if err := s.writeShard(ctx, merged); err != nil {
+	if err != nil {
 		return 0, err
 	}
-	consolidated := shardPrefix + core.ComputeHash(mustMarshal(merged))
+
+	// An empty catalog has no consolidated shard to write. The inputs are still
+	// removed: every entry they named is gone, which is the deletion this
+	// compaction exists to make durable.
+	if consolidated != "" {
+		if err := s.ObjectStore.Put(ctx, consolidated, sealed); err != nil {
+			return 0, fmt.Errorf("write pack index shard %s: %w", consolidated, err)
+		}
+		s.debugf("pack: wrote consolidated shard %s", consolidated)
+	}
 
 	// Only now remove the inputs. Anything that fails to delete merges to the
 	// same result, so a later compaction reclaims it.
@@ -247,19 +283,12 @@ func (s *PackStore) CompactCatalog(ctx context.Context) (int, error) {
 
 	s.mu.Lock()
 	s.needsCompaction = false
-	s.mergedIndex = map[string]bool{consolidated: true}
+	s.mergedIndex = make(map[string]bool, 1)
+	if consolidated != "" {
+		s.mergedIndex[consolidated] = true
+	}
 	s.mu.Unlock()
 
 	s.debugf("pack: compacted %d index objects into %s", removed, consolidated)
 	return removed, nil
-}
-
-// mustMarshal reproduces the shard key for an already-validated map. The map
-// came from writeShard, which marshalled it successfully a moment earlier.
-func mustMarshal(entries map[string]PackEntry) []byte {
-	data, err := json.Marshal(entries)
-	if err != nil {
-		return nil
-	}
-	return data
 }

--- a/internal/storelayer/packshard_test.go
+++ b/internal/storelayer/packshard_test.go
@@ -20,13 +20,13 @@ func TestPackStore_LoadShardsInternsPackRefs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := writer.writeShard(ctx, map[string]PackEntry{
+	if _, err := writer.writeShard(ctx, map[string]PackEntry{
 		"filemeta/a": {PackRef: "packs/shared", Offset: 0, Length: 1},
 		"filemeta/b": {PackRef: "packs/shared", Offset: 1, Length: 1},
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if err := writer.writeShard(ctx, map[string]PackEntry{
+	if _, err := writer.writeShard(ctx, map[string]PackEntry{
 		"node/c": {PackRef: "packs/shared", Offset: 2, Length: 1},
 		"node/d": {PackRef: "packs/other", Offset: 0, Length: 1},
 	}); err != nil {


### PR DESCRIPTION
## Summary

- Split `sealShard` (render a shard, return its key and bytes, no I/O) from `writeShard` (seal plus `Put`, returning the key it wrote)
- `CompactCatalog` seals the catalog in place under the read lock it already holds, so it neither copies the catalog nor marshals it twice
- An emptied catalog records no consolidated shard, instead of recording the hash of `{}` as an absorbed object that was never written

`CompactCatalog` marshalled the catalog twice and copied it once: `writeShard`
marshalled it to derive the key it wrote to, then `mustMarshal` marshalled the
identical map again solely to recompute that key. On a 50k-file repository each
marshal is a ~19 MB byte slice, both live alongside the duplicate map.

Closes #438

## The correctness half

`mustMarshal` returned `nil` on error, so a failed marshal named
`core.ComputeHash(nil)` — the hash of no bytes. Compaction would then record a
consolidated shard that was never written *and* delete the shards it was meant to
replace.

The same key showed up on a path that needs no marshal failure at all. When every
entry has been deleted, `writeShard` returns early without writing, but the caller
still computed `shardPrefix + ComputeHash(mustMarshal(merged))` and stored it in
`mergedIndex`. Verified against `main` at `ee61760`:

```
mergedIndex names index/packmap/44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a,
which does not exist: not found: index/packmap/44136fa...
```

That is `sha256("{}")`. `TestCompactCatalog_EmptiedCatalogRemovesItsShards` fails
on `main` and passes here.

## Note on the lock

Sealing now happens under `s.mu.RLock` rather than after copying the catalog out.
Sealing does no I/O — the `Put` still happens after the unlock — so the lock is
held for a marshal rather than a round trip, and it is a read lock, so concurrent
readers are unaffected. A repository large enough for compaction to matter is
exactly the one whose catalog is expensive to duplicate.

## Verification

```bash
env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./internal/storelayer/... ./internal/engine/... .
```

```bash
env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./internal/storelayer/...
```

Both pass; lint reports 0 issues.
