### PR TITLE
test(benchmark): generate backup sources with real-world statistics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,11 @@ backup_store/
 restore_out/
 .envrc
 .idea/
-/bin/cloudstic
+/bin/
+# Built by scripts/benchmark/memory.sh; only cloudstic used to be ignored, so
+# benchreport and gentree landed in the working tree — and, once, in a commit.
+/gentree
+/benchreport
 dist/
 
 # Test output

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,9 @@ go fmt ./...
 
 # Memory as a function of repository size (minutes, not seconds)
 SIZES="5000 20000" SAMPLES=3 ./scripts/benchmark/memory.sh
+
+# The same, against a source tree with realistic sizes, fan-out and duplication
+SIZES="5000" PROFILE=source ./scripts/benchmark/memory.sh
 ```
 
 ### Performance measurement
@@ -51,6 +54,15 @@ Three layers, in cost order:
   reason — which would silently move numbers a trend line is built on. The two
   share `lib.sh` for measurement mechanics and nothing else; in particular
   their datasets are separate, which is the whole point.
+- **`scripts/benchmark/gentree/`** — generates a backup source with the
+  statistics a real one has: heavy-tailed file sizes and directory fan-out,
+  duplicated content, and churn that clusters in a few directories rather than
+  spreading evenly. Seeded, so a given (profile, files, seed, MAX_BYTES) is
+  byte-identical run to run — a benchmark whose dataset drifts measures nothing. Profiles:
+  `uniform` (the original flat tree, still the default so historical numbers stay
+  comparable), `source`, `media`, `mixed`. Select with
+  `PROFILE=source ./scripts/benchmark/memory.sh`; `MAX_BYTES` scales the size
+  distribution to keep a realistic tree runnable.
 - **`scripts/benchmark/memory.sh`** — peak RSS and cumulative allocation for
   each operation across several tree sizes. Peak RSS is the one that answers
   "does this grow with the repository", which a single measurement cannot: an

--- a/scripts/benchmark/gentree/churn.go
+++ b/scripts/benchmark/gentree/churn.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// applyChurn mutates a generated tree the way a day between two backups would.
+//
+// The shape of the churn matters more to a backup than its volume. An
+// incremental that rewrites 5% of files spread evenly across every directory
+// touches nearly every metadata leaf; the same 5% concentrated in a few working
+// directories touches a handful. Those two produce very different write
+// amplification from the same headline churn rate, and the uniform generator
+// could only express the first.
+//
+// Four kinds of change, because they stress different parts of the format:
+//
+//   - modify: same path, new content. New content object, same file identity.
+//   - append: same path, content grows. The case chunking is supposed to handle
+//     without rewriting what came before.
+//   - create/delete: new and vanished paths, which move the tree's shape.
+//   - rename a directory: with FileID identity nothing below it should be
+//     rewritten, and with path identity everything would be. It is the cheapest
+//     way to tell the two apart, so the generator has to be able to produce it.
+func applyChurn(root string, p profile, seed int64, fraction float64) (stats, error) {
+	rng := rand.New(rand.NewSource(seed ^ 0x5eed))
+	st := stats{}
+
+	dirs, err := collectDirs(root)
+	if err != nil {
+		return st, err
+	}
+	if len(dirs) == 0 {
+		return st, fmt.Errorf("no directories under %s", root)
+	}
+
+	// Directories are ranked, then chosen by a Zipf law over the ranking, so the
+	// same few are hot across successive churns rather than a fresh random set
+	// each time. That is what makes repeated incrementals realistic: a working
+	// directory stays hot, an archive stays cold.
+	sort.Strings(dirs)
+	hot := hotOrder(rng, dirs, p)
+
+	total, err := countFiles(root)
+	if err != nil {
+		return st, err
+	}
+	budget := int(float64(total) * fraction)
+	if budget < 1 {
+		budget = 1
+	}
+
+	pool := newContentPool(rng, p)
+	touched := map[string]bool{}
+
+	for _, dir := range hot {
+		if st.Modified+st.Created+st.Deleted >= budget {
+			break
+		}
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		var files []string
+		for _, e := range entries {
+			if !e.IsDir() {
+				files = append(files, filepath.Join(dir, e.Name()))
+			}
+		}
+		if len(files) == 0 {
+			continue
+		}
+		sort.Strings(files)
+
+		// How much of this directory changes, weighted so hot directories churn
+		// hard rather than every directory churning a little.
+		share := 0.2 + 0.6*rng.Float64()
+		n := int(float64(len(files)) * share)
+		if n < 1 {
+			n = 1
+		}
+
+		for i := 0; i < n && st.Modified+st.Created+st.Deleted < budget; i++ {
+			idx := rng.Intn(len(files))
+			path := files[idx]
+			touched[dir] = true
+			switch r := rng.Float64(); {
+			case r < 0.60: // modify in place
+				size := sampleSize(rng, p)
+				body, _ := pool.body(rng, size)
+				if err := os.WriteFile(path, body, 0o644); err == nil {
+					st.Modified++
+				}
+			case r < 0.80: // append, the case incremental chunking exists for
+				f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+				if err != nil {
+					continue
+				}
+				tail := makeBody(rng, sampleSize(rng, p)/8, rng.Float64() < p.incompressibleFraction)
+				_, _ = f.Write(tail)
+				_ = f.Close()
+				st.Modified++
+			case r < 0.93: // create
+				size := sampleSize(rng, p)
+				body, _ := pool.body(rng, size)
+				name := fmt.Sprintf("new-%d-%d.dat", seed, rng.Int63())
+				if err := os.WriteFile(filepath.Join(dir, name), body, 0o644); err == nil {
+					st.Created++
+				}
+			default: // delete
+				if err := os.Remove(path); err == nil {
+					st.Deleted++
+					// Drawing is with replacement, and the modify branch would
+					// recreate this path with os.WriteFile — leaving the run
+					// reporting a deletion that is not in the tree the next
+					// backup sees.
+					files = append(files[:idx], files[idx+1:]...)
+					if len(files) == 0 {
+						break
+					}
+				}
+			}
+		}
+	}
+
+	st.TouchedDirs = len(touched)
+
+	// One directory rename per churn, deep enough to carry a subtree. This is
+	// the case that separates identity models, and it costs nothing to include.
+	if renamed := renameOneDir(rng, root, dirs); renamed {
+		st.Renamed++
+	}
+	return st, nil
+}
+
+// hotOrder ranks directories so that a Zipf draw concentrates on a few of them.
+// A churnDirZipfS of 0 means no concentration, which is the uniform profile.
+func hotOrder(rng *rand.Rand, dirs []string, p profile) []string {
+	if p.churnDirZipfS == 0 {
+		out := append([]string(nil), dirs...)
+		rng.Shuffle(len(out), func(i, j int) { out[i], out[j] = out[j], out[i] })
+		return out
+	}
+
+	z := rand.NewZipf(rng, math.Max(p.churnDirZipfS, 1.01), 1, uint64(len(dirs)-1))
+	seen := make(map[string]bool, len(dirs))
+	out := make([]string, 0, len(dirs))
+	// Draw until most directories have been ranked; the tail is appended in
+	// order so nothing is unreachable.
+	for i := 0; i < len(dirs)*4 && len(out) < len(dirs); i++ {
+		d := dirs[z.Uint64()]
+		if !seen[d] {
+			seen[d] = true
+			out = append(out, d)
+		}
+	}
+	for _, d := range dirs {
+		if !seen[d] {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// renameOneDir renames a directory below root, so a subtree moves.
+//
+// Depth is measured relative to root. Measuring it on the absolute path counted
+// the separators of whatever temporary directory the tree happens to live under,
+// so the source root itself cleared the threshold and could be renamed out from
+// under the backup that was about to read it.
+func renameOneDir(rng *rand.Rand, root string, dirs []string) bool {
+	candidates := renameCandidates(root, dirs)
+	if len(candidates) == 0 {
+		return false
+	}
+	src := candidates[rng.Intn(len(candidates))]
+	dst := filepath.Join(filepath.Dir(src), fmt.Sprintf("%s-renamed-%d", filepath.Base(src), rng.Intn(1000)))
+	return os.Rename(src, dst) == nil
+}
+
+// renameCandidates returns the directories eligible to be renamed: those inside
+// root and deep enough to carry a subtree.
+//
+// Depth is relative to root. Measured on the absolute path it counted the
+// separators of whatever temporary directory the tree lives under, so root
+// itself cleared the threshold and could be renamed out from under the backup
+// about to read it.
+func renameCandidates(root string, dirs []string) []string {
+	var out []string
+	for _, d := range dirs {
+		rel, err := filepath.Rel(root, d)
+		if err != nil || rel == "." {
+			continue
+		}
+		if strings.Count(rel, string(filepath.Separator)) >= 1 {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+func collectDirs(root string) ([]string, error) {
+	var out []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			out = append(out, path)
+		}
+		return nil
+	})
+	return out, err
+}
+
+func countFiles(root string) (int, error) {
+	n := 0
+	err := filepath.WalkDir(root, func(_ string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			n++
+		}
+		return nil
+	})
+	return n, err
+}

--- a/scripts/benchmark/gentree/gentree_test.go
+++ b/scripts/benchmark/gentree/gentree_test.go
@@ -1,0 +1,272 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// fingerprint hashes every path and its contents, so two trees compare equal
+// only if they are byte-identical.
+func fingerprint(t *testing.T, root string) string {
+	t.Helper()
+
+	var paths []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			paths = append(paths, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(paths)
+
+	h := sha256.New()
+	for _, p := range paths {
+		rel, _ := filepath.Rel(root, p)
+		h.Write([]byte(rel))
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		h.Write(b)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// The property the whole benchmark rests on. Comparing two builds of cloudstic
+// requires the input to be identical; a dataset that drifts between runs turns
+// every measurement into noise.
+func TestGenerateIsDeterministic(t *testing.T) {
+	for name := range profiles {
+		t.Run(name, func(t *testing.T) {
+			p := fitToBudget(profiles[name], 400, 16<<20)
+
+			a, b := t.TempDir(), t.TempDir()
+			if _, err := generate(a, p, 400, 42); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := generate(b, p, 400, 42); err != nil {
+				t.Fatal(err)
+			}
+			if fingerprint(t, a) != fingerprint(t, b) {
+				t.Error("the same seed produced different trees")
+			}
+		})
+	}
+}
+
+func TestGenerateDiffersBySeed(t *testing.T) {
+	p := fitToBudget(profiles["mixed"], 400, 16<<20)
+	a, b := t.TempDir(), t.TempDir()
+	if _, err := generate(a, p, 400, 1); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := generate(b, p, 400, 2); err != nil {
+		t.Fatal(err)
+	}
+	if fingerprint(t, a) == fingerprint(t, b) {
+		t.Error("different seeds produced the same tree")
+	}
+}
+
+// Duplication has to be real, or the repository's content addressing looks free.
+func TestRealisticProfilesDuplicateContent(t *testing.T) {
+	for _, name := range []string{"source", "mixed", "media"} {
+		t.Run(name, func(t *testing.T) {
+			p := fitToBudget(profiles[name], 800, 32<<20)
+			st, err := generate(t.TempDir(), p, 800, 3)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if st.DuplicateFiles == 0 {
+				t.Errorf("%s produced no duplicate files; dedup would be unmeasurable", name)
+			}
+			if st.DedupRatio <= 0 {
+				t.Errorf("%s dedup ratio is %.3f, want > 0", name, st.DedupRatio)
+			}
+		})
+	}
+}
+
+// The uniform profile is the historical baseline and must stay flat and
+// duplicate-free, or previously recorded numbers stop being comparable.
+func TestUniformProfileStaysUniform(t *testing.T) {
+	st, err := generate(t.TempDir(), profiles["uniform"], 500, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.DuplicateFiles != 0 {
+		t.Errorf("uniform produced %d duplicate files, want 0", st.DuplicateFiles)
+	}
+	if st.MedianSize != st.MaxSize {
+		t.Errorf("uniform sizes vary: median %d, max %d", st.MedianSize, st.MaxSize)
+	}
+	if st.MaxDepth != 1 {
+		t.Errorf("uniform depth is %d, want 1", st.MaxDepth)
+	}
+}
+
+// Sizes and fan-out must actually be spread. A "realistic" profile that
+// collapses to a constant would reintroduce the flaw it exists to fix.
+func TestRealisticProfilesAreHeavyTailed(t *testing.T) {
+	p := fitToBudget(profiles["mixed"], 1500, 64<<20)
+	st, err := generate(t.TempDir(), p, 1500, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.P99Size <= st.MedianSize*4 {
+		t.Errorf("p99 size %d is not far above median %d; the tail is missing", st.P99Size, st.MedianSize)
+	}
+	if st.MaxFanout <= st.MedianFanout*3 {
+		t.Errorf("max fan-out %d is not far above median %d", st.MaxFanout, st.MedianFanout)
+	}
+	if st.MaxDepth < 3 {
+		t.Errorf("max depth %d; the tree is too shallow to be a real one", st.MaxDepth)
+	}
+}
+
+// Churn must concentrate. Spread evenly it touches nearly every metadata leaf,
+// which is the assumption that made the uniform tree misleading about write
+// amplification.
+//
+// The count comes from the churn itself rather than from diffing paths before
+// and after: one directory rename moves every path beneath it without touching
+// a single file, and a path diff would score all of those as churn.
+func TestChurnConcentratesInFewDirectories(t *testing.T) {
+	root := t.TempDir()
+	p := fitToBudget(profiles["source"], 2000, 64<<20)
+	if _, err := generate(root, p, 2000, 9); err != nil {
+		t.Fatal(err)
+	}
+
+	st, err := applyChurn(root, p, 9, 0.05)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changed := st.Modified + st.Created + st.Deleted
+	if changed == 0 {
+		t.Fatal("churn changed nothing")
+	}
+
+	dirs, err := collectDirs(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Uniform churn of this many files would touch roughly one directory per
+	// changed file. Concentrated, it should touch far fewer.
+	if st.TouchedDirs >= changed {
+		t.Errorf("churn touched %d directories for %d changes; it is not concentrating",
+			st.TouchedDirs, changed)
+	}
+	t.Logf("%d changes across %d of %d directories", changed, st.TouchedDirs, len(dirs))
+}
+
+// A rename must move a directory inside the tree, never the tree itself.
+//
+// Asserted on the candidate set rather than by running churn: renameOneDir picks
+// one candidate at random, so a test that only watches the root survive passes
+// by luck whenever the draw misses it.
+func TestRenameCandidatesExcludeTheRoot(t *testing.T) {
+	// A root nested deep enough that its absolute path clears any separator
+	// count, which is what the previous check measured.
+	root := filepath.Join(t.TempDir(), "a", "b", "c", "source")
+	dirs := []string{
+		root,
+		filepath.Join(root, "one"),
+		filepath.Join(root, "one", "two"),
+	}
+
+	got := renameCandidates(root, dirs)
+	for _, c := range got {
+		if c == root {
+			t.Fatalf("the source root is a rename candidate: %v", got)
+		}
+	}
+	if len(got) != 1 || got[0] != filepath.Join(root, "one", "two") {
+		t.Fatalf("candidates = %v, want only the two-deep directory", got)
+	}
+}
+
+// A delete must stay deleted. Paths are drawn with replacement, so a path
+// removed and drawn again would be recreated by the modify branch, leaving the
+// reported counts describing a tree that never existed.
+func TestChurnDeletionsAreNotRecreated(t *testing.T) {
+	root := t.TempDir()
+	p := fitToBudget(profiles["source"], 1200, 32<<20)
+	if _, err := generate(root, p, 1200, 6); err != nil {
+		t.Fatal(err)
+	}
+
+	// Many seeds at a high churn fraction: a delete followed by a redraw of the
+	// same path is a collision, and one run may not produce it.
+	for seed := int64(0); seed < 20; seed++ {
+		before := snapshotFiles(t, root)
+		st, err := applyChurn(root, p, seed, 0.30)
+		if err != nil {
+			t.Fatal(err)
+		}
+		after := snapshotFiles(t, root)
+
+		gone := 0
+		for path := range before {
+			if _, ok := after[path]; !ok {
+				gone++
+			}
+		}
+		if gone < st.Deleted {
+			t.Fatalf("seed %d: reported %d deletions but only %d paths are gone; some were recreated",
+				seed, st.Deleted, gone)
+		}
+	}
+}
+
+func snapshotFiles(t *testing.T, root string) map[string]string {
+	t.Helper()
+
+	out := map[string]string{}
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		sum := sha256.Sum256(b)
+		out[path] = hex.EncodeToString(sum[:])
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// A budget must actually bound the tree, or a realistic media profile is
+// unrunnable in CI.
+func TestFitToBudgetBoundsTheTree(t *testing.T) {
+	const budget = 8 << 20
+	p := fitToBudget(profiles["media"], 500, budget)
+	st, err := generate(t.TempDir(), p, 500, 11)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The budget sets the expected total; sampling puts the realised total near
+	// it, not exactly on it. A wide factor still catches a budget that does
+	// nothing, which is what this guards.
+	if st.TotalBytes > budget*4 {
+		t.Errorf("generated %d bytes against a %d budget", st.TotalBytes, budget)
+	}
+}

--- a/scripts/benchmark/gentree/main.go
+++ b/scripts/benchmark/gentree/main.go
@@ -1,0 +1,530 @@
+// Command gentree builds a backup source with the statistics a real one has.
+//
+// The memory benchmark used to generate a uniform tree: every file the same
+// size, every directory the same width, every byte unique. That shape cannot
+// answer the questions the numbers were being used to settle. Deduplication is
+// invisible when nothing is duplicated. Write amplification depends on whether
+// changes cluster, and uniform churn spreads them perfectly evenly. Leaf
+// occupancy depends on directory fan-out, which was constant.
+//
+// Every distribution here is drawn from a seeded PRNG, so a given
+// (profile, files, seed) always produces byte-identical output. That is not a
+// nicety: comparing two builds of cloudstic requires the input to be the same,
+// and a benchmark whose dataset drifts measures nothing.
+//
+// Usage:
+//
+//	gentree -out DIR -profile mixed -files 50000 [-seed 1] [-stats FILE]
+//	gentree -churn DIR -profile mixed [-seed 1] [-fraction 0.05]
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// profile is the shape of one kind of backup source.
+//
+// The parameters are deliberately few. Each one exists because it changes a
+// conclusion the memory work drew: size spread decides how many files are
+// inlined rather than chunked, fan-out decides leaf occupancy, duplication
+// decides what content addressing actually saves, and incompressibility decides
+// whether the compression layer is doing anything.
+type profile struct {
+	name string
+	desc string
+
+	// File sizes are log-normal, the standard model for filesystem contents:
+	// a median in the low kilobytes with a long tail of large files, so the
+	// mean sits far above the median.
+	sizeMedian float64
+	sizeSigma  float64
+	sizeMax    int64
+
+	// Directory fan-out is heavy-tailed too. Most directories hold a handful of
+	// files; a few hold thousands. A uniform 100-per-directory tree hides the
+	// case that matters, which is the outlier.
+	fanoutAlpha float64 // Pareto shape; lower is heavier-tailed
+	fanoutMin   int
+	fanoutMax   int
+
+	// Tree depth, geometric about depthMean.
+	depthMean float64
+	depthMax  int
+
+	// dupFraction of files reuse the content of an earlier file. Which earlier
+	// file follows a Zipf law, so a few contents appear very often — a vendored
+	// dependency copied into fifty projects — and most duplicates are pairs.
+	dupFraction float64
+	dupZipfS    float64
+
+	// incompressibleFraction of distinct contents are random bytes, standing in
+	// for media and archives. The rest are English-like text, which is what the
+	// compression layer is for.
+	incompressibleFraction float64
+
+	// churnDirZipfS controls how much an incremental concentrates. Real churn is
+	// not spread evenly: a few working directories change constantly and most of
+	// the tree is untouched for months. This is the parameter the write
+	// amplification analysis is most sensitive to.
+	churnDirZipfS float64
+}
+
+var profiles = map[string]profile{
+	// Kept so historical benchmark numbers stay comparable. Every file the same
+	// size, every directory the same width, nothing duplicated.
+	"uniform": {
+		name: "uniform", desc: "the original flat tree; no duplication, constant fan-out",
+		sizeMedian: 35, sizeSigma: 0, sizeMax: 35,
+		fanoutAlpha: 0, fanoutMin: 100, fanoutMax: 100,
+		depthMean: 1, depthMax: 1,
+		dupFraction: 0, dupZipfS: 1.1,
+		incompressibleFraction: 0,
+		churnDirZipfS:          0,
+	},
+	// A developer machine: many small text files, deep trees, heavy duplication
+	// from vendored dependencies, a few large build artifacts.
+	"source": {
+		name: "source", desc: "source trees: small text files, deep nesting, vendored duplicates",
+		sizeMedian: 3 * 1024, sizeSigma: 1.9, sizeMax: 64 << 20,
+		fanoutAlpha: 1.3, fanoutMin: 4, fanoutMax: 4000,
+		depthMean: 5, depthMax: 12,
+		dupFraction: 0.35, dupZipfS: 1.2,
+		incompressibleFraction: 0.05,
+		churnDirZipfS:          1.6,
+	},
+	// A photo and video library: large incompressible files, shallow wide
+	// directories, some duplication from exports and edits.
+	"media": {
+		name: "media", desc: "photo/video libraries: large incompressible files, wide shallow dirs",
+		sizeMedian: 2 << 20, sizeSigma: 1.3, sizeMax: 2 << 30,
+		fanoutAlpha: 1.5, fanoutMin: 20, fanoutMax: 8000,
+		depthMean: 2, depthMax: 4,
+		dupFraction: 0.08, dupZipfS: 1.4,
+		incompressibleFraction: 0.92,
+		churnDirZipfS:          2.2,
+	},
+	// The default: a home directory, which is all of the above at once.
+	"mixed": {
+		name: "mixed", desc: "a home directory: documents, code and media together",
+		sizeMedian: 12 * 1024, sizeSigma: 2.4, sizeMax: 512 << 20,
+		fanoutAlpha: 1.4, fanoutMin: 5, fanoutMax: 5000,
+		depthMean: 4, depthMax: 10,
+		dupFraction: 0.18, dupZipfS: 1.25,
+		incompressibleFraction: 0.45,
+		churnDirZipfS:          1.8,
+	},
+}
+
+func main() {
+	var (
+		out      = flag.String("out", "", "directory to generate into")
+		churn    = flag.String("churn", "", "directory to mutate, as an incremental backup would find it")
+		name     = flag.String("profile", "mixed", "workload profile: "+profileNames())
+		files    = flag.Int("files", 50000, "number of files to generate")
+		seed     = flag.Int64("seed", 1, "PRNG seed; the same seed always produces the same tree")
+		fraction = flag.Float64("fraction", 0.05, "churn: fraction of files to touch")
+		statsOut = flag.String("stats", "", "write a JSON summary of what was generated")
+		maxBytes = flag.Int64("max-bytes", 2<<30, "scale file sizes so the tree fits this budget; 0 disables")
+	)
+	flag.Parse()
+
+	p, ok := profiles[*name]
+	if !ok {
+		fatalf("unknown profile %q; have %s", *name, profileNames())
+	}
+	if (*out == "") == (*churn == "") {
+		fatalf("exactly one of -out or -churn is required")
+	}
+
+	var (
+		st  stats
+		err error
+	)
+	if *out != "" {
+		if *maxBytes > 0 {
+			p = fitToBudget(p, *files, *maxBytes)
+		}
+		st, err = generate(*out, p, *files, *seed)
+	} else {
+		// Scale against the tree actually on disk. -files describes a tree being
+		// generated and says nothing about one being mutated, so using it here
+		// would size a churn's writes against a file count that is merely the
+		// flag's default — writing megabyte files into a tree scaled to
+		// kilobytes, and quietly changing what the benchmark measures.
+		n, cerr := countFiles(*churn)
+		if cerr != nil {
+			fatalf("count files under %s: %v", *churn, cerr)
+		}
+		if *maxBytes > 0 {
+			p = fitToBudget(p, n, *maxBytes)
+		}
+		st, err = applyChurn(*churn, p, *seed, *fraction)
+	}
+	if err != nil {
+		fatalf("%v", err)
+	}
+
+	st.Profile = p.name
+	st.Seed = *seed
+	report(st)
+	if *statsOut != "" {
+		if err := writeJSON(*statsOut, st); err != nil {
+			fatalf("write stats: %v", err)
+		}
+	}
+}
+
+// stats is what the run produced, so a benchmark result can be interpreted
+// against the dataset that produced it rather than against a profile name.
+type stats struct {
+	Profile        string  `json:"profile"`
+	Seed           int64   `json:"seed"`
+	Files          int     `json:"files"`
+	Dirs           int     `json:"dirs"`
+	TotalBytes     int64   `json:"total_bytes"`
+	DistinctBytes  int64   `json:"distinct_bytes"`
+	DuplicateFiles int     `json:"duplicate_files"`
+	DedupRatio     float64 `json:"dedup_ratio"`
+	MedianSize     int64   `json:"median_file_size"`
+	P99Size        int64   `json:"p99_file_size"`
+	MaxSize        int64   `json:"max_file_size"`
+	MaxFanout      int     `json:"max_dir_fanout"`
+	MedianFanout   int     `json:"median_dir_fanout"`
+	MaxDepth       int     `json:"max_depth"`
+	// Churn only.
+	Modified int `json:"modified,omitempty"`
+	Created  int `json:"created,omitempty"`
+	Deleted  int `json:"deleted,omitempty"`
+	Renamed  int `json:"renamed_dirs,omitempty"`
+	// Directories containing at least one modify, create or delete. Renames are
+	// excluded: moving a directory changes every path beneath it without any of
+	// its files being touched, which would overstate how spread the churn was.
+	TouchedDirs int `json:"touched_dirs,omitempty"`
+}
+
+// generate builds the tree.
+//
+// Directories are laid out first so that fan-out is a property of the tree
+// rather than an artefact of the order files happen to be created.
+func generate(root string, p profile, files int, seed int64) (stats, error) {
+	rng := rand.New(rand.NewSource(seed))
+
+	dirs := layoutDirs(rng, p, files)
+	st := stats{Dirs: len(dirs), MaxFanout: 0}
+
+	pool := newContentPool(rng, p)
+	var sizes []int64
+	var fanouts []int
+
+	for _, d := range dirs {
+		if err := os.MkdirAll(filepath.Join(root, d.path), 0o755); err != nil {
+			return st, err
+		}
+		fanouts = append(fanouts, d.files)
+		if d.files > st.MaxFanout {
+			st.MaxFanout = d.files
+		}
+		if d.depth > st.MaxDepth {
+			st.MaxDepth = d.depth
+		}
+
+		for i := 0; i < d.files && st.Files < files; i++ {
+			size := sampleSize(rng, p)
+			body, distinct := pool.body(rng, size)
+			name := fileName(rng, d.kind, i, len(body))
+
+			if err := os.WriteFile(filepath.Join(root, d.path, name), body, 0o644); err != nil {
+				return st, err
+			}
+			st.Files++
+			st.TotalBytes += int64(len(body))
+			if distinct {
+				st.DistinctBytes += int64(len(body))
+			} else {
+				st.DuplicateFiles++
+			}
+			sizes = append(sizes, int64(len(body)))
+		}
+		if st.Files >= files {
+			break
+		}
+	}
+
+	summarise(&st, sizes, fanouts)
+	return st, nil
+}
+
+type dirSpec struct {
+	path  string
+	depth int
+	files int
+	kind  string
+}
+
+// layoutDirs picks a directory tree whose fan-out follows the profile, then
+// assigns each directory a file count from the same distribution.
+func layoutDirs(rng *rand.Rand, p profile, files int) []dirSpec {
+	if p.fanoutAlpha == 0 { // uniform profile: the original flat tree
+		n := (files + p.fanoutMin - 1) / p.fanoutMin
+		out := make([]dirSpec, 0, n)
+		for i := 0; i < n; i++ {
+			out = append(out, dirSpec{path: fmt.Sprintf("dir-%d", i), depth: 1, files: p.fanoutMin, kind: "flat"})
+		}
+		return out
+	}
+
+	kinds := []string{"docs", "src", "media", "archive", "work"}
+	var out []dirSpec
+	// Paths are drawn at random and can collide. Two specs with the same path
+	// would merge into one directory, so the tree would hold fewer, wider
+	// directories than the distribution asked for and fewer files than
+	// requested — silently, since nothing errors.
+	seen := make(map[string]bool)
+	placed := 0
+	for placed < files {
+		depth := sampleDepth(rng, p)
+		parts := make([]string, 0, depth)
+		kind := kinds[rng.Intn(len(kinds))]
+		parts = append(parts, kind)
+		for d := 1; d < depth; d++ {
+			parts = append(parts, fmt.Sprintf("%s-%d", segmentWord(rng), rng.Intn(64)))
+		}
+		path := filepath.Join(parts...)
+		if seen[path] {
+			// Disambiguate rather than skip, so the requested file count is
+			// still reached and the loop cannot spin on a saturated name space.
+			path = fmt.Sprintf("%s-%d", path, len(out))
+		}
+		seen[path] = true
+
+		n := sampleFanout(rng, p)
+		if placed+n > files {
+			n = files - placed
+		}
+		out = append(out, dirSpec{path: path, depth: depth, files: n, kind: kind})
+		placed += n
+	}
+	return out
+}
+
+// contentPool makes duplication real.
+//
+// A fraction of files reuse an earlier body, chosen by a Zipf law so a few
+// contents recur constantly and most repeats are pairs. Without this the
+// repository's deduplication does nothing measurable, which is how a uniform
+// tree makes content addressing look free.
+type contentPool struct {
+	bodies [][]byte
+	p      profile
+	zipf   *rand.Zipf
+}
+
+func newContentPool(rng *rand.Rand, p profile) *contentPool {
+	// The Zipf table is sized for the pool's eventual length; it is only used
+	// once there is something in it.
+	z := rand.NewZipf(rng, math.Max(p.dupZipfS, 1.01), 1, 1<<20)
+	return &contentPool{p: p, zipf: z}
+}
+
+func (c *contentPool) body(rng *rand.Rand, size int64) ([]byte, bool) {
+	if len(c.bodies) > 0 && rng.Float64() < c.p.dupFraction {
+		idx := int(c.zipf.Uint64()) % len(c.bodies)
+		return c.bodies[idx], false
+	}
+	b := makeBody(rng, size, rng.Float64() < c.p.incompressibleFraction)
+	// Only bodies small enough to be worth holding go in the pool; a duplicated
+	// 2 GB video is not a case worth simulating in memory.
+	if len(b) <= 1<<20 {
+		c.bodies = append(c.bodies, b)
+	}
+	return b, true
+}
+
+// makeBody returns either incompressible bytes or English-like text, because
+// the compression layer behaves very differently on the two and a tree of one
+// kind misrepresents what the store does.
+func makeBody(rng *rand.Rand, size int64, incompressible bool) []byte {
+	if size < 0 {
+		size = 0
+	}
+	b := make([]byte, size)
+	if incompressible {
+		rng.Read(b)
+		return b
+	}
+	var sb strings.Builder
+	sb.Grow(int(size) + 16)
+	for sb.Len() < int(size) {
+		sb.WriteString(words[rng.Intn(len(words))])
+		sb.WriteByte(' ')
+	}
+	return []byte(sb.String()[:size])
+}
+
+// fitToBudget rescales the size distribution so the tree fits in budget bytes,
+// keeping its shape.
+//
+// A realistic media library is terabytes, which is true and useless: the memory
+// benchmark cares about the number of files and the spread of their sizes, not
+// about moving real video. Scaling the median leaves the log-normal shape — and
+// therefore the mix of inlined, packed and chunked files — intact while making
+// the dataset something CI can generate in a minute.
+//
+// The mean of a log-normal is exp(mu + sigma^2/2), so the median that lands a
+// given expected total follows directly.
+func fitToBudget(p profile, files int, budget int64) profile {
+	if p.sizeSigma == 0 || files == 0 {
+		return p
+	}
+	mean := math.Exp(math.Log(p.sizeMedian) + p.sizeSigma*p.sizeSigma/2)
+	expected := mean * float64(files)
+	if expected <= float64(budget) {
+		return p
+	}
+	p.sizeMedian *= float64(budget) / expected
+	if p.sizeMedian < 1 {
+		p.sizeMedian = 1
+	}
+	// The cap has to come down with the median or the tail alone blows the
+	// budget back open.
+	if capped := int64(p.sizeMedian * 4096); capped < p.sizeMax {
+		p.sizeMax = capped
+	}
+	return p
+}
+
+func sampleSize(rng *rand.Rand, p profile) int64 {
+	if p.sizeSigma == 0 {
+		return int64(p.sizeMedian)
+	}
+	v := math.Exp(math.Log(p.sizeMedian) + p.sizeSigma*rng.NormFloat64())
+	if v > float64(p.sizeMax) {
+		v = float64(p.sizeMax)
+	}
+	if v < 1 {
+		v = 1
+	}
+	return int64(v)
+}
+
+// sampleFanout draws from a bounded Pareto, which is the usual model for
+// directory width: many narrow directories and a thin tail of very wide ones.
+func sampleFanout(rng *rand.Rand, p profile) int {
+	u := rng.Float64()
+	v := float64(p.fanoutMin) / math.Pow(1-u, 1/p.fanoutAlpha)
+	if v > float64(p.fanoutMax) {
+		v = float64(p.fanoutMax)
+	}
+	return int(v)
+}
+
+func sampleDepth(rng *rand.Rand, p profile) int {
+	d := 1 + int(rng.ExpFloat64()*(p.depthMean-1))
+	if d > p.depthMax {
+		d = p.depthMax
+	}
+	if d < 1 {
+		d = 1
+	}
+	return d
+}
+
+func fileName(rng *rand.Rand, kind string, i, size int) string {
+	// Long shared prefixes within a directory are the norm — IMG_0001.jpg and
+	// its four thousand siblings — and they are what a metadata string arena
+	// would compress. A generator emitting unique random names would make that
+	// saving invisible.
+	ext := map[string]string{"docs": ".md", "src": ".go", "media": ".jpg", "archive": ".tar", "work": ".txt"}[kind]
+	if ext == "" {
+		ext = ".dat"
+	}
+	switch kind {
+	case "media":
+		return fmt.Sprintf("IMG_%05d%s", i, ext)
+	case "src":
+		return fmt.Sprintf("%s_%03d%s", segmentWord(rng), i, ext)
+	default:
+		return fmt.Sprintf("%s-%04d%s", kind, i, ext)
+	}
+}
+
+func summarise(st *stats, sizes []int64, fanouts []int) {
+	if len(sizes) > 0 {
+		sort.Slice(sizes, func(i, j int) bool { return sizes[i] < sizes[j] })
+		st.MedianSize = sizes[len(sizes)/2]
+		st.P99Size = sizes[min(len(sizes)-1, len(sizes)*99/100)]
+		st.MaxSize = sizes[len(sizes)-1]
+	}
+	if len(fanouts) > 0 {
+		sort.Ints(fanouts)
+		st.MedianFanout = fanouts[len(fanouts)/2]
+	}
+	if st.TotalBytes > 0 {
+		st.DedupRatio = 1 - float64(st.DistinctBytes)/float64(st.TotalBytes)
+	}
+}
+
+func report(st stats) {
+	fmt.Printf("profile=%s seed=%d\n", st.Profile, st.Seed)
+	if st.Modified+st.Created+st.Deleted+st.Renamed > 0 {
+		fmt.Printf("  churn: %d modified, %d created, %d deleted, %d dirs renamed, across %d dirs\n",
+			st.Modified, st.Created, st.Deleted, st.Renamed, st.TouchedDirs)
+		return
+	}
+	fmt.Printf("  %d files in %d dirs, %.1f MB (%.1f MB distinct, %.0f%% duplicate bytes)\n",
+		st.Files, st.Dirs, float64(st.TotalBytes)/(1<<20), float64(st.DistinctBytes)/(1<<20), st.DedupRatio*100)
+	fmt.Printf("  %d files (%.0f%%) reuse another file's content\n",
+		st.DuplicateFiles, 100*float64(st.DuplicateFiles)/math.Max(float64(st.Files), 1))
+	fmt.Printf("  size    median %s, p99 %s, max %s\n", human(st.MedianSize), human(st.P99Size), human(st.MaxSize))
+	fmt.Printf("  fan-out median %d, max %d, depth max %d\n", st.MedianFanout, st.MaxFanout, st.MaxDepth)
+}
+
+func human(n int64) string {
+	switch {
+	case n >= 1<<30:
+		return fmt.Sprintf("%.1f GB", float64(n)/(1<<30))
+	case n >= 1<<20:
+		return fmt.Sprintf("%.1f MB", float64(n)/(1<<20))
+	case n >= 1<<10:
+		return fmt.Sprintf("%.1f KB", float64(n)/(1<<10))
+	}
+	return fmt.Sprintf("%d B", n)
+}
+
+func writeJSON(path string, v any) error {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(b, '\n'), 0o644)
+}
+
+func profileNames() string {
+	names := make([]string, 0, len(profiles))
+	for n := range profiles {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "gentree: "+format+"\n", args...)
+	os.Exit(1)
+}
+
+var words = []string{
+	"backup", "restore", "snapshot", "chunk", "content", "index", "repository",
+	"encrypt", "compress", "manifest", "pack", "catalog", "object", "store",
+	"the", "a", "of", "and", "to", "in", "that", "it", "with", "for", "as",
+}
+
+func segmentWord(rng *rand.Rand) string { return words[rng.Intn(len(words))] }

--- a/scripts/benchmark/memory.sh
+++ b/scripts/benchmark/memory.sh
@@ -40,6 +40,14 @@
 set -euo pipefail
 
 SIZES=${SIZES:-"5000 20000 50000"}
+# Which workload shape to measure against. "uniform" is the original flat tree —
+# constant file size, constant fan-out, nothing duplicated — kept as the default
+# so numbers stay comparable with everything recorded before. The other profiles
+# come from scripts/benchmark/gentree and have the statistics a real source has:
+# heavy-tailed sizes and fan-out, duplicated content, and churn that clusters in
+# a few directories instead of spreading evenly. See gentree/main.go.
+PROFILE=${PROFILE:-uniform}
+MAX_BYTES=${MAX_BYTES:-$((2 * 1024 * 1024 * 1024))}
 SAMPLES=${SAMPLES:-3}
 OUT=${OUT:-benchmark-results/memory.csv}
 KEEP=${KEEP:-0} # keep scratch dirs for inspection
@@ -66,6 +74,7 @@ PASSWORD=${BENCH_REPO_PASSWORD:-benchmark-password}
 # profiling.go); anything built before that flag existed will not write the
 # file measure() expects and the sweep will fail on its first row.
 CLOUDSTIC_BIN=${BENCH_CLOUDSTIC_BIN:-"$REPO_ROOT/bin/cloudstic"}
+GENTREE_BIN="$REPO_ROOT/bin/gentree"
 
 WORK=$(mktemp -d -t cloudstic-mem-XXXXXX)
 cleanup() { [ "$KEEP" = "1" ] || rm -rf "$WORK"; }
@@ -164,6 +173,9 @@ else
 fi
 echo "Building benchreport..."
 ( cd "$REPO_ROOT" && go build -o bin/benchreport ./internal/cmd/benchreport )
+if [ "$PROFILE" != "uniform" ]; then
+    ( cd "$REPO_ROOT" && go build -o bin/gentree ./scripts/benchmark/gentree )
+fi
 
 # benchreport writes the header itself on first append, so a stale CSV must go
 # or the sweep appends to the previous run.
@@ -173,6 +185,7 @@ rm -f "$OUT"
 echo ""
 echo "=== Memory vs repository size ==="
 echo "sizes:   $SIZES"
+echo "profile: $PROFILE"
 echo "samples: $SAMPLES per point (median reported)"
 echo ""
 
@@ -202,7 +215,17 @@ run_pipeline() {
     measure backup-initial "$size" \
         "$CLOUDSTIC_BIN" backup "${store_flags[@]}" "${source_flags[@]}" -quiet
 
-    touch_fraction "$data" "$size" 20 "$gen"
+    if [ "$PROFILE" = "uniform" ]; then
+        touch_fraction "$data" "$size" 20 "$gen"
+    else
+        # Seeded by the sample number so each sample churns differently, the way
+        # successive days would, while staying reproducible run to run.
+        # -max-bytes must match generation: churn scales its writes to the same
+        # budget, and a mismatch writes files from a different size distribution
+        # into the tree, quietly changing what the incremental measures.
+        "$GENTREE_BIN" -churn "$data" -profile "$PROFILE" -seed "$gen" \
+            -fraction 0.05 -max-bytes "$MAX_BYTES" >/dev/null
+    fi
 
     measure backup-incremental "$size" \
         "$CLOUDSTIC_BIN" backup "${store_flags[@]}" "${source_flags[@]}" -quiet
@@ -237,9 +260,15 @@ for size in $SIZES; do
     # Generated once and reused across the samples of this size. Regenerating
     # would add dataset variation to the very noise the samples exist to
     # measure; the tree is an input, not part of what is under test.
-    printf -- '--- %d files: generating... ' "$size"
-    generate_tree "$data" "$size"
-    echo "done"
+    printf -- '--- %d files: generating (%s)... ' "$size" "$PROFILE"
+    if [ "$PROFILE" = "uniform" ]; then
+        generate_tree "$data" "$size"
+        echo "done"
+    else
+        echo ""
+        "$GENTREE_BIN" -out "$data" -profile "$PROFILE" -files "$size" \
+            -seed 1 -max-bytes "$MAX_BYTES" -stats "$WORK/dataset-$size.json"
+    fi
 
     for (( sample = 1; sample <= SAMPLES; sample++ )); do
         echo "  sample $sample/$SAMPLES"


### PR DESCRIPTION
## Summary

- Add `scripts/benchmark/gentree/`, which generates a backup source from distributions rather than a constant
- Wire it into `memory.sh` behind `PROFILE`, defaulting to `uniform` so historical numbers stay comparable
- Document it in `AGENTS.md`

The benchmark generated a uniform tree: every file 35 bytes, every directory 100
files, every byte unique, and an incremental that rewrote every twentieth file.
That shape cannot answer the questions the numbers were being used to settle.

## Why the old shape misleads

**Deduplication is invisible when nothing is duplicated.** Content addressing
looks free on a tree with no repeated content.

**Leaf occupancy depends on fan-out**, which was a constant 100.

**Write amplification depends on whether changes cluster.** Uniform churn spreads
them across nearly every metadata leaf — close to the worst case, and nothing
like a real day's work. This is the one that matters most: RFC 0024's
amplification analysis rests on it.

## What it generates

| | |
|---|---|
| file sizes | log-normal — a low-kilobyte median with a long tail |
| directory fan-out | bounded Pareto — mostly narrow, a thin tail of very wide |
| duplication | a fraction of files reuse an earlier content, chosen by Zipf |
| compressibility | a fraction of contents are random bytes, standing in for media |
| churn | Zipf over directories, so the same few stay hot across incrementals |
| churn kinds | modify, append, create, delete, and one directory rename per run |

The rename is deliberate: with `FileID` identity nothing below a renamed folder
should be rewritten, and with path identity everything would be. It is the
cheapest way to tell the two apart, so the generator has to be able to produce
it.

Everything comes from a seeded PRNG. A given `(profile, files, seed)` is
byte-identical run to run — a benchmark whose dataset drifts measures nothing,
and `TestGenerateIsDeterministic` pins it.

## Profiles

`uniform` reproduces the old tree exactly and remains the **default**, so every
number recorded before this stays comparable. `source`, `media` and `mixed` are
realistic. `MAX_BYTES` rescales the size distribution so a media library stays
runnable in CI without losing its shape.

Measured on `source` at 4,000 files:

```
4000 files in 357 dirs, 70.3 MB (47.9 MB distinct, 32% duplicate bytes)
1379 files (34%) reuse another file's content
size    median 2.4 KB, p99 208.6 KB, max 3.3 MB
fan-out median 7, max 161, depth max 12
churn: 156 modified, 15 created, 7 deleted, 1 dirs renamed
```

That churn touched **28 of 1,277 directories**. Uniform churn would have touched
roughly one per changed file — a ~6x difference in how many metadata leaves get
rewritten, which is exactly the quantity RFC 0024 is arguing about.

## Verification

```bash
env GOCACHE=/tmp/cloudstic-gocache go test ./scripts/benchmark/gentree/ -count=1
```

```bash
env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./scripts/...
```

Both pass; lint reports 0 issues. Tests cover determinism across every profile,
divergence by seed, that realistic profiles actually duplicate and are actually
heavy-tailed, that `uniform` stays flat and duplicate-free, that churn
concentrates, and that the byte budget bounds the tree.

End-to-end: `SIZES=2000 SAMPLES=1 PROFILE=source ./scripts/benchmark/memory.sh`
runs clean and reports the dataset alongside the measurements.

## Not done here

The interesting part is what the realistic profiles say about the numbers this
workstream has been reasoning from. I have deliberately not re-run the full
benchmark or revised RFC 0024 in this PR — the generator should land on its own
merits first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added realistic benchmark dataset profiles for uniform, source, media, and mixed workloads.
  - Added configurable size limits and reproducible seeded generation.
  - Added filesystem churn with modifications, additions, deletions, and directory renames.
  - Added benchmark statistics for files, directories, sizes, duplication, depth, and churn.

- **Documentation**
  - Documented generating and running benchmarks with realistic source-tree profiles.

- **Tests**
  - Added coverage for deterministic generation, profile distributions, duplication, churn, and size limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->