### PR TITLE
test(benchmark): resolve smaller effects in memory.sh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,8 @@ golangci-lint run ./...
 # Format
 go fmt ./...
 
-# Peak memory as a function of repository size (minutes, not seconds)
-SIZES="5000 20000" ./scripts/benchmark/memory.sh
+# Memory as a function of repository size (minutes, not seconds)
+SIZES="5000 20000" SAMPLES=3 ./scripts/benchmark/memory.sh
 ```
 
 ### Performance measurement
@@ -51,12 +51,18 @@ Three layers, in cost order:
   reason — which would silently move numbers a trend line is built on. The two
   share `lib.sh` for measurement mechanics and nothing else; in particular
   their datasets are separate, which is the whole point.
-- **`scripts/benchmark/memory.sh`** — peak RSS for each operation across
-  several tree sizes. This is the one that answers "does this grow with the
-  repository", which a single measurement cannot: an operation holding a fixed
-  working set is fine at any scale, one holding a per-entry structure
-  eventually meets a repository it cannot open. What the `Memory scaling`
-  workflow runs.
+- **`scripts/benchmark/memory.sh`** — peak RSS and cumulative allocation for
+  each operation across several tree sizes. Peak RSS is the one that answers
+  "does this grow with the repository", which a single measurement cannot: an
+  operation holding a fixed working set is fine at any scale, one holding a
+  per-entry structure eventually meets a repository it cannot open.
+  Peak RSS is a high-water mark, though, and blind to churn the collector
+  reclaims: PR #449 removed 36 MB of allocation from `CompactCatalog` and
+  moved peak RSS by 5 MB, inside the ±60 MB run-to-run spread observed on one
+  machine — allocation is the column that shows a change like that. Each
+  point is `SAMPLES` repetitions (default 3) reduced to a median with its
+  min–max band, because a single sample cannot tell a real change from a
+  noisy run. What the `Memory scaling` workflow runs.
 
 Both workflows trigger the same two ways: dispatched by hand against any ref,
 or by putting the `benchmark` label on a pull request. One label asks for the
@@ -77,7 +83,20 @@ after that is Go: `benchreport run` measures a child process (peak RSS comes
 from the wait4 rusage rather than parsing `/usr/bin/time`, whose flag, label
 and unit all differ between BSD and GNU), `benchreport row` accepts numbers a
 harness measured itself, and `benchreport render` produces the table and
-charts. That half is unit-tested; the same logic in awk and bc was not.
+charts — including the sample median and min–max band once a CSV holds more
+than one row per point, and a second table for the allocation total once any
+row carries one. That half is unit-tested; the same logic in awk and bc was
+not.
+
+Allocation comes from inside the measured process, not the parent: `-memstats
+<path>` (`cmd/cloudstic/profiling.go`) makes cloudstic dump
+`runtime.MemStats.TotalAlloc` as JSON on exit, and `benchreport run -alloc-from
+<path>` reads it back. That is deliberately not a heap profile — `go tool pprof
+-alloc_space` samples one allocation per 512 KB by default, which puts a
+30–50 MB delta inside the sampling error at the sizes this sweep uses, and
+running a profiler at all perturbs the RSS being measured in the same pass.
+`TotalAlloc` is a counter the runtime already maintains, so reading it back is
+exact and free.
 
 Retention bugs are invisible to `B/op` — see `docs/caching.md` for a worked
 example where the allocation delta understated the cost roughly fivefold.

--- a/cmd/cloudstic/main.go
+++ b/cmd/cloudstic/main.go
@@ -14,15 +14,15 @@ func main() {
 }
 
 func run() int {
-	cpuprofile, memprofile := parseProfileFlags()
+	prof := parseProfileFlags()
 
 	if len(os.Args) < 2 {
 		printUsage(os.Stdout)
 		return 1
 	}
 
-	if cpuprofile != "" {
-		stop := startCPUProfile(cpuprofile)
+	if prof.cpuProfile != "" {
+		stop := startCPUProfile(prof.cpuProfile)
 		defer stop()
 	}
 
@@ -34,8 +34,11 @@ func run() int {
 
 	exitCode := runCmd(newRunner(os.Args[2:]), ctx, os.Args[1])
 
-	if memprofile != "" {
-		writeMemProfile(memprofile)
+	if prof.memProfile != "" {
+		writeMemProfile(prof.memProfile)
+	}
+	if prof.memStats != "" {
+		writeMemStats(prof.memStats)
 	}
 
 	return exitCode

--- a/cmd/cloudstic/profiling.go
+++ b/cmd/cloudstic/profiling.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"runtime"
@@ -8,31 +9,59 @@ import (
 	"strings"
 )
 
-// parseProfileFlags strips -cpuprofile and -memprofile from os.Args and
-// returns their values. os.Args is updated in place with those flags removed
-// so the rest of the CLI flag parsing is unaffected.
-func parseProfileFlags() (cpuprofile, memprofile string) {
-	var newArgs []string
-	newArgs = append(newArgs, os.Args[0])
+// profileFlags are the measurement knobs, stripped from os.Args before the
+// ordinary flag parsing runs.
+//
+// They are deliberately handled here rather than declared as flagSpecs: they
+// belong to the benchmark harness, not to the command surface, and routing them
+// through flagspec.go would put them in `-h` output, shell completion and the
+// help golden files for every command.
+type profileFlags struct {
+	cpuProfile string
+	memProfile string
+	memStats   string
+}
+
+// parseProfileFlags strips -cpuprofile, -memprofile and -memstats from os.Args
+// and returns their values. os.Args is updated in place with those flags
+// removed so the rest of the CLI flag parsing is unaffected.
+func parseProfileFlags() profileFlags {
+	var p profileFlags
+	// Each knob is a name and where its value lands, so adding one is a line
+	// rather than another pair of switch arms.
+	knobs := []struct {
+		name string
+		dst  *string
+	}{
+		{"-cpuprofile", &p.cpuProfile},
+		{"-memprofile", &p.memProfile},
+		{"-memstats", &p.memStats},
+	}
+
+	newArgs := []string{os.Args[0]}
 	for i := 1; i < len(os.Args); i++ {
 		a := os.Args[i]
-		switch {
-		case strings.HasPrefix(a, "-cpuprofile="):
-			cpuprofile = strings.TrimPrefix(a, "-cpuprofile=")
-		case a == "-cpuprofile" && i+1 < len(os.Args):
-			i++
-			cpuprofile = os.Args[i]
-		case strings.HasPrefix(a, "-memprofile="):
-			memprofile = strings.TrimPrefix(a, "-memprofile=")
-		case a == "-memprofile" && i+1 < len(os.Args):
-			i++
-			memprofile = os.Args[i]
-		default:
+		matched := false
+		for _, k := range knobs {
+			switch {
+			case strings.HasPrefix(a, k.name+"="):
+				*k.dst = strings.TrimPrefix(a, k.name+"=")
+				matched = true
+			case a == k.name && i+1 < len(os.Args):
+				i++
+				*k.dst = os.Args[i]
+				matched = true
+			}
+			if matched {
+				break
+			}
+		}
+		if !matched {
 			newArgs = append(newArgs, a)
 		}
 	}
 	os.Args = newArgs
-	return
+	return p
 }
 
 func startCPUProfile(path string) (stop func()) {
@@ -68,6 +97,53 @@ func startCPUProfile(path string) (stop func()) {
 				_ = pf.Close()
 			}
 		}
+	}
+}
+
+// memStats is the allocation summary written by -memstats.
+//
+// Peak RSS answers "how much was live at once" and is blind to allocation that
+// is freed again: a change removing 36 MB of transient garbage moves TotalAlloc
+// by 36 MB and peak RSS by nothing measurable. The benchmark harness reports
+// both for that reason.
+//
+// The counters come from runtime.MemStats rather than the two alternatives:
+//
+//   - A heap profile (-memprofile) read with `go tool pprof -alloc_space` is
+//     *sampled* — one sample per 512 KB by default — so a small delta lands in
+//     the sampling error, and collecting it perturbs the RSS being measured in
+//     the same pass. Measuring the two separately would double the harness's
+//     runtime.
+//   - GODEBUG=gctrace=1 emits a debug format the Go release notes explicitly
+//     decline to keep stable, and reports heap size at each GC rather than a
+//     cumulative total, which has to be reconstructed by summing.
+//
+// TotalAlloc is a counter the runtime maintains regardless. Reading it is
+// exact, costs nothing, needs no parsing, and happens in the same run that
+// produced the RSS number beside it.
+type memStats struct {
+	TotalAllocBytes uint64 `json:"total_alloc_bytes"` // cumulative, including freed
+	Mallocs         uint64 `json:"mallocs"`
+	HeapSysBytes    uint64 `json:"heap_sys_bytes"`
+	NumGC           uint32 `json:"num_gc"`
+}
+
+func writeMemStats(path string) {
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+
+	data, err := json.Marshal(memStats{
+		TotalAllocBytes: ms.TotalAlloc,
+		Mallocs:         ms.Mallocs,
+		HeapSysBytes:    ms.HeapSys,
+		NumGC:           ms.NumGC,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "could not encode memory stats: %v\n", err)
+		return
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "could not write memory stats: %v\n", err)
 	}
 }
 

--- a/internal/benchreport/csv.go
+++ b/internal/benchreport/csv.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 )
 
-var header = []string{"tool", "operation", "scale", "seconds", "peak_mb", "repo_delta"}
+var header = []string{"tool", "operation", "scale", "seconds", "peak_mb", "alloc_mb", "repo_delta"}
 
 // AppendRow adds one measurement to path, writing the header first if the file
 // is new.
@@ -37,10 +37,17 @@ func AppendRow(path string, row Row) error {
 		"",
 		strconv.FormatFloat(row.Seconds, 'f', 2, 64),
 		strconv.FormatFloat(row.PeakMB, 'f', 1, 64),
+		"",
 		row.RepoDelta,
 	}
 	if row.Scale > 0 {
 		rec[2] = strconv.Itoa(row.Scale)
+	}
+	// Left empty rather than written as 0 when the harness did not measure it,
+	// for the same reason as Scale: a zero reads as a real measurement, and
+	// only cloudstic can report its own allocation total.
+	if row.AllocMB > 0 {
+		rec[5] = strconv.FormatFloat(row.AllocMB, 'f', 1, 64)
 	}
 	if err := w.Write(rec); err != nil {
 		return err

--- a/internal/benchreport/measure.go
+++ b/internal/benchreport/measure.go
@@ -1,6 +1,7 @@
 package benchreport
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -34,4 +35,30 @@ func Measure(name string, args []string, stdout, stderr io.Writer) (seconds floa
 		return elapsed.Seconds(), 0, err
 	}
 	return elapsed.Seconds(), float64(bytes) / (1024 * 1024), nil
+}
+
+// ReadAllocMB reads the cumulative allocation total from the file cloudstic
+// wrote for -memstats.
+//
+// Peak RSS is a high-water mark, so it says nothing about allocation the
+// collector reclaimed before the peak — which is where most of the churn in a
+// backup lives. The measured process reports its own runtime.MemStats.TotalAlloc
+// because that counter is exact and free, where a sampled heap profile would put
+// the change inside its own sampling error and perturb the RSS beside it. See
+// cmd/cloudstic/profiling.go.
+func ReadAllocMB(path string) (float64, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, fmt.Errorf("read memstats: %w", err)
+	}
+	var ms struct {
+		TotalAllocBytes uint64 `json:"total_alloc_bytes"`
+	}
+	if err := json.Unmarshal(data, &ms); err != nil {
+		return 0, fmt.Errorf("parse memstats %s: %w", path, err)
+	}
+	if ms.TotalAllocBytes == 0 {
+		return 0, fmt.Errorf("memstats %s reports no allocation; was -memstats passed to the measured command?", path)
+	}
+	return float64(ms.TotalAllocBytes) / (1024 * 1024), nil
 }

--- a/internal/benchreport/render.go
+++ b/internal/benchreport/render.go
@@ -20,11 +20,27 @@ func Render(w io.Writer, rep *Report, title string) error {
 
 	switch rep.Kind() {
 	case KindScaling:
-		b.WriteString("Peak resident set size of the real binary, per operation, at each tree\n" +
-			"size. A row that stays flat holds a working set; one that tracks the file\n" +
-			"count holds a per-entry structure, and will eventually meet a repository it\n" +
-			"cannot open.\n\n")
-		renderScalingTable(b, rep)
+		b.WriteString("Measurements of the real binary, per operation, at each tree size. A row\n" +
+			"that stays flat holds a working set; one that tracks the file count holds a\n" +
+			"per-entry structure, and will eventually meet a repository it cannot open.\n\n")
+		writeSampleNote(b, rep)
+
+		b.WriteString("### Peak RSS (MB)\n\n")
+		b.WriteString("The largest amount live at once — what decides whether an operation fits\n" +
+			"in the memory available.\n\n")
+		renderScalingTable(b, rep, PeakMB)
+
+		// Peak RSS is blind to allocation that is freed again, which is most of
+		// it: a change removing tens of MB of garbage leaves the high-water mark
+		// where it was. The two columns answer different questions and neither
+		// substitutes for the other.
+		if rep.hasAlloc() {
+			b.WriteString("\n### Total allocated (MB)\n\n")
+			b.WriteString("Cumulative bytes allocated, freed or not. Peak RSS cannot see churn that\n" +
+				"the collector reclaims, so this is the column that moves when an operation\n" +
+				"stops allocating something it did not need.\n\n")
+			renderScalingTable(b, rep, AllocMB)
+		}
 	case KindComparison:
 		if len(rep.Tools()) > 1 {
 			b.WriteString("Each tool over the same dataset. Times on a shared runner carry several\n" +
@@ -35,6 +51,7 @@ func Render(w io.Writer, rep *Report, title string) error {
 				"percent of noise, so read them for their order of magnitude rather than\n" +
 				"their last digit; the bytes added are exact.\n\n")
 		}
+		writeSampleNote(b, rep)
 		renderComparisonTable(b, rep)
 	}
 
@@ -51,11 +68,23 @@ func Render(w io.Writer, rep *Report, title string) error {
 	return err
 }
 
+// writeSampleNote explains the median and the band, but only for a harness
+// that actually repeated itself. Saying "median of 1 run" would advertise a
+// precision the numbers do not have.
+func writeSampleNote(b *strings.Builder, rep *Report) {
+	n := rep.Samples()
+	if n < 2 {
+		return
+	}
+	fmt.Fprintf(b, "Each point is the median of %d runs, with the min–max band in\n"+
+		"parentheses. A difference smaller than that band is noise, not a result.\n\n", n)
+}
+
 // ---------------------------------------------------------------------------
 // Tables
 // ---------------------------------------------------------------------------
 
-func renderScalingTable(b *strings.Builder, rep *Report) {
+func renderScalingTable(b *strings.Builder, rep *Report, m Metric) {
 	scales := rep.Scales()
 
 	b.WriteString("| Operation |")
@@ -73,23 +102,38 @@ func renderScalingTable(b *strings.Builder, rep *Report) {
 		var first, last float64
 		var haveFirst bool
 		for _, s := range scales {
-			row, ok := rep.find("", op, s)
-			if !ok {
+			c, ok := rep.cell("", op, s)
+			stat := m.Value(c)
+			if !ok || stat.N == 0 {
 				b.WriteString(" - |")
 				continue
 			}
-			fmt.Fprintf(b, " %s MB |", trim(row.PeakMB))
+			fmt.Fprintf(b, " %s |", statCell(stat))
 			if !haveFirst {
-				first, haveFirst = row.PeakMB, true
+				first, haveFirst = stat.Median, true
 			}
-			last = row.PeakMB
+			last = stat.Median
 		}
+		// Growth compares medians. Comparing the extremes instead would report
+		// the worst case at one end against the best at the other and turn the
+		// sampling noise into apparent scaling.
 		if haveFirst && first > 0 {
 			fmt.Fprintf(b, " %.2fx |\n", last/first)
 		} else {
 			b.WriteString(" - |\n")
 		}
 	}
+}
+
+// statCell renders a measurement as its median, followed by the observed band
+// when repeated samples actually disagreed. A point measured once, or one whose
+// samples landed on the same number, prints as a bare value rather than an
+// unhelpful "148.9 (148.9–148.9)".
+func statCell(s Stat) string {
+	if s.N < 2 || s.Spread() < 0.05 {
+		return trim(s.Median)
+	}
+	return fmt.Sprintf("%s (%s–%s)", trim(s.Median), trim(s.Min), trim(s.Max))
 }
 
 func renderComparisonTable(b *strings.Builder, rep *Report) {
@@ -101,15 +145,27 @@ func renderComparisonTable(b *strings.Builder, rep *Report) {
 	// different format, so "bytes added" is not measuring the same thing twice.
 	withDelta := len(tools) == 1 && rep.hasRepoDelta()
 
+	// Allocation is gated the same way, for a stronger version of the same
+	// reason: only cloudstic reports it at all, so a cross-tool column would be
+	// one number and a row of dashes. A single-size memory run lands here, and
+	// it is the column that shows churn peak RSS cannot.
+	withAlloc := len(tools) == 1 && rep.hasAlloc()
+
 	b.WriteString("| Operation |")
 	for _, t := range tools {
 		fmt.Fprintf(b, " %s |", t)
+	}
+	if withAlloc {
+		b.WriteString(" Allocated |")
 	}
 	if withDelta {
 		b.WriteString(" Repo added |")
 	}
 	b.WriteString("\n|---|")
 	for range tools {
+		b.WriteString("---:|")
+	}
+	if withAlloc {
 		b.WriteString("---:|")
 	}
 	if withDelta {
@@ -119,15 +175,24 @@ func renderComparisonTable(b *strings.Builder, rep *Report) {
 
 	for _, op := range rep.Operations() {
 		fmt.Fprintf(b, "| `%s` |", op)
-		var delta string
+		var delta, alloc string
 		for _, t := range tools {
-			row, ok := rep.find(t, op, scale)
+			c, ok := rep.cell(t, op, scale)
 			if !ok {
 				b.WriteString(" - |")
 				continue
 			}
-			fmt.Fprintf(b, " %ss · %s MB |", trim(row.Seconds), trim(row.PeakMB))
-			delta = row.RepoDelta
+			fmt.Fprintf(b, " %ss · %s MB |", statCell(c.Seconds), statCell(c.PeakMB))
+			delta = c.RepoDelta
+			if c.HasAlloc {
+				alloc = statCell(c.AllocMB) + " MB"
+			}
+		}
+		if withAlloc {
+			if alloc == "" {
+				alloc = "-"
+			}
+			fmt.Fprintf(b, " %s |", alloc)
 		}
 		if withDelta {
 			if delta == "" {
@@ -137,7 +202,11 @@ func renderComparisonTable(b *strings.Builder, rep *Report) {
 		}
 		b.WriteString("\n")
 	}
-	b.WriteString("\nEach cell is wall time and peak RSS.\n")
+	b.WriteString("\nEach cell is wall time and peak RSS.")
+	if withAlloc {
+		b.WriteString(" `Allocated` is cumulative bytes allocated,\nfreed or not — the column that moves when an operation stops allocating\nsomething it did not need.")
+	}
+	b.WriteString("\n")
 }
 
 // ---------------------------------------------------------------------------
@@ -154,21 +223,29 @@ func renderComparisonTable(b *strings.Builder, rep *Report) {
 func renderCharts(b *strings.Builder, rep *Report) {
 	switch rep.Kind() {
 	case KindScaling:
-		ymax := axisMax(rep, PeakMB)
+		metrics := []Metric{PeakMB}
+		if rep.hasAlloc() {
+			metrics = append(metrics, AllocMB)
+		}
 		xs := make([]string, 0, len(rep.Scales()))
 		for _, s := range rep.Scales() {
 			xs = append(xs, strconv.Itoa(s))
 		}
-		for _, op := range rep.Operations() {
-			var vals []string
-			for _, s := range rep.Scales() {
-				row, ok := rep.find("", op, s)
-				if !ok {
-					continue
+		for _, m := range metrics {
+			ymax := axisMax(rep, m)
+			label := strings.ToLower(m.Name) + " (" + m.Unit + ")"
+			for _, op := range rep.Operations() {
+				var vals []string
+				for _, s := range rep.Scales() {
+					c, ok := rep.cell("", op, s)
+					stat := m.Value(c)
+					if !ok || stat.N == 0 {
+						continue
+					}
+					vals = append(vals, trim(stat.Median))
 				}
-				vals = append(vals, trim(row.PeakMB))
+				chart(b, fmt.Sprintf("%s — %s", op, label), "files in tree", label, xs, vals, ymax, "line")
 			}
-			chart(b, fmt.Sprintf("%s — peak RSS (MB)", op), "files in tree", "peak RSS (MB)", xs, vals, ymax, "line")
 		}
 	case KindComparison:
 		ymax := axisMax(rep, Seconds)
@@ -177,12 +254,12 @@ func renderCharts(b *strings.Builder, rep *Report) {
 		for _, op := range rep.Operations() {
 			var xs, vals []string
 			for _, t := range tools {
-				row, ok := rep.find(t, op, scale)
+				c, ok := rep.cell(t, op, scale)
 				if !ok {
 					continue
 				}
 				xs = append(xs, t)
-				vals = append(vals, trim(row.Seconds))
+				vals = append(vals, trim(c.Seconds.Median))
 			}
 			if len(vals) < 2 {
 				continue // a single bar compares nothing
@@ -206,11 +283,22 @@ func chart(b *strings.Builder, title, xLabel, yLabel string, xs, vals []string, 
 
 // axisMax leaves headroom above the largest value so the top point is not
 // clipped against the frame.
+//
+// It bounds the medians, which are what get plotted — bounding the raw samples
+// would size every axis for an outlier that appears on no chart.
 func axisMax(rep *Report, m Metric) float64 {
 	var max float64
-	for _, row := range rep.Rows {
-		if v := m.Value(row); v > max {
-			max = v
+	for _, t := range rep.Tools() {
+		for _, op := range rep.Operations() {
+			for _, s := range rep.Scales() {
+				c, ok := rep.cell(t, op, s)
+				if !ok {
+					continue
+				}
+				if v := m.Value(c).Median; v > max {
+					max = v
+				}
+			}
 		}
 	}
 	return float64(int(max*1.15)) + 1

--- a/internal/benchreport/report.go
+++ b/internal/benchreport/report.go
@@ -21,13 +21,63 @@ import (
 // varies. The memory sweep holds Tool constant and varies Scale; the
 // competitive run holds Scale constant and varies Tool. Kind() reads that off
 // the data rather than being told.
+//
+// A row is one *sample*, not one point. Several rows may share
+// (Tool, Operation, Scale) — the memory sweep writes one per repetition, and
+// the report reduces them with cell(). Keeping the samples in the CSV rather
+// than collapsing them at write time means the artifact still shows how noisy a
+// point was, which a median alone hides.
 type Row struct {
 	Tool      string // cloudstic, restic, borg, duplicacy
 	Operation string // "backup-initial", "Initial Backup", …
 	Scale     int    // files in tree; 0 when the harness has only one size
 	Seconds   float64
 	PeakMB    float64
-	RepoDelta string // human-formatted, passed through untouched
+	AllocMB   float64 // cumulative bytes allocated, including freed; 0 when unmeasured
+	RepoDelta string  // human-formatted, passed through untouched
+}
+
+// Stat summarises repeated samples of one measurement.
+//
+// The median is reported rather than the mean because the noise here is
+// one-sided: a run perturbed by another process on the runner is slow and
+// memory-hungry, never the reverse, so a single bad sample drags a mean and
+// leaves a median alone. Min and Max are carried alongside so a point whose
+// samples disagree is visible as a wide band rather than hidden behind a
+// confident-looking middle value.
+type Stat struct {
+	Median float64
+	Min    float64
+	Max    float64
+	N      int
+}
+
+// Spread is the distance between the extremes — the width of the noise band a
+// difference has to clear before it means anything.
+func (s Stat) Spread() float64 { return s.Max - s.Min }
+
+func newStat(vs []float64) Stat {
+	if len(vs) == 0 {
+		return Stat{}
+	}
+	sorted := append([]float64(nil), vs...)
+	sort.Float64s(sorted)
+
+	mid := len(sorted) / 2
+	median := sorted[mid]
+	if len(sorted)%2 == 0 {
+		median = (sorted[mid-1] + sorted[mid]) / 2
+	}
+	return Stat{Median: median, Min: sorted[0], Max: sorted[len(sorted)-1], N: len(sorted)}
+}
+
+// Cell is every sample for one (tool, operation, scale) point, reduced.
+type Cell struct {
+	Seconds   Stat
+	PeakMB    Stat
+	AllocMB   Stat
+	HasAlloc  bool
+	RepoDelta string
 }
 
 // Report is a parsed measurement set.
@@ -108,6 +158,11 @@ func Parse(r io.Reader) (*Report, error) {
 				return nil, fmt.Errorf("row %d: peak_mb %q: %w", n+2, v, err)
 			}
 		}
+		if v := get(rec, "alloc_mb"); v != "" {
+			if row.AllocMB, err = strconv.ParseFloat(v, 64); err != nil {
+				return nil, fmt.Errorf("row %d: alloc_mb %q: %w", n+2, v, err)
+			}
+		}
 		rep.Rows = append(rep.Rows, row)
 	}
 	if len(rep.Rows) == 0 {
@@ -160,16 +215,37 @@ func distinct(rows []Row, key func(Row) string) []string {
 	return out
 }
 
-// find returns the row for one cell, and whether it was measured. A missing
-// cell is normal: a tool may not support an operation, or a sweep may skip a
-// size.
-func (r *Report) find(tool, op string, scale int) (Row, bool) {
+// cell reduces every sample for one point, and reports whether any was
+// measured. A missing cell is normal: a tool may not support an operation, or a
+// sweep may skip a size.
+//
+// A harness taking one sample per point gets a Stat whose median, min and max
+// are that sample, so the single-sample and repeated-sample paths are the same
+// code.
+func (r *Report) cell(tool, op string, scale int) (Cell, bool) {
+	var seconds, peak, alloc []float64
+	var c Cell
 	for _, row := range r.Rows {
-		if row.Operation == op && row.Scale == scale && (tool == "" || row.Tool == tool) {
-			return row, true
+		if row.Operation != op || row.Scale != scale || (tool != "" && row.Tool != tool) {
+			continue
+		}
+		seconds = append(seconds, row.Seconds)
+		peak = append(peak, row.PeakMB)
+		// An unmeasured allocation total is absent, not zero: averaging a real
+		// 300 MB with a placeholder 0 would report 150 MB and look plausible.
+		if row.AllocMB > 0 {
+			alloc = append(alloc, row.AllocMB)
+		}
+		if row.RepoDelta != "" {
+			c.RepoDelta = row.RepoDelta
 		}
 	}
-	return Row{}, false
+	if len(peak) == 0 {
+		return Cell{}, false
+	}
+	c.Seconds, c.PeakMB, c.AllocMB = newStat(seconds), newStat(peak), newStat(alloc)
+	c.HasAlloc = len(alloc) > 0
+	return c, true
 }
 
 // hasRepoDelta reports whether any row measured repository growth. The memory
@@ -183,14 +259,42 @@ func (r *Report) hasRepoDelta() bool {
 	return false
 }
 
+// hasAlloc reports whether any row carries an allocation total. Only the memory
+// sweep measures it, and only for cloudstic, so the competitive table must not
+// grow an empty column because of it.
+func (r *Report) hasAlloc() bool {
+	for _, row := range r.Rows {
+		if row.AllocMB > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// Samples reports the largest number of repetitions behind any single point,
+// which is what the prose quotes when explaining the median.
+func (r *Report) Samples() int {
+	counts := map[string]int{}
+	most := 0
+	for _, row := range r.Rows {
+		k := fmt.Sprintf("%s\x00%s\x00%d", row.Tool, row.Operation, row.Scale)
+		counts[k]++
+		if counts[k] > most {
+			most = counts[k]
+		}
+	}
+	return most
+}
+
 // Metric selects which measurement a table or chart reports.
 type Metric struct {
 	Name  string // column heading
 	Unit  string
-	Value func(Row) float64
+	Value func(Cell) Stat
 }
 
 var (
-	PeakMB  = Metric{Name: "Peak RSS", Unit: "MB", Value: func(r Row) float64 { return r.PeakMB }}
-	Seconds = Metric{Name: "Time", Unit: "s", Value: func(r Row) float64 { return r.Seconds }}
+	PeakMB  = Metric{Name: "Peak RSS", Unit: "MB", Value: func(c Cell) Stat { return c.PeakMB }}
+	AllocMB = Metric{Name: "Total allocated", Unit: "MB", Value: func(c Cell) Stat { return c.AllocMB }}
+	Seconds = Metric{Name: "Time", Unit: "s", Value: func(c Cell) Stat { return c.Seconds }}
 )

--- a/internal/benchreport/report_test.go
+++ b/internal/benchreport/report_test.go
@@ -277,6 +277,200 @@ func TestScalingTableHasNoRepoColumn(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Repeated samples
+// ---------------------------------------------------------------------------
+
+// Three runs of the same point, deliberately noisy: 408/405/352 is the spread
+// actually observed on one machine while chasing a 36 MB regression, which a
+// single sample could not resolve at all.
+const sampledCSV = `tool,operation,scale,seconds,peak_mb,alloc_mb,repo_delta
+cloudstic,prune,5000,1.00,408.0,900.0,
+cloudstic,prune,5000,1.10,405.0,901.0,
+cloudstic,prune,5000,0.90,352.0,900.5,
+cloudstic,prune,20000,2.00,512.0,1800.0,
+cloudstic,prune,20000,2.10,515.0,1802.0,
+cloudstic,prune,20000,1.90,511.0,1801.0,
+`
+
+// The whole point of sampling: one wild run must not become the reported
+// number. The mean of 408/405/352 is 388.3 — reporting that would fold the
+// outlier into the result instead of discarding it.
+func TestRepeatedSamplesReportTheMedian(t *testing.T) {
+	rep := parse(t, sampledCSV)
+	c, ok := rep.cell("", "prune", 5000)
+	if !ok {
+		t.Fatal("point not found")
+	}
+	if c.PeakMB.Median != 405 {
+		t.Errorf("median peak RSS = %v, want 405 (not the mean 388.3, not the first sample 408)", c.PeakMB.Median)
+	}
+	if c.PeakMB.Min != 352 || c.PeakMB.Max != 408 {
+		t.Errorf("band = %v–%v, want 352–408", c.PeakMB.Min, c.PeakMB.Max)
+	}
+	if c.PeakMB.N != 3 {
+		t.Errorf("N = %d, want 3", c.PeakMB.N)
+	}
+}
+
+// A median on its own is a confident-looking number with no error bar. The
+// band has to reach the page, or a 5 MB difference inside a 56 MB spread reads
+// as a result.
+func TestScalingTableShowsTheSampleBand(t *testing.T) {
+	var b strings.Builder
+	if err := Render(&b, parse(t, sampledCSV), "T"); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := b.String()
+	if !strings.Contains(out, "405 (352–408)") {
+		t.Errorf("median with min–max band missing; got:\n%s", out)
+	}
+	if !strings.Contains(out, "median of 3 runs") {
+		t.Errorf("prose should say how many runs the median came from; got:\n%s", out)
+	}
+}
+
+// A harness taking one sample per point must not grow a band of one value.
+func TestSingleSampleRendersBareValue(t *testing.T) {
+	var b strings.Builder
+	if err := Render(&b, parse(t, scalingCSV), "T"); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := b.String()
+	if strings.Contains(out, "(148.9–148.9)") {
+		t.Errorf("single sample rendered as a degenerate band:\n%s", out)
+	}
+	if strings.Contains(out, "median of") {
+		t.Errorf("unsampled report claims to report a median:\n%s", out)
+	}
+}
+
+func TestMedianOfEvenSampleCountAveragesTheMiddle(t *testing.T) {
+	got := newStat([]float64{10, 20, 30, 40}).Median
+	if got != 25 {
+		t.Errorf("median of 4 samples = %v, want 25", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Allocation totals
+// ---------------------------------------------------------------------------
+
+// The column that exists because peak RSS could not see PR #449: a change that
+// removed 36 MB of transient allocation moved the high-water mark by less than
+// the run-to-run noise.
+func TestAllocationTotalGetsItsOwnTable(t *testing.T) {
+	var b strings.Builder
+	if err := Render(&b, parse(t, sampledCSV), "T"); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := b.String()
+	if !strings.Contains(out, "### Total allocated (MB)") {
+		t.Errorf("allocation table missing; got:\n%s", out)
+	}
+	if !strings.Contains(out, "### Peak RSS (MB)") {
+		t.Errorf("peak RSS table missing; got:\n%s", out)
+	}
+	// 900.5 is the median of 900.0/901.0/900.5.
+	if !strings.Contains(out, "900.5") {
+		t.Errorf("allocation median missing; got:\n%s", out)
+	}
+}
+
+// A harness that cannot report allocation — every tool in compare.sh except
+// cloudstic — must not produce an empty table.
+func TestReportWithoutAllocationHasNoAllocationTable(t *testing.T) {
+	var b strings.Builder
+	if err := Render(&b, parse(t, scalingCSV), "T"); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if strings.Contains(b.String(), "Total allocated") {
+		t.Errorf("allocation table rendered for a sweep that measured none:\n%s", b.String())
+	}
+}
+
+// An unmeasured sample is absent, not zero. Averaging a real 900 MB with a
+// placeholder 0 would report 450 MB, which is a plausible-looking lie.
+func TestUnmeasuredAllocationIsExcludedNotAveragedAsZero(t *testing.T) {
+	csv := "tool,operation,scale,seconds,peak_mb,alloc_mb\n" +
+		"cloudstic,prune,5000,1.00,400.0,900.0\n" +
+		"cloudstic,prune,5000,1.00,400.0,\n"
+	rep := parse(t, csv)
+	c, ok := rep.cell("", "prune", 5000)
+	if !ok {
+		t.Fatal("point not found")
+	}
+	if c.AllocMB.N != 1 || c.AllocMB.Median != 900 {
+		t.Errorf("alloc = %+v, want a single 900 sample with the blank excluded", c.AllocMB)
+	}
+	if c.PeakMB.N != 2 {
+		t.Errorf("peak RSS should still count both samples, got N=%d", c.PeakMB.N)
+	}
+}
+
+// The CSV keeps one row per sample so the artifact shows the spread; a reader
+// (and a later re-render) has to be able to get back to the same numbers.
+func TestAppendRowRoundTripsAllocation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "out.csv")
+	if err := AppendRow(path, Row{
+		Tool: "cloudstic", Operation: "prune", Scale: 5000, Seconds: 1, PeakMB: 400, AllocMB: 936.5,
+	}); err != nil {
+		t.Fatalf("AppendRow: %v", err)
+	}
+	// A tool with no allocation number leaves the column empty rather than 0.
+	if err := AppendRow(path, Row{Tool: "restic", Operation: "prune", Scale: 5000, Seconds: 1, PeakMB: 380}); err != nil {
+		t.Fatalf("AppendRow: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rep, err := Parse(strings.NewReader(string(data)))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if rep.Rows[0].AllocMB != 936.5 {
+		t.Errorf("alloc_mb did not round-trip: %v", rep.Rows[0].AllocMB)
+	}
+	if rep.Rows[1].AllocMB != 0 {
+		t.Errorf("unmeasured alloc should read back as 0, got %v", rep.Rows[1].AllocMB)
+	}
+	if strings.Contains(string(data), ",0.0,") {
+		t.Errorf("unmeasured allocation written as a zero measurement:\n%s", data)
+	}
+}
+
+// A -memstats file that is missing or empty means the flag never reached the
+// measured command. Recording 0 would put a hole in the column that reads as
+// "this operation allocates nothing".
+func TestReadAllocMBRejectsAMissingOrEmptyProfile(t *testing.T) {
+	if _, err := ReadAllocMB(filepath.Join(t.TempDir(), "absent.json")); err == nil {
+		t.Error("expected an error for a missing memstats file")
+	}
+
+	path := filepath.Join(t.TempDir(), "empty.json")
+	if err := os.WriteFile(path, []byte(`{"total_alloc_bytes":0}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadAllocMB(path); err == nil {
+		t.Error("expected an error for a memstats file reporting no allocation")
+	}
+}
+
+func TestReadAllocMBConvertsToMegabytes(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ms.json")
+	if err := os.WriteFile(path, []byte(`{"total_alloc_bytes":36700160}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadAllocMB(path)
+	if err != nil {
+		t.Fatalf("ReadAllocMB: %v", err)
+	}
+	if got != 35 {
+		t.Errorf("got %v MB, want 35", got)
+	}
+}
+
 func lineContaining(t *testing.T, s, want string) string {
 	t.Helper()
 	for _, line := range strings.Split(s, "\n") {

--- a/internal/cmd/benchreport/main.go
+++ b/internal/cmd/benchreport/main.go
@@ -62,6 +62,7 @@ func runCmd(args []string) error {
 	scale := fs.Int("scale", 0, "dataset size this step ran against")
 	out := fs.String("out", "", "CSV to append to (required)")
 	repoDelta := fs.String("repo-delta", "", "repository growth, pre-formatted")
+	allocFrom := fs.String("alloc-from", "", "read the allocation total from this cloudstic -memstats file")
 	quiet := fs.Bool("quiet", false, "discard the measured command's output")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -84,12 +85,25 @@ func runCmd(args []string) error {
 		return err
 	}
 
+	// The measured process writes this itself, so it is read after the run
+	// rather than derived from anything the parent can observe. A missing or
+	// unreadable file is fatal: silently recording no allocation total would
+	// leave a hole in the column that reads as "this operation allocates
+	// nothing".
+	var allocMB float64
+	if *allocFrom != "" {
+		if allocMB, err = benchreport.ReadAllocMB(*allocFrom); err != nil {
+			return err
+		}
+	}
+
 	if err := benchreport.AppendRow(*out, benchreport.Row{
 		Tool:      *tool,
 		Operation: *op,
 		Scale:     *scale,
 		Seconds:   seconds,
 		PeakMB:    peakMB,
+		AllocMB:   allocMB,
 		RepoDelta: *repoDelta,
 	}); err != nil {
 		return err
@@ -97,7 +111,11 @@ func runCmd(args []string) error {
 
 	// Echo the row so a script's own console output stays readable without it
 	// having to re-read the CSV it just appended to.
-	fmt.Printf("  %-28s %10s  %8.1f MB  %7.2fs\n", *op, scaleLabel(*scale), peakMB, seconds)
+	alloc := ""
+	if allocMB > 0 {
+		alloc = fmt.Sprintf("  %8.1f MB alloc", allocMB)
+	}
+	fmt.Printf("  %-28s %10s  %8.1f MB peak  %7.2fs%s\n", *op, scaleLabel(*scale), peakMB, seconds, alloc)
 	return nil
 }
 

--- a/scripts/benchmark/memory.sh
+++ b/scripts/benchmark/memory.sh
@@ -1,33 +1,71 @@
 #!/usr/bin/env bash
 #
-# Peak memory as a function of repository size.
+# Memory as a function of repository size.
 #
-# scripts/benchmark/run.sh already reports peak RSS, but at one dataset size,
-# and a single point cannot distinguish memory that is constant from memory
-# that grows with the repository. That difference is the whole question: an
-# operation holding a fixed working set is fine at any scale, one holding a
+# scripts/benchmark/cloudstic.sh already reports peak RSS, but at one dataset
+# size, and a single point cannot distinguish memory that is constant from
+# memory that grows with the repository. That difference is the whole question:
+# an operation holding a fixed working set is fine at any scale, one holding a
 # per-file structure eventually meets a repository it cannot open. Telling them
 # apart needs the same operation measured at several sizes.
 #
-# The dataset is therefore many small files rather than run.sh's gigabyte of
-# large ones: the independent variable is the number of entries, and file size
-# is held down so throughput does not drown out per-entry cost.
+# The dataset is therefore many small files rather than cloudstic.sh's gigabyte
+# of large ones: the independent variable is the number of entries, and file
+# size is held down so throughput does not drown out per-entry cost.
+#
+# Two measurements per point, because peak RSS alone was not enough:
+#
+#   peak RSS   the largest amount live at once — what decides whether an
+#              operation fits in the memory available.
+#   allocated  cumulative bytes allocated, freed or not. Peak RSS is a
+#              high-water mark and cannot see churn the collector reclaims, so
+#              a change removing tens of MB of transient garbage moves it by
+#              nothing measurable. PR #449 removed 36 MB of allocation from
+#              CompactCatalog and shifted peak RSS by 5 MB, well inside the
+#              noise. This column is the one that moved.
+#
+# And SAMPLES repetitions per point, reported as a median with its min–max
+# band. Repeated runs of one binary on one machine gave 408/405/352 MB — a
+# ±60 MB spread, wider than most of the improvements being chased. A single
+# sample cannot tell a 40 MB win from a lucky run; three and a median can.
+# Every operation here mutates the repository, so a sample repeats the whole
+# pipeline against a fresh repository rather than re-running one command.
 #
 # Usage:
-#   scripts/benchmark/memory.sh                   # default sizes
-#   SIZES="1000 5000" scripts/benchmark/memory.sh # override
+#   scripts/benchmark/memory.sh                     # defaults
+#   SIZES="1000 5000" scripts/benchmark/memory.sh   # override sizes
+#   SAMPLES=5 scripts/benchmark/memory.sh           # more repetitions
 #   OUT=/tmp/mem.csv scripts/benchmark/memory.sh
 
 set -euo pipefail
 
 SIZES=${SIZES:-"5000 20000 50000"}
+SAMPLES=${SAMPLES:-3}
 OUT=${OUT:-benchmark-results/memory.csv}
 KEEP=${KEEP:-0} # keep scratch dirs for inspection
 
+case "$SAMPLES" in
+    '' | *[!0-9]* | 0)
+        echo "SAMPLES must be a positive integer, got '$SAMPLES'" >&2
+        exit 2
+        ;;
+esac
+
 REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
-CLOUDSTIC_BIN="$REPO_ROOT/bin/cloudstic"
 BENCHREPORT="$REPO_ROOT/bin/benchreport"
 PASSWORD=${BENCH_REPO_PASSWORD:-benchmark-password}
+
+# A prebuilt binary to measure instead of this checkout's.
+#
+# The question this harness gets asked is almost always "did that change help",
+# which means measuring two commits. Building each into its own path and
+# pointing the sweep at them in turn compares like with like — the alternative,
+# checking out the other commit, also swaps out the harness doing the measuring.
+#
+# It has to be a binary built from a tree carrying -memstats (cmd/cloudstic/
+# profiling.go); anything built before that flag existed will not write the
+# file measure() expects and the sweep will fail on its first row.
+CLOUDSTIC_BIN=${BENCH_CLOUDSTIC_BIN:-"$REPO_ROOT/bin/cloudstic"}
 
 WORK=$(mktemp -d -t cloudstic-mem-XXXXXX)
 cleanup() { [ "$KEEP" = "1" ] || rm -rf "$WORK"; }
@@ -37,6 +75,10 @@ trap cleanup EXIT
 # Measurement
 # ---------------------------------------------------------------------------
 
+# Where the measured process drops its allocation counters. Rewritten by every
+# run and read back immediately, so one path serves the whole sweep.
+MEMSTATS="$WORK/memstats.json"
+
 # measure <operation> <files> <command...>
 #
 # Delegates to benchreport, which takes peak RSS from the wait4 rusage the
@@ -44,11 +86,23 @@ trap cleanup EXIT
 # and unit all differ between BSD and GNU, and which is absent on a minimal
 # Linux image. It appends the CSV row and echoes a console line.
 #
+# -memstats is appended to the measured command rather than threaded through
+# its arguments: cloudstic strips that flag from os.Args before any command
+# parsing, so its position does not matter. The allocation total has to come
+# from inside the process — the parent can observe a high-water mark through
+# rusage, but not bytes that were allocated and freed again.
+#
+# One row is appended per sample rather than one per point. The median is
+# computed at render time, which keeps every sample in the CSV where a reader
+# can see how noisy a point actually was.
+#
 # A failing command is fatal: a curve with a hole in it is worse than no curve.
 measure() {
     local op=$1 files=$2
     shift 2
-    "$BENCHREPORT" run -op "$op" -scale "$files" -out "$OUT" -quiet -- "$@"
+    rm -f "$MEMSTATS"
+    "$BENCHREPORT" run -op "$op" -scale "$files" -out "$OUT" \
+        -alloc-from "$MEMSTATS" -quiet -- "$@" -memstats "$MEMSTATS"
 }
 
 # ---------------------------------------------------------------------------
@@ -76,15 +130,21 @@ generate_tree() {
     done
 }
 
-# touch_fraction <root> <count> <denominator>
+# touch_fraction <root> <count> <denominator> <generation>
 #
 # Rewrites every Nth file so the follow-up backup has real work to do. An
 # incremental over an unchanged tree measures the scan path only; changing a
 # slice exercises upload and the HAMT rewrite too.
+#
+# The generation is in the written bytes so that repeated samples over one tree
+# stay honest. Without it the second sample would rewrite the same files with
+# the same content, content-address to the objects already there, and measure
+# an incremental backup that uploads nothing.
 touch_fraction() {
-    local root=$1 count=$2 denom=$3
+    local root=$1 count=$2 denom=$3 gen=$4
     for (( i = 0; i < count; i += denom )); do
-        printf 'cloudstic benchmark entry %d modified\n' "$i" > "$root/dir-$(( i / 100 ))/file-$i.txt"
+        printf 'cloudstic benchmark entry %d modified %d\n' "$i" "$gen" \
+            > "$root/dir-$(( i / 100 ))/file-$i.txt"
     done
 }
 
@@ -92,8 +152,17 @@ touch_fraction() {
 # Run
 # ---------------------------------------------------------------------------
 
-echo "Building cloudstic and benchreport..."
-( cd "$REPO_ROOT" && go build -o bin/cloudstic ./cmd/cloudstic )
+if [ -n "${BENCH_CLOUDSTIC_BIN:-}" ]; then
+    echo "Measuring prebuilt $CLOUDSTIC_BIN"
+    if [ ! -x "$CLOUDSTIC_BIN" ]; then
+        echo "BENCH_CLOUDSTIC_BIN is not an executable file: $CLOUDSTIC_BIN" >&2
+        exit 2
+    fi
+else
+    echo "Building cloudstic..."
+    ( cd "$REPO_ROOT" && go build -o bin/cloudstic ./cmd/cloudstic )
+fi
+echo "Building benchreport..."
 ( cd "$REPO_ROOT" && go build -o bin/benchreport ./internal/cmd/benchreport )
 
 # benchreport writes the header itself on first append, so a stale CSV must go
@@ -102,23 +171,29 @@ mkdir -p "$(dirname "$OUT")"
 rm -f "$OUT"
 
 echo ""
-echo "=== Peak memory vs repository size ==="
-echo "sizes: $SIZES"
+echo "=== Memory vs repository size ==="
+echo "sizes:   $SIZES"
+echo "samples: $SAMPLES per point (median reported)"
 echo ""
 
 export CLOUDSTIC_PASSWORD="$PASSWORD"
 
-for size in $SIZES; do
-    echo "--- $size files ---"
-    data="$WORK/data-$size"
-    repo="$WORK/repo-$size"
-    restore="$WORK/restore-$size"
-    mkdir -p "$data" "$repo" "$restore"
+# run_pipeline <data> <size> <generation>
+#
+# One full sample: every operation once, over a repository built from scratch.
+#
+# The repository is rebuilt per sample because every operation here mutates it.
+# Re-running `prune` against an already-pruned repository, or `backup-initial`
+# against a populated one, measures a different operation that happens to share
+# a name — so the unit of repetition has to be the pipeline, not the command.
+run_pipeline() {
+    local data=$1 size=$2 gen=$3
+    local repo="$WORK/repo" restore="$WORK/restore"
 
-    printf '  generating %d files... ' "$size"
-    generate_tree "$data" "$size"
-    echo "done"
+    rm -rf "$repo" "$restore"
+    mkdir -p "$repo" "$restore"
 
+    local store_flags source_flags
     store_flags=(-store "local:$repo")
     source_flags=(-source "local:$data")
 
@@ -127,7 +202,7 @@ for size in $SIZES; do
     measure backup-initial "$size" \
         "$CLOUDSTIC_BIN" backup "${store_flags[@]}" "${source_flags[@]}" -quiet
 
-    touch_fraction "$data" "$size" 20
+    touch_fraction "$data" "$size" 20 "$gen"
 
     measure backup-incremental "$size" \
         "$CLOUDSTIC_BIN" backup "${store_flags[@]}" "${source_flags[@]}" -quiet
@@ -135,6 +210,7 @@ for size in $SIZES; do
     # diff needs two explicit refs, and list reports newest first. Written
     # without mapfile or a negative array index: macOS still ships bash 3.2,
     # where both are syntax errors rather than graceful failures.
+    local refs newest oldest
     refs=$("$CLOUDSTIC_BIN" list "${store_flags[@]}" -json 2>/dev/null \
         | grep -o 'snapshot/[a-f0-9]\{64\}')
     newest=$(printf '%s\n' "$refs" | head -1)
@@ -151,9 +227,28 @@ for size in $SIZES; do
     measure prune "$size" \
         "$CLOUDSTIC_BIN" prune "${store_flags[@]}" -quiet
 
+    rm -rf "$repo" "$restore"
+}
+
+for size in $SIZES; do
+    data="$WORK/data-$size"
+    mkdir -p "$data"
+
+    # Generated once and reused across the samples of this size. Regenerating
+    # would add dataset variation to the very noise the samples exist to
+    # measure; the tree is an input, not part of what is under test.
+    printf -- '--- %d files: generating... ' "$size"
+    generate_tree "$data" "$size"
+    echo "done"
+
+    for (( sample = 1; sample <= SAMPLES; sample++ )); do
+        echo "  sample $sample/$SAMPLES"
+        run_pipeline "$data" "$size" "$sample"
+    done
+
     # Reclaim before the next size so the scratch dir does not grow without
     # bound over the sweep; each size is independent anyway.
-    rm -rf "$data" "$repo" "$restore"
+    rm -rf "$data"
     echo ""
 done
 


### PR DESCRIPTION
## Summary
- Take `SAMPLES` repetitions per (operation, size) point (default 3, overridable like `SIZES`/`OUT`/`KEEP`) and report the median with its min–max band, so a noisy point is visible instead of hidden behind one measurement.
- Report cumulative allocated bytes alongside peak RSS. Peak RSS is a high-water mark and is blind to allocation the collector reclaims; a new `-memstats <path>` flag (`cmd/cloudstic/profiling.go`) dumps `runtime.MemStats.TotalAlloc` from inside the measured process — exact and free, unlike a sampled `-alloc_space` heap profile, which would land a small delta inside its own sampling error and perturb the RSS measured in the same pass.
- `internal/benchreport` grows an `alloc_mb` CSV column and a `Stat` (median/min/max) reduction shared by both harnesses; `render()` gets a second "Total allocated" table for the scaling report and an `Allocated` column for the single-tool comparison table. `cloudstic.sh`'s multi-tool comparison is unaffected — it never populates the column, so nothing renders for it.
- `memory.sh` gains `BENCH_CLOUDSTIC_BIN` to point the sweep at a prebuilt binary, since comparing two commits means measuring with one harness rather than checking out the other commit (which would also swap the harness doing the measuring).

Closes nothing on its own; motivated by the evidence in #449, where the memory sweep reported peak RSS moving 5 MB against a measured ±60 MB run-to-run spread for a change that provably removed 36 MB of allocation from `CompactCatalog`.

## Verification
I built `main` (1ca7e68) and its parent (ee61760, before #449) and pointed the sweep at each via `BENCH_CLOUDSTIC_BIN`. At 5,000–20,000 files most operations already show a tight band (peak RSS spread under ~10 MB, allocation spread under ~2 MB across 3–5 samples). For `prune` specifically at 20,000 files, 5 samples gave:

| | peak RSS | allocated |
|---|---|---|
| before (ee61760) | 163.1–171.8 MB | 340.2 MB (all 5 samples identical to 0.1 MB) |
| after (1ca7e68) | 154.8–163.8 MB | 324.9–325.0 MB |

The allocated column resolves a clean ~15 MB signal with an essentially zero noise band, where peak RSS alone (spread ~9 MB against a ~16 MB delta) is borderline. I also isolated the `CompactCatalog` delta itself with `go tool pprof -alloc_space -diff_base` against byte-identical repository copies built with each binary, which attributed −11.08 MB (the removed catalog copy) and −5.43 MB (the removed extra marshal) to that function specifically, confirming the mechanism the PR describes.

One caveat worth recording: at 50,000 files, `prune`'s *total* allocation is dominated by `PackStore.Repack`'s mark-phase pack-cache behavior, whose cost varies by up to several GB between runs — traced to Go's randomized map iteration order feeding a bounded pack cache, unrelated to this PR's code path. That's a pre-existing, independent source of noise at that scale; I didn't attempt to fix it here, and picked 20,000 files for the demonstration above because it isn't dominated by that effect.

```bash
env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./internal/benchreport/... ./internal/cmd/benchreport/... ./cmd/cloudstic/...
env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./internal/benchreport/... ./internal/cmd/benchreport/... ./cmd/cloudstic/...
shellcheck -x scripts/benchmark/memory.sh
SIZES="5000 20000" SAMPLES=3 ./scripts/benchmark/memory.sh   # ran clean under /bin/bash (3.2) and the Homebrew bash (5.3)
go run ./internal/cmd/benchreport render -in benchmark-results/memory.csv -title "Peak memory vs repository size"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Benchmark reports now include cumulative memory allocation metrics alongside peak memory measurements.
  * Added statistical aggregation with median, minimum, and maximum values for benchmark samples.
  * Extended profiling support for detailed memory statistics collection.

* **Documentation**
  * Enhanced benchmark documentation explaining allocation measurement methods and their interpretation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->