### PR TITLE
perf(store): key backup key-existence cache by raw digest

### DIFF
--- a/docs/caching.md
+++ b/docs/caching.md
@@ -21,7 +21,7 @@ event (`docs/compatibility.md`).
 
 | Cache | Where | Key → value | Lifetime | Bound |
 |---|---|---|---|---|
-| `KeyCacheStore.knownKeys` | `internal/storelayer/keycache.go` | object key → exists | one `backup` run | every key under the preloaded prefixes |
+| `KeyCacheStore.knownDigests` / `knownKeys` | `internal/storelayer/keycache.go` | raw digest (fallback: object key) → exists | one `backup` run | every key under the preloaded prefixes |
 | `PackStore.catalog` / `packKeys` | `internal/storelayer/pack.go` | object key → pack ref + offset | `Client` | one entry per packed object |
 | `PackStore.packCache` | `internal/storelayer/pack.go` | pack ref → raw packfile bytes | `Client` | LRU, 4 packs (~32 MB at 8 MB/pack) |
 | `NodeStore.cache` | `internal/hamt/nodestore.go` | node ref → decoded `*node` | `hamt.Tree` | LRU, 4096 nodes |
@@ -141,10 +141,20 @@ transaction are never serialized at all.
 Most of these are explicitly bounded. Two are not, and both are bounded by the
 work rather than by a constant:
 
-- `KeyCacheStore.knownKeys` holds every key under `chunk/`, `content/` and
-  `node/` after `PreloadKeys`. On a large repository that is a set of millions
-  of short strings, live for the length of one backup. This is the deliberate
-  trade — one `List` per prefix instead of an `Exists` per object.
+- `KeyCacheStore.knownDigests` holds every key under `chunk/`, `content/` and
+  `node/` after `PreloadKeys` — millions of entries on a large repository, live
+  for the length of one backup. This is the deliberate trade — one `List` per
+  prefix instead of an `Exists` per object. The set is keyed by the raw
+  32-byte digest decoded from each key's hex suffix, one map per preloaded
+  prefix, rather than by the hex string itself (issue #430): a
+  `map[[32]byte]struct{}` has no pointer in its key, so the GC does not scan
+  it, and it does not need a separately retained string backing array the way
+  a `map[string]struct{}` does. Measured via
+  `BenchmarkKeySetShapeRetained` (`internal/storelayer/keycache_bench_test.go`)
+  at 500k entries: 136 B/entry retained for the string-keyed set versus 84
+  B/entry for the digest-keyed one. A key whose suffix isn't a well-formed
+  64-hex-char digest falls back to `knownKeys`, keyed by the full string, so
+  it is still tracked correctly rather than mis-filed or dropped.
 - `metaLoader.cache`, where enabled, grows with the number of distinct
   filemetas an operation touches. Only `backup` and `diff` enable it, because
   they are the two that read the same ref more than once — `diff` walks both
@@ -229,7 +239,7 @@ change and a cached entry can never go stale.
 The exceptions are the mutable keys, and they are handled explicitly:
 
 - `KeyCacheStore.Put` only elides writes for keys under a listed
-  content-addressed prefix (`isContentAddressed`). Mutable keys such as
+  content-addressed prefix (`contentAddressedPrefix`). Mutable keys such as
   `index/latest` are always written through.
 - `KeyCacheStore.Delete` and `PackStore`'s delete and repack paths evict.
 - `secretref.Resolver` caches only the interactive native backends, where the

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -152,9 +152,12 @@ work rather than by a constant:
   a `map[string]struct{}` does. Measured via
   `BenchmarkKeySetShapeRetained` (`internal/storelayer/keycache_bench_test.go`)
   at 500k entries: 136 B/entry retained for the string-keyed set versus 84
-  B/entry for the digest-keyed one. A key whose suffix isn't a well-formed
-  64-hex-char digest falls back to `knownKeys`, keyed by the full string, so
-  it is still tracked correctly rather than mis-filed or dropped.
+  B/entry for the digest-keyed one. Only the canonical lowercase hex spelling
+  decodes into the digest map — the one `core.ComputeHash` ever produces; a
+  key whose suffix isn't that exact shape (wrong length, uppercase, or any
+  other non-digest suffix) falls back to `knownKeys`, keyed by the full
+  string, so it is still tracked correctly, byte-exact, rather than mis-filed
+  or aliased with a differently-cased key that names a different object.
 - `metaLoader.cache`, where enabled, grows with the number of distinct
   filemetas an operation touches. Only `backup` and `diff` enable it, because
   they are the two that read the same ref more than once — `diff` walks both

