### PR TITLE
rfc: metadata in the tree, and how a snapshot is read (RFC 0024, RFC 0025)

### DIFF
--- a/rfcs/0024-metadata-in-the-tree.md
+++ b/rfcs/0024-metadata-in-the-tree.md
@@ -1,0 +1,419 @@
+# RFC 0024: Metadata in the Tree
+
+- **Status:** Draft (exploratory)
+- **Date:** 2026-08-04, revised 2026-08-08
+- **Affects:** repository format, `internal/hamt`, `internal/engine`, `internal/storelayer`
+- **See also:** [RFC 0025](0025-traversal-order-and-demand-counted-reads.md), which
+  covers how a snapshot is *read*. It was split out of this document because it
+  needs no format change and can proceed independently.
+
+## Abstract
+
+A snapshot of 50,000 files is about 109,600 objects. Almost all of them are one
+`filemeta/` and one `content/` object per file, each a separate JSON document
+that has to be fetched, decoded and indexed individually.
+
+This RFC proposes storing file metadata **inside the HAMT leaves that already
+point at it**, in a compact binary encoding, and inlining small-file content
+alongside it. The same snapshot becomes about 9,100 objects.
+
+Every structure this workstream has spent months trying to bound — the pack
+catalog, the pack body cache, `check`'s verified set, `prune`'s reachable set —
+is proportional to object count, so a ~12x reduction does more for memory than
+bounding any of them individually.
+
+It deliberately does not change the identity model. That is the point of the
+constraint section below.
+
+## Context
+
+Issue #441 tracked "peak memory grows with repository size for every operation".
+Seven merged changes later, the growth from 5,000 to 50,000 files is down about
+a third and `check` is nearly flat, but every remaining structure is still
+O(objects):
+
+| structure | at 50k files |
+|---|---|
+| pack catalog | ~109,600 entries, 18.2 MB on disk, 73 B/entry resident |
+| pack body cache | bounded, but sized against pack count |
+| `CheckManager.verified` | one entry per object verified |
+| `prune` reachable set | one entry per object |
+| `ObjectStore.List` result | one string per object, materialised |
+
+Each was attacked separately. The pattern across all of them, and the reason the
+last several attempts measured as no-gain, is that they are symptoms of the same
+cause: **the format produces an enormous number of small objects, and everything
+downstream carries one entry per object.**
+
+Two measurements from that work bound the design space:
+
+- Peak RSS is dominated by transient allocation around I/O, not by resident
+  structures. 100,000 JSON decodes cost more than the maps holding their results.
+- Trading residency for re-reads is only a good trade when the re-read is cheap.
+  A pack-cache miss re-reads ~9 MB to return ~200 bytes.
+
+Both point the same way: reduce the number of objects rather than shrink the
+bookkeeping about them.
+
+## The constraint this design must respect
+
+An earlier draft proposed keying the tree by path. That is wrong for this
+product, for three reasons that are worth stating because they are not
+recoverable from the code:
+
+1. **A file can have several parents.** A Google Drive file lives in two folders
+   at once. `fileMetaPaths` exists precisely because callers need *every* path by
+   which an entry can be reached. Path is not an identity.
+1. **Path keying unbalances the tree.** A directory with a million files becomes a
+   million siblings under one prefix. The HAMT is hash-balanced to avoid exactly
+   that.
+1. **Path keying destroys rename stability.** With `FileID` identity, renaming a
+   folder leaves every descendant's key untouched and nothing below it is
+   rewritten. With path identity, one rename rewrites the entire subtree — the
+   worst possible behaviour for an incremental backup of a cloud source.
+
+So identity stays exactly as it is: `FileID` assigned by the source, `Parents` a
+list, routing by `AffinityKey(primaryParentID, FileID)`.
+
+**Identity and layout are separable.** Everything below changes only where bytes
+are placed, never what names them.
+
+## Proposal
+
+### 1. Leaf entries carry the metadata
+
+Today a leaf entry points at a separate object:
+
+```go
+type leafEntry struct {
+    Key     string `json:"key"`                // source file ID
+    PathKey string `json:"path_key,omitempty"` // routing key (affinity)
+    Value   string `json:"filemeta"`           // "filemeta/<sha256>"
+}
+```
+
+Reading one file's metadata is therefore two round trips: the node, then the
+`filemeta/` object it names. For a full traversal that is one extra object read
+per file, plus one more for `content/`.
+
+The proposal replaces `Value` with the metadata itself. A leaf then answers for
+every entry it holds, and the `filemeta/` and `content/` namespaces disappear for
+all but chunked files.
+
+Deduplication moves from per-file to per-leaf granularity: changing one file
+rewrites its leaf-mates' metadata rather than one file's. What that costs on an
+incremental is worked through in "What subsequent backups cost" below rather than
+waved away.
+
+#### What replaces the `filemeta/` ref
+
+The ref is load-bearing beyond storage. `internal/engine/backup_scan.go` reads
+`oldRef` from `tree.Lookup` and compares it against a freshly computed
+`FileMetaRef` to decide whether a file changed — a cheap equality test on a
+content address, with no decode. Removing the ref removes that test, so the
+replacement has to be stated:
+
+- `Lookup` returns the decoded entry rather than a ref. Change detection compares
+  the fields that define a change (size, mtime, mode, content identity) directly.
+  Those are fixed-offset fields in the record, so the comparison stays
+  allocation-free and does not require decoding the arena.
+- A per-entry content address is still needed for `check` to verify metadata
+  integrity. The leaf as a whole is content-addressed, which covers every entry
+  in it; per-entry addresses are not reintroduced.
+- **Mixed-era repositories.** A leaf is either the JSON form or the binary form,
+  distinguished by its magic. Readers accept both. Writers emit the new form
+  only. An old leaf is converted when a write happens to pass over it, which is
+  the same opportunistic upgrade `docs/compatibility.md` already mandates —
+  a repository stays a mixture of eras indefinitely and that is the steady
+  state. `filemeta/` and `content/` objects referenced by surviving JSON leaves
+  stay readable and are never rewritten in place.
+
+### 2. Leaves are a binary record array, not JSON
+
+A leaf is a fixed-width record array plus a string arena. Variable-length fields
+are `(offset, length)` spans into the arena, so a reader can locate any field
+without parsing, and can decode one entry without touching the others.
+
+All integers are **little-endian**. All arena offsets are relative to the start
+of the arena, not to the start of the object.
+
+```text
+leaf object
+┌────────────────────────────────────────────────────────────┐
+│ magic "CSLF"          4 bytes                              │
+│ version               u8                                   │
+│ (reserved)            u8                                   │
+│ entry count           u16                                  │
+│ parents table offset  u32   absolute, from object start    │
+│ arena offset          u32   absolute, from object start    │
+│                             header is 16 bytes, padded     │
+├────────────────────────────────────────────────────────────┤
+│ entry[0..n]           56 bytes each, sorted by routing     │
+├────────────────────────────────────────────────────────────┤
+│ parents table         (u32 arena-offset, u16 len) pairs    │
+├────────────────────────────────────────────────────────────┤
+│ arena                 concatenated bytes, no padding       │
+└────────────────────────────────────────────────────────────┘
+```
+
+```text
+entry — 56 bytes, 8-byte aligned, no pointers, no allocation to read
+┌──────────────┬─────────┬────────────────────────────────────────┐
+│ routing      │ u64     │ first 8 bytes of the affinity key       │
+│ fileID       │ u32+u16 │ arena offset, length                    │
+│ name         │ u32+u16 │ arena offset, length                    │
+│ content      │ u32+u32 │ arena offset, length — see below        │
+│ parents      │ u32+u16 │ parents-table index, count              │
+│ size         │ u64     │ logical file size                       │
+│ mtime        │ i64     │ unix nanoseconds                        │
+│ mode         │ u32     │                                         │
+│ type         │ u8      │ file, folder, symlink                   │
+│ flags        │ u8      │ inline-content, has-xattrs, …           │
+└──────────────┴─────────┴────────────────────────────────────────┘
+                            8+6+6+8+6+8+8+4+1+1 = 56
+```
+
+The `content` span is one field serving both cases, which is what makes inline
+bytes addressable at all:
+
+- **inline flag set** — the span locates the file's bytes in the arena.
+- **inline flag clear, length non-zero** — the span locates the
+  `content/<hash>` ref string in the arena.
+- **length zero** — no content: a folder, or an empty file.
+
+It is `u32+u32` rather than `u32+u16` for the same reason: a `u16` length caps at
+65,535 bytes and could not express an inline file of any interesting size. The
+other spans keep `u16` lengths, which bounds `fileID` and `name` at 65,535 bytes
+each — far above any real source identifier or filename, and enforced at encode
+time rather than assumed.
+
+Entries are sorted by `routing`, so a lookup inside a leaf is a binary search
+over a contiguous array, and a range scan over a directory is sequential.
+
+The 8-byte `routing` prefix is a filter, not the key: a match is confirmed
+against the full `fileID` in the arena. That keeps the record fixed-width while
+`FileID` stays an arbitrary-length source-assigned string.
+
+#### Validation
+
+A decoder rejects a leaf rather than trusting it, because a leaf is read from a
+store and `docs/compatibility.md` requires that "cannot decode" never degrades to
+"empty":
+
+- magic is `CSLF`; version is known, else reject naming the version.
+- `parents table offset` and `arena offset` are within the object, and ordered
+  header < entries < parents table < arena.
+- entry count × 56 fits between the header and the parents table.
+- every span satisfies `offset + length <= arena length`, checked before any read.
+- every parents-table index plus count is within the parents table.
+- `routing` is non-decreasing across entries, so binary search is sound.
+
+### 3. Small-file content moves inline
+
+A file whose content fits the inline budget carries its bytes in the arena and
+sets the inline flag. Only chunked files keep a `content/` object listing chunk
+refs.
+
+The budget is **not** inherited from `maxObjectSize` (512 KB). At `maxLeafSize`
+= 32 entries, a 512 KB budget would allow a 16 MB leaf, and a one-byte edit
+would rewrite all of it. See "What subsequent backups cost": something in the
+1–4 KB range keeps a full leaf near ~128 KB, and the right value is a
+measurement, not a choice.
+
+For a tree of very small files this removes one object per file on its own.
+
+## Worked example
+
+The tree the memory benchmark builds: 50,000 files of ~35 bytes in 500
+directories, one snapshot.
+
+| | today | proposed |
+|---|---|---|
+| `filemeta/` objects | 50,500 | 0 |
+| `content/` objects | 50,000 | 0 (inline) |
+| `node/` objects | 9,096 | ~9,100 |
+| `snapshot/` objects | 1 | 1 |
+| **total objects** | **~109,600** | **~9,100** |
+| pack catalog on disk | 18.2 MB | ~0.7 MB |
+| pack catalog resident | ~8 MB | ~0.3 MB |
+| objects read for a full traversal | ~109,600 | ~9,100 |
+| JSON documents decoded | ~109,600 | 0 |
+
+A full `restore` today issues 50,000 filemeta reads and 50,000 content reads on
+top of the tree walk. Proposed, the tree walk *is* the metadata read: ~9,100 node
+fetches, each yielding several files' metadata with no per-file decode.
+
+Object count is not request count — packs bundle many objects into one transfer,
+which is why a 5,000-file snapshot restores in 58–112 requests today rather than
+tens of thousands. Fewer objects reduces requests indirectly, by making each
+backup's packs smaller and its catalog cheaper, not one-for-one. RFC 0025 covers
+what actually decides the request count.
+
+### What a leaf looks like
+
+Two entries sharing a leaf, with every offset computed. `FileID` values are
+opaque, as a source assigns them — they are deliberately not paths.
+
+```text
+header    @0    magic "CSLF" | version 1 | count 2 | parents@128 | arena@140
+
+entry[0]  @16   routing 0x8f3a91c4d2e07b15
+                fileID  (arena+0,  6)   name (arena+6,  8)
+                content (arena+35, 12)  flags=inline
+                parents (index 0, count 1)   size 12   type=file
+entry[1]  @72   routing 0x8f3b02a7e1554c9d
+                fileID  (arena+14, 6)   name (arena+20, 9)
+                content (arena+47, 71)  flags=0        (a content/ ref)
+                parents (index 1, count 1)   size 4194304   type=file
+
+parents   @128  [0] = (arena+29, 6)      ← both name the same directory
+                [1] = (arena+29, 6)
+
+arena     @140  +0   "f_9a3c"          fileID of entry 0
+                +6   "notes.md"        name of entry 0
+                +14  "f_9a3d"          fileID of entry 1
+                +20  "photo.jpg"       name of entry 1
+                +29  "d_41f0"          the parent directory's FileID
+                +35  <12 bytes>        inline content of notes.md
+                +47  "content/7b2e…"   71-byte ref for photo.jpg
+```
+
+`d_41f0` appears once in the arena and is referenced by both entries. Today it is
+repeated in two separate JSON documents, along with two copies of the
+`"parents":[…]` key.
+
+## What subsequent backups cost
+
+The headline numbers above are an initial backup. Incrementals are where
+embedding metadata could plausibly make things worse, so they are worked through
+here rather than asserted to be free.
+
+`maxLeafSize` is 32, so a leaf holds up to 32 entries and changing one file
+dirties its whole leaf. The naive reading is 32x write amplification; the
+measured baseline says otherwise, because **the HAMT spine already dominates a
+single-file incremental today**:
+
+| one file changed | today | metadata in leaf | metadata + inline at 3.6 KB median |
+|---|---|---|---|
+| `filemeta/` + `content/` | ~400 B | 0 | 0 |
+| leaf (metadata) | — | ~6.4 KB | ~6.4 KB |
+| leaf (inline content) | — | — | ~115 KB |
+| dirty spine | ~5 KB | ~4 KB | ~4 KB |
+| **total written** | **~5 KB** | **~10 KB** | **~125 KB** |
+
+Two conclusions, pointing in opposite directions:
+
+- **Metadata embedding is roughly 2x on a single-file incremental**, not 32x. The
+  spine was always the larger term, and 2x of 5 KB is not a number worth changing
+  the design for.
+- **Inline content is the real cost**, scaling with `inline budget × maxLeafSize`.
+  It is why §3 refuses to inherit the 512 KB budget.
+
+**Clustered churn inverts the comparison.** Files changed in one directory tend
+to share a leaf, so they cost one leaf rewrite rather than one `filemeta` plus one
+`content/` object each. Real churn clusters — that is why `gentree` models it with
+a Zipf distribution over directories — so the common case is a win and the worst
+case is scattered single-file edits across many directories.
+
+Both cases are already in the benchmark: `backup-incremental-1` is the scattered
+single edit, `backup-incremental-1000` the clustered batch. Whichever way the
+design lands, they will show it, and neither should be accepted on reasoning
+alone.
+
+**A caveat on "its leaf".** Affinity routing makes leaf-mates *likely* to be
+siblings, not certainly. `maxLeafSize` is 32, so a directory with more than 32
+children spans several leaves; and the affinity prefix is 16 bits, so directories
+collide and a leaf can mix entries from more than one. Rewrite projections should
+therefore be stated over *all affected leaves*, not "the leaf" — for a directory
+of `n` children that is `ceil(n/32)` leaves at minimum, plus whatever collides.
+
+## Do packfiles still earn their place?
+
+Worth asking directly, because this design changes their cost model.
+
+Packs exist because writing ~109,600 small objects to S3 is ~109,600 PUTs. At
+~9,100 objects that argument weakens considerably, and two things follow:
+
+- **`maxObjectSize` is 512 KB** — anything larger bypasses packing already. Leaf
+  size is a tunable. Tuned large enough, the metadata path stops being packed at
+  all, and the pack catalog stops existing for it.
+- **Chunk data was never the problem.** Chunks of large files are already large,
+  already content-addressed, and already random-access by nature.
+
+This is a question to measure, not a recommendation to remove packs. Pack
+membership is not neutral to transfer volume: a pack holding unrelated leaves
+overfetches relative to standalone objects, and a pack holding a directory's
+leaves together underfetches relative to them. Whether packing pays for the
+metadata path at 9,100 objects depends on which of those the packing policy
+produces, which is exactly what should be measured rather than assumed.
+
+## What this does not solve
+
+- **`prune` still materialises every key**, because `ObjectStore.List` returns a
+  slice. ~9,100 strings instead of ~109,600 is a large improvement and still
+  O(n). A streaming enumeration is a separate change on a public interface
+  (a non-goal in RFC 0023).
+- **The ~150 MB floor stays.** It is Argon2id's 64 MB doubled by `GOGC=100`, and
+  it is correct behaviour. Releasing it explicitly after unlock is worth doing
+  and is independent of this RFC.
+- **Chunked files still cost a `content/` object each.** For a repository of
+  large files the object count is dominated by chunks, and this design does
+  nothing for it. It targets the many-small-files case, which is where the
+  measured growth was.
+- **Read cost is not addressed here at all.** Object count is one factor; the
+  order objects are read in and what the cache knows about them are others, and
+  they turn out to matter more for a restore. See RFC 0025.
+
+  The two do compose at one specific seam, worth naming because it is not
+  obvious. A pack mixes namespaces, and on today's format a restore of small
+  files reads roughly as many `content/` objects as metadata objects — they are
+  read in a different phase, with reference-counted rather than single-use
+  demand, so RFC 0025's manifest has to treat them as a separate kind and covers
+  only about half a restore's packed reads. Inlining small-file content here
+  collapses the two classes into one, at which point the traversal set *is* the
+  read set. Neither RFC needs the other; each makes the other worth more.
+
+## Open questions
+
+1. **What is the right inline budget?** The parameter with the most cost behind
+   it: metadata embedding is ~2x on a single-file incremental while inline
+   content at 512 KB could reach 16 MB per leaf. It has to be set against a full
+   leaf staying comparable to the spine, and measured on `backup-incremental-1`
+   and `backup-incremental-1000` rather than reasoned about.
+1. **Is `maxLeafSize = 32` still right once leaves carry metadata?** Bigger leaves
+   mean fewer objects and more rewritten bytes per change; it also decides whether
+   the metadata path clears `maxObjectSize` and stops being packed. It has been an
+   internal HAMT detail; this makes it a format-level trade.
+1. **Does the arena want compression?** Sibling file names share long prefixes.
+   Front-coding within a leaf is cheap and might halve the arena, but it costs
+   the zero-copy property for names.
+1. **How are xattrs and ACLs carried?** They are rare and variable-length. A
+   side-table keyed by entry index, present only when the flag is set, keeps the
+   common record at 56 bytes.
+1. **Is `routing` as a u64 prefix enough?** It is a filter over entries that
+   already share a leaf, so collisions cost a comparison, not a correctness
+   problem. Worth confirming against a source that assigns adversarial IDs.
+1. **What happens to content-addressed filemeta dedup?** Two identical files in
+   different directories share a `content/` object today and would still share
+   chunk data, but their metadata now lives in two leaves. That is a storage cost,
+   and it should be quantified.
+1. **How is the JSON→binary conversion paced?** Opportunistic upgrade means a
+   repository holds both forms indefinitely, so every reader carries both decoders
+   and `check` must accept both. Whether an explicit bulk conversion is also
+   wanted — and whether `prune`'s existing rewrite is the place for it — is open.
+
+## Why this over the alternatives
+
+**Bounding the pack catalog** (RFC 0023) attacks the index rather than what it
+indexes. Measurement showed the bounded-cache trade is a bad one when a miss is
+expensive, and that the catalog is not the largest term anyway.
+
+**A sorted on-disk index with fence pointers** — an earlier sketch — would make
+the catalog nearly free to hold. But lookups are by content hash and therefore in
+random order, so a block-cached on-disk index thrashes the same way the pack body
+cache did. It solves residency and creates a read-amplification problem.
+
+**Reducing object count** makes both of those problems smaller rather than
+solving them in place, and it is the only one of the three that also reduces
+what a remote backend is asked to do. It is not sufficient on its own: RFC 0025
+covers the read path, and the two are independent.

