### PR TITLE
perf(store): hold the pack catalog compactly

### DIFF
--- a/internal/storelayer/pack.go
+++ b/internal/storelayer/pack.go
@@ -40,7 +40,7 @@ type PackStore struct {
 	packKeys   map[string]PackEntry
 
 	// The stateless JSON catalog mapped from index/packs
-	catalog       map[string]PackEntry
+	catalog       *packCatalog
 	catalogLoaded bool
 
 	// Set when entries have been removed from the in-memory catalog. Shards are
@@ -121,7 +121,7 @@ func NewPackStore(inner store.ObjectStore, opts ...PackOption) (*PackStore, erro
 		ObjectStore: inner,
 		packBuffer:  new(bytes.Buffer),
 		packKeys:    make(map[string]PackEntry),
-		catalog:     make(map[string]PackEntry),
+		catalog:     newPackCatalog(),
 		pendingKeys: make(map[string]struct{}),
 		mergedIndex: make(map[string]bool),
 		packCache:   cache,
@@ -229,13 +229,17 @@ func (s *PackStore) discardPack(packRef string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	for key, entry := range s.catalog {
+	var stale []string
+	s.catalog.Each(func(key string, entry PackEntry) {
 		if entry.PackRef == packRef {
-			delete(s.catalog, key)
+			stale = append(stale, key)
 		}
+	})
+	for _, key := range stale {
+		s.catalog.Delete(key)
 	}
 	for key := range s.pendingKeys {
-		if entry, ok := s.catalog[key]; !ok || entry.PackRef == packRef {
+		if entry, ok := s.catalog.Get(key); !ok || entry.PackRef == packRef {
 			delete(s.pendingKeys, key)
 		}
 	}
@@ -306,7 +310,7 @@ func (s *PackStore) prepareFlushLocked() (string, []byte, error) {
 	// Assign the PackRef to all entries that were bundled and move to catalog
 	for key, entry := range s.packKeys {
 		entry.PackRef = packRef
-		s.catalog[key] = entry
+		s.catalog.Set(key, entry)
 		s.pendingKeys[key] = struct{}{}
 	}
 
@@ -331,7 +335,7 @@ func (s *PackStore) Get(ctx context.Context, key string) ([]byte, error) {
 	}
 
 	// 2. Is it in our catalog?
-	entry, inCatalog := s.catalog[key]
+	entry, inCatalog := s.catalog.Get(key)
 	s.mu.RUnlock()
 
 	// If not in catalog, wait: we might need to load the catalog from the remote store first,
@@ -342,7 +346,7 @@ func (s *PackStore) Get(ctx context.Context, key string) ([]byte, error) {
 				return nil, err
 			}
 			s.mu.RLock()
-			entry, inCatalog = s.catalog[key]
+			entry, inCatalog = s.catalog.Get(key)
 			s.mu.RUnlock()
 		}
 
@@ -480,7 +484,7 @@ func (s *PackStore) Exists(ctx context.Context, key string) (bool, error) {
 		s.mu.RUnlock()
 		return true, nil
 	}
-	if _, ok := s.catalog[key]; ok {
+	if s.catalog.Has(key) {
 		s.mu.RUnlock()
 		return true, nil
 	}
@@ -508,11 +512,11 @@ func (s *PackStore) List(ctx context.Context, prefix string) ([]string, error) {
 
 	s.mu.RLock()
 	var packedKeys []string
-	for key := range s.catalog {
+	s.catalog.Each(func(key string, _ PackEntry) {
 		if strings.HasPrefix(key, prefix) {
 			packedKeys = append(packedKeys, key)
 		}
-	}
+	})
 	for key := range s.packKeys {
 		if strings.HasPrefix(key, prefix) {
 			packedKeys = append(packedKeys, key)
@@ -562,7 +566,7 @@ func (s *PackStore) Flush(ctx context.Context) error {
 	// erase them. See packshard.go.
 	pending := s.pendingKeys
 	s.pendingKeys = make(map[string]struct{})
-	totalEntries := len(s.catalog)
+	totalEntries := s.catalog.Len()
 	// Seal here, under the lock that already guards catalog, so the shard is
 	// rendered straight from it. Materialising the pending entries into a map
 	// first would reinstate the duplicate this change removes — pending is a
@@ -643,16 +647,15 @@ func (s *PackStore) loadCatalogLocked(ctx context.Context) (err error) {
 	}()
 
 	s.debugf("loading pack catalog")
-	refs := newPackRefInterner(s.catalog)
 
 	// The monolithic catalog is the pre-shard layout. It is still read so that
 	// repositories written before sharding stay readable, but nothing writes it
 	// any more; compaction folds it into a shard and removes it.
-	legacyEntries, err := s.loadLegacyCatalogLocked(ctx, refs)
+	legacyEntries, err := s.loadLegacyCatalogLocked(ctx)
 	if err != nil {
 		return err
 	}
-	shardEntries, err := s.loadShardsLocked(ctx, refs)
+	shardEntries, err := s.loadShardsLocked(ctx)
 	if err != nil {
 		return err
 	}
@@ -675,7 +678,7 @@ func (s *PackStore) loadCatalogLocked(ctx context.Context) (err error) {
 	}
 
 	s.catalogLoaded = true
-	s.debugf("loaded %d entries into the pack catalog", len(s.catalog))
+	s.debugf("loaded %d entries into the pack catalog", s.catalog.Len())
 	return nil
 }
 
@@ -684,10 +687,10 @@ func (s *PackStore) loadCatalogLocked(ctx context.Context) (err error) {
 // entries named by pendingKeys, whether locally written or recovered from a pack
 // footer. mu must be held.
 func (s *PackStore) resetCatalogAfterLoadFailureLocked() {
-	catalog := make(map[string]PackEntry, len(s.pendingKeys))
+	catalog := newPackCatalog()
 	for key := range s.pendingKeys {
-		if entry, ok := s.catalog[key]; ok {
-			catalog[key] = entry
+		if entry, ok := s.catalog.Get(key); ok {
+			catalog.Set(key, entry)
 		}
 	}
 	s.catalog = catalog
@@ -701,7 +704,7 @@ func (s *PackStore) resetCatalogAfterLoadFailureLocked() {
 // The count, rather than a found/not-found flag, is what loadCatalogLocked needs:
 // a catalog object that exists and lists nothing leaves the repository just as
 // unindexed as one that was deleted.
-func (s *PackStore) loadLegacyCatalogLocked(ctx context.Context, refs packRefInterner) (int, error) {
+func (s *PackStore) loadLegacyCatalogLocked(ctx context.Context) (int, error) {
 	// A fresh repository legitimately has no catalog. Establish that up front so
 	// a missing object is never conflated with an unreadable one; backends do
 	// not expose a typed not-found error, so an existence check is the only
@@ -731,7 +734,7 @@ func (s *PackStore) loadLegacyCatalogLocked(ctx context.Context, refs packRefInt
 		return 0, fmt.Errorf("open pack catalog %s: %w", indexPacksKey, err)
 	}
 
-	decoded, err := mergePackIndex(data, s.catalog, refs)
+	decoded, err := mergePackIndex(data, s.catalog)
 	if err != nil {
 		return 0, fmt.Errorf("unmarshal packs catalog: %w", err)
 	}
@@ -789,8 +792,8 @@ func (s *PackStore) Delete(ctx context.Context, key string) error {
 
 	// 2. Remove from catalog. Shards are append-only, so this is durable only
 	// once the index is compacted — see CompactCatalog.
-	if _, ok := s.catalog[key]; ok {
-		delete(s.catalog, key)
+	if s.catalog.Has(key) {
+		s.catalog.Delete(key)
 		s.needsCompaction = true
 		return nil
 	}
@@ -805,7 +808,7 @@ func (s *PackStore) Size(ctx context.Context, key string) (int64, error) {
 		s.mu.RUnlock()
 		return entry.Length, nil
 	}
-	if entry, ok := s.catalog[key]; ok {
+	if entry, ok := s.catalog.Get(key); ok {
 		s.mu.RUnlock()
 		return entry.Length, nil
 	}
@@ -830,10 +833,10 @@ func (s *PackStore) Repack(ctx context.Context, maxWastedRatio float64) (int64, 
 	// Calculate active bytes per pack and map keys to packs
 	packActiveSizes := make(map[string]int64)
 	packToKeys := make(map[string][]string)
-	for key, entry := range s.catalog {
+	s.catalog.Each(func(key string, entry PackEntry) {
 		packActiveSizes[entry.PackRef] += entry.Length
 		packToKeys[entry.PackRef] = append(packToKeys[entry.PackRef], key)
-	}
+	})
 	s.mu.RUnlock()
 
 	// List all physical packfiles
@@ -915,7 +918,7 @@ func (s *PackStore) Repack(ctx context.Context, maxWastedRatio float64) (int64, 
 			keys := packToKeys[packRef]
 			for _, key := range keys {
 				s.mu.RLock()
-				entry, ok := s.catalog[key]
+				entry, ok := s.catalog.Get(key)
 				s.mu.RUnlock()
 
 				if !ok || entry.PackRef != packRef {
@@ -973,12 +976,13 @@ func (s *PackStore) Repack(ctx context.Context, maxWastedRatio float64) (int64, 
 func (s *PackStore) packIsReferenced(packRef string) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	for _, entry := range s.catalog {
+	referenced := false
+	s.catalog.Each(func(_ string, entry PackEntry) {
 		if entry.PackRef == packRef {
-			return true
+			referenced = true
 		}
-	}
-	return false
+	})
+	return referenced
 }
 
 func (s *PackStore) TotalSize(ctx context.Context) (int64, error) {

--- a/internal/storelayer/pack_heal_trigger_test.go
+++ b/internal/storelayer/pack_heal_trigger_test.go
@@ -145,7 +145,7 @@ func TestPackStore_DoesNotHealWhenIndexEntriesAreAlreadyKnown(t *testing.T) {
 	// Pre-populate the catalog the way an auto-flush would, so every entry the
 	// stored shard names is already present and none of them is inserted.
 	fresh.mu.Lock()
-	fresh.catalog[key] = entry
+	fresh.catalog.Set(key, entry)
 	fresh.pendingKeys[key] = struct{}{}
 	fresh.mu.Unlock()
 
@@ -188,18 +188,18 @@ func shardEntryFor(t *testing.T, ctx context.Context, mem *storetest.MemStore, k
 	if err != nil {
 		t.Fatalf("list pack index shards under %s: %v", shardPrefix, err)
 	}
-	catalog := make(map[string]PackEntry)
+	catalog := newPackCatalog()
 	for _, k := range keys {
 		data, err := mem.Get(ctx, k)
 		if err != nil {
 			t.Fatalf("read pack index shard %s: %v", k, err)
 		}
-		if _, err := mergePackIndex(data, catalog, newPackRefInterner(catalog)); err != nil {
+		if _, err := mergePackIndex(data, catalog); err != nil {
 			t.Fatalf("merge pack index shard %s: %v", k, err)
 		}
 	}
 
-	entry, ok := catalog[key]
+	entry, ok := catalog.Get(key)
 	if !ok {
 		t.Fatalf("no shard records an entry for %s; the fixture never indexed it", key)
 	}
@@ -211,8 +211,8 @@ func shardEntryFor(t *testing.T, ctx context.Context, mem *storetest.MemStore, k
 func TestMergePackIndex_CountsDecodedEntriesNotInsertions(t *testing.T) {
 	shard := []byte(`{"filemeta/a":{"p":"packs/one","o":0,"l":1},"filemeta/b":{"p":"packs/one","o":1,"l":1}}`)
 
-	catalog := make(map[string]PackEntry)
-	decoded, err := mergePackIndex(shard, catalog, newPackRefInterner(catalog))
+	catalog := newPackCatalog()
+	decoded, err := mergePackIndex(shard, catalog)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,7 +222,7 @@ func TestMergePackIndex_CountsDecodedEntriesNotInsertions(t *testing.T) {
 
 	// Same object into a catalog that already holds both keys: nothing is
 	// inserted, but the object still described two entries.
-	again, err := mergePackIndex(shard, catalog, newPackRefInterner(catalog))
+	again, err := mergePackIndex(shard, catalog)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -230,8 +230,8 @@ func TestMergePackIndex_CountsDecodedEntriesNotInsertions(t *testing.T) {
 		t.Fatalf("decoded on re-merge = %d, want 2 (insertions would be 0)", again)
 	}
 
-	empty := make(map[string]PackEntry)
-	if n, err := mergePackIndex([]byte("{}"), empty, newPackRefInterner(empty)); err != nil || n != 0 {
+	empty := newPackCatalog()
+	if n, err := mergePackIndex([]byte("{}"), empty); err != nil || n != 0 {
 		t.Fatalf("empty object: got (%d, %v), want (0, nil)", n, err)
 	}
 }

--- a/internal/storelayer/packcatalog.go
+++ b/internal/storelayer/packcatalog.go
@@ -1,0 +1,179 @@
+package storelayer
+
+import (
+	"encoding/hex"
+	"strings"
+)
+
+// packCatalog maps an object key to its location in a packfile.
+//
+// It is the largest resident structure a repository forces on an operation — one
+// entry per packed object — so it is stored compactly rather than as the obvious
+// map[string]PackEntry.
+//
+// Almost every key is "<prefix>/<64 hex characters>": a namespace from a fixed
+// set, and a SHA-256. Held as a string that is 73 bytes of text plus a header,
+// for 32 bytes of hash. Decoding the hash and reducing the prefix to a byte puts
+// the key inline in the map, with no separate allocation and no pointer for the
+// garbage collector to chase. Pack refs are interned to an index into packRefs,
+// and offsets fit in uint32 because a packfile is bounded by maxPackSize.
+//
+// Measured on 200,000 entries: 158 B/entry as map[string]PackEntry with pack refs
+// already interned, against 73 B/entry here.
+//
+// Keys that do not have that shape — a legacy repository packed index/latest
+// before the packable-prefix restriction existed — live in a fallback map. There
+// are a handful at most, so it costs nothing to keep them exact rather than
+// refuse them.
+type packCatalog struct {
+	compact  map[compactKey]compactEntry
+	fallback map[string]PackEntry
+
+	packRefs []string
+	packIdx  map[string]uint32
+}
+
+// compactKey is a namespace byte followed by a decoded SHA-256.
+type compactKey [1 + 32]byte
+
+type compactEntry struct {
+	pack   uint32
+	offset uint32
+	length uint32
+}
+
+// packableNamespaces are the prefixes a compact key can encode. The order fixes
+// the namespace byte, so entries must only ever be appended.
+var packableNamespaces = []string{"filemeta/", "node/", "snapshot/", "chunk/", "content/"}
+
+func newPackCatalog() *packCatalog {
+	return &packCatalog{
+		compact:  make(map[compactKey]compactEntry),
+		fallback: make(map[string]PackEntry),
+		packIdx:  make(map[string]uint32),
+	}
+}
+
+// encodeKey renders key compactly, reporting false for a key that does not have
+// the "<known prefix>/<64 hex>" shape.
+func encodeKey(key string) (compactKey, bool) {
+	var out compactKey
+	for i, prefix := range packableNamespaces {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		hexPart := key[len(prefix):]
+		if len(hexPart) != 64 {
+			return out, false
+		}
+		if _, err := hex.Decode(out[1:], []byte(hexPart)); err != nil {
+			return out, false
+		}
+		out[0] = byte(i)
+		return out, true
+	}
+	return out, false
+}
+
+func decodeKey(k compactKey) string {
+	return packableNamespaces[k[0]] + hex.EncodeToString(k[1:])
+}
+
+// internPack returns the index for ref, adding it if new.
+func (c *packCatalog) internPack(ref string) uint32 {
+	if i, ok := c.packIdx[ref]; ok {
+		return i
+	}
+	i := uint32(len(c.packRefs))
+	c.packRefs = append(c.packRefs, ref)
+	c.packIdx[ref] = i
+	return i
+}
+
+func (c *packCatalog) Len() int { return len(c.compact) + len(c.fallback) }
+
+// Get returns the entry for key.
+//
+// The fallback map is consulted even for a well-shaped key, because Set sends a
+// location that does not fit the compact form there rather than truncating it.
+// Checking only the compact map would make such an entry vanish — and an entry
+// that silently disappears from this catalog is an object prune cannot see.
+func (c *packCatalog) Get(key string) (PackEntry, bool) {
+	if k, ok := encodeKey(key); ok {
+		if e, found := c.compact[k]; found {
+			return PackEntry{
+				PackRef: c.packRefs[e.pack],
+				Offset:  int64(e.offset),
+				Length:  int64(e.length),
+			}, true
+		}
+	}
+	e, found := c.fallback[key]
+	return e, found
+}
+
+func (c *packCatalog) Has(key string) bool {
+	if k, ok := encodeKey(key); ok {
+		if _, found := c.compact[k]; found {
+			return true
+		}
+	}
+	_, found := c.fallback[key]
+	return found
+}
+
+// Set records where key lives.
+//
+// An offset or length beyond what uint32 holds cannot come from a packfile this
+// code writes — maxPackSize bounds both — but the catalog is also read from a
+// store, so such an entry goes to the fallback map rather than being truncated
+// into a location that points somewhere else entirely.
+func (c *packCatalog) Set(key string, entry PackEntry) {
+	k, ok := encodeKey(key)
+	if !ok || entry.Offset > int64(^uint32(0)) || entry.Length > int64(^uint32(0)) ||
+		entry.Offset < 0 || entry.Length < 0 {
+		// Interned here too. A fallback entry is rare, but "entries sharing a
+		// pack share one string" should hold whatever shape the key has —
+		// otherwise the property depends on which branch an entry happened to
+		// take, which is not something a caller can reason about.
+		entry.PackRef = c.packRefs[c.internPack(entry.PackRef)]
+		c.fallback[key] = entry
+		return
+	}
+	c.compact[k] = compactEntry{
+		pack:   c.internPack(entry.PackRef),
+		offset: uint32(entry.Offset),
+		length: uint32(entry.Length),
+	}
+}
+
+// Delete removes key from wherever it is held. Both maps are touched for the
+// same reason Get consults both: a well-shaped key may still be in the fallback.
+func (c *packCatalog) Delete(key string) {
+	if k, ok := encodeKey(key); ok {
+		delete(c.compact, k)
+	}
+	delete(c.fallback, key)
+}
+
+// Each calls fn for every entry. Iteration order is unspecified, as it was for
+// the map this replaced.
+func (c *packCatalog) Each(fn func(key string, entry PackEntry)) {
+	for k, e := range c.compact {
+		fn(decodeKey(k), PackEntry{
+			PackRef: c.packRefs[e.pack],
+			Offset:  int64(e.offset),
+			Length:  int64(e.length),
+		})
+	}
+	for key, entry := range c.fallback {
+		fn(key, entry)
+	}
+}
+
+// Keys returns every key, for callers that need the set rather than the entries.
+func (c *packCatalog) Keys() []string {
+	out := make([]string, 0, c.Len())
+	c.Each(func(key string, _ PackEntry) { out = append(out, key) })
+	return out
+}

--- a/internal/storelayer/packcatalog_test.go
+++ b/internal/storelayer/packcatalog_test.go
@@ -1,0 +1,106 @@
+package storelayer
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestPackCatalog_RoundTripsCompactKeys(t *testing.T) {
+	c := newPackCatalog()
+	for _, prefix := range packableNamespaces {
+		key := prefix + fmt.Sprintf("%064x", 42)
+		want := PackEntry{PackRef: "packs/" + fmt.Sprintf("%064x", 7), Offset: 1234, Length: 5678}
+		c.Set(key, want)
+
+		got, ok := c.Get(key)
+		if !ok {
+			t.Fatalf("%s: not found after Set", key)
+		}
+		if got != want {
+			t.Fatalf("%s: got %#v, want %#v", key, got, want)
+		}
+		if !c.Has(key) {
+			t.Errorf("%s: Has said false", key)
+		}
+	}
+	if len(c.fallback) != 0 {
+		t.Errorf("compact keys landed in the fallback map: %v", c.fallback)
+	}
+}
+
+// Keys that are not "<known prefix>/<64 hex>" must still work. A legacy
+// repository packed index/latest before the packable-prefix restriction existed.
+func TestPackCatalog_KeepsUnshapedKeysExact(t *testing.T) {
+	c := newPackCatalog()
+	for _, key := range []string{
+		"index/latest",
+		"filemeta/short",
+		"filemeta/" + fmt.Sprintf("%064s", "zz"), // 64 chars, not hex
+		"unknown/" + fmt.Sprintf("%064x", 1),
+	} {
+		want := PackEntry{PackRef: "packs/x", Offset: 9, Length: 3}
+		c.Set(key, want)
+		got, ok := c.Get(key)
+		if !ok || got != want {
+			t.Errorf("%s: got (%#v, %v), want (%#v, true)", key, got, ok, want)
+		}
+	}
+	if len(c.compact) != 0 {
+		t.Errorf("unshaped keys were encoded compactly: %v", c.compact)
+	}
+}
+
+// An offset or length beyond uint32 cannot come from a pack this code writes,
+// but the catalog is read from a store. Such an entry must be returned exactly,
+// never truncated into a location pointing somewhere else.
+func TestPackCatalog_DoesNotTruncateOutOfRangeLocations(t *testing.T) {
+	c := newPackCatalog()
+	key := "chunk/" + fmt.Sprintf("%064x", 3)
+	want := PackEntry{PackRef: "packs/y", Offset: 1 << 40, Length: 12}
+	c.Set(key, want)
+
+	got, ok := c.Get(key)
+	if !ok {
+		t.Fatal("not found")
+	}
+	if got != want {
+		t.Fatalf("got %#v, want %#v — an out-of-range offset was not preserved", got, want)
+	}
+}
+
+func TestPackCatalog_DeleteAndLenAndEach(t *testing.T) {
+	c := newPackCatalog()
+	compactKeyName := "node/" + fmt.Sprintf("%064x", 1)
+	c.Set(compactKeyName, PackEntry{PackRef: "packs/a", Length: 1})
+	c.Set("index/latest", PackEntry{PackRef: "packs/a", Length: 2})
+
+	if c.Len() != 2 {
+		t.Fatalf("Len = %d, want 2", c.Len())
+	}
+	seen := map[string]PackEntry{}
+	c.Each(func(k string, e PackEntry) { seen[k] = e })
+	if len(seen) != 2 || seen[compactKeyName].Length != 1 || seen["index/latest"].Length != 2 {
+		t.Fatalf("Each yielded %v", seen)
+	}
+
+	c.Delete(compactKeyName)
+	if c.Has(compactKeyName) || c.Len() != 1 {
+		t.Errorf("Delete left %d entries, Has=%v", c.Len(), c.Has(compactKeyName))
+	}
+	c.Delete("index/latest")
+	if c.Len() != 0 {
+		t.Errorf("Len = %d after deleting both", c.Len())
+	}
+}
+
+// Pack refs are shared, which is where interning's benefit came from.
+func TestPackCatalog_SharesPackRefs(t *testing.T) {
+	c := newPackCatalog()
+	ref := "packs/" + fmt.Sprintf("%064x", 9)
+	for i := 0; i < 100; i++ {
+		c.Set("filemeta/"+fmt.Sprintf("%064x", i), PackEntry{PackRef: ref, Length: 1})
+	}
+	if len(c.packRefs) != 1 {
+		t.Fatalf("stored %d distinct pack refs for one pack", len(c.packRefs))
+	}
+}

--- a/internal/storelayer/packcatalog_testhelper_test.go
+++ b/internal/storelayer/packcatalog_testhelper_test.go
@@ -1,0 +1,23 @@
+package storelayer
+
+import "testing"
+
+// catalogOf builds a packCatalog from a plain map, for tests that describe a
+// catalog literally.
+func catalogOf(entries map[string]PackEntry) *packCatalog {
+	c := newPackCatalog()
+	for key, entry := range entries {
+		c.Set(key, entry)
+	}
+	return c
+}
+
+// mustCatalogGet returns the entry for key, failing the test if it is absent.
+func mustCatalogGet(t *testing.T, c *packCatalog, key string) PackEntry {
+	t.Helper()
+	entry, ok := c.Get(key)
+	if !ok {
+		t.Fatalf("catalog has no entry for %s", key)
+	}
+	return entry
+}

--- a/internal/storelayer/packfooter.go
+++ b/internal/storelayer/packfooter.go
@@ -282,8 +282,8 @@ func (s *PackStore) rebuildFromPacksLocked(ctx context.Context, packRefs []strin
 		}
 
 		for key, entry := range info.entries {
-			if _, exists := s.catalog[key]; !exists {
-				s.catalog[key] = entry
+			if !s.catalog.Has(key) {
+				s.catalog.Set(key, entry)
 				// Recovered entries are pending like any other, so the next
 				// flush persists them and the repair is paid for once.
 				s.pendingKeys[key] = struct{}{}

--- a/internal/storelayer/packfooter_test.go
+++ b/internal/storelayer/packfooter_test.go
@@ -192,7 +192,7 @@ func TestPackStore_WritesFooterMatchingCatalog(t *testing.T) {
 			continue
 		}
 		ps.mu.RLock()
-		catalogEntry := ps.catalog[key]
+		catalogEntry := mustCatalogGet(t, ps.catalog, key)
 		ps.mu.RUnlock()
 		if footerEntry != catalogEntry {
 			t.Errorf("%s: footer %+v != catalog %+v", key, footerEntry, catalogEntry)
@@ -372,7 +372,7 @@ func TestPackStore_FooterIsInertToOffsetBasedReaders(t *testing.T) {
 	}
 
 	ps.mu.RLock()
-	entry := ps.catalog["filemeta/a"]
+	entry := mustCatalogGet(t, ps.catalog, "filemeta/a")
 	ps.mu.RUnlock()
 
 	// Read the way a pre-footer client does: raw pack bytes, sliced by the

--- a/internal/storelayer/packlayering_test.go
+++ b/internal/storelayer/packlayering_test.go
@@ -45,7 +45,7 @@ func TestPackStore_DoesNotReEncryptObjectBytes(t *testing.T) {
 	}
 
 	pack.mu.RLock()
-	entry := pack.catalog["filemeta/a"]
+	entry := mustCatalogGet(t, pack.catalog, "filemeta/a")
 	pack.mu.RUnlock()
 
 	raw, err := base.Get(ctx, entry.PackRef)

--- a/internal/storelayer/packseal_bench_test.go
+++ b/internal/storelayer/packseal_bench_test.go
@@ -68,14 +68,14 @@ func BenchmarkPackCatalogFlush(b *testing.B) {
 				}
 				entries := benchEntries(n)
 				ps.mu.Lock()
-				ps.catalog = entries
+				ps.catalog = catalogOf(entries)
 				ps.catalogLoaded = true
 				ps.mu.Unlock()
 
 				b.ReportAllocs()
 				for b.Loop() {
 					ps.mu.Lock()
-					ps.catalog = entries
+					ps.catalog = catalogOf(entries)
 					ps.pendingKeys = keySetOf(entries)
 					ps.mu.Unlock()
 					if err := ps.Flush(ctx); err != nil {
@@ -113,7 +113,7 @@ func BenchmarkPackCatalogLoad(b *testing.B) {
 				}
 				entries := benchEntries(n)
 				writer.mu.Lock()
-				writer.catalog = entries
+				writer.catalog = catalogOf(entries)
 				writer.pendingKeys = keySetOf(entries)
 				writer.catalogLoaded = true
 				writer.mu.Unlock()

--- a/internal/storelayer/packshard.go
+++ b/internal/storelayer/packshard.go
@@ -34,32 +34,6 @@ import (
 // See RFC 0018 and docs/compatibility.md.
 const shardPrefix = "index/packmap/"
 
-// packRefInterner keeps the one canonical copy of each pack name while index
-// objects are decoded. It is needed only for the duration of a catalog load:
-// the catalog entries retain the canonical strings after this map is released.
-type packRefInterner map[string]string
-
-func newPackRefInterner(catalog map[string]PackEntry) packRefInterner {
-	refs := make(packRefInterner)
-	for key, entry := range catalog {
-		if ref, ok := refs[entry.PackRef]; ok {
-			entry.PackRef = ref
-			catalog[key] = entry
-			continue
-		}
-		refs[entry.PackRef] = entry.PackRef
-	}
-	return refs
-}
-
-func (i packRefInterner) intern(ref string) string {
-	if existing, ok := i[ref]; ok {
-		return existing
-	}
-	i[ref] = ref
-	return ref
-}
-
 // mergePackIndex decodes one JSON index object directly into catalog. Decoding
 // an entry before deciding whether to insert it keeps duplicate keys harmless,
 // while avoiding an intermediate map proportional to the whole shard.
@@ -69,7 +43,7 @@ func (i packRefInterner) intern(ref string) string {
 // did the stored index describe anything — is answered by the former. Counting
 // insertions instead would read a healthy index as empty whenever the entries it
 // names were already in the catalog, which is what auto-flush leaves behind.
-func mergePackIndex(data []byte, catalog map[string]PackEntry, refs packRefInterner) (int, error) {
+func mergePackIndex(data []byte, catalog *packCatalog) (int, error) {
 	dec := json.NewDecoder(bytes.NewReader(data))
 	start, err := dec.Token()
 	if err != nil {
@@ -95,11 +69,10 @@ func mergePackIndex(data []byte, catalog map[string]PackEntry, refs packRefInter
 			return decoded, err
 		}
 		decoded++
-		if _, exists := catalog[key]; exists {
+		if catalog.Has(key) {
 			continue
 		}
-		entry.PackRef = refs.intern(entry.PackRef)
-		catalog[key] = entry
+		catalog.Set(key, entry)
 	}
 
 	end, err := dec.Token()
@@ -155,14 +128,14 @@ func (s *PackStore) sealShard(entries map[string]PackEntry) (string, []byte, err
 // what marshalling an equivalent map would produce.
 //
 // The caller must hold mu: catalog and keys are both read here.
-func (s *PackStore) sealShardFor(catalog map[string]PackEntry, keys map[string]struct{}) (string, []byte, error) {
+func (s *PackStore) sealShardFor(catalog *packCatalog, keys map[string]struct{}) (string, []byte, error) {
 	if len(keys) == 0 {
 		return "", nil, nil
 	}
 
 	ordered := make([]string, 0, len(keys))
 	for key := range keys {
-		if _, ok := catalog[key]; ok {
+		if catalog.Has(key) {
 			ordered = append(ordered, key)
 		}
 	}
@@ -183,7 +156,8 @@ func (s *PackStore) sealShardFor(catalog map[string]PackEntry, keys map[string]s
 		}
 		buf.Write(name)
 		buf.WriteByte(':')
-		entry, err := json.Marshal(catalog[key])
+		located, _ := catalog.Get(key)
+		entry, err := json.Marshal(located)
 		if err != nil {
 			return "", nil, fmt.Errorf("marshal pack index shard entry: %w", err)
 		}
@@ -230,7 +204,7 @@ func (s *PackStore) writeShard(ctx context.Context, entries map[string]PackEntry
 // A shard that cannot be read fails the caller. Continuing with a partial merge
 // would produce a catalog that looks complete and is not, which is how a prune
 // deletes objects it simply could not see.
-func (s *PackStore) loadShardsLocked(ctx context.Context, refs packRefInterner) (int, error) {
+func (s *PackStore) loadShardsLocked(ctx context.Context) (int, error) {
 	keys, err := s.ObjectStore.List(ctx, shardPrefix)
 	if err != nil {
 		return 0, fmt.Errorf("list pack index shards: %w", err)
@@ -247,7 +221,7 @@ func (s *PackStore) loadShardsLocked(ctx context.Context, refs packRefInterner) 
 			return 0, fmt.Errorf("open pack index shard %s: %w", key, err)
 		}
 
-		decoded, err := mergePackIndex(plain, s.catalog, refs)
+		decoded, err := mergePackIndex(plain, s.catalog)
 		if err != nil {
 			return 0, fmt.Errorf("unmarshal pack index shard %s: %w", key, err)
 		}
@@ -297,7 +271,7 @@ func (s *PackStore) CompactCatalog(ctx context.Context) (int, error) {
 	var sealed []byte
 	var err error
 	if shouldCompact {
-		consolidated, sealed, err = s.sealShard(s.catalog)
+		consolidated, sealed, err = s.sealShardFor(s.catalog, keySetOfCatalog(s.catalog))
 	}
 	s.mu.RUnlock()
 
@@ -344,4 +318,12 @@ func (s *PackStore) CompactCatalog(ctx context.Context) (int, error) {
 
 	s.debugf("pack: compacted %d index objects into %s", removed, consolidated)
 	return removed, nil
+}
+
+// keySetOfCatalog names every entry, for a compaction that seals the whole
+// catalog rather than one flush's worth of it.
+func keySetOfCatalog(c *packCatalog) map[string]struct{} {
+	keys := make(map[string]struct{}, c.Len())
+	c.Each(func(key string, _ PackEntry) { keys[key] = struct{}{} })
+	return keys
 }

--- a/internal/storelayer/packshard_seal_test.go
+++ b/internal/storelayer/packshard_seal_test.go
@@ -24,7 +24,7 @@ func TestSealShardFor_MatchesMarshallingAnEquivalentMap(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	gotRef, gotBytes, err := s.sealShardFor(catalog, pending)
+	gotRef, gotBytes, err := s.sealShardFor(catalogOf(catalog), pending)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,7 +67,7 @@ func TestSealShardFor_SkipsKeysMissingFromTheCatalog(t *testing.T) {
 	catalog := map[string]PackEntry{"filemeta/a": {PackRef: "packs/one", Length: 2}}
 	pending := map[string]struct{}{"filemeta/a": {}, "filemeta/gone": {}}
 
-	_, data, err := s.sealShardFor(catalog, pending)
+	_, data, err := s.sealShardFor(catalogOf(catalog), pending)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func TestSealShardFor_EmptyPendingSetWritesNothing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ref, data, err := s.sealShardFor(map[string]PackEntry{"a": {}}, nil)
+	ref, data, err := s.sealShardFor(catalogOf(map[string]PackEntry{"a": {}}), nil)
 	if err != nil || ref != "" || data != nil {
 		t.Fatalf("got (%q, %v, %v), want (\"\", nil, nil)", ref, data, err)
 	}

--- a/internal/storelayer/packshard_test.go
+++ b/internal/storelayer/packshard_test.go
@@ -41,13 +41,13 @@ func TestPackStore_LoadShardsInternsPackRefs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	a := reader.catalog["filemeta/a"].PackRef
-	b := reader.catalog["filemeta/b"].PackRef
-	c := reader.catalog["node/c"].PackRef
+	a := mustCatalogGet(t, reader.catalog, "filemeta/a").PackRef
+	b := mustCatalogGet(t, reader.catalog, "filemeta/b").PackRef
+	c := mustCatalogGet(t, reader.catalog, "node/c").PackRef
 	if unsafe.StringData(a) != unsafe.StringData(b) || unsafe.StringData(a) != unsafe.StringData(c) {
 		t.Fatal("entries sharing a pack ref retained separate string allocations")
 	}
-	if unsafe.StringData(a) == unsafe.StringData(reader.catalog["node/d"].PackRef) {
+	if unsafe.StringData(a) == unsafe.StringData(mustCatalogGet(t, reader.catalog, "node/d").PackRef) {
 		t.Fatal("distinct pack refs unexpectedly share storage")
 	}
 }
@@ -62,16 +62,20 @@ func TestMergePackIndex_IsFirstWriterWinsOrderIndependentAndIdempotent(t *testin
 		"filemeta/shared":{"p":"packs/one","o":1,"l":1}
 	}`)
 
+	// The result is compared as a plain map, not as a *packCatalog: the catalog
+	// interns pack refs in encounter order, so two equivalent catalogs built from
+	// shards in different orders differ in a field that carries no meaning.
 	merge := func(parts ...[]byte) map[string]PackEntry {
 		t.Helper()
-		catalog := make(map[string]PackEntry)
-		refs := newPackRefInterner(catalog)
+		catalog := newPackCatalog()
 		for _, part := range parts {
-			if _, err := mergePackIndex(part, catalog, refs); err != nil {
+			if _, err := mergePackIndex(part, catalog); err != nil {
 				t.Fatal(err)
 			}
 		}
-		return catalog
+		out := make(map[string]PackEntry, catalog.Len())
+		catalog.Each(func(key string, entry PackEntry) { out[key] = entry })
+		return out
 	}
 
 	forward := merge(first, second)
@@ -84,11 +88,11 @@ func TestMergePackIndex_IsFirstWriterWinsOrderIndependentAndIdempotent(t *testin
 	}
 
 	winner := PackEntry{PackRef: "packs/winner", Offset: 7, Length: 9}
-	catalog := map[string]PackEntry{"filemeta/shared": winner}
-	if _, err := mergePackIndex(first, catalog, newPackRefInterner(catalog)); err != nil {
+	catalog := catalogOf(map[string]PackEntry{"filemeta/shared": winner})
+	if _, err := mergePackIndex(first, catalog); err != nil {
 		t.Fatal(err)
 	}
-	if got := catalog["filemeta/shared"]; got != winner {
+	if got := mustCatalogGet(t, catalog, "filemeta/shared"); got != winner {
 		t.Fatalf("later shard replaced the first entry: got %#v, want %#v", got, winner)
 	}
 }
@@ -104,8 +108,8 @@ func TestMergePackIndex_RejectsMalformedInput(t *testing.T) {
 	}
 	for name, input := range tests {
 		t.Run(name, func(t *testing.T) {
-			catalog := make(map[string]PackEntry)
-			if _, err := mergePackIndex([]byte(input), catalog, newPackRefInterner(catalog)); err == nil {
+			catalog := newPackCatalog()
+			if _, err := mergePackIndex([]byte(input), catalog); err == nil {
 				t.Fatal("merge succeeded for malformed input")
 			}
 		})


### PR DESCRIPTION
## Summary

- `packCatalog` replaces `map[string]PackEntry`: keys are decoded to a namespace byte plus a 32-byte hash held inline, pack refs become an index into a slice, offsets fit `uint32`
- Keys without that shape, and locations too large for `uint32`, go to a fallback map and are returned exactly
- `packRefInterner` is gone — the catalog interns on every insert instead

Almost every catalog key is `<prefix>/<64 hex>`: a namespace from a fixed set and
a SHA-256, previously held as 73 bytes of text plus a header for 32 bytes of
hash, with the map storing a pointer for the collector to chase.

Part of #440.

## Measurements

Per-entry cost, 200,000 entries, pack refs already interned in both:

| | B/entry |
|---|---|
| `map[string]PackEntry` | 158 |
| `packCatalog` | **73** |

`check` at 50,000 files:

| | live heap | peak RSS |
|---|---|---|
| `main` @ `1217d50` | 74.1 MB | 166 MB |
| this PR | **57.8 MB** | **156 MB** |

This reduces the linear coefficient rather than removing the growth — the catalog
is still one entry per packed object. It is the change that survived the analysis
on #440: it shrinks a resident structure without changing how often anything is
transferred, so it is not the residency-for-re-reads trade that
[failed when applied to `packCache`](https://github.com/Cloudstic/cli/issues/440#issuecomment-5184019650).

I should correct one thing I wrote on #440: I estimated ~230 B/entry and a 5x
win. Measured, it is 158 B/entry and 2.2x. The 5x figure assumed a sorted array
with binary search, which would need reworking incremental insertion and is a
much larger change for the remaining 25 B/entry.

## Two things the encoding has to tolerate

**Unshaped keys.** A legacy repository packed `index/latest` before the
packable-prefix restriction existed (`TestPackStore_LegacyPackedIndexLatestStaysReadable`).
Those go to a fallback map.

**Out-of-range locations.** An offset or length beyond `uint32` cannot come from a
pack this code writes — `maxPackSize` bounds both — but the catalog is read from a
store. Such an entry goes to the fallback rather than being truncated into a
location pointing somewhere else.

`Get`, `Has` and `Delete` consult the fallback **even for a well-shaped key**. My
first version did not, and the test I wrote for the out-of-range case caught it:
`Set` sent the entry to the fallback, the lookups only checked the compact map,
and the entry vanished. An entry that silently disappears from this catalog is an
object `prune` cannot see.

## Notes for review

- `TestMergePackIndex_IsFirstWriterWinsOrderIndependentAndIdempotent` now compares
  extracted maps rather than the catalogs themselves. The catalog interns pack
  refs in encounter order, so two equivalent catalogs built from shards in
  different orders differ in a field that carries no meaning — `reflect.DeepEqual`
  on them would fail for the wrong reason.
- Interning moved into `Set`, including the fallback branch, so the property
  `TestPackStore_LoadShardsInternsPackRefs` pins holds whatever shape the key has.
  That test uses short keys, so it exercises the fallback path specifically.

## Verification

```bash
env GOCACHE=/tmp/cloudstic-gocache go test -race -count=1 ./internal/... .
```

```bash
env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./internal/storelayer/...
```

Both pass; lint reports 0 issues. New tests cover round-tripping every namespace,
unshaped keys, out-of-range locations, delete/len/iteration, and pack-ref sharing.
