### PR TITLE
perf(engine): restore leaves in walk order, not tree order

### DIFF
--- a/internal/engine/restore.go
+++ b/internal/engine/restore.go
@@ -290,12 +290,12 @@ func (rm *RestoreManager) prepareRestore(ctx context.Context, snapshotRef string
 		return restorePlan{}, err
 	}
 
-	byID, err := rm.collectMetadata(ctx, snap.Root)
+	byID, walkOrder, err := rm.collectMetadata(ctx, snap.Root)
 	if err != nil {
 		return restorePlan{}, err
 	}
 
-	sorted := topoSort(byID)
+	sorted := restoreOrder(byID, walkOrder)
 	if cfg.pathFilter != "" {
 		sorted = filterByPath(sorted, byID, cfg.pathFilter)
 	}
@@ -752,14 +752,22 @@ func (rm *RestoreManager) resolveSnapshot(ctx context.Context, ref string) (*cor
 // Metadata collection
 // ---------------------------------------------------------------------------
 
-func (rm *RestoreManager) collectMetadata(ctx context.Context, root string) (map[string]core.FileMeta, error) {
+// collectMetadata loads every entry in the snapshot, and reports the order the
+// tree walk yielded them in as well as the entries themselves.
+//
+// The order matters to what comes after. Objects are laid out in packfiles in
+// the order backup wrote them, and the walk yields them in that same order, so
+// reading in walk order touches each pack once. Restoring in some other order
+// scatters reads across every pack instead — measured at 55% pack-cache misses
+// against 0.6% for this phase (RFC 0023).
+func (rm *RestoreManager) collectMetadata(ctx context.Context, root string) (map[string]core.FileMeta, []string, error) {
 	var refs []string
 	err := rm.tree.Walk(ctx, root, func(_, valueRef string) error {
 		refs = append(refs, valueRef)
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	phase := rm.reporter.StartPhase("Loading metadata", int64(len(refs)), false)
@@ -768,12 +776,17 @@ func (rm *RestoreManager) collectMetadata(ctx context.Context, root string) (map
 	// small, independent JSON object with no ordering requirement among
 	// them, unlike a file's content chunks, so results can land in the map
 	// as soon as they arrive rather than needing to be sequenced.
+	//
+	// Walk order is kept separately, by writing each result to its own index
+	// rather than appending as it lands: concurrency decides when a result
+	// arrives, and that must not decide the order the restore writes in.
 	byID := make(map[string]core.FileMeta, len(refs))
+	walkOrder := make([]string, len(refs))
 	var mu sync.Mutex
 
 	g, gCtx := errgroup.WithContext(ctx)
 	g.SetLimit(store.GetConcurrencyHint(rm.store, 10))
-	for _, ref := range refs {
+	for i, ref := range refs {
 		g.Go(func() error {
 			fm, err := rm.metas.load(gCtx, ref)
 			if err != nil {
@@ -781,6 +794,7 @@ func (rm *RestoreManager) collectMetadata(ctx context.Context, root string) (map
 			}
 			mu.Lock()
 			byID[fm.FileID] = *fm
+			walkOrder[i] = fm.FileID
 			mu.Unlock()
 			phase.Increment(1)
 			return nil
@@ -788,35 +802,56 @@ func (rm *RestoreManager) collectMetadata(ctx context.Context, root string) (map
 	}
 	if err := g.Wait(); err != nil {
 		phase.Error()
-		return nil, err
+		return nil, nil, err
 	}
 	phase.Done()
-	return byID, nil
+	return byID, walkOrder, nil
 }
 
 // ---------------------------------------------------------------------------
 // Ordering
 // ---------------------------------------------------------------------------
 
-// topoSort returns FileIDs in parent-before-child order so that directories are
-// created before the files they contain. Parents contain FileIDs.
+// restoreOrder returns FileIDs in the order a restore should write them.
 //
-// It orders byID rather than copying out of it: the caller already holds every
-// entry, and a second slice of core.FileMeta doubled a snapshot's metadata for
-// the sake of sequencing it.
-func topoSort(byID map[string]core.FileMeta) []string {
+// The constraint is that an entry's parents exist before it does, so a directory
+// is created before anything it contains. That constraint binds only the entries
+// that *are* parents — everything else is a leaf, and a leaf may be written at
+// any point after the interior of the tree exists.
+//
+// So the interior is emitted first, in parent-before-child order, and the leaves
+// follow in walkOrder. Leaves are the overwhelming majority (50,000 of 50,500 in
+// the tree RFC 0023 measured) and walk order is the order backup wrote them,
+// which is the order they are laid out in packfiles. Ordering the whole tree
+// topologically instead scattered reads across every pack: 55% pack-cache misses
+// against 0.6% for the metadata phase, which already reads in walk order.
+//
+// Interior membership is derived from the data rather than from Type. A regular
+// file is a leaf in every source model this supports, but a snapshot is data
+// read off a store, and an entry that claims a file as its parent must still be
+// ordered after it rather than trusted not to exist.
+func restoreOrder(byID map[string]core.FileMeta, walkOrder []string) []string {
+	interior := make(map[string]bool)
+	for _, meta := range byID {
+		for _, parentID := range meta.Parents {
+			if _, ok := byID[parentID]; ok {
+				interior[parentID] = true
+			}
+		}
+	}
+
 	out := make([]string, 0, len(byID))
-	visited := make(map[string]bool, len(byID))
+	emitted := make(map[string]bool, len(byID))
 
 	var visit func(core.FileMeta)
 	visit = func(meta core.FileMeta) {
-		if visited[meta.FileID] {
+		if emitted[meta.FileID] {
 			return
 		}
 		// Marked before recursing, not after: a parent cycle would otherwise
 		// revisit this entry forever. Marking first makes a cycle terminate with
 		// the entry emitted once, in an order the cycle itself does not define.
-		visited[meta.FileID] = true
+		emitted[meta.FileID] = true
 		for _, parentID := range meta.Parents {
 			if parent, ok := byID[parentID]; ok {
 				visit(parent)
@@ -825,8 +860,36 @@ func topoSort(byID map[string]core.FileMeta) []string {
 		out = append(out, meta.FileID)
 	}
 
-	for _, meta := range byID {
-		visit(meta)
+	// Interior nodes in walk order too, so that sibling directories are created
+	// in the order they were backed up rather than in map-iteration order. visit
+	// pulls in any ancestor that has not been reached yet.
+	for _, id := range walkOrder {
+		if interior[id] {
+			visit(byID[id])
+		}
+	}
+	// A cycle among interior nodes can leave one unreached from walkOrder if the
+	// snapshot is malformed; nothing may be dropped.
+	for id := range interior {
+		if !emitted[id] {
+			visit(byID[id])
+		}
+	}
+
+	for _, id := range walkOrder {
+		if emitted[id] {
+			continue
+		}
+		emitted[id] = true
+		out = append(out, id)
+	}
+	// walkOrder comes from the same walk that built byID, so this adds nothing in
+	// practice. It is here because dropping an entry silently loses a file.
+	for id := range byID {
+		if !emitted[id] {
+			emitted[id] = true
+			out = append(out, id)
+		}
 	}
 	return out
 }

--- a/internal/engine/restore_ordering_test.go
+++ b/internal/engine/restore_ordering_test.go
@@ -16,54 +16,10 @@ func indexOf(order []string, id string) int {
 	return -1
 }
 
-// topoSort's contract is parent-before-child. It returns FileIDs, so the caller
-// keeps one copy of each entry rather than two.
-func TestTopoSort_OrdersParentsBeforeChildren(t *testing.T) {
-	byID := map[string]core.FileMeta{
-		"root":  {FileID: "root", Type: core.FileTypeFolder},
-		"a":     {FileID: "a", Type: core.FileTypeFolder, Parents: []string{"root"}},
-		"b":     {FileID: "b", Type: core.FileTypeFolder, Parents: []string{"a"}},
-		"leaf":  {FileID: "leaf", Parents: []string{"b"}},
-		"other": {FileID: "other", Parents: []string{"root"}},
-	}
+// assertComplete checks that every entry appears exactly once.
+func assertComplete(t *testing.T, order []string, byID map[string]core.FileMeta) {
+	t.Helper()
 
-	order := topoSort(byID)
-	if len(order) != len(byID) {
-		t.Fatalf("ordering has %d entries, want %d", len(order), len(byID))
-	}
-
-	seen := make(map[string]bool, len(order))
-	for _, id := range order {
-		if seen[id] {
-			t.Fatalf("%s appears twice in the ordering", id)
-		}
-		seen[id] = true
-	}
-
-	for _, child := range []struct{ child, parent string }{
-		{"a", "root"}, {"b", "a"}, {"leaf", "b"}, {"other", "root"},
-	} {
-		if indexOf(order, child.parent) > indexOf(order, child.child) {
-			t.Errorf("%s (parent) is ordered after %s (child)", child.parent, child.child)
-		}
-	}
-}
-
-// A parent cycle is not reachable from a repository this code wrote, but it is
-// reachable from a corrupt or hostile one. Marking an entry visited before
-// recursing makes the walk terminate and emit each entry once; marking after
-// recursing, as it did before, recurses until the stack is exhausted.
-func TestTopoSort_TerminatesOnAParentCycle(t *testing.T) {
-	byID := map[string]core.FileMeta{
-		"x": {FileID: "x", Type: core.FileTypeFolder, Parents: []string{"y"}},
-		"y": {FileID: "y", Type: core.FileTypeFolder, Parents: []string{"x"}},
-		"z": {FileID: "z", Parents: []string{"x"}},
-	}
-
-	done := make(chan []string, 1)
-	go func() { done <- topoSort(byID) }()
-
-	order := <-done
 	if len(order) != len(byID) {
 		t.Fatalf("ordering has %d entries, want %d", len(order), len(byID))
 	}
@@ -81,16 +37,134 @@ func TestTopoSort_TerminatesOnAParentCycle(t *testing.T) {
 	}
 }
 
+// The ordering constraint restore actually depends on: an entry's parents are
+// written before it is.
+func TestRestoreOrder_OrdersParentsBeforeChildren(t *testing.T) {
+	byID := map[string]core.FileMeta{
+		"root":  {FileID: "root", Type: core.FileTypeFolder},
+		"a":     {FileID: "a", Type: core.FileTypeFolder, Parents: []string{"root"}},
+		"b":     {FileID: "b", Type: core.FileTypeFolder, Parents: []string{"a"}},
+		"leaf":  {FileID: "leaf", Parents: []string{"b"}},
+		"other": {FileID: "other", Parents: []string{"root"}},
+	}
+	walk := []string{"root", "a", "b", "leaf", "other"}
+
+	order := restoreOrder(byID, walk)
+	assertComplete(t, order, byID)
+
+	for _, rel := range []struct{ child, parent string }{
+		{"a", "root"}, {"b", "a"}, {"leaf", "b"}, {"other", "root"},
+	} {
+		if indexOf(order, rel.parent) > indexOf(order, rel.child) {
+			t.Errorf("%s (parent) is ordered after %s (child)", rel.parent, rel.child)
+		}
+	}
+}
+
+// The point of the change: entries that are nobody's parent keep walk order,
+// which is the order they sit in packfiles. A topological order over the whole
+// tree groups them by directory instead, and scatters pack reads.
+func TestRestoreOrder_LeavesKeepWalkOrder(t *testing.T) {
+	byID := map[string]core.FileMeta{
+		"dirA": {FileID: "dirA", Type: core.FileTypeFolder},
+		"dirB": {FileID: "dirB", Type: core.FileTypeFolder},
+		// Interleaved across two directories, as a pack laid them out.
+		"a1": {FileID: "a1", Parents: []string{"dirA"}},
+		"b1": {FileID: "b1", Parents: []string{"dirB"}},
+		"a2": {FileID: "a2", Parents: []string{"dirA"}},
+		"b2": {FileID: "b2", Parents: []string{"dirB"}},
+	}
+	walk := []string{"dirA", "a1", "dirB", "b1", "a2", "b2"}
+
+	order := restoreOrder(byID, walk)
+	assertComplete(t, order, byID)
+
+	var leaves []string
+	for _, id := range order {
+		switch id {
+		case "a1", "a2", "b1", "b2":
+			leaves = append(leaves, id)
+		}
+	}
+	want := []string{"a1", "b1", "a2", "b2"}
+	for i := range want {
+		if leaves[i] != want[i] {
+			t.Fatalf("leaf order = %v, want %v (walk order)", leaves, want)
+		}
+	}
+
+	for _, rel := range []struct{ child, parent string }{
+		{"a1", "dirA"}, {"a2", "dirA"}, {"b1", "dirB"}, {"b2", "dirB"},
+	} {
+		if indexOf(order, rel.parent) > indexOf(order, rel.child) {
+			t.Errorf("%s is ordered after %s", rel.parent, rel.child)
+		}
+	}
+}
+
+// Interior membership comes from the data, not from Type. A snapshot is read off
+// a store, so an entry naming a plain file as its parent must still be ordered
+// after it rather than trusted not to exist.
+func TestRestoreOrder_TreatsAnyNamedParentAsInterior(t *testing.T) {
+	byID := map[string]core.FileMeta{
+		"file":  {FileID: "file", Type: core.FileTypeFile},
+		"child": {FileID: "child", Type: core.FileTypeFile, Parents: []string{"file"}},
+	}
+
+	order := restoreOrder(byID, []string{"file", "child"})
+	assertComplete(t, order, byID)
+	if indexOf(order, "file") > indexOf(order, "child") {
+		t.Errorf("a file named as a parent was ordered after its child: %v", order)
+	}
+}
+
+// A parent cycle is not reachable from a repository this code wrote, but it is
+// from a corrupt or hostile one. It must terminate and emit each entry once.
+func TestRestoreOrder_TerminatesOnAParentCycle(t *testing.T) {
+	byID := map[string]core.FileMeta{
+		"x": {FileID: "x", Type: core.FileTypeFolder, Parents: []string{"y"}},
+		"y": {FileID: "y", Type: core.FileTypeFolder, Parents: []string{"x"}},
+		"z": {FileID: "z", Parents: []string{"x"}},
+	}
+
+	done := make(chan []string, 1)
+	go func() { done <- restoreOrder(byID, []string{"x", "y", "z"}) }()
+	assertComplete(t, <-done, byID)
+}
+
 // An entry naming a parent that is not in the snapshot must still be ordered,
-// not dropped. Restore relies on that: a filtered or partial tree has entries
-// whose parents were never loaded.
-func TestTopoSort_KeepsEntriesWithUnknownParents(t *testing.T) {
+// not dropped: a filtered or partial tree has entries whose parents were never
+// loaded.
+func TestRestoreOrder_KeepsEntriesWithUnknownParents(t *testing.T) {
 	byID := map[string]core.FileMeta{
 		"orphan": {FileID: "orphan", Parents: []string{"missing"}},
 	}
 
-	order := topoSort(byID)
+	order := restoreOrder(byID, []string{"orphan"})
 	if len(order) != 1 || order[0] != "orphan" {
 		t.Fatalf("order = %v, want [orphan]", order)
+	}
+}
+
+// A walk order that does not mention every entry must still restore all of them.
+// Nothing produces that today; dropping a file silently is bad enough to guard.
+func TestRestoreOrder_EmitsEntriesMissingFromWalkOrder(t *testing.T) {
+	byID := map[string]core.FileMeta{
+		"dir":     {FileID: "dir", Type: core.FileTypeFolder},
+		"listed":  {FileID: "listed", Parents: []string{"dir"}},
+		"missing": {FileID: "missing", Parents: []string{"dir"}},
+	}
+
+	order := restoreOrder(byID, []string{"dir", "listed"})
+	assertComplete(t, order, byID)
+	if indexOf(order, "dir") > indexOf(order, "missing") {
+		t.Errorf("dir is ordered after missing: %v", order)
+	}
+}
+
+// An empty snapshot is not an error.
+func TestRestoreOrder_Empty(t *testing.T) {
+	if order := restoreOrder(map[string]core.FileMeta{}, nil); len(order) != 0 {
+		t.Fatalf("order = %v, want empty", order)
 	}
 }

--- a/internal/engine/restore_parallel_test.go
+++ b/internal/engine/restore_parallel_test.go
@@ -86,12 +86,23 @@ func TestRestoreManager_CollectMetadata_FetchesConcurrently(t *testing.T) {
 		t.Fatalf("resolveSnapshot: %v", err)
 	}
 
-	byID, err := rsMgr.collectMetadata(ctx, snap.Root)
+	byID, walkOrder, err := rsMgr.collectMetadata(ctx, snap.Root)
 	if err != nil {
 		t.Fatalf("collectMetadata: %v", err)
 	}
 	if len(byID) == 0 {
 		t.Fatal("expected at least one file/dir in collected metadata")
+	}
+	// Walk order is what the pack-locality ordering rests on, so it must be
+	// complete and free of the gaps a concurrent fetch would leave if results
+	// were appended as they landed rather than placed by index.
+	if len(walkOrder) != len(byID) {
+		t.Errorf("walk order has %d entries, byID has %d", len(walkOrder), len(byID))
+	}
+	for i, id := range walkOrder {
+		if id == "" {
+			t.Fatalf("walk order has a gap at index %d", i)
+		}
 	}
 
 	if peak := tracker.peakConcurrency(); peak < 2 {


### PR DESCRIPTION
## Summary

- `restoreOrder` replaces `topoSort`: the interior of the tree is ordered parent-before-child, and the leaves follow in tree-walk order
- `collectMetadata` reports walk order alongside the entries, placing results by index so fetch concurrency cannot decide the write order
- Interior membership is derived from the data, not from `Type`

`topoSort` ordered the whole snapshot topologically. Only entries that *are*
parents need that; everything else is a leaf and may be written at any point once
the interior exists. Ordering leaves topologically grouped them by directory,
which bears no relation to packfile layout.

Part of RFC 0023 §5.

## Measurement

Traced which pack each catalog resolution lands in, on a 50,000-file tree
configured to produce 51 packs, then modelled `PackStore`'s four-pack body cache
over the traces.

| configuration | whole-pack transfers | ranged reads | cache hits |
|---|---|---|---|
| `main` | 51,413 | 0 | 58,184 |
| **this PR** | **6,726** | **0** | 102,871 |
| `main` + #452 | 6,834 | 47,982 | 54,781 |
| this PR + #452 | 1,704 | 11,950 | 95,943 |

A 7.6x reduction in pack transfers, and unlike #452 it costs no extra requests —
these are reads that were happening anyway, in a better order. The two compose:
together they are 30x fewer transfers than `main`.

Pack-cache miss rate for the write phase drops from 55.47% to 0.74%, which now
matches the metadata phase's 0.62% — the asymmetry between the two phases is
gone.

## On deriving interior membership from data

RFC 0023 §5 left an open question: is a regular file ever a parent? Checking the
source models — `local` and `sftp` take the parent from `path.Dir`, `onedrive`
from `ParentReference.ID`, `gdrive` from the Drive `parents` field, and gdrive
types a folder purely by mime type with no shortcut handling — the answer is no.

The implementation does not rely on that. A snapshot is data read off a store,
and `collectMetaPaths` already guards against unresolvable parents and cycles, so
an entry naming a file as its parent is ordered after it rather than trusted not
to exist. That costs nothing: in practice the interior set is the folders.

## Note on a measurement method

An earlier version of this used `-debug` output line counts. Those are not
reliable: when a progress reporter is active, `SafeLogWriter.Write` routes to
`pw.Log()`, a bounded buffer that drops under load — a restore issuing 109,597
lookups produced 9,097 log lines. The figures above come from the trace
instrumentation instead, which writes synchronously under a mutex. I have posted
a correction on #452, whose description carried a figure derived the unreliable
way.

## Verification

```bash
env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./internal/... .
```

```bash
env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./internal/engine/...
```

Both pass; lint reports 0 issues. A full restore of the 50,000-file fixture
produces all 50,000 files.

Ordering tests cover parent-before-child, leaves keeping walk order, a file named
as a parent, cycle termination, unknown parents, entries absent from walk order,
and the empty snapshot. `restore_parallel_test.go` additionally asserts walk order
is complete and gap-free, which is what the index-placement change guarantees.