--- a/internal/storelayer/keycache.go
+++ b/internal/storelayer/keycache.go
@@ -105,15 +105,25 @@ func (s *KeyCacheStore) Put(ctx context.Context, key string, data []byte) error 
 // means key is immutable (same key = same data) and eligible for existence
 // caching and write elision. Mutable keys like index/* were never listed and
 // must always be written through.
+//
+// listedPrefixes is a map, so iteration order is undefined; today's callers
+// only ever list "chunk/", "content/" and "node/", none a prefix of another,
+// so this can't actually pick two different answers for one key. It resolves
+// the longest match anyway rather than leaving that an unstated assumption:
+// a key matching two listed prefixes must consistently resolve to the same
+// one across Exists, Put and Delete, or a write can be elided for a key the
+// backend was never told about.
 func (s *KeyCacheStore) contentAddressedPrefix(key string) (string, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+	var longest string
+	var matched bool
 	for prefix := range s.listedPrefixes {
-		if strings.HasPrefix(key, prefix) {
-			return prefix, true
+		if strings.HasPrefix(key, prefix) && (!matched || len(prefix) > len(longest)) {
+			longest, matched = prefix, true
 		}
 	}
-	return "", false
+	return longest, matched
 }
 
 // knows reports whether key, known to fall under prefix, has been recorded
@@ -156,9 +166,18 @@ func (s *KeyCacheStore) forgetLocked(prefix, key string) {
 }
 
 // decodeDigest decodes the suffix of key after prefix as a raw sha256 digest.
-// It returns ok=false for any key that isn't exactly "<prefix><64 hex
-// chars>", so callers fall back to string-keyed storage instead of mis-filing
-// a key that doesn't have that shape.
+// It returns ok=false for any key that isn't exactly "<prefix><64 lowercase
+// hex chars>", so callers fall back to string-keyed storage instead of
+// mis-filing a key that doesn't have that shape.
+//
+// Only the canonical lowercase spelling decodes. core.ComputeHash always
+// produces lowercase hex, so every key this store ever writes or preloads
+// takes that form; a decoder that also accepted uppercase would fold two
+// byte-distinct object keys ("aa..." and "AA...") into one digest and let a
+// write for one be elided because the other was seen — the exact "permissive
+// direction" failure the prefix matching above is written to avoid. A
+// non-canonical key simply isn't recognized as a digest and falls back to the
+// string map, where it stays byte-exact.
 //
 // This is called on every Exists and Put for a content-addressed key, so it
 // decodes by hand rather than through hex.DecodeString: that call allocates a
@@ -170,8 +189,8 @@ func decodeDigest(prefix, key string) (digest [32]byte, ok bool) {
 		return digest, false
 	}
 	for i := range 32 {
-		hi, ok1 := hexNibble(suffix[2*i])
-		lo, ok2 := hexNibble(suffix[2*i+1])
+		hi, ok1 := lowerHexNibble(suffix[2*i])
+		lo, ok2 := lowerHexNibble(suffix[2*i+1])
 		if !ok1 || !ok2 {
 			return digest, false
 		}
@@ -180,14 +199,14 @@ func decodeDigest(prefix, key string) (digest [32]byte, ok bool) {
 	return digest, true
 }
 
-func hexNibble(c byte) (byte, bool) {
+// lowerHexNibble decodes a single canonical (lowercase) hex digit. It
+// deliberately rejects 'A'-'F': see decodeDigest.
+func lowerHexNibble(c byte) (byte, bool) {
 	switch {
 	case c >= '0' && c <= '9':
 		return c - '0', true
 	case c >= 'a' && c <= 'f':
 		return c - 'a' + 10, true
-	case c >= 'A' && c <= 'F':
-		return c - 'A' + 10, true
 	default:
 		return 0, false
 	}

--- a/internal/storelayer/keycache.go
+++ b/internal/storelayer/keycache.go
@@ -11,11 +11,25 @@ import (
 	"github.com/cloudstic/cli/pkg/store"
 )
 
+// digestHexLen is the length of a hex-encoded sha256 digest, the suffix shape
+// of every content-addressed key this store preloads (chunk/, content/, node/).
+const digestHexLen = 64
+
 // KeyCacheStore wraps an store.ObjectStore and caches key existence from List calls,
 // so that Exists returns immediately for known keys. Thread-safe.
+//
+// Preloaded keys are almost always content-addressed: "<prefix><64-hex-char
+// sha256>". Those are decoded once and kept as a raw 32-byte digest in a map
+// scoped to their prefix, so the set carries no pointers and the garbage
+// collector does not have to scan it — a [32]byte map has no interior
+// pointers to trace, unlike a map keyed by the hex string. A key under a
+// listed prefix whose suffix does not decode to a digest (unexpected, but not
+// impossible) falls back to knownKeys, keyed by the full string, so it is
+// tracked correctly rather than silently dropped.
 type KeyCacheStore struct {
 	inner          store.ObjectStore
-	knownKeys      map[string]struct{}
+	knownDigests   map[string]map[[32]byte]struct{} // listed prefix -> digests known under it
+	knownKeys      map[string]struct{}              // fallback for keys that aren't a bare digest
 	listedPrefixes map[string]struct{}
 	mu             sync.RWMutex
 	putFlight      singleflight.Group
@@ -26,6 +40,7 @@ func (s *KeyCacheStore) Unwrap() store.ObjectStore { return s.inner }
 func NewKeyCacheStore(inner store.ObjectStore) *KeyCacheStore {
 	return &KeyCacheStore{
 		inner:          inner,
+		knownDigests:   make(map[string]map[[32]byte]struct{}),
 		knownKeys:      make(map[string]struct{}),
 		listedPrefixes: make(map[string]struct{}),
 	}
@@ -42,7 +57,7 @@ func (s *KeyCacheStore) PreloadKeys(ctx context.Context, prefixes ...string) err
 			}
 			s.mu.Lock()
 			for _, key := range keys {
-				s.knownKeys[key] = struct{}{}
+				s.learnLocked(prefix, key)
 			}
 			s.listedPrefixes[prefix] = struct{}{}
 			s.mu.Unlock()
@@ -53,65 +68,129 @@ func (s *KeyCacheStore) PreloadKeys(ctx context.Context, prefixes ...string) err
 }
 
 func (s *KeyCacheStore) Exists(ctx context.Context, key string) (bool, error) {
-	s.mu.RLock()
-	_, ok := s.knownKeys[key]
-	if ok {
-		s.mu.RUnlock()
-		return true, nil
+	prefix, matched := s.contentAddressedPrefix(key)
+	if !matched {
+		return s.inner.Exists(ctx, key)
 	}
-	for prefix := range s.listedPrefixes {
-		if strings.HasPrefix(key, prefix) {
-			s.mu.RUnlock()
-			return false, nil
-		}
-	}
-	s.mu.RUnlock()
-	return s.inner.Exists(ctx, key)
+	return s.knows(prefix, key), nil
 }
 
 func (s *KeyCacheStore) Put(ctx context.Context, key string, data []byte) error {
-	if s.isContentAddressed(key) {
-		s.mu.RLock()
-		_, known := s.knownKeys[key]
-		s.mu.RUnlock()
-		if known {
-			return nil
-		}
-
-		_, err, _ := s.putFlight.Do(key, func() (interface{}, error) {
-			s.mu.RLock()
-			_, already := s.knownKeys[key]
-			s.mu.RUnlock()
-			if already {
-				return nil, nil
-			}
-
-			if err := s.inner.Put(ctx, key, data); err != nil {
-				return nil, err
-			}
-			s.mu.Lock()
-			s.knownKeys[key] = struct{}{}
-			s.mu.Unlock()
-			return nil, nil
-		})
-		return err
+	prefix, contentAddressed := s.contentAddressedPrefix(key)
+	if !contentAddressed {
+		return s.inner.Put(ctx, key, data)
 	}
 
-	return s.inner.Put(ctx, key, data)
+	if s.knows(prefix, key) {
+		return nil
+	}
+
+	_, err, _ := s.putFlight.Do(key, func() (any, error) {
+		if s.knows(prefix, key) {
+			return nil, nil
+		}
+
+		if err := s.inner.Put(ctx, key, data); err != nil {
+			return nil, err
+		}
+		s.mu.Lock()
+		s.learnLocked(prefix, key)
+		s.mu.Unlock()
+		return nil, nil
+	})
+	return err
 }
 
-// isContentAddressed returns true for keys under prefixes that were listed,
-// which are immutable (same key = same data). Mutable keys like index/*
+// contentAddressedPrefix returns the listed prefix key falls under, which
+// means key is immutable (same key = same data) and eligible for existence
+// caching and write elision. Mutable keys like index/* were never listed and
 // must always be written through.
-func (s *KeyCacheStore) isContentAddressed(key string) bool {
+func (s *KeyCacheStore) contentAddressedPrefix(key string) (string, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	for prefix := range s.listedPrefixes {
 		if strings.HasPrefix(key, prefix) {
-			return true
+			return prefix, true
 		}
 	}
-	return false
+	return "", false
+}
+
+// knows reports whether key, known to fall under prefix, has been recorded
+// as existing.
+func (s *KeyCacheStore) knows(prefix, key string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if digest, ok := decodeDigest(prefix, key); ok {
+		_, found := s.knownDigests[prefix][digest]
+		return found
+	}
+	_, found := s.knownKeys[key]
+	return found
+}
+
+// learnLocked records key, known to fall under prefix, as existing. Callers
+// must hold s.mu for writing.
+func (s *KeyCacheStore) learnLocked(prefix, key string) {
+	digest, ok := decodeDigest(prefix, key)
+	if !ok {
+		s.knownKeys[key] = struct{}{}
+		return
+	}
+	set := s.knownDigests[prefix]
+	if set == nil {
+		set = make(map[[32]byte]struct{})
+		s.knownDigests[prefix] = set
+	}
+	set[digest] = struct{}{}
+}
+
+// forgetLocked removes key, known to fall under prefix, from the cache.
+// Callers must hold s.mu for writing.
+func (s *KeyCacheStore) forgetLocked(prefix, key string) {
+	if digest, ok := decodeDigest(prefix, key); ok {
+		delete(s.knownDigests[prefix], digest)
+		return
+	}
+	delete(s.knownKeys, key)
+}
+
+// decodeDigest decodes the suffix of key after prefix as a raw sha256 digest.
+// It returns ok=false for any key that isn't exactly "<prefix><64 hex
+// chars>", so callers fall back to string-keyed storage instead of mis-filing
+// a key that doesn't have that shape.
+//
+// This is called on every Exists and Put for a content-addressed key, so it
+// decodes by hand rather than through hex.DecodeString: that call allocates a
+// fresh []byte per invocation, which would put a heap allocation back on the
+// hot path this cache exists to keep allocation-free.
+func decodeDigest(prefix, key string) (digest [32]byte, ok bool) {
+	suffix := key[len(prefix):]
+	if len(suffix) != digestHexLen {
+		return digest, false
+	}
+	for i := range 32 {
+		hi, ok1 := hexNibble(suffix[2*i])
+		lo, ok2 := hexNibble(suffix[2*i+1])
+		if !ok1 || !ok2 {
+			return digest, false
+		}
+		digest[i] = hi<<4 | lo
+	}
+	return digest, true
+}
+
+func hexNibble(c byte) (byte, bool) {
+	switch {
+	case c >= '0' && c <= '9':
+		return c - '0', true
+	case c >= 'a' && c <= 'f':
+		return c - 'a' + 10, true
+	case c >= 'A' && c <= 'F':
+		return c - 'A' + 10, true
+	default:
+		return 0, false
+	}
 }
 
 func (s *KeyCacheStore) Get(ctx context.Context, key string) ([]byte, error) {
@@ -119,9 +198,11 @@ func (s *KeyCacheStore) Get(ctx context.Context, key string) ([]byte, error) {
 }
 
 func (s *KeyCacheStore) Delete(ctx context.Context, key string) error {
-	s.mu.Lock()
-	delete(s.knownKeys, key)
-	s.mu.Unlock()
+	if prefix, ok := s.contentAddressedPrefix(key); ok {
+		s.mu.Lock()
+		s.forgetLocked(prefix, key)
+		s.mu.Unlock()
+	}
 	return s.inner.Delete(ctx, key)
 }
 

--- a/internal/storelayer/keycache_bench_test.go
+++ b/internal/storelayer/keycache_bench_test.go
@@ -1,0 +1,137 @@
+package storelayer
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"testing"
+)
+
+// digestHexKeys returns n distinct content-addressed keys under prefix, in
+// the "<prefix><64 hex chars>" shape a real repository uses.
+func digestHexKeys(prefix string, n int) []string {
+	keys := make([]string, n)
+	for i := range n {
+		keys[i] = fmt.Sprintf("%s%064x", prefix, i)
+	}
+	return keys
+}
+
+// BenchmarkKeyCachePreload measures allocation for populating the existence
+// set at a realistic object count, the operation issue #430 is about: a
+// backup preloads chunk/, content/ and node/ once up front.
+func BenchmarkKeyCachePreload(b *testing.B) {
+	for _, n := range []int{100_000, 500_000} {
+		b.Run(fmt.Sprintf("entries=%d", n), func(b *testing.B) {
+			keys := digestHexKeys("chunk/", n)
+
+			b.ReportAllocs()
+			for b.Loop() {
+				kc := NewKeyCacheStore(nil)
+				kc.mu.Lock()
+				for _, key := range keys {
+					kc.learnLocked("chunk/", key)
+				}
+				kc.listedPrefixes["chunk/"] = struct{}{}
+				kc.mu.Unlock()
+			}
+		})
+	}
+}
+
+// BenchmarkKeyCacheExists measures the steady-state existence check, the
+// operation backup's dedup path calls once per object.
+func BenchmarkKeyCacheExists(b *testing.B) {
+	for _, n := range []int{100_000, 500_000} {
+		b.Run(fmt.Sprintf("entries=%d", n), func(b *testing.B) {
+			ctx := context.Background()
+			kc := NewKeyCacheStore(nil)
+			keys := digestHexKeys("chunk/", n)
+			kc.mu.Lock()
+			for _, key := range keys {
+				kc.learnLocked("chunk/", key)
+			}
+			kc.listedPrefixes["chunk/"] = struct{}{}
+			kc.mu.Unlock()
+
+			b.ReportAllocs()
+			for i := 0; b.Loop(); i++ {
+				if _, err := kc.Exists(ctx, keys[i%n]); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// retainedBytes reports the heap growth attributable to fn's return value,
+// via a GC + ReadMemStats delta around the call (mirrors
+// internal/engine/metaloader_bench_test.go's helper of the same name — see
+// that file and docs/caching.md for why this, and not -benchmem's cumulative
+// B/op, is the right metric for a retained set's footprint: B/op counts every
+// allocation regardless of whether it survives, so it cannot see memory a
+// different representation lets the GC reclaim.
+func retainedBytes(fn func() any) uint64 {
+	runtime.GC()
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	held := fn()
+
+	runtime.GC()
+	runtime.ReadMemStats(&after)
+	runtime.KeepAlive(held)
+
+	if after.HeapAlloc < before.HeapAlloc {
+		return 0
+	}
+	return after.HeapAlloc - before.HeapAlloc
+}
+
+// BenchmarkKeySetShapeRetained is a direct, KeyCacheStore-independent
+// comparison of the two set shapes: a map keyed by the full hex string (what
+// this store used before #430) against a map keyed by the raw 32-byte digest
+// (what it uses now). Each key string is freshly generated inside the
+// measured region, as inner.List would return it, so the string variant pays
+// for retaining that backing array (it is the map key) while the digest
+// variant does not (it decodes and discards it) — that discard, not bucket
+// layout alone, is most of the win in practice.
+func BenchmarkKeySetShapeRetained(b *testing.B) {
+	for _, n := range []int{100_000, 500_000} {
+		b.Run(fmt.Sprintf("string/entries=%d", n), func(b *testing.B) {
+			var held uint64
+			for b.Loop() {
+				held = retainedBytes(func() any {
+					keys := digestHexKeys("chunk/", n)
+					set := make(map[string]struct{}, n)
+					for _, key := range keys {
+						set[key] = struct{}{}
+					}
+					return set
+				})
+			}
+			b.ReportMetric(float64(held)/1e6, "MB-retained")
+			b.ReportMetric(float64(held)/float64(n), "B/entry")
+		})
+
+		b.Run(fmt.Sprintf("digest/entries=%d", n), func(b *testing.B) {
+			var held uint64
+			for b.Loop() {
+				held = retainedBytes(func() any {
+					keys := digestHexKeys("chunk/", n)
+					set := make(map[[32]byte]struct{}, n)
+					for _, key := range keys {
+						digest, ok := decodeDigest("chunk/", key)
+						if !ok {
+							b.Fatal("key did not decode as a digest")
+						}
+						set[digest] = struct{}{}
+					}
+					return set
+				})
+			}
+			b.ReportMetric(float64(held)/1e6, "MB-retained")
+			b.ReportMetric(float64(held)/float64(n), "B/entry")
+		})
+	}
+}

--- a/internal/storelayer/keycache_test.go
+++ b/internal/storelayer/keycache_test.go
@@ -230,14 +230,15 @@ func TestKeyCacheStore_DigestKeyExistsAfterPreload(t *testing.T) {
 	}
 }
 
-func TestKeyCacheStore_NonHexKeyUnderListedPrefixFallsBack(t *testing.T) {
+// TestKeyCacheStore_CaseVariantDigestKeyDoesNotAlias guards against decoding
+// both hex cases into one digest: that would let a Put for one spelling be
+// elided because the other, byte-distinct, key was already known.
+func TestKeyCacheStore_CaseVariantDigestKeyDoesNotAlias(t *testing.T) {
 	ctx := context.Background()
 	inner := newCountingStore()
-	// A key under a listed prefix whose suffix is not a 64-char hex digest
-	// (e.g. malformed or legacy) must not be mis-filed into the digest map for
-	// a different key.
-	nonHexKey := "chunk/not-a-valid-digest"
-	_ = inner.Put(ctx, nonHexKey, []byte("data"))
+	lower := "chunk/" + strings.Repeat("ab", 32)
+	upper := "chunk/" + strings.Repeat("AB", 32)
+	_ = inner.Put(ctx, lower, []byte("data"))
 	inner.exists.Store(0)
 
 	kc := NewKeyCacheStore(inner)
@@ -245,33 +246,107 @@ func TestKeyCacheStore_NonHexKeyUnderListedPrefixFallsBack(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ok, _ := kc.Exists(ctx, nonHexKey)
-	if !ok {
-		t.Error("non-hex key should exist after preload via fallback")
-	}
-	if inner.exists.Load() != 0 {
-		t.Error("Exists should not have called backend for known non-hex key")
-	}
-
-	// Put-elision and Delete must also work through the fallback path.
-	inner.puts.Store(0)
-	if err := kc.Put(ctx, nonHexKey, []byte("data")); err != nil {
-		t.Fatal(err)
-	}
-	if inner.puts.Load() != 0 {
-		t.Error("Put should have been elided for already-known non-hex key")
-	}
-
-	if err := kc.Delete(ctx, nonHexKey); err != nil {
-		t.Fatal(err)
-	}
-	inner.exists.Store(0)
-	ok, _ = kc.Exists(ctx, nonHexKey)
+	// The uppercase spelling is a different object key and must not read as
+	// known just because the lowercase one was preloaded.
+	ok, _ := kc.Exists(ctx, upper)
 	if ok {
-		t.Error("non-hex key should not exist after delete")
+		t.Error("uppercase-hex key must not alias the preloaded lowercase key")
+	}
+
+	// Put for the uppercase key must go through, not be elided.
+	inner.puts.Store(0)
+	if err := kc.Put(ctx, upper, []byte("other data")); err != nil {
+		t.Fatal(err)
+	}
+	if inner.puts.Load() != 1 {
+		t.Errorf("Put for distinct uppercase-hex key should not be elided, got %d puts", inner.puts.Load())
+	}
+
+	// Both keys are now independently known via the fallback (non-canonical)
+	// and digest paths respectively.
+	inner.exists.Store(0)
+	if ok, _ := kc.Exists(ctx, lower); !ok {
+		t.Error("lowercase key should still exist")
+	}
+	if ok, _ := kc.Exists(ctx, upper); !ok {
+		t.Error("uppercase key should exist after being put")
 	}
 	if inner.exists.Load() != 0 {
-		t.Error("should resolve from cache (listed prefix, absent key)")
+		t.Error("both keys should resolve from cache")
+	}
+}
+
+// TestKeyCacheStore_OverlappingPrefixesResolveLongestMatch guards
+// contentAddressedPrefix's tie-break: a key matching two listed prefixes must
+// consistently resolve to the longer, more specific one everywhere, not
+// whichever the map happens to iterate first.
+func TestKeyCacheStore_OverlappingPrefixesResolveLongestMatch(t *testing.T) {
+	ctx := context.Background()
+	inner := newCountingStore()
+	kc := NewKeyCacheStore(inner)
+	if err := kc.PreloadKeys(ctx, "chunk/", "chunk/a"); err != nil {
+		t.Fatal(err)
+	}
+
+	key := "chunk/a" + strings.Repeat("b", digestHexLen)
+	for range 20 {
+		prefix, ok := kc.contentAddressedPrefix(key)
+		if !ok || prefix != "chunk/a" {
+			t.Fatalf("contentAddressedPrefix(%q) = (%q, %v), want (\"chunk/a\", true)", key, prefix, ok)
+		}
+	}
+}
+
+func TestKeyCacheStore_NonHexKeyUnderListedPrefixFallsBack(t *testing.T) {
+	// A key under a listed prefix whose suffix does not decode to a digest
+	// must not be mis-filed into the digest map for a different key. Cover
+	// both ways decodeDigest can say no: wrong length, and right length with
+	// a character that isn't a hex nibble.
+	cases := map[string]string{
+		"wrong-length": "chunk/not-a-valid-digest",
+		"bad-nibble":   "chunk/" + strings.Repeat("a", digestHexLen-1) + "g",
+	}
+	for name, nonHexKey := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			inner := newCountingStore()
+			_ = inner.Put(ctx, nonHexKey, []byte("data"))
+			inner.exists.Store(0)
+
+			kc := NewKeyCacheStore(inner)
+			if err := kc.PreloadKeys(ctx, "chunk/"); err != nil {
+				t.Fatal(err)
+			}
+
+			ok, _ := kc.Exists(ctx, nonHexKey)
+			if !ok {
+				t.Error("non-hex key should exist after preload via fallback")
+			}
+			if inner.exists.Load() != 0 {
+				t.Error("Exists should not have called backend for known non-hex key")
+			}
+
+			// Put-elision and Delete must also work through the fallback path.
+			inner.puts.Store(0)
+			if err := kc.Put(ctx, nonHexKey, []byte("data")); err != nil {
+				t.Fatal(err)
+			}
+			if inner.puts.Load() != 0 {
+				t.Error("Put should have been elided for already-known non-hex key")
+			}
+
+			if err := kc.Delete(ctx, nonHexKey); err != nil {
+				t.Fatal(err)
+			}
+			inner.exists.Store(0)
+			ok, _ = kc.Exists(ctx, nonHexKey)
+			if ok {
+				t.Error("non-hex key should not exist after delete")
+			}
+			if inner.exists.Load() != 0 {
+				t.Error("should resolve from cache (listed prefix, absent key)")
+			}
+		})
 	}
 }
 

--- a/internal/storelayer/keycache_test.go
+++ b/internal/storelayer/keycache_test.go
@@ -2,6 +2,7 @@ package storelayer
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -198,6 +199,79 @@ func TestKeyCacheStore_PutMakesExistsTrue(t *testing.T) {
 	}
 	if inner.exists.Load() != 0 {
 		t.Error("should resolve from cache after put")
+	}
+}
+
+func TestKeyCacheStore_DigestKeyExistsAfterPreload(t *testing.T) {
+	ctx := context.Background()
+	inner := newCountingStore()
+	digestKey := "chunk/" + strings.Repeat("ab", 32)
+	_ = inner.Put(ctx, digestKey, []byte("data"))
+	inner.exists.Store(0)
+
+	kc := NewKeyCacheStore(inner)
+	if err := kc.PreloadKeys(ctx, "chunk/"); err != nil {
+		t.Fatal(err)
+	}
+
+	ok, _ := kc.Exists(ctx, digestKey)
+	if !ok {
+		t.Error("digest key should exist after preload")
+	}
+	if inner.exists.Load() != 0 {
+		t.Error("Exists should not have called backend for known digest key")
+	}
+
+	// A different digest under the same prefix must not collide.
+	otherKey := "chunk/" + strings.Repeat("cd", 32)
+	ok, _ = kc.Exists(ctx, otherKey)
+	if ok {
+		t.Error("distinct digest key should not exist")
+	}
+}
+
+func TestKeyCacheStore_NonHexKeyUnderListedPrefixFallsBack(t *testing.T) {
+	ctx := context.Background()
+	inner := newCountingStore()
+	// A key under a listed prefix whose suffix is not a 64-char hex digest
+	// (e.g. malformed or legacy) must not be mis-filed into the digest map for
+	// a different key.
+	nonHexKey := "chunk/not-a-valid-digest"
+	_ = inner.Put(ctx, nonHexKey, []byte("data"))
+	inner.exists.Store(0)
+
+	kc := NewKeyCacheStore(inner)
+	if err := kc.PreloadKeys(ctx, "chunk/"); err != nil {
+		t.Fatal(err)
+	}
+
+	ok, _ := kc.Exists(ctx, nonHexKey)
+	if !ok {
+		t.Error("non-hex key should exist after preload via fallback")
+	}
+	if inner.exists.Load() != 0 {
+		t.Error("Exists should not have called backend for known non-hex key")
+	}
+
+	// Put-elision and Delete must also work through the fallback path.
+	inner.puts.Store(0)
+	if err := kc.Put(ctx, nonHexKey, []byte("data")); err != nil {
+		t.Fatal(err)
+	}
+	if inner.puts.Load() != 0 {
+		t.Error("Put should have been elided for already-known non-hex key")
+	}
+
+	if err := kc.Delete(ctx, nonHexKey); err != nil {
+		t.Fatal(err)
+	}
+	inner.exists.Store(0)
+	ok, _ = kc.Exists(ctx, nonHexKey)
+	if ok {
+		t.Error("non-hex key should not exist after delete")
+	}
+	if inner.exists.Load() != 0 {
+		t.Error("should resolve from cache (listed prefix, absent key)")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Key `KeyCacheStore`'s existence set by the raw 32-byte digest decoded from a content-addressed key's hex suffix (one `map[[32]byte]struct{}` per listed prefix), instead of by the full hex string
- A key under a listed prefix whose suffix isn't a well-formed 64-hex-char digest falls back to the previous string-keyed map, so it's still tracked correctly rather than mis-filed
- `Exists`, `Put` write-elision (including `singleflight` dedup), and `Delete` behaviour are unchanged
- Added `BenchmarkKeySetShapeRetained`, using this repo's existing retained-heap methodology (`internal/engine/metaloader_bench_test.go`'s `retainedBytes` GC-delta pattern), quantifying the win: 135.9 B/entry retained before vs 83.97 B/entry after at 500k entries — matching the numbers in the issue
- Updated `docs/caching.md`'s inventory table and memory-characteristics section

Closes #430

## Verification
- `go test -race -count=1 ./internal/storelayer ./internal/engine`
- `golangci-lint run ./internal/storelayer/... ./internal/engine/...`
- `go test ./internal/storelayer/... -run '^$' -bench 'BenchmarkKeyCache|BenchmarkKeySetShapeRetained' -benchmem`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache handling for content-addressed keys, including reliable existence checks, updates, and deletions.
  * Prevented collisions and incorrect cache hits for malformed or non-content-addressed keys.
  * Reduced unnecessary backend operations when cached data can be used.

* **Performance**
  * Improved memory efficiency for large collections of cached digest keys.

* **Documentation**
  * Expanded caching documentation with key handling, memory retention, benchmarks, and invalidation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->