### PR TITLE
test(bench): cover the structures this workstream changed

### DIFF
--- a/internal/engine/restore_bench_test.go
+++ b/internal/engine/restore_bench_test.go
@@ -1,0 +1,44 @@
+package engine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cloudstic/cli/internal/core"
+)
+
+// benchTree builds a snapshot's worth of metadata: dirs files each, in walk
+// order, which is the order restore now writes leaves in.
+func benchTree(dirs, perDir int) (map[string]core.FileMeta, []string) {
+	byID := make(map[string]core.FileMeta, dirs*(perDir+1))
+	walk := make([]string, 0, dirs*(perDir+1))
+
+	for d := 0; d < dirs; d++ {
+		dir := fmt.Sprintf("dir-%d", d)
+		byID[dir] = core.FileMeta{FileID: dir, Type: core.FileTypeFolder}
+		walk = append(walk, dir)
+		for f := 0; f < perDir; f++ {
+			id := fmt.Sprintf("%s/file-%d", dir, f)
+			byID[id] = core.FileMeta{FileID: id, Parents: []string{dir}}
+			walk = append(walk, id)
+		}
+	}
+	return byID, walk
+}
+
+// restoreOrder sequences every entry in a snapshot before the first byte is
+// written, so it is on the critical path of every restore.
+func BenchmarkRestoreOrder(b *testing.B) {
+	for _, files := range []int{5000, 50000} {
+		b.Run(fmt.Sprintf("files=%d", files), func(b *testing.B) {
+			byID, walk := benchTree(files/100, 100)
+
+			b.ReportAllocs()
+			for b.Loop() {
+				if got := restoreOrder(byID, walk); len(got) != len(byID) {
+					b.Fatalf("ordered %d of %d", len(got), len(byID))
+				}
+			}
+		})
+	}
+}

--- a/internal/storelayer/packcatalog_bench_test.go
+++ b/internal/storelayer/packcatalog_bench_test.go
@@ -1,0 +1,106 @@
+package storelayer
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+)
+
+// benchCatalogKeys returns n realistic catalog keys: a packable namespace and a
+// 64-character hex digest, which is the shape the compact encoding exists for.
+func benchCatalogKeys(n int) []string {
+	keys := make([]string, n)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("filemeta/%064x", i)
+	}
+	return keys
+}
+
+func BenchmarkPackCatalogSet(b *testing.B) {
+	keys := benchCatalogKeys(4096)
+	entry := PackEntry{PackRef: "packs/" + fmt.Sprintf("%064x", 1), Offset: 4096, Length: 512}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		c := newPackCatalog()
+		for _, k := range keys {
+			c.Set(k, entry)
+		}
+	}
+}
+
+func BenchmarkPackCatalogGet(b *testing.B) {
+	keys := benchCatalogKeys(4096)
+	entry := PackEntry{PackRef: "packs/" + fmt.Sprintf("%064x", 1), Offset: 4096, Length: 512}
+	c := newPackCatalog()
+	for _, k := range keys {
+		c.Set(k, entry)
+	}
+
+	b.ReportAllocs()
+	i := 0
+	for b.Loop() {
+		if _, ok := c.Get(keys[i%len(keys)]); !ok {
+			b.Fatal("miss")
+		}
+		i++
+	}
+}
+
+// BenchmarkPackCatalogBytesPerEntry reports what an entry costs to hold, which
+// is the number #457 was about and the reason the catalog is not a
+// map[string]PackEntry.
+//
+// Reported as a custom metric rather than read off B/op: B/op is allocation per
+// iteration, and what matters here is what survives the fill. The two differ by
+// whatever the map discarded while growing.
+//
+// Keys are built inside the measured region, not hoisted into a slice the two
+// variants share. A map[string]PackEntry retains the key string it is given, so
+// pre-allocating the keys hands it the 73 bytes of hex for free and makes the
+// two representations look identical — which is exactly what the first version
+// of this benchmark reported. In production those strings arrive from a JSON
+// decode and nothing else holds them.
+func BenchmarkPackCatalogBytesPerEntry(b *testing.B) {
+	const n = 200000
+	entry := PackEntry{PackRef: "packs/" + fmt.Sprintf("%064x", 1), Offset: 4096, Length: 512}
+
+	for b.Loop() {
+		var before, after runtime.MemStats
+		runtime.GC()
+		runtime.ReadMemStats(&before)
+
+		c := newPackCatalog()
+		for i := 0; i < n; i++ {
+			c.Set(fmt.Sprintf("filemeta/%064x", i), entry)
+		}
+
+		runtime.ReadMemStats(&after)
+		b.ReportMetric(float64(after.HeapAlloc-before.HeapAlloc)/float64(n), "B/entry")
+		runtime.KeepAlive(c)
+	}
+}
+
+// BenchmarkPackCatalogBytesPerEntry_Map is the representation packCatalog
+// replaced, kept so the comparison stays honest as both sides change.
+func BenchmarkPackCatalogBytesPerEntry_Map(b *testing.B) {
+	const n = 200000
+	// Pack refs interned, as they were before the compact encoding, so this
+	// measures the encoding rather than a saving already taken.
+	ref := "packs/" + fmt.Sprintf("%064x", 1)
+
+	for b.Loop() {
+		var before, after runtime.MemStats
+		runtime.GC()
+		runtime.ReadMemStats(&before)
+
+		m := make(map[string]PackEntry)
+		for i := 0; i < n; i++ {
+			m[fmt.Sprintf("filemeta/%064x", i)] = PackEntry{PackRef: ref, Offset: 4096, Length: 512}
+		}
+
+		runtime.ReadMemStats(&after)
+		b.ReportMetric(float64(after.HeapAlloc-before.HeapAlloc)/float64(n), "B/entry")
+		runtime.KeepAlive(m)
+	}
+}

