### PR TITLE
perf(store): name pending catalog entries instead of copying them

### DIFF
--- a/internal/storelayer/pack.go
+++ b/internal/storelayer/pack.go
@@ -56,10 +56,20 @@ type PackStore struct {
 	// Key sealing the catalog and pack footers; empty leaves them in plaintext.
 	indexKey []byte
 
-	// Entries added since the last shard was written. Flushed as one immutable
-	// shard rather than merged into a shared object, so concurrent writers
-	// cannot erase each other. See packshard.go.
-	pendingShard map[string]PackEntry
+	// Keys added to the catalog since the last shard was written, flushed as one
+	// immutable shard rather than merged into a shared object so that concurrent
+	// writers cannot erase each other. See packshard.go.
+	//
+	// A key set rather than a second copy of the entries: the values are already
+	// in catalog, and holding them twice cost a whole duplicate of a run's worth
+	// of entries -- the largest single allocation in a backup. The strings are
+	// shared with catalog's keys, so an entry costs a header and a map slot.
+	//
+	// It also records which catalog entries are authoritative. loadCatalogLocked
+	// streams remote entries straight into catalog, so a failed load can leave
+	// entries behind; these are the ones that survive it, because nothing but a
+	// local write or a footer rebuild puts a key here.
+	pendingKeys map[string]struct{}
 
 	// LRU cache for recently downloaded packfiles to accelerate Get() and HAMT walks
 	packCache *lru.Cache[string, []byte]
@@ -108,14 +118,14 @@ func NewPackStore(inner store.ObjectStore, opts ...PackOption) (*PackStore, erro
 	}
 
 	s := &PackStore{
-		ObjectStore:  inner,
-		packBuffer:   new(bytes.Buffer),
-		packKeys:     make(map[string]PackEntry),
-		catalog:      make(map[string]PackEntry),
-		pendingShard: make(map[string]PackEntry),
-		mergedIndex:  make(map[string]bool),
-		packCache:    cache,
-		packMisses:   misses,
+		ObjectStore: inner,
+		packBuffer:  new(bytes.Buffer),
+		packKeys:    make(map[string]PackEntry),
+		catalog:     make(map[string]PackEntry),
+		pendingKeys: make(map[string]struct{}),
+		mergedIndex: make(map[string]bool),
+		packCache:   cache,
+		packMisses:  misses,
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -224,9 +234,9 @@ func (s *PackStore) discardPack(packRef string) {
 			delete(s.catalog, key)
 		}
 	}
-	for key, entry := range s.pendingShard {
-		if entry.PackRef == packRef {
-			delete(s.pendingShard, key)
+	for key := range s.pendingKeys {
+		if entry, ok := s.catalog[key]; !ok || entry.PackRef == packRef {
+			delete(s.pendingKeys, key)
 		}
 	}
 	s.packCache.Remove(packRef)
@@ -297,7 +307,7 @@ func (s *PackStore) prepareFlushLocked() (string, []byte, error) {
 	for key, entry := range s.packKeys {
 		entry.PackRef = packRef
 		s.catalog[key] = entry
-		s.pendingShard[key] = entry
+		s.pendingKeys[key] = struct{}{}
 	}
 
 	// Reset active buffer
@@ -550,36 +560,43 @@ func (s *PackStore) Flush(ctx context.Context) error {
 	// Take this flush's entries. They are written as their own immutable shard
 	// rather than merged into a shared object, so a concurrent writer cannot
 	// erase them. See packshard.go.
-	pending := s.pendingShard
-	s.pendingShard = make(map[string]PackEntry)
+	pending := s.pendingKeys
+	s.pendingKeys = make(map[string]struct{})
 	totalEntries := len(s.catalog)
+	// Seal here, under the lock that already guards catalog, so the shard is
+	// rendered straight from it. Materialising the pending entries into a map
+	// first would reinstate the duplicate this change removes — pending is a
+	// whole run's worth of entries by the time a backup flushes.
+	shardRef, shardData, sealErr := s.sealShardFor(s.catalog, pending)
 	s.mu.Unlock()
+
+	restorePending := func() {
+		s.mu.Lock()
+		for k := range pending {
+			s.pendingKeys[k] = struct{}{}
+		}
+		s.mu.Unlock()
+	}
 
 	if packRef != "" {
 		if err := s.ObjectStore.Put(ctx, packRef, packData); err != nil {
-			// Restore the entries that belong to packs already written, and
-			// drop the ones that belong to this pack — it does not exist, so a
+			// Restore the keys that belong to packs already written; discardPack
+			// drops the ones belonging to this pack, which does not exist, so a
 			// shard naming it would point every one of its objects at nothing.
-			s.mu.Lock()
-			for k, v := range pending {
-				if v.PackRef != packRef {
-					s.pendingShard[k] = v
-				}
-			}
-			s.mu.Unlock()
+			restorePending()
 			s.discardPack(packRef)
 			return fmt.Errorf("flush pack %s: %w", packRef, err)
 		}
 	}
 
-	if len(pending) > 0 {
-		if _, err := s.writeShard(ctx, pending); err != nil {
-			s.mu.Lock()
-			for k, v := range pending {
-				s.pendingShard[k] = v
-			}
-			s.mu.Unlock()
-			return err
+	if sealErr != nil {
+		restorePending()
+		return sealErr
+	}
+	if shardRef != "" {
+		if err := s.ObjectStore.Put(ctx, shardRef, shardData); err != nil {
+			restorePending()
+			return fmt.Errorf("write pack index shard %s: %w", shardRef, err)
 		}
 		s.debugf("pack: flushed %d new entries (%d total)", len(pending), totalEntries)
 	}
@@ -618,7 +635,7 @@ func (s *PackStore) loadCatalogLocked(ctx context.Context) (err error) {
 
 	// Streaming writes directly into s.catalog. If any part of the load fails,
 	// remove those uncommitted remote entries before releasing mu while keeping
-	// authoritative entries tracked in pendingShard.
+	// authoritative entries named by pendingKeys.
 	defer func() {
 		if err != nil {
 			s.resetCatalogAfterLoadFailureLocked()
@@ -664,12 +681,14 @@ func (s *PackStore) loadCatalogLocked(ctx context.Context) (err error) {
 
 // resetCatalogAfterLoadFailureLocked discards entries streamed from an index
 // that did not load completely while retaining independently authoritative
-// entries in pendingShard, whether locally written or recovered from a pack
+// entries named by pendingKeys, whether locally written or recovered from a pack
 // footer. mu must be held.
 func (s *PackStore) resetCatalogAfterLoadFailureLocked() {
-	catalog := make(map[string]PackEntry, len(s.pendingShard))
-	for key, entry := range s.pendingShard {
-		catalog[key] = entry
+	catalog := make(map[string]PackEntry, len(s.pendingKeys))
+	for key := range s.pendingKeys {
+		if entry, ok := s.catalog[key]; ok {
+			catalog[key] = entry
+		}
 	}
 	s.catalog = catalog
 	s.mergedIndex = make(map[string]bool)

--- a/internal/storelayer/pack_heal_trigger_test.go
+++ b/internal/storelayer/pack_heal_trigger_test.go
@@ -146,7 +146,7 @@ func TestPackStore_DoesNotHealWhenIndexEntriesAreAlreadyKnown(t *testing.T) {
 	// stored shard names is already present and none of them is inserted.
 	fresh.mu.Lock()
 	fresh.catalog[key] = entry
-	fresh.pendingShard[key] = entry
+	fresh.pendingKeys[key] = struct{}{}
 	fresh.mu.Unlock()
 
 	// Read a key the catalog does not hold, so the load actually runs rather

--- a/internal/storelayer/packfooter.go
+++ b/internal/storelayer/packfooter.go
@@ -286,7 +286,7 @@ func (s *PackStore) rebuildFromPacksLocked(ctx context.Context, packRefs []strin
 				s.catalog[key] = entry
 				// Recovered entries are pending like any other, so the next
 				// flush persists them and the repair is paid for once.
-				s.pendingShard[key] = entry
+				s.pendingKeys[key] = struct{}{}
 				recovered++
 			}
 		}

--- a/internal/storelayer/packseal_bench_test.go
+++ b/internal/storelayer/packseal_bench_test.go
@@ -75,7 +75,8 @@ func BenchmarkPackCatalogFlush(b *testing.B) {
 				b.ReportAllocs()
 				for b.Loop() {
 					ps.mu.Lock()
-					ps.pendingShard = entries
+					ps.catalog = entries
+					ps.pendingKeys = keySetOf(entries)
 					ps.mu.Unlock()
 					if err := ps.Flush(ctx); err != nil {
 						b.Fatal(err)
@@ -113,7 +114,7 @@ func BenchmarkPackCatalogLoad(b *testing.B) {
 				entries := benchEntries(n)
 				writer.mu.Lock()
 				writer.catalog = entries
-				writer.pendingShard = entries
+				writer.pendingKeys = keySetOf(entries)
 				writer.catalogLoaded = true
 				writer.mu.Unlock()
 				if err := writer.Flush(ctx); err != nil {
@@ -133,4 +134,14 @@ func BenchmarkPackCatalogLoad(b *testing.B) {
 			})
 		}
 	}
+}
+
+// keySetOf names every entry in a catalog, as pendingKeys does for the entries a
+// run has added.
+func keySetOf(entries map[string]PackEntry) map[string]struct{} {
+	keys := make(map[string]struct{}, len(entries))
+	for key := range entries {
+		keys[key] = struct{}{}
+	}
+	return keys
 }

--- a/internal/storelayer/packshard.go
+++ b/internal/storelayer/packshard.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 
 	"github.com/cloudstic/cli/internal/core"
 )
@@ -143,6 +144,58 @@ func (s *PackStore) sealShard(entries map[string]PackEntry) (string, []byte, err
 
 	// Name by the plaintext hash so the key is stable regardless of the nonce a
 	// sealed shard carries.
+	return shardPrefix + core.ComputeHash(plain), sealed, nil
+}
+
+// sealShardFor renders a shard containing exactly the catalog entries named by
+// keys, without building a map of them first.
+//
+// json.Marshal of a map sorts its keys, so the entries are sorted here too and
+// the bytes — and therefore the content-addressed shard key — are identical to
+// what marshalling an equivalent map would produce.
+//
+// The caller must hold mu: catalog and keys are both read here.
+func (s *PackStore) sealShardFor(catalog map[string]PackEntry, keys map[string]struct{}) (string, []byte, error) {
+	if len(keys) == 0 {
+		return "", nil, nil
+	}
+
+	ordered := make([]string, 0, len(keys))
+	for key := range keys {
+		if _, ok := catalog[key]; ok {
+			ordered = append(ordered, key)
+		}
+	}
+	if len(ordered) == 0 {
+		return "", nil, nil
+	}
+	sort.Strings(ordered)
+
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	for i, key := range ordered {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		name, err := json.Marshal(key)
+		if err != nil {
+			return "", nil, fmt.Errorf("marshal pack index shard key: %w", err)
+		}
+		buf.Write(name)
+		buf.WriteByte(':')
+		entry, err := json.Marshal(catalog[key])
+		if err != nil {
+			return "", nil, fmt.Errorf("marshal pack index shard entry: %w", err)
+		}
+		buf.Write(entry)
+	}
+	buf.WriteByte('}')
+
+	plain := buf.Bytes()
+	sealed, err := sealIndex(plain, s.indexKey)
+	if err != nil {
+		return "", nil, fmt.Errorf("seal pack index shard: %w", err)
+	}
 	return shardPrefix + core.ComputeHash(plain), sealed, nil
 }
 

--- a/internal/storelayer/packshard_seal_test.go
+++ b/internal/storelayer/packshard_seal_test.go
@@ -1,0 +1,96 @@
+package storelayer
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// sealShardFor renders a shard without building a map of the entries first. The
+// bytes must match what marshalling the equivalent map would produce, because
+// the shard's key is the hash of those bytes.
+func TestSealShardFor_MatchesMarshallingAnEquivalentMap(t *testing.T) {
+	catalog := map[string]PackEntry{
+		"filemeta/b": {PackRef: "packs/one", Offset: 5, Length: 7},
+		"filemeta/a": {PackRef: "packs/one", Offset: 0, Length: 5},
+		"node/z":     {PackRef: "packs/two", Offset: 3, Length: 9},
+		// Present in the catalog but not pending: must not appear in the shard.
+		"content/x": {PackRef: "packs/three", Offset: 1, Length: 1},
+	}
+	pending := map[string]struct{}{
+		"filemeta/a": {}, "filemeta/b": {}, "node/z": {},
+	}
+
+	s, err := NewPackStore(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotRef, gotBytes, err := s.sealShardFor(catalog, pending)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	subset := map[string]PackEntry{
+		"filemeta/a": catalog["filemeta/a"],
+		"filemeta/b": catalog["filemeta/b"],
+		"node/z":     catalog["node/z"],
+	}
+	wantRef, wantBytes, err := s.sealShard(subset)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotBytes) != string(wantBytes) {
+		t.Fatalf("bytes differ:\n got %s\nwant %s", gotBytes, wantBytes)
+	}
+	if gotRef != wantRef {
+		t.Fatalf("ref = %s, want %s", gotRef, wantRef)
+	}
+
+	var decoded map[string]PackEntry
+	if err := json.Unmarshal(gotBytes, &decoded); err != nil {
+		t.Fatalf("shard does not decode: %v", err)
+	}
+	if len(decoded) != 3 {
+		t.Fatalf("shard has %d entries, want 3: %v", len(decoded), decoded)
+	}
+	if _, ok := decoded["content/x"]; ok {
+		t.Error("a catalog entry that was not pending leaked into the shard")
+	}
+}
+
+// A pending key whose catalog entry has since been removed names nothing, and
+// must not produce a shard entry pointing at a zero location.
+func TestSealShardFor_SkipsKeysMissingFromTheCatalog(t *testing.T) {
+	s, err := NewPackStore(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	catalog := map[string]PackEntry{"filemeta/a": {PackRef: "packs/one", Length: 2}}
+	pending := map[string]struct{}{"filemeta/a": {}, "filemeta/gone": {}}
+
+	_, data, err := s.sealShardFor(catalog, pending)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]PackEntry
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := decoded["filemeta/gone"]; ok {
+		t.Error("a pending key with no catalog entry produced a shard entry")
+	}
+	if len(decoded) != 1 {
+		t.Fatalf("shard has %d entries, want 1", len(decoded))
+	}
+}
+
+// Nothing pending is not an error and names no object.
+func TestSealShardFor_EmptyPendingSetWritesNothing(t *testing.T) {
+	s, err := NewPackStore(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref, data, err := s.sealShardFor(map[string]PackEntry{"a": {}}, nil)
+	if err != nil || ref != "" || data != nil {
+		t.Fatalf("got (%q, %v, %v), want (\"\", nil, nil)", ref, data, err)
+	}
+}


### PR DESCRIPTION
## Summary

- `pendingShard map[string]PackEntry` becomes `pendingKeys map[string]struct{}` — the values are already in `catalog` and the key strings are shared with it
- `Flush` renders the shard straight from the catalog via `sealShardFor`, rather than materialising the pending entries into a map to marshal
- Entries are sorted so the bytes, and the content-addressed shard key, are identical to marshalling an equivalent map

By the time a backup flushes, `pendingShard` held a whole run's worth of entries.
It was the largest single allocation in a backup: **50.2 MB flat, 41% of live
heap** at 50k files.

Closes #437

## Measurements

Backup, 50,000 files:

| | live heap | peak RSS |
|---|---|---|
| `main` @ `f4deb56` | 141 MB | 360 MB |
| this PR | **101.6 MB** | **336 MB** |

`prepareFlushLocked` leaves the profile's top entries entirely — it was the
number one line before.

## Why this rather than #440

This started as #440. Profiling `main` first put the growth somewhere else than
RFC 0023 assumed, so the work followed the measurement:

| operation | dominant live-heap term at 50k |
|---|---|
| backup (141 MB) | `prepareFlushLocked` **50.2 MB** — this PR |
| check (74.5 MB) | `packCache` 36 MB, catalog ~20 MB, `verified` map 7 MB |

The pack catalog — #440's target — is roughly 20 MB of `check`'s 74.5 MB, behind
the 36 MB body cache. Bounding it is still worth doing, but it is not where the
largest growth was, and #437 was blocked on #440 only because of a coupling this
PR resolves.

**This reduces the linear coefficient; it does not remove the growth.** The
catalog, the `verified` set and backup's cached `metaLoader` are all still
O(repository). I have written up what remains on #440.

## On the authoritative-entry role

The set keeps the second job `pendingShard` acquired in #444: recording which
catalog entries are authoritative, so a failed catalog load can drop streamed
remote entries and keep locally written and footer-recovered ones. That still
holds, because nothing but a local write or a footer rebuild puts a key there,
and `mergePackIndex` is first-writer-wins — so a pending key's value in the
catalog cannot have come from the failed load.

## Verification

```bash
env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./internal/... .
```

```bash
env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./internal/storelayer/...
```

Both pass; lint reports 0 issues. New tests cover the byte-identical rendering
against `sealShard`, a pending key whose catalog entry has been removed, and an
empty pending set. The existing pack durability and upload-failure tests cover
the restore-on-failure paths, which now restore keys rather than entries.
