### PR TITLE
perf(store): read packed objects with ranged reads

### DIFF
--- a/internal/storelayer/pack.go
+++ b/internal/storelayer/pack.go
@@ -63,6 +63,10 @@ type PackStore struct {
 
 	// LRU cache for recently downloaded packfiles to accelerate Get() and HAMT walks
 	packCache *lru.Cache[string, []byte]
+
+	// Misses per pack since it was last cached, used to decide when reading one
+	// object at a time is no longer the cheaper option. See resolveFromPack.
+	packMisses *lru.Cache[string, int]
 }
 
 // PackEntry represents the location of a small object within a packfile.
@@ -98,6 +102,11 @@ func NewPackStore(inner store.ObjectStore, opts ...PackOption) (*PackStore, erro
 		return nil, fmt.Errorf("pack cache init: %w", err)
 	}
 
+	misses, err := lru.New[string, int](packMissWindow)
+	if err != nil {
+		return nil, fmt.Errorf("pack miss counter init: %w", err)
+	}
+
 	s := &PackStore{
 		ObjectStore:  inner,
 		packBuffer:   new(bytes.Buffer),
@@ -106,6 +115,7 @@ func NewPackStore(inner store.ObjectStore, opts ...PackOption) (*PackStore, erro
 		pendingShard: make(map[string]PackEntry),
 		mergedIndex:  make(map[string]bool),
 		packCache:    cache,
+		packMisses:   misses,
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -343,14 +353,76 @@ func (s *PackStore) Get(ctx context.Context, key string) ([]byte, error) {
 		return data, nil
 	}
 
-	s.debugf("get %s: downloading pack %s", key, entry.PackRef)
-	// 4. Download the entire packfile, cache it, and return the slice
+	return s.resolveFromPack(ctx, key, entry)
+}
+
+const (
+	// packPromoteAfter is how many times a pack may be read one object at a time
+	// before the whole thing is fetched and cached instead.
+	//
+	// The two access patterns this sits between were measured (RFC 0023). A scan
+	// -- check, ls, prune -- walks a pack's objects consecutively, so one transfer
+	// serves thousands of reads and ranged reads would be thousands of round
+	// trips instead of one. A scattered read -- restore's write phase, or a cat
+	// of a single file -- touches a pack once or twice, so fetching up to
+	// maxPackSize to return a few hundred bytes is nearly all waste.
+	//
+	// The threshold is asymmetric in what it costs each pattern, which is why it
+	// is not 2. A scan pays at most packPromoteAfter-1 extra small requests per
+	// pack visit -- a few hundred across a repository, against transfers it makes
+	// anyway. A scattered read pays one whole pack per packPromoteAfter misses,
+	// which is bytes, and bytes are what a remote backend bills for.
+	//
+	// Measured on a 51-pack tree, restore's whole-pack transfers against this
+	// value: 2857 at 2, 1419 at 4, 719 at 8, 358 at 16, 179 at 32. Most of the
+	// benefit is captured by 8, and beyond it the round trips traded away start
+	// to matter more than the bytes saved.
+	packPromoteAfter = 8
+
+	// packMissWindow bounds the miss counter. It only has to span the packs in
+	// flight around a given moment, and it must not become a second unbounded
+	// per-repository structure -- which is the thing RFC 0023 is about.
+	packMissWindow = 64
+)
+
+// resolveFromPack returns one object from a pack that is not in the body cache.
+//
+// Reading the whole pack to return a slice of it is right when the pack is being
+// scanned and wrong when it is being sampled, and the two are indistinguishable
+// at the first miss. So the first misses are served by ranged reads, and a pack
+// that keeps missing is fetched whole and cached -- see packPromoteAfter.
+func (s *PackStore) resolveFromPack(ctx context.Context, key string, entry PackEntry) ([]byte, error) {
+	ranger, canRange := s.ObjectStore.(store.RangeGetter)
+
+	misses := 0
+	if n, ok := s.packMisses.Get(entry.PackRef); ok {
+		misses = n
+	}
+	misses++
+	s.packMisses.Add(entry.PackRef, misses)
+
+	if canRange && misses < packPromoteAfter {
+		data, err := ranger.GetRange(ctx, entry.PackRef, entry.Offset, entry.Length)
+		if err != nil {
+			return nil, fmt.Errorf("read %s from pack %s: %w", key, entry.PackRef, err)
+		}
+		if int64(len(data)) != entry.Length {
+			return nil, fmt.Errorf("ranged read of %s from pack %s returned %d bytes, want %d",
+				key, entry.PackRef, len(data), entry.Length)
+		}
+		s.debugf("get %s: ranged read from pack %s (len=%d)", key, entry.PackRef, entry.Length)
+		return data, nil
+	}
+
+	s.debugf("get %s: downloading pack %s (miss %d)", key, entry.PackRef, misses)
 	packData, err := s.ObjectStore.Get(ctx, entry.PackRef)
 	if err != nil {
 		return nil, fmt.Errorf("fetch pack %s for key %s: %w", entry.PackRef, key, err)
 	}
 
 	s.packCache.Add(entry.PackRef, packData)
+	// The pack is cached now, so the misses that led here are spent.
+	s.packMisses.Remove(entry.PackRef)
 
 	if int64(len(packData)) < entry.Offset+entry.Length {
 		return nil, fmt.Errorf("downloaded packfile %s is too small", entry.PackRef)

--- a/internal/storelayer/pack.go
+++ b/internal/storelayer/pack.go
@@ -385,6 +385,35 @@ const (
 	packMissWindow = 64
 )
 
+// rangesNatively reports whether a ranged read on s reaches a backend that
+// serves it as a ranged read, rather than one that emulates it by transferring
+// the whole object and slicing.
+//
+// Implementing store.RangeGetter is not the same claim. DebugStore declares the
+// method unconditionally and falls back to a full Get over an inner store that
+// cannot range, which is right for the footer path — there the fallback costs
+// exactly what not ranging would have cost anyway. It is wrong here, because
+// this decides *whether* to range: emulated ranging would transfer the whole
+// pack on every one of the first packPromoteAfter misses and never populate the
+// body cache, which is worse than not ranging at all.
+//
+// So walk to the bottom of the wrapper chain and ask the backend itself.
+func rangesNatively(s store.ObjectStore) bool {
+	for {
+		u, ok := s.(store.Unwrapper)
+		if !ok {
+			break
+		}
+		inner := u.Unwrap()
+		if inner == nil {
+			break
+		}
+		s = inner
+	}
+	_, ok := s.(store.RangeGetter)
+	return ok
+}
+
 // resolveFromPack returns one object from a pack that is not in the body cache.
 //
 // Reading the whole pack to return a slice of it is right when the pack is being
@@ -393,6 +422,7 @@ const (
 // that keeps missing is fetched whole and cached -- see packPromoteAfter.
 func (s *PackStore) resolveFromPack(ctx context.Context, key string, entry PackEntry) ([]byte, error) {
 	ranger, canRange := s.ObjectStore.(store.RangeGetter)
+	canRange = canRange && rangesNatively(s.ObjectStore)
 
 	misses := 0
 	if n, ok := s.packMisses.Get(entry.PackRef); ok {

--- a/internal/storelayer/packrange_object_test.go
+++ b/internal/storelayer/packrange_object_test.go
@@ -1,0 +1,189 @@
+package storelayer
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cloudstic/cli/pkg/store"
+	"github.com/cloudstic/cli/pkg/store/local"
+)
+
+// seedPackWithObjects writes n objects of the given size through a PackStore and
+// flushes, returning the keys and the counting store wrapping the backend.
+func seedPackWithObjects(t *testing.T, ctx context.Context, n, size int) ([]string, *countingRangeStore, *PackStore) {
+	t.Helper()
+
+	base, err := local.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	counting := &countingRangeStore{ObjectStore: base}
+	writer, err := NewPackStore(counting)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	payload := bytes.Repeat([]byte("x"), size)
+	keys := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		key := fmt.Sprintf("filemeta/%064x", i)
+		if err := writer.Put(ctx, key, payload); err != nil {
+			t.Fatal(err)
+		}
+		keys = append(keys, key)
+	}
+	if err := writer.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	reader, err := NewPackStore(counting)
+	if err != nil {
+		t.Fatal(err)
+	}
+	counting.fullGets, counting.rangeGets, counting.bytesRead = 0, 0, 0
+	counting.rangeCalls = nil
+	return keys, counting, reader
+}
+
+// A one-off read must transfer the object, not the packfile around it. This is
+// the sampled pattern: `cat` of a single file, or restore touching a pack once.
+func TestPackStore_ReadsOneObjectWithARangedRead(t *testing.T) {
+	ctx := context.Background()
+	keys, counting, reader := seedPackWithObjects(t, ctx, 40, 16*1024)
+
+	got, err := reader.Get(ctx, keys[7])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 16*1024 {
+		t.Fatalf("got %d bytes, want %d", len(got), 16*1024)
+	}
+
+	if counting.fullGets != 0 {
+		t.Errorf("transferred %d whole packfiles for a single object", counting.fullGets)
+	}
+	if counting.rangeGets != 1 {
+		t.Errorf("ranged reads = %d, want 1", counting.rangeGets)
+	}
+	// The pack holds 40 x 16 KB; a ranged read must be about one object.
+	if counting.bytesRead > 64*1024 {
+		t.Errorf("read %d bytes to return %d", counting.bytesRead, len(got))
+	}
+}
+
+// A scan of the same pack must not degrade into one request per object. After a
+// couple of misses the pack is fetched whole and cached, so the rest are served
+// from memory -- which is what makes check, ls and prune cheap.
+func TestPackStore_PromotesToWholePackWhenScanning(t *testing.T) {
+	ctx := context.Background()
+	keys, counting, reader := seedPackWithObjects(t, ctx, 40, 16*1024)
+
+	for _, key := range keys {
+		if _, err := reader.Get(ctx, key); err != nil {
+			t.Fatalf("Get(%s): %v", key, err)
+		}
+	}
+
+	if counting.fullGets != 1 {
+		t.Errorf("whole-pack transfers = %d, want 1 (a scan should promote once)", counting.fullGets)
+	}
+	if counting.rangeGets >= len(keys) {
+		t.Errorf("ranged reads = %d for %d objects; the scan never promoted", counting.rangeGets, len(keys))
+	}
+	if counting.rangeGets > packPromoteAfter {
+		t.Errorf("ranged reads = %d, want at most %d before promotion", counting.rangeGets, packPromoteAfter)
+	}
+}
+
+// Sampling many packs must stay ranged rather than promoting each one, which is
+// the pattern that made restore expensive.
+func TestPackStore_SampledReadsAcrossPacksStayRanged(t *testing.T) {
+	ctx := context.Background()
+
+	base, err := local.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	counting := &countingRangeStore{ObjectStore: base}
+	writer, err := NewPackStore(counting)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// One object per pack: flushing after each Put forces a pack boundary.
+	payload := bytes.Repeat([]byte("y"), 8*1024)
+	var keys []string
+	for i := 0; i < 12; i++ {
+		key := fmt.Sprintf("filemeta/%064x", i)
+		if err := writer.Put(ctx, key, payload); err != nil {
+			t.Fatal(err)
+		}
+		if err := writer.Flush(ctx); err != nil {
+			t.Fatal(err)
+		}
+		keys = append(keys, key)
+	}
+
+	reader, err := NewPackStore(counting)
+	if err != nil {
+		t.Fatal(err)
+	}
+	counting.fullGets, counting.rangeGets, counting.bytesRead = 0, 0, 0
+
+	for _, key := range keys {
+		if _, err := reader.Get(ctx, key); err != nil {
+			t.Fatalf("Get(%s): %v", key, err)
+		}
+	}
+
+	if counting.fullGets != 0 {
+		t.Errorf("whole-pack transfers = %d; touching each pack once should stay ranged", counting.fullGets)
+	}
+	if counting.rangeGets != len(keys) {
+		t.Errorf("ranged reads = %d, want %d", counting.rangeGets, len(keys))
+	}
+}
+
+// A backend without RangeGetter keeps the old behaviour, which is correct
+// everywhere and merely slower.
+func TestPackStore_FallsBackToWholePackWithoutRangeGetter(t *testing.T) {
+	ctx := context.Background()
+
+	base, err := local.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	plain := &noRangeStore{ObjectStore: base}
+	writer, err := NewPackStore(plain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := fmt.Sprintf("filemeta/%064x", 1)
+	payload := bytes.Repeat([]byte("z"), 16*1024)
+	if err := writer.Put(ctx, key, payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	reader, err := NewPackStore(plain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := reader.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("got %d bytes, want %d", len(got), len(payload))
+	}
+}
+
+// noRangeStore hides an inner store's GetRange, so PackStore must take the
+// whole-pack path.
+type noRangeStore struct{ store.ObjectStore }
+
+func (n *noRangeStore) Unwrap() store.ObjectStore { return nil }

--- a/internal/storelayer/packrange_object_test.go
+++ b/internal/storelayer/packrange_object_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"testing"
 
 	"github.com/cloudstic/cli/pkg/store"
@@ -92,8 +93,11 @@ func TestPackStore_PromotesToWholePackWhenScanning(t *testing.T) {
 	if counting.rangeGets >= len(keys) {
 		t.Errorf("ranged reads = %d for %d objects; the scan never promoted", counting.rangeGets, len(keys))
 	}
-	if counting.rangeGets > packPromoteAfter {
-		t.Errorf("ranged reads = %d, want at most %d before promotion", counting.rangeGets, packPromoteAfter)
+	// Exactly the configured boundary: fewer would mean promotion fired early
+	// (and zero would mean ranging never happened at all, which these checks
+	// must not accept), more would mean it never fired.
+	if want := packPromoteAfter - 1; counting.rangeGets != want {
+		t.Errorf("ranged reads before promotion = %d, want %d", counting.rangeGets, want)
 	}
 }
 
@@ -187,3 +191,79 @@ func TestPackStore_FallsBackToWholePackWithoutRangeGetter(t *testing.T) {
 type noRangeStore struct{ store.ObjectStore }
 
 func (n *noRangeStore) Unwrap() store.ObjectStore { return nil }
+
+// A DebugStore over a backend that cannot range satisfies store.RangeGetter but
+// emulates it with a full transfer. Treating that as native would make every
+// miss before promotion download the whole pack *and* skip the body cache --
+// worse than never ranging. The whole-pack path must be taken instead.
+func TestPackStore_DoesNotRangeThroughAnEmulatingWrapper(t *testing.T) {
+	ctx := context.Background()
+
+	base, err := local.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// noRangeStore hides local's GetRange; DebugStore then re-declares it and
+	// emulates, which is exactly the shape being guarded against.
+	emulating := store.NewDebugStore(&noRangeStore{ObjectStore: base}, io.Discard)
+	if _, ok := interface{}(emulating).(store.RangeGetter); !ok {
+		t.Fatal("fixture is wrong: DebugStore should satisfy RangeGetter")
+	}
+	if rangesNatively(emulating) {
+		t.Fatal("emulated ranging was reported as native")
+	}
+
+	counting := &countingRangeStore{ObjectStore: emulating}
+	writer, err := NewPackStore(counting)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := fmt.Sprintf("filemeta/%064x", 3)
+	payload := bytes.Repeat([]byte("w"), 16*1024)
+	if err := writer.Put(ctx, key, payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	reader, err := NewPackStore(counting)
+	if err != nil {
+		t.Fatal(err)
+	}
+	counting.fullGets, counting.rangeGets, counting.bytesRead = 0, 0, 0
+
+	got, err := reader.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("got %d bytes, want %d", len(got), len(payload))
+	}
+	if counting.rangeGets != 0 {
+		t.Errorf("ranged reads = %d through an emulating wrapper, want 0", counting.rangeGets)
+	}
+	if counting.fullGets != 1 {
+		t.Errorf("whole-pack transfers = %d, want 1", counting.fullGets)
+	}
+
+	// And the pack must be cached, so a second read costs nothing.
+	if _, err := reader.Get(ctx, key); err != nil {
+		t.Fatal(err)
+	}
+	if counting.fullGets != 1 {
+		t.Errorf("whole-pack transfers = %d after a second read; the pack was not cached", counting.fullGets)
+	}
+}
+
+// A native ranger behind a DebugStore is still native -- --debug must not turn
+// ranged reads off any more than it should turn them on.
+func TestPackStore_RangesThroughADebugStoreOverANativeRanger(t *testing.T) {
+	base, err := local.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rangesNatively(store.NewDebugStore(base, io.Discard)) {
+		t.Error("a native ranger behind DebugStore was reported as emulated")
+	}
+}

--- a/internal/storelayer/packrange_test.go
+++ b/internal/storelayer/packrange_test.go
@@ -19,6 +19,10 @@ type countingRangeStore struct {
 	rangeCalls []int64
 }
 
+// Unwrap exposes the inner store, as every wrapper in this codebase does. It is
+// what lets rangesNatively see past a counter to the backend underneath.
+func (c *countingRangeStore) Unwrap() store.ObjectStore { return c.ObjectStore }
+
 func (c *countingRangeStore) Get(ctx context.Context, key string) ([]byte, error) {
 	data, err := c.ObjectStore.Get(ctx, key)
 	if strings.HasPrefix(key, packPrefix) {


### PR DESCRIPTION
## Summary

- `PackStore.Get` resolves a packed object with a ranged read instead of downloading the whole packfile
- A pack that keeps missing the body cache is still fetched whole and cached, so a scan does not degrade into one request per object
- Backends without `store.RangeGetter` keep the previous behaviour

`readPackFooter` has used `RangeGetter` since RFC 0018, and
`TestPackStore_UsesRangedReadsForFooters` exists to stop that path regressing to
whole-pack transfers. The object path never got the same treatment, so retrieving
one ~200-byte filemeta from a cold pack transferred up to `maxPackSize`, and any
working set larger than the four-entry body cache re-transferred packs.

Closes #451

## Why not simply always range

Because that would be worse for three of the four operations. Tracing for
RFC 0023 showed `check`, `ls` and `prune` walk a pack's objects consecutively —
one transfer serves thousands of reads, and serving those individually would be
thousands of round trips instead of one.

So the first misses on a pack are ranged, and a pack that keeps missing is
promoted to a whole-pack fetch. The threshold is deliberately not 2, because it
costs the two patterns asymmetrically: a scan pays at most seven extra small
requests per pack visit against transfers it already makes, while a scattered
read pays one whole pack per eight misses instead of one per miss.

Restore's whole-pack transfers on a 51-pack tree, sweeping the threshold:

| threshold | 2 | 4 | **8** | 16 | 32 |
|---|---|---|---|---|---|
| whole-pack | 2857 | 1419 | **719** | 358 | 179 |
| ranged | 2860 | 4269 | **5060** | 5422 | 5661 |

Most of the benefit is captured by 8; past it the round trips traded away start
to outweigh the bytes saved. Against `main`, which does 5728 whole-pack transfers
and no ranged reads, that is an 8x reduction in pack transfers.

## Scope note

This limits the damage rather than removing it. The reason restore scatters
across packs at all is its write-phase ordering (`topoSort`), measured at 55.5%
misses against 0.6% for its metadata phase. RFC 0023 §5 covers fixing that, which
would make this path largely moot for restore — but the ranged read is still the
right behaviour for `cat`, for partial restores, and for any sampled access.

## Verification

New tests cover both patterns and the fallback, and each fails if the whole-pack
path is forced:

- `TestPackStore_ReadsOneObjectWithARangedRead` — a single cold read transfers the object, not the pack (forced whole-pack: "read 659499 bytes to return 16384")
- `TestPackStore_PromotesToWholePackWhenScanning` — a scan promotes once and does not issue a request per object
- `TestPackStore_SampledReadsAcrossPacksStayRanged` — touching many packs once each stays ranged
- `TestPackStore_FallsBackToWholePackWithoutRangeGetter`

```bash
env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./internal/storelayer/... ./internal/engine/... .
```

```bash
env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./internal/storelayer/...
```

Both pass; lint reports 0 issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved pack access by using targeted ranged reads for initial object requests.
  * Automatically switches to full-pack caching after repeated accesses for faster subsequent retrievals.
  * Supports efficient reads across multiple packs and gracefully falls back when ranged reads are unavailable.

* **Reliability**
  * Added clearer handling and reporting for ranged-read failures and incomplete responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->