--- a/rfcs/0025-traversal-order-and-demand-counted-reads.md
+++ b/rfcs/0025-traversal-order-and-demand-counted-reads.md
@@ -1,0 +1,421 @@
+# RFC 0025: Traversal Order and Demand-Counted Reads
+
+- **Status:** Draft (exploratory)
+- **Date:** 2026-08-08
+- **Affects:** `internal/engine`, `internal/storelayer`, snapshot format (additive)
+- **See also:** [RFC 0024](0024-metadata-in-the-tree.md), which reduces object
+  count. This RFC was split out of it: the two are independent, and this half
+  needs no change to how objects are encoded.
+
+## Abstract
+
+`restore`, `check` and `prune`'s mark phase all traverse a whole snapshot. All
+three are slower and larger than they need to be, for two reasons that have
+nothing to do with how many objects there are:
+
+1. **Nothing reads in a useful order.** The HAMT walk is a pass over hash
+   buckets — deterministic, but not topological, and contiguous on disk only by
+   accident. So `restore` rebuilds the topology at runtime and holds six
+   O(files) structures before writing a byte.
+2. **The pack cache guesses.** For a traversal that reads each metadata object
+   exactly once, recency is *anti-correlated* with future need, so LRU retains
+   precisely the packs that are finished. Two separate heuristics
+   (`packPromoteAfter`, `packPenalized`) exist to paper over information the
+   snapshot could simply state. A pack mixes object kinds with different demand
+   semantics, which is why the answer is a per-kind count rather than one number
+   per pack.
+
+This RFC proposes deriving the traversal order from the routing key that already
+exists, and having a snapshot record how many of its objects of each kind live in
+each pack. Together those make `restore` stream in O(depth) rather than O(files),
+and take a pack visit from ~9 requests to 1.
+
+## Context
+
+`hamt.walk` is a depth-first pass over hash buckets. It is deterministic, but it
+is **not topological** — routing by `AffinityKey` says nothing about whether a
+parent sorts before its child — and it is only contiguous on disk because backup
+happened to write objects during that same walk.
+
+The consequences are visible in `internal/engine/restore.go`:
+
+- `collectMetadata` loads **every** entry in the snapshot before anything is
+  written: `refs[]`, then `byID{}` and `walkOrder[]`.
+- `restoreOrder` then rebuilds the topology at runtime into `interior{}`,
+  `emitted{}` and `out[]` — with cycle handling and three fallback passes,
+  because it is reconstructing information from data rather than reading it.
+- Only then does the first file get written.
+
+That is six O(files) structures live simultaneously before any output. `FileMeta`
+is a twenty-field struct with two maps and a slice, retaining roughly 400 bytes
+per entry, so a million-file snapshot needs ~400 MB of plan before it writes a
+byte — and cannot start early, because the order is not known until the whole
+thing is built.
+
+Meanwhile **the routing key already encodes the order nobody reads.**
+`AffinityKey` puts a directory's children under a shared prefix, so a
+parent-before-child walk is recoverable from the tree rather than needing to be
+recorded. #455 got at this by hand for restore's write phase, sorting leaves back
+into walk order to take pack-cache misses from 55.5% to 0.74%.
+
+### What the pack cache has cost so far
+
+The pack body cache was tuned three times, and each attempt traded one cost for
+another rather than removing it:
+
+| attempt | result |
+|---|---|
+| shrink it (RFC 0023 §1–2 prototype) | worse — a miss re-reads ~9 MB to return ~200 bytes |
+| size it to the working set (#460) | worked for one repository shape; broke when the benchmark grew to build 13/21/37 packs at 5k/20k/50k files |
+| size it to the *new* working set (#474, reverted) | fixed transfers by holding every pack resident — +347 MB peak RSS on `check`, +580 MB on `prune`. O(repository) residency, which RFC 0023 exists to remove |
+| bound the cost of overrunning it (#474, shipped) | 15x less transferred, 2.7x faster, peak RSS flat — but requests rise 1.4–2.7x, because a penalised pack is read one object at a time |
+
+What every one of those has in common is that it tuned a *policy* while leaving
+the *information* alone. The cache is asked to predict which packs will be wanted
+again from nothing but which ones were wanted recently — and for a traversal, that
+signal is worse than useless (§2).
+
+## Proposal
+
+### 1. The read order is derived, not stored
+
+A traversal needs parents before children, and wants to touch each pack once.
+Both fall out of the routing key that already exists, so nothing has to be
+recorded and nothing has to be rewritten per backup.
+
+```go
+func AffinityKey(parentID, fileID string) string {
+    parentHash := core.ComputeHash([]byte(parentID))
+    fileHash := core.ComputeHash([]byte(fileID))
+    return parentHash[:4] + fileHash[4:]
+}
+```
+
+The leading 4 hex characters come from the *parent*. Every child of a directory
+therefore shares a 16-bit routing prefix and lands in the same HAMT subtree.
+Listing a directory is a descent to that prefix and a scan, discarding entries
+that do not name it as their primary parent:
+
+```text
+children(D) = scan(subtree under prefix hash(D)[:4]) where Parents[0] == D
+```
+
+A traversal is then the obvious depth-first walk: take the snapshot's root ID,
+list its children, recurse into the folders. **Parent-before-child is guaranteed
+by construction** — a directory has to be read before its children can be
+located, since locating them requires its `FileID` — so `restoreOrder` and
+everything it builds disappears without anything replacing it. Note that this
+does not depend on ordering *within* a leaf: entries are sorted by `routing`, not
+topologically, and it does not matter, because the descent supplies the ordering.
+
+#### What this enumerates, and what it does not
+
+`AffinityKey` routes by **primary** parent, so this walk visits every entry
+exactly once, under `Parents[0]`. That is the right set for `restore`, `check`
+and `prune`: each writes, verifies or marks an entry once.
+
+It is **not** a complete directory listing. A file whose `Parents[1]` is `D` —
+the multi-parent case the identity model exists to support — will not appear
+under `D` in this walk. Anything that must show every path to an entry (`ls` of a
+secondary parent, `fileMetaPaths`) needs a secondary-parent index, which this RFC
+does not propose. Traversal and listing are different operations and only the
+first is claimed here.
+
+#### Locality, and what bounds it
+
+Backup writes a directory's entries together and affinity routing groups them, so
+a directory's metadata tends to be contiguous. When that directory is next
+touched, its entries are rewritten together into the same new pack, so **each
+backup re-establishes locality for whatever it touched.**
+
+Two things bound how strong that is, and both should be stated rather than
+assumed:
+
+- `maxLeafSize` is 32, so a directory with more than 32 children spans several
+  leaves. "A directory is one leaf" is a convenient approximation, not an
+  invariant.
+- The affinity prefix is 16 bits, so directories collide once their count
+  approaches 65,536: a listing scans ~1.08 directories' worth of entries at 5,000
+  directories, ~15 at 1,000,000. That makes the prefix width a parameter worth
+  choosing rather than inheriting (open question 1).
+
+**A stored order list was considered and rejected.** It costs ~291 KB per
+50,000-file snapshot, and an incremental that changed three files still rewrites
+all of it, so every backup pays in proportion to repository size rather than to
+churn. Chunking and content-addressing the list recovers that, at which point it
+is more machinery than derivation for a weaker locality guarantee.
+
+### 2. The pack cache is demand-counted, not LRU
+
+During a traversal **every metadata object is read exactly once** — `check` keeps
+a `verified` set specifically to guarantee it. That single fact makes LRU the
+wrong policy, and not merely a suboptimal one:
+
+> The moment a pack's last needed object is consumed, that pack becomes the
+> *most recently used* entry in the cache, and simultaneously the one entry
+> guaranteed never to be needed again. LRU preferentially retains finished packs
+> and evicts packs with outstanding demand that happen not to have been touched
+> lately.
+
+The measured cost of guessing instead of knowing is ~9 requests per pack visit
+(§3), of which `packPromoteAfter - 1` are ranged reads issued purely to discover
+whether the pack is worth fetching whole. `packPenalized` (#474) is the same
+guess from the other side — inferring that a pack is not worth caching from the
+fact that it was evicted.
+
+None of that is necessary, because **the demand is knowable**. A snapshot carries
+a manifest of `(packRef, kind) → count of this snapshot's objects of that kind in
+that pack`. It is O(packs × kinds), not O(objects) — hundreds of entries, a few
+KB — and it is maintained incrementally: snapshot *N*'s manifest is snapshot
+*N−1*'s, less the counts for packs holding superseded entries, plus the counts for
+what this backup wrote. That is O(churn), which is what keeps it from becoming the
+per-backup cost that ruled out the stored order list in §1.
+
+#### Why the count is per kind, not per pack
+
+A pack is not a bag of one thing. `packablePrefixes` admits five namespaces —
+`node/`, `filemeta/`, `snapshot/`, `content/`, `chunk/` — and `isSmallObject`
+takes anything under 512 KB, measured *after* compression and encryption, since
+`PackStore` sits below both layers. So a single pack routinely mixes tree nodes,
+per-file metadata, chunk manifests, inlined small-file bodies, and compressed
+chunks that happened to shrink below the threshold.
+
+Those kinds do not share demand semantics, and a single count per pack would be
+wrong in three separate ways:
+
+- **They are read in different phases.** A restore reads `node/` and `filemeta/`
+  while traversing, and `content/` and `chunk/` while writing file bodies. One
+  combined count either pins a pack from the traversal that first touched it
+  until the last body is written, or releases it at zero and re-fetches it.
+- **They have different multiplicities.** A metadata object is read exactly once.
+  A `content/` or `chunk/` object shared by several files through deduplication
+  is read once *per referencing file*, so its demand is a reference count.
+- **Different operations want different subsets.** `check` verifies everything;
+  `prune`'s mark phase needs metadata but not file bodies; a `-path` restore
+  needs a subtree of both. A count that cannot be sliced serves one of them.
+
+Per-kind counts let each caller sum the kinds it will actually read. A streaming
+restore sums metadata and content together — and because §1 makes it read a
+directory's metadata and then immediately write that directory's files, the two
+phases interleave per directory rather than running end to end, so a pack holding
+both is used contiguously and released once.
+
+This is also where the two RFCs stop being merely independent and start
+composing. In the benchmark repository — 5,000 files, 3.6 KB median, below
+`cdcMinSize` so nothing is chunked — roughly 6,500 packed objects are metadata
+and roughly 5,000 are `content/` objects holding inlined bodies. Demand counting
+over the traversal set alone would therefore cover a little over half of what a
+restore reads. [RFC 0024](0024-metadata-in-the-tree.md) moves small-file content
+into the leaf, which collapses those two classes into one: the traversal set
+becomes the whole read set, and the manifest covers all of it. Neither RFC needs
+the other, but this is the seam where each makes the other worth more.
+
+With exact counts a reader gets three things it cannot have today:
+
+- **Optimal admission.** Fetch a pack whole if this traversal needs enough of it,
+  ranged-read it otherwise — decided once, before the first read, instead of
+  after seven probes.
+- **Immediate release.** Free a pack when its count reaches zero rather than
+  waiting for eviction pressure to notice. The cache holds only packs with
+  outstanding demand.
+- **Belady-optimal eviction** when memory is short: evict by furthest next use,
+  which the manifest supplies, rather than by least recent use, which is
+  anti-correlated with it here.
+
+Two limits worth stating rather than discovering later:
+
+- **"Exactly once" is a property of metadata, not of file data.** A `content/` or
+  `chunk/` object shared by several files through deduplication is fetched once
+  per referencing file. The per-kind manifest expresses that naturally — it is a
+  count either way — but "read once" must not be assumed uniformly, and the
+  counting pass has to follow references rather than count distinct objects.
+- **Demand counting alone does not bound residency.** A pack stays resident from
+  the first to the last access of its objects; if traversal order were
+  uncorrelated with pack layout, that span would be the whole traversal and every
+  pack would be live at once. §1 is what keeps the spans short. The two compose:
+  derived order makes residency brief, demand counting makes admission and
+  eviction exact.
+
+This supersedes `packPromoteAfter` and `packPenalized` **for the kinds the
+manifest covers**. Both remain the right heuristics everywhere else: `cat` of one
+file, a dedup probe during backup, and any read of a kind a given operation did
+not count — where nothing can say what comes next.
+
+### 3. Operations become streaming
+
+Given §1 and §2, the O(files) plan disappears:
+
+- **`restore`** walks directories in derived order and writes each entry as it is
+  decoded. No `byID`, no `walkOrder`, no `interior`/`emitted`/`out`, no
+  `restoreOrder` at all. Memory becomes O(tree depth + in-flight writes) rather
+  than O(files), and the first file is written after the first directory rather
+  than after the last.
+- **`check`** verifies directory by directory. Its `verified` set is then needed
+  only for objects reachable more than once — deduplicated `content/` and
+  `chunk/` objects, and metadata reachable through a secondary parent — rather
+  than one entry per object verified.
+- **`prune`'s mark phase** marks reachable refs as it streams, instead of
+  building a set over every key first. The *sweep* still materialises every key,
+  because `ObjectStore.List` returns a slice; that is unchanged and remains a
+  non-goal (RFC 0023).
+
+**How large a cache this needs is conditional, and the condition should be
+stated.** With a freshly written or compacted repository, a directory's entries
+are contiguous and a very small cache suffices. After churn, a snapshot's
+entries span one pack per contributing backup (§4), and the working set is the
+number of packs live across the current directory — still small, but not one.
+Demand counting is what makes that degrade gracefully instead of thrashing: packs
+are admitted on known need and released at zero, so exceeding the budget costs
+ranged reads rather than repeated whole-pack transfers.
+
+## What it costs to restore, N backups later
+
+Each backup flushes its own packs, so a later snapshot's tree is assembled from
+all of them. Measured against MinIO — 5,000 files, then six incrementals of 200
+changed files each, restoring the latest snapshot after every one:
+
+| | packs | requests | transferred |
+|---|---|---|---|
+| after 1 backup | 3 | 58 | 177.8 MB |
+| after 2 backups | 4 | 67 | 179.1 MB |
+| after 4 backups | 6 | 85 | 181.6 MB |
+| after 7 backups | 9 | 112 | 184.5 MB |
+
+Exactly linear: **+1 pack, +9 requests and +1.1 MB per backup**, and the churn
+volume barely enters into it — 200 changed files out of 5,000 costs the same as
+any other small change, because what is added is a pack visit, not the data. The
++9 is `packPromoteAfter` showing through: a pack contributing a handful of
+objects is read ~7 times by ranged read, then fetched whole once.
+
+The mechanism is confirmed by restoring an *old* snapshot from the same
+repository:
+
+| | requests | transferred |
+|---|---|---|
+| latest (7th) snapshot | 112 | 184.5 MB |
+| 1st snapshot, six backups later | 63 | 178.3 MB |
+
+The first snapshot still restores at its original cost. Nothing moved it: its
+entries were all written by one backup and still sit in that backup's three
+packs. So the cost is not "the repository has many packs" — it is **how many
+distinct backups contributed entries to the snapshot being read**. A stable tree
+with occasional churn keeps most of its entries in the original epoch and stays
+cheap; a heavily churned one accumulates.
+
+The linear term has two factors — how many packs a snapshot spans, and what each
+visit costs — and this RFC addresses only the second:
+
+- **Ordering does not change the pack count.** §1 decides whether a pack is
+  revisited, not how many packs a snapshot spans.
+- **Demand counting attacks the per-visit cost.** Of those ~9 requests, 8 are
+  probing. §2 knows the answer before the first read, so a visit costs one
+  request instead of nine: the slope falls roughly 9x and the term stays linear.
+- **Only compaction removes the linear term**, by rewriting scattered entries
+  back into contiguous packs. `prune`/`Repack` is where that belongs, and today
+  it does not happen on its own: measured on a repository with every snapshot
+  still reachable, `prune` left the pack count unchanged, because nothing was
+  garbage. Compaction has to be driven by *layout*, not only by reachability.
+
+Two further options were considered for removing the linear term outright and are
+recorded rather than proposed, because each is a larger change than this RFC asks
+for:
+
+- **Carry the partial pack forward** instead of sealing one per backup, so pack
+  count grows with data rather than with backup count. The obstacle is that a
+  pack is named by its contents (`packRef = packPrefix + packHash`), so a growing
+  pack changes identity; it would need sequence-named packs with integrity from
+  the footer, and it reopens the concurrent-writer question that the append-only
+  shard design in `packshard.go` exists to answer.
+- **Serialise metadata as a content-defined-chunked stream** in traversal order,
+  the way file content already is. Unchanged regions dedupe, chunks land above
+  `maxObjectSize` and bypass packing entirely, and a restore reads a number of
+  objects set by metadata size rather than by backup count. The cost is write
+  amplification: a one-byte change rewrites a whole chunk, trading incremental
+  cost against restore cost through the chunk-size parameter.
+
+## What this does not solve
+
+- **Restore cost still grows with backup count.** §2 takes a visit from ~9
+  requests to 1 and the slope falls accordingly, but the term stays linear:
+  nothing here reduces how many packs a snapshot spans. Removing it needs
+  layout-driven compaction, which does not exist yet (open question 3).
+- **`prune`'s sweep still materialises every key.** `ObjectStore.List` returns a
+  slice; a streaming enumeration is a public-API change and its own RFC.
+- **Streaming is not primarily a wall-clock win on a local store.** Measured on a
+  20,000-file restore to a local backend, metadata collection is 189 ms of
+  1.53 s — about 12%. The win is that memory stops scaling with file count, that
+  the ordering logic disappears, and that a remote backend reads a directory at a
+  time. Anyone expecting restore to get 2x faster on a local disk will be
+  disappointed.
+- **Demand counting covers only the kinds an operation counts.** A pack mixes
+  five namespaces, and anything a caller does not count still falls back to
+  `packPromoteAfter`. On today's format that leaves a real fraction uncovered for
+  a restore of small files — measured on the benchmark repository, `content/`
+  objects holding inlined bodies are roughly 5,000 of the ~11,500 packed objects
+  a restore reads. RFC 0024 is what collapses that class into the traversal set.
+- **Secondary parents are not enumerated.** See §1; `ls` of a secondary parent
+  needs an index this RFC does not propose.
+
+## Open questions
+
+1. **How wide should the parent prefix be?** §1 derives directory listings from
+   `hash(parentID)[:4]` — 16 bits, so junk grows once directory count approaches
+   65,536. Widening to 6 hex characters gives 16M buckets and keeps junk
+   negligible at any plausible scale; the fileID half retains ample entropy
+   either way. It is currently 4 because that is what `AffinityKey` was written
+   with, which is not a reason.
+1. **How is the pack manifest kept correct?** §2 maintains it incrementally, so
+   it is derived state that can drift from the tree it describes. A count too low
+   frees a pack early and costs a re-fetch; too high wastes residency. Neither is
+   a correctness failure, which is the right property, but the manifest should be
+   cheaply verifiable — `check` is the natural place — and `RebuildCatalog` is
+   precedent for repairing derived state from the objects themselves.
+1. **What is the right granularity of "kind"?** §2 counts per `(packRef, kind)`
+   because the five packable namespaces differ in read phase and multiplicity.
+   Whether `node/` and `filemeta/` need separating from each other — they are read
+   in the same phase, exactly once each — or whether the useful split is simply
+   *metadata* versus *file data*, decides how large the manifest is and how much a
+   caller has to know to slice it. Under RFC 0024 the distinction largely
+   dissolves, which is an argument for not over-specifying it now.
+1. **What does the reference-counting pass cost?** Metadata demand is one per
+   object, but `content/` and `chunk/` demand is one per *reference*, so building
+   those counts means walking references rather than distinct objects. For a
+   heavily deduplicated repository that is more work than counting, and it happens
+   at backup time on the incremental path. Whether it can be maintained as a delta
+   like the rest of the manifest, or has to be recomputed, is unresolved.
+1. **What triggers compaction?** The largest unresolved item, and the one this RFC
+   flattens rather than solves. `prune`/`Repack` compacts on *reachability* and
+   leaves layout alone, so a repository whose snapshots are all still live keeps
+   every pack. A layout-driven trigger needs designing, and its cost measured
+   against the backup it would compete with for I/O.
+1. **Does derivation hold up under a partial restore?** `-path` filtering selects
+   a subtree. Derivation should be *better* here than a global order — it can
+   descend straight to the directories it wants — and the manifest's counts then
+   become upper bounds rather than exact, since some counted objects fall outside
+   the filter. Both need measuring.
+1. **What does a secondary-parent index cost?** Out of scope here, but the
+   multi-parent case is real and `ls` needs it. Whether it is a second routing of
+   the same entry, or a side index, changes the write cost of a multi-parent file.
+
+## Why this over the alternatives
+
+**A better eviction policy alone** is the obvious thing to reach for, and it does
+not work. The problem is not that LRU picks badly among equals; it is that for a
+traversal reading each metadata object once, recency is anti-correlated with
+future need — a pack is most recently used at precisely the moment it becomes
+useless. No policy over that signal recovers what the snapshot could state.
+
+**A bigger cache** was measured three times (see Context) and the last attempt
+reintroduced O(repository) residency, which is what RFC 0023 exists to remove. A
+cache budget is a tuning knob, not a bound: some repository always exceeds it,
+and what matters is the cost when it does.
+
+**Recording the traversal order** works but is paid for on every backup in
+proportion to repository size rather than churn (§1), and derivation gets the
+same property for nothing.
+
+**Reducing object count** ([RFC 0024](0024-metadata-in-the-tree.md)) is
+complementary and independent. It makes each backup's packs smaller and the
+catalog cheaper; it does not change how many packs a snapshot spans or what the
+cache knows about them. Either RFC is useful without the other, which is why they
+are separate documents.

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -23,3 +23,5 @@
 - [RFC 0021: Restore Destinations and Formats](0021-restore-destinations-and-formats.md)
 - [RFC 0022: Public Go API Boundaries](0022-public-go-api-boundaries.md)
 - [RFC 0023: Bounding the Pack Catalog](0023-bounding-the-pack-catalog.md)
+- [RFC 0024: Metadata in the Tree](0024-metadata-in-the-tree.md)
+- [RFC 0025: Traversal Order and Demand-Counted Reads](0025-traversal-order-and-demand-counted-reads.md)


### PR DESCRIPTION
## Summary

- Add `rfcs/0024-metadata-in-the-tree.md` — the leaf format
- Add `rfcs/0025-traversal-order-and-demand-counted-reads.md` — the read path
- List both in `rfcs/README.md`

Exploratory design records. Written without regard to backward compatibility, as
asked — the question is what the best organisation looks like, not how to get
there.

## Why two documents now

Review made the seam obvious: every finding fell into either **binary-format
precision** (entry width, `u16` limits, inline addressability, encoding rules) or
**read-path semantics** (multi-parent routing, cache conditionality, request
counts). The two halves share no dependency:

- **RFC 0025 needs no format change at all.** `AffinityKey` already carries the
  parent prefix, so derived order works on today's JSON leaves; demand counting
  works on today's packs. It is where the measured wins are.
- **RFC 0024 is a breaking format change** needing a precise binary spec,
  validation and a migration story.

Bundling them would make the cheap, low-risk, measured half wait on the expensive
one. **Happy to split 0025 into its own PR** if you'd rather they merge
independently — that was the point of separating them, and this PR keeps both
only because you asked for one squashed commit.

## RFC 0024 — Metadata in the Tree

Store metadata inside the HAMT leaves that already point at it, in a compact
binary encoding, and inline small-file content. ~109,600 objects → ~9,100 for a
50,000-file snapshot, shrinking every O(objects) structure at once.

## RFC 0025 — Traversal Order and Demand-Counted Reads

Two things, both independent of the format:

1. **Derive the traversal order.** `AffinityKey` is `parentHash[:4] + fileHash[4:]`,
   so a directory's children already share a routing prefix. Depth-first from the
   root is parent-before-child *by construction*, and `restoreOrder` plus its six
   O(files) structures disappear with nothing replacing them.
2. **Demand-count the pack cache.** For a traversal reading each metadata object
   exactly once, recency is *anti-correlated* with future need — a pack is most
   recently used at the moment it becomes useless. A snapshot carries
   `packRef → count`, maintained incrementally (O(churn)), giving optimal
   admission, release at zero, and Belady-optimal eviction.

Carries the restore-cost measurements: **+1 pack, +9 requests, +1.1 MB per
contributing backup**, and an old snapshot still restoring at its original cost
(63 vs 112 requests), which isolates the cause.

## Review fixes — all of them real

| finding | fix |
|---|---|
| entry width stated 48, fields sum to 54 | now **56**, 8-byte aligned, arithmetic shown |
| `u16` length cannot express 512 KB inline | content is one **`u32+u32` span** |
| inline content unaddressable | same span serves inline bytes *and* the `content/` ref — the flag said it was there, nothing said where |
| no canonical encoding | little-endian, arena-relative offsets, plus a **validation section** — a leaf is read from a store, and "cannot decode" must never degrade to "empty" |
| worked example offsets don't follow | recomputed end to end, opaque `FileID`s rather than paths |
| `filemeta/` ref contract undefined | states what replaces it for `backup_scan.go`'s change detection, and how mixed-era repositories read |
| `children(D)` filters `Parents[0]` | **real gap** — the multi-parent case the identity model exists to support isn't enumerated. Now scoped: traversal is complete, directory *listing* is not |
| affinity prefix ≠ one leaf | `maxLeafSize` is 32 and 16-bit prefixes collide; projections stated over all affected leaves |
| object counts ≠ request counts | packs bundle; the "9,100 requests instead of 109,601" claim is gone |
| small-cache guarantee unconditional | now conditional on locality, with post-churn behaviour stated |
| "each object once" too broad | scoped to *metadata* objects; chunk demand is a reference count |

## Verification

- `npx markdownlint-cli2 "**/*.md"` — 0 issues across 42 files
- Documentation only; no code paths touched