--- a/internal/storelayer/packshard_bench_test.go
+++ b/internal/storelayer/packshard_bench_test.go
@@ -1,0 +1,69 @@
+package storelayer
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+// benchShard renders a shard object holding n entries, as loadShardsLocked
+// would read from the store.
+func benchShard(b *testing.B, n int) []byte {
+	b.Helper()
+
+	entries := make(map[string]PackEntry, n)
+	ref := "packs/" + fmt.Sprintf("%064x", 1)
+	for i := 0; i < n; i++ {
+		entries[fmt.Sprintf("filemeta/%064x", i)] = PackEntry{
+			PackRef: ref, Offset: int64(i * 512), Length: 512,
+		}
+	}
+	data, err := json.Marshal(entries)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return data
+}
+
+// mergePackIndex decodes a shard straight into the catalog. It runs once per
+// shard on every operation that opens a repository, so its cost is paid before
+// any work the user asked for begins.
+func BenchmarkMergePackIndex(b *testing.B) {
+	for _, n := range []int{1000, 20000} {
+		b.Run(fmt.Sprintf("entries=%d", n), func(b *testing.B) {
+			data := benchShard(b, n)
+
+			b.ReportAllocs()
+			b.SetBytes(int64(len(data)))
+			for b.Loop() {
+				c := newPackCatalog()
+				if _, err := mergePackIndex(data, c); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// sealShardFor renders a shard without materialising the pending entries into a
+// map first, which is what keeps a flush from holding a second copy of a run's
+// worth of entries (#456).
+func BenchmarkSealShardFor(b *testing.B) {
+	const n = 20000
+	c := newPackCatalog()
+	pending := make(map[string]struct{}, n)
+	ref := "packs/" + fmt.Sprintf("%064x", 1)
+	for i := 0; i < n; i++ {
+		key := fmt.Sprintf("filemeta/%064x", i)
+		c.Set(key, PackEntry{PackRef: ref, Offset: int64(i * 512), Length: 512})
+		pending[key] = struct{}{}
+	}
+	s := &PackStore{}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, _, err := s.sealShardFor(c, pending); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Benchmarks for `packCatalog` (set, get, bytes per entry), `mergePackIndex`, `sealShardFor` and `restoreOrder`

The memory work changed all of these and added a benchmark for none. #457's
headline — the catalog costs fewer bytes per entry — was measured with a
throwaway `MemStats` delta in a scratch test I then deleted, so nothing guards
it.

```
goos: darwin / goarch: arm64 / cpu: Apple M3 Max

BenchmarkPackCatalogBytesPerEntry-14         103.5 B/entry
BenchmarkPackCatalogBytesPerEntry_Map-14     177.3 B/entry
BenchmarkPackCatalogGet-14                   48.63 ns/op    0 B/op   0 allocs/op
BenchmarkRestoreOrder/files=50000-14         5.376 ms/op  2613154 B/op  145 allocs/op
```

Bytes per entry is a custom metric rather than `B/op`: `B/op` is allocation per
iteration and the question here is what *survives* the fill. The map variant is
kept so the comparison stays honest as both sides change.

## The first version was wrong, and instructively so

It reported **101.6 against 99.27 B/entry** — no difference, contradicting #457.
The benchmark was at fault, not the PR: both variants drew keys from one
pre-allocated slice, and a `map[string]PackEntry` *retains the key string it is
handed*. Hoisting the keys gave the map 73 bytes of hex for free and hid the
entire saving.

Keys are now built inside the measured region, as they are in production where
they arrive from a JSON decode and nothing else holds them. That is the same trap
recorded on #440 in a different guise: measuring the harness rather than the
representation.

## Verification

```bash
go test ./internal/storelayer/ ./internal/engine/ -bench 'PackCatalog|MergePackIndex|SealShardFor|RestoreOrder' -benchmem -run XXX
```

Tests pass in both packages; `golangci-lint` reports 0 issues. Follows the
repo's existing convention — `*_bench_test.go`, `b.Loop()`, `b.ReportAllocs()`.

## Note

Single-run figures, not `benchstat` comparisons — there is no before/after here,
these establish the baseline. A change claiming to move one of them should post
`benchstat` output against it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added performance benchmarks for restoring large snapshots containing up to 50,000 files.
  * Added benchmarks measuring pack catalog set/get speed and memory usage.
  * Added benchmarks for merging pack indexes and sealing large pack shards.
  * Benchmarks report allocations, processed data, and retained memory to support performance monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->