### PR TITLE
test(benchmark): restore scenarios and repo-growth measurement in bench.sh

### DIFF
--- a/docs/benchmark-results.md
+++ b/docs/benchmark-results.md
@@ -24,10 +24,14 @@ BACKENDS="local minio" ./scripts/benchmark/bench.sh
 PROFILES="mixed media" ./scripts/benchmark/bench.sh
 ```
 
-One pipeline run per cell of `PROFILES x SIZES x BACKENDS x SAMPLES`, collecting
-wall time, peak RSS, cumulative allocation, and — on MinIO — requests and bytes
-with a per-API breakdown. Writes one CSV per backend plus a sidecar recording the
-machine, since timings belong to the hardware as much as to the code.
+One pipeline run per cell of `PROFILES x SIZES x BACKENDS x SAMPLES`: an initial
+backup, incrementals (no changes, one file, a bounded batch), 200 MB of new
+data, a deduplicated backup, check, restore (with and without `-no-verify`),
+and prune. Collects wall time, peak RSS, cumulative allocation, repository
+growth per operation, and — on MinIO — requests and bytes with a per-API
+breakdown, plus the final repository size and the logical/stored ratio as
+summary rows. Writes one CSV per backend plus a sidecar recording the machine,
+since timings belong to the hardware as much as to the code.
 
 Requirements: Go toolchain; `bc`; docker, `aws` and `curl` only for
 `BACKENDS=minio`.

--- a/internal/benchreport/render.go
+++ b/internal/benchreport/render.go
@@ -55,6 +55,8 @@ func Render(w io.Writer, rep *Report, title string) error {
 		renderComparisonTable(b, rep)
 	}
 
+	renderRepoSummary(b, rep)
+
 	// A comparison of one tool has nothing to chart — a single bar compares
 	// nothing — so the heading is written only if something follows it.
 	charts := &strings.Builder{}
@@ -207,6 +209,53 @@ func renderComparisonTable(b *strings.Builder, rep *Report) {
 		b.WriteString(" `Allocated` is cumulative bytes allocated,\nfreed or not — the column that moves when an operation stops allocating\nsomething it did not need.")
 	}
 	b.WriteString("\n")
+}
+
+// renderRepoSummary renders the final repository size and the logical/stored
+// ratio, when a self-benchmark recorded them.
+//
+// These are not timed operations — they have no seconds or peak_mb worth
+// showing — so they get their own small section rather than a row of zeros in
+// the per-operation tables above. A scaling sweep gets one row per tree size;
+// a single-size run gets two plain lines, since a one-row table of "5,000
+// files" tells the reader nothing a bare sentence would not.
+func renderRepoSummary(b *strings.Builder, rep *Report) {
+	if !rep.hasSummaryRows() {
+		return
+	}
+	scales := rep.Scales()
+
+	b.WriteString("\n### Repository\n\n")
+
+	if len(scales) <= 1 {
+		var scale int
+		if len(scales) == 1 {
+			scale = scales[0]
+		}
+		if c, ok := rep.cell("", OpFinalRepoSize, scale); ok && c.RepoDelta != "" {
+			fmt.Fprintf(b, "Final repository size: **%s**\n\n", c.RepoDelta)
+		}
+		if c, ok := rep.cell("", OpLogicalStored, scale); ok && c.RepoDelta != "" {
+			fmt.Fprintf(b, "Logical / stored: **%s**\n\n", c.RepoDelta)
+		}
+		return
+	}
+
+	b.WriteString("| Tree size | Final repo size | Logical / stored |\n|---|---:|---:|\n")
+	for _, s := range scales {
+		fmt.Fprintf(b, "| %s files |", humanInt(s))
+
+		if c, ok := rep.cell("", OpFinalRepoSize, s); ok && c.RepoDelta != "" {
+			fmt.Fprintf(b, " %s |", c.RepoDelta)
+		} else {
+			b.WriteString(" - |")
+		}
+		if c, ok := rep.cell("", OpLogicalStored, s); ok && c.RepoDelta != "" {
+			fmt.Fprintf(b, " %s |\n", c.RepoDelta)
+		} else {
+			b.WriteString(" - |\n")
+		}
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/benchreport/report.go
+++ b/internal/benchreport/report.go
@@ -15,6 +15,20 @@ import (
 	"strings"
 )
 
+// Reserved operation names for the two summary rows a self-benchmark can emit:
+// the repository's final size and its logical-to-stored ratio. Neither is a
+// timed operation — they carry no seconds or peak_mb worth showing — so they
+// are excluded from Operations() and rendered in their own section rather than
+// polluting the per-operation time/memory tables with a row of zeros.
+const (
+	OpFinalRepoSize = "Final Repo Size"
+	OpLogicalStored = "Logical / Stored"
+)
+
+func isSummaryOp(op string) bool {
+	return op == OpFinalRepoSize || op == OpLogicalStored
+}
+
 // Row is one measured operation.
 //
 // One schema serves both harnesses because they differ only in which column
@@ -180,9 +194,29 @@ func (r *Report) Kind() Kind {
 }
 
 // Operations returns the distinct operations in first-seen order, which is the
-// order the harness ran them and therefore the order a reader expects.
+// order the harness ran them and therefore the order a reader expects. The two
+// summary rows are excluded — they have their own section, rendered by
+// renderRepoSummary.
 func (r *Report) Operations() []string {
-	return distinct(r.Rows, func(row Row) string { return row.Operation })
+	all := distinct(r.Rows, func(row Row) string { return row.Operation })
+	out := make([]string, 0, len(all))
+	for _, op := range all {
+		if !isSummaryOp(op) {
+			out = append(out, op)
+		}
+	}
+	return out
+}
+
+// hasSummaryRows reports whether the harness recorded a final repository size
+// or a logical/stored ratio, which the memory sweep and compare.sh never do.
+func (r *Report) hasSummaryRows() bool {
+	for _, row := range r.Rows {
+		if isSummaryOp(row.Operation) {
+			return true
+		}
+	}
+	return false
 }
 
 // Tools returns the distinct tools in first-seen order.

--- a/internal/benchreport/report_test.go
+++ b/internal/benchreport/report_test.go
@@ -278,6 +278,76 @@ func TestScalingTableHasNoRepoColumn(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Repository summary rows
+// ---------------------------------------------------------------------------
+
+// Final Repo Size and Logical / Stored are not timed operations. They must not
+// show up in the per-operation tables and charts as a row of zeros.
+func TestSummaryRowsExcludedFromOperations(t *testing.T) {
+	csv := "tool,operation,scale,seconds,peak_mb,repo_delta\n" +
+		"cloudstic,Initial Backup,,0.70,534.4,344.0 MB\n" +
+		"cloudstic,Final Repo Size,,0,0,546.0 MB\n" +
+		"cloudstic,Logical / Stored,,0,0,1.16 GB / 545.7 MB (2.18x)\n"
+	ops := parse(t, csv).Operations()
+	if len(ops) != 1 || ops[0] != "Initial Backup" {
+		t.Errorf("Operations() = %v, want only [Initial Backup]", ops)
+	}
+}
+
+// The two summary rows get their own section rather than a table row, and the
+// values must reach the page.
+func TestRepoSummaryRendersFinalSizeAndRatio(t *testing.T) {
+	csv := "tool,operation,scale,seconds,peak_mb,repo_delta\n" +
+		"cloudstic,Initial Backup,,0.70,534.4,344.0 MB\n" +
+		"cloudstic,Final Repo Size,,0,0,546.0 MB\n" +
+		"cloudstic,Logical / Stored,,0,0,1.16 GB / 545.7 MB (2.18x)\n"
+	var b strings.Builder
+	if err := Render(&b, parse(t, csv), "T"); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := b.String()
+	if !strings.Contains(out, "### Repository") {
+		t.Fatalf("no repository summary section; got:\n%s", out)
+	}
+	if !strings.Contains(out, "546.0 MB") {
+		t.Errorf("final repo size missing; got:\n%s", out)
+	}
+	if !strings.Contains(out, "1.16 GB / 545.7 MB (2.18x)") {
+		t.Errorf("logical/stored ratio missing; got:\n%s", out)
+	}
+}
+
+// A scaling sweep gets one row of the summary per tree size, not just the
+// last one measured.
+func TestRepoSummaryRendersPerScaleForAScalingSweep(t *testing.T) {
+	csv := "tool,operation,scale,seconds,peak_mb,repo_delta\n" +
+		"cloudstic,backup,5000,0.50,148.9,\n" +
+		"cloudstic,backup,20000,1.20,188.1,\n" +
+		"cloudstic,Final Repo Size,5000,0,0,50.0 MB\n" +
+		"cloudstic,Final Repo Size,20000,0,0,200.0 MB\n"
+	var b strings.Builder
+	if err := Render(&b, parse(t, csv), "T"); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := b.String()
+	if !strings.Contains(out, "50.0 MB") || !strings.Contains(out, "200.0 MB") {
+		t.Errorf("expected a final repo size row per scale; got:\n%s", out)
+	}
+}
+
+// A harness that never measured the repository (the memory sweep) must not
+// grow an empty summary section.
+func TestNoRepoSummaryWhenUnmeasured(t *testing.T) {
+	var b strings.Builder
+	if err := Render(&b, parse(t, scalingCSV), "T"); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if strings.Contains(b.String(), "### Repository") {
+		t.Errorf("repository summary rendered with nothing measured:\n%s", b.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Repeated samples
 // ---------------------------------------------------------------------------
 

--- a/internal/cmd/gentree/churn.go
+++ b/internal/cmd/gentree/churn.go
@@ -71,14 +71,20 @@ func applyChurn(root string, p profile, seed int64, fraction float64, count int)
 
 	pool := newContentPool(rng, p)
 	touched := map[string]bool{}
+	changed := func() int { return st.Modified + st.Created + st.Deleted }
 
-	for _, dir := range hot {
-		if st.Modified+st.Created+st.Deleted >= budget {
-			break
+	// Each directory's file list is read once and then consumed across passes
+	// as changed() progresses, so a directory already exhausted is not
+	// re-listed from disk on the next pass.
+	remaining := make(map[string][]string, len(hot))
+	filesIn := func(dir string) []string {
+		if files, ok := remaining[dir]; ok {
+			return files
 		}
 		entries, err := os.ReadDir(dir)
 		if err != nil {
-			continue
+			remaining[dir] = nil
+			return nil
 		}
 		var files []string
 		for _, e := range entries {
@@ -86,59 +92,92 @@ func applyChurn(root string, p profile, seed int64, fraction float64, count int)
 				files = append(files, filepath.Join(dir, e.Name()))
 			}
 		}
-		if len(files) == 0 {
-			continue
-		}
 		sort.Strings(files)
+		remaining[dir] = files
+		return files
+	}
 
-		// How much of this directory changes, weighted so hot directories churn
-		// hard rather than every directory churning a little.
-		share := 0.2 + 0.6*rng.Float64()
-		n := int(float64(len(files)) * share)
-		if n < 1 {
-			n = 1
-		}
+	// One pass touches at most a share of each directory's files, so budget
+	// can require more than one pass over hot to reach — a budget capped at
+	// the tree's total file count (an exact count larger than the tree) means
+	// touching every file, which a single share-weighted pass never reaches.
+	// A pass that changes nothing means every directory is exhausted, so the
+	// loop stops instead of spinning.
+	for changed() < budget {
+		progressed := false
 
-		for i := 0; i < n && st.Modified+st.Created+st.Deleted < budget; i++ {
-			idx := rng.Intn(len(files))
-			path := files[idx]
-			touched[dir] = true
-			switch r := rng.Float64(); {
-			case r < 0.60: // modify in place
-				size := sampleSize(rng, p)
-				body, _ := pool.body(rng, size)
-				if err := os.WriteFile(path, body, 0o644); err == nil {
-					st.Modified++
-				}
-			case r < 0.80: // append, the case incremental chunking exists for
-				f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
-				if err != nil {
-					continue
-				}
-				tail := makeBody(rng, sampleSize(rng, p)/8, rng.Float64() < p.incompressibleFraction)
-				_, _ = f.Write(tail)
-				_ = f.Close()
-				st.Modified++
-			case r < 0.93: // create
-				size := sampleSize(rng, p)
-				body, _ := pool.body(rng, size)
-				name := fmt.Sprintf("new-%d-%d.dat", seed, rng.Int63())
-				if err := os.WriteFile(filepath.Join(dir, name), body, 0o644); err == nil {
-					st.Created++
-				}
-			default: // delete
-				if err := os.Remove(path); err == nil {
-					st.Deleted++
-					// Drawing is with replacement, and the modify branch would
-					// recreate this path with os.WriteFile — leaving the run
-					// reporting a deletion that is not in the tree the next
-					// backup sees.
-					files = append(files[:idx], files[idx+1:]...)
-					if len(files) == 0 {
-						break
+		for _, dir := range hot {
+			if changed() >= budget {
+				break
+			}
+			files := filesIn(dir)
+			if len(files) == 0 {
+				continue
+			}
+
+			// How much of this directory changes this pass, weighted so hot
+			// directories churn hard rather than every directory churning a
+			// little.
+			share := 0.2 + 0.6*rng.Float64()
+			n := int(float64(len(files)) * share)
+			if n < 1 {
+				n = 1
+			}
+			if n > len(files) {
+				n = len(files)
+			}
+
+			// Shuffled and consumed without replacement: drawing with
+			// replacement let the same path be modified twice in one pass
+			// while a distinct file in the same directory was never picked,
+			// which is what made a capped budget (an exact count at or above
+			// the tree size) unreachable no matter how many files existed.
+			rng.Shuffle(len(files), func(i, j int) { files[i], files[j] = files[j], files[i] })
+
+			taken := 0
+			for taken < n && changed() < budget {
+				path := files[taken]
+				taken++
+				touched[dir] = true
+				progressed = true
+				switch r := rng.Float64(); {
+				case r < 0.60: // modify in place
+					size := sampleSize(rng, p)
+					body, _ := pool.body(rng, size)
+					if err := os.WriteFile(path, body, 0o644); err == nil {
+						st.Modified++
 					}
+				case r < 0.80: // append, the case incremental chunking exists for
+					f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+					if err != nil {
+						continue
+					}
+					tail := makeBody(rng, sampleSize(rng, p)/8, rng.Float64() < p.incompressibleFraction)
+					_, _ = f.Write(tail)
+					_ = f.Close()
+					st.Modified++
+				case r < 0.93: // create
+					size := sampleSize(rng, p)
+					body, _ := pool.body(rng, size)
+					name := fmt.Sprintf("new-%d-%d.dat", seed, rng.Int63())
+					if err := os.WriteFile(filepath.Join(dir, name), body, 0o644); err == nil {
+						st.Created++
+					}
+				default: // delete
+					if err := os.Remove(path); err != nil {
+						continue
+					}
+					st.Deleted++
 				}
 			}
+			// Consumed files — modified, appended to, deleted, or merely the
+			// slot a create happened to draw — are not eligible again, so a
+			// later pass only ever touches files this pass has not seen.
+			remaining[dir] = files[taken:]
+		}
+
+		if !progressed {
+			break // every directory is exhausted; budget cannot be reached
 		}
 	}
 

--- a/internal/cmd/gentree/churn.go
+++ b/internal/cmd/gentree/churn.go
@@ -28,7 +28,12 @@ import (
 //   - rename a directory: with FileID identity nothing below it should be
 //     rewritten, and with path identity everything would be. It is the cheapest
 //     way to tell the two apart, so the generator has to be able to produce it.
-func applyChurn(root string, p profile, seed int64, fraction float64) (stats, error) {
+//
+// count, when greater than zero, sets the churn budget directly — "1000
+// changed" has to mean 1000 files at every tree size, which a fraction cannot
+// express without scaling with the tree. Zero defers to fraction, the
+// original size-relative behaviour.
+func applyChurn(root string, p profile, seed int64, fraction float64, count int) (stats, error) {
 	rng := rand.New(rand.NewSource(seed ^ 0x5eed))
 	st := stats{}
 
@@ -51,9 +56,17 @@ func applyChurn(root string, p profile, seed int64, fraction float64) (stats, er
 	if err != nil {
 		return st, err
 	}
-	budget := int(float64(total) * fraction)
+	var budget int
+	if count > 0 {
+		budget = count
+	} else {
+		budget = int(float64(total) * fraction)
+	}
 	if budget < 1 {
 		budget = 1
+	}
+	if budget > total {
+		budget = total
 	}
 
 	pool := newContentPool(rng, p)

--- a/internal/cmd/gentree/gentree_test.go
+++ b/internal/cmd/gentree/gentree_test.go
@@ -196,7 +196,10 @@ func TestChurnCountIsExactAcrossTreeSizes(t *testing.T) {
 }
 
 // A count larger than the tree must not be requested forever: it should be
-// capped at the number of files that actually exist.
+// capped at the number of files that actually exist, and reached exactly —
+// not just approached. A single share-weighted pass over each directory
+// (20-80% of its files) never reaches every file on its own, so hitting the
+// cap requires revisiting directories across passes.
 func TestChurnCountIsCappedByTreeSize(t *testing.T) {
 	root := t.TempDir()
 	p := fitToBudget(profiles["source"], 100, 16<<20)
@@ -208,8 +211,8 @@ func TestChurnCountIsCappedByTreeSize(t *testing.T) {
 		t.Fatal(err)
 	}
 	changed := st.Modified + st.Created + st.Deleted
-	if changed > 100 {
-		t.Errorf("changed %d files in a 100-file tree; count was not capped", changed)
+	if changed != 100 {
+		t.Errorf("changed %d files in a 100-file tree, want exactly 100 (the capped budget)", changed)
 	}
 }
 

--- a/internal/cmd/gentree/gentree_test.go
+++ b/internal/cmd/gentree/gentree_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -148,7 +149,7 @@ func TestChurnConcentratesInFewDirectories(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	st, err := applyChurn(root, p, 9, 0.05)
+	st, err := applyChurn(root, p, 9, 0.05, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,6 +169,48 @@ func TestChurnConcentratesInFewDirectories(t *testing.T) {
 			st.TouchedDirs, changed)
 	}
 	t.Logf("%d changes across %d of %d directories", changed, st.TouchedDirs, len(dirs))
+}
+
+// An exact count must hold regardless of tree size: "1000 changed" has to mean
+// 1000 files whether the tree has 2000 or 50000, which -fraction cannot
+// express since it scales with the tree.
+func TestChurnCountIsExactAcrossTreeSizes(t *testing.T) {
+	const count = 50
+	for _, files := range []int{200, 2000} {
+		t.Run(fmt.Sprintf("%d files", files), func(t *testing.T) {
+			root := t.TempDir()
+			p := fitToBudget(profiles["source"], files, 64<<20)
+			if _, err := generate(root, p, files, 9); err != nil {
+				t.Fatal(err)
+			}
+			st, err := applyChurn(root, p, 9, 0.05, count)
+			if err != nil {
+				t.Fatal(err)
+			}
+			changed := st.Modified + st.Created + st.Deleted
+			if changed != count {
+				t.Errorf("changed %d files out of %d in tree, want exactly %d", changed, files, count)
+			}
+		})
+	}
+}
+
+// A count larger than the tree must not be requested forever: it should be
+// capped at the number of files that actually exist.
+func TestChurnCountIsCappedByTreeSize(t *testing.T) {
+	root := t.TempDir()
+	p := fitToBudget(profiles["source"], 100, 16<<20)
+	if _, err := generate(root, p, 100, 3); err != nil {
+		t.Fatal(err)
+	}
+	st, err := applyChurn(root, p, 3, 0.05, 10000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changed := st.Modified + st.Created + st.Deleted
+	if changed > 100 {
+		t.Errorf("changed %d files in a 100-file tree; count was not capped", changed)
+	}
 }
 
 // A rename must move a directory inside the tree, never the tree itself.
@@ -210,7 +253,7 @@ func TestChurnDeletionsAreNotRecreated(t *testing.T) {
 	// same path is a collision, and one run may not produce it.
 	for seed := int64(0); seed < 20; seed++ {
 		before := snapshotFiles(t, root)
-		st, err := applyChurn(root, p, seed, 0.30)
+		st, err := applyChurn(root, p, seed, 0.30, 0)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/cmd/gentree/main.go
+++ b/internal/cmd/gentree/main.go
@@ -16,6 +16,7 @@
 //
 //	gentree -out DIR -profile mixed -files 50000 [-seed 1] [-stats FILE]
 //	gentree -churn DIR -profile mixed [-seed 1] [-fraction 0.05]
+//	gentree -churn DIR -profile mixed [-seed 1] [-count 1000]
 package main
 
 import (
@@ -131,6 +132,7 @@ func main() {
 		files    = flag.Int("files", 50000, "number of files to generate")
 		seed     = flag.Int64("seed", 1, "PRNG seed; the same seed always produces the same tree")
 		fraction = flag.Float64("fraction", 0.05, "churn: fraction of files to touch")
+		count    = flag.Int("count", 0, "churn: exact number of files to touch; overrides -fraction when > 0")
 		statsOut = flag.String("stats", "", "write a JSON summary of what was generated")
 		maxBytes = flag.Int64("max-bytes", 2<<30, "scale file sizes so the tree fits this budget; 0 disables")
 	)
@@ -166,7 +168,7 @@ func main() {
 		if *maxBytes > 0 {
 			p = fitToBudget(p, n, *maxBytes)
 		}
-		st, err = applyChurn(*churn, p, *seed, *fraction)
+		st, err = applyChurn(*churn, p, *seed, *fraction, *count)
 	}
 	if err != nil {
 		fatalf("%v", err)

--- a/scripts/benchmark/bench.sh
+++ b/scripts/benchmark/bench.sh
@@ -34,6 +34,8 @@ set -euo pipefail
 REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 # shellcheck source=scripts/benchmark/minio.sh
 . "$REPO_ROOT/scripts/benchmark/minio.sh"
+# shellcheck source=scripts/benchmark/lib.sh
+. "$REPO_ROOT/scripts/benchmark/lib.sh"
 
 PROFILES=${PROFILES:-source}
 SIZES=${SIZES:-"5000 20000 50000"}
@@ -56,6 +58,9 @@ MINIO_STARTED=0
 cleanup() {
     [ "$MINIO_STARTED" = "1" ] && minio_stop
     [ "$KEEP" = "1" ] || rm -rf "$WORK"
+    # RESTORE_DIR is created by sourcing lib.sh and unused here; bench.sh keeps
+    # its own restore scratch space under $WORK.
+    rm -rf "$RESTORE_DIR"
 }
 trap cleanup EXIT
 
@@ -102,6 +107,9 @@ measure() {
         minio_api_counts >"$WORK/api-before"
     fi
 
+    local repo_kb_before
+    repo_kb_before=$(get_repo_size_kb)
+
     local rc=0
     if [ "$TIME_FLAVOUR" = bsd ]; then
         /usr/bin/time -l "$@" -memstats "$stats" >"$out" 2>"$err" || rc=$?
@@ -142,14 +150,22 @@ measure() {
         by_api=$(minio_api_delta "$WORK/api-before" "$WORK/api-after")
     fi
 
-    printf 'cloudstic,%s,%s,%d,%d,%s,%s,%.1f,%s,%s,%s,%s\n' \
+    # Repository growth, using lib.sh's get_repo_size_kb rather than a second
+    # implementation — it already handles both a local directory and an S3
+    # prefix, which matters now that a MinIO backend exists alongside local.
+    local repo_kb_after repo_delta
+    repo_kb_after=$(get_repo_size_kb)
+    repo_delta=$(format_size_kb $(( repo_kb_after - repo_kb_before )))
+
+    printf 'cloudstic,%s,%s,%d,%d,%s,%s,%.1f,%s,%s,%s,%s,%s\n' \
         "$backend" "$profile" "$size" "$sample" "$op" \
         "$seconds" "$(echo "scale=1; $peak_kb / 1024" | bc)" \
-        "$alloc_mb" "$requests" "$sent_mb" "$by_api" >>"$(backend_csv "$backend")"
+        "$alloc_mb" "$requests" "$sent_mb" "$by_api" "$repo_delta" >>"$(backend_csv "$backend")"
 
     printf '    %-20s %7ss %8.1f MB peak' "$op" "$seconds" "$(echo "scale=1; $peak_kb / 1024" | bc)"
     [ -n "$alloc_mb" ] && printf ' %9s MB alloc' "$alloc_mb"
     [ -n "$requests" ] && printf ' %6s req %8s MB sent' "$requests" "$sent_mb"
+    printf ' %10s repo' "$repo_delta"
     printf '\n'
 }
 
@@ -166,11 +182,48 @@ store_flags() {
     fi
 }
 
+# reset_store empties the backend and points get_repo_size_kb at it, so
+# repository-growth tracking (measure(), measure_summary()) sees the right
+# place for whichever backend this cell is measuring against.
 reset_store() {
     if [ "$backend" = minio ]; then
         minio_reset_bucket
+        BENCH_REPO_DIR=""
+        BENCH_S3_PREFIX="s3://$MINIO_BUCKET/bench/"
+        BENCH_S3_ENDPOINT=$(minio_endpoint)
+        export AWS_ACCESS_KEY_ID="$MINIO_USER" AWS_SECRET_ACCESS_KEY="$MINIO_PASSWORD"
     else
         rm -rf "$WORK/repo"; mkdir -p "$WORK/repo"
+        BENCH_REPO_DIR="$WORK/repo"
+        BENCH_S3_PREFIX=""
+        BENCH_S3_ENDPOINT=""
+    fi
+}
+
+# measure_summary appends the two rows that describe the whole pipeline rather
+# than one operation in it: the repository's final size, and how that compares
+# to the logical size of the tree that was backed up — the headline
+# deduplication and compression number. Neither is a timed operation, so
+# seconds and peak_mb are left at zero; benchreport renders them in their own
+# section rather than the per-operation tables.
+measure_summary() {
+    local stored_kb logical_kb stored_fmt logical_fmt
+    stored_kb=$(get_repo_size_kb)
+    logical_kb=$(du -sk "$data" | awk '{print $1}')
+    stored_fmt=$(format_size_kb "$stored_kb")
+    logical_fmt=$(format_size_kb "$logical_kb")
+
+    printf 'cloudstic,%s,%s,%d,%d,Final Repo Size,0,0,,,,,%s\n' \
+        "$backend" "$profile" "$size" "$sample" "$stored_fmt" >>"$(backend_csv "$backend")"
+    printf '    %-20s %s\n' "Final Repo Size" "$stored_fmt"
+
+    if [ "$stored_kb" -gt 0 ]; then
+        local ratio
+        ratio=$(echo "scale=2; $logical_kb / $stored_kb" | bc)
+        printf 'cloudstic,%s,%s,%d,%d,Logical / Stored,0,0,,,,,%s / %s (%sx)\n' \
+            "$backend" "$profile" "$size" "$sample" "$logical_fmt" "$stored_fmt" "$ratio" \
+            >>"$(backend_csv "$backend")"
+        printf '    %-20s %s / %s (%sx)\n' "Logical / Stored" "$logical_fmt" "$stored_fmt" "$ratio"
     fi
 }
 
@@ -179,24 +232,81 @@ reset_store() {
 # The unit of repetition is the whole pipeline, not the command: re-running
 # prune against an already-pruned repository, or an initial backup against a
 # populated one, measures a different operation that happens to share a name.
+#
+# The sequence mirrors what a real repository sees over time: an initial
+# backup, then the incrementals that follow it (nothing changed, a single
+# edit, a bounded batch of edits), then growth (new data), then the case that
+# separates this design from a naive copy (content it already has).
 run_pipeline() {
-    local flags restore
+    local flags restore restore_no_verify
     flags=$(store_flags)
     restore="$WORK/restore"
+    restore_no_verify="$WORK/restore-no-verify"
 
     reset_store
-    rm -rf "$restore"; mkdir -p "$restore"
+    rm -rf "$restore" "$restore_no_verify"
+    mkdir -p "$restore" "$restore_no_verify"
 
-    measure init    "$CLOUDSTIC_BIN" init $flags -quiet
-    measure backup  "$CLOUDSTIC_BIN" backup $flags -source "local:$data" -quiet
+    measure init   "$CLOUDSTIC_BIN" init $flags -quiet
+    measure backup "$CLOUDSTIC_BIN" backup $flags -source "local:$data" -quiet
 
-    "$GENTREE_BIN" -churn "$data" -profile "$profile" -seed "$sample" \
-        -fraction 0.05 -max-bytes "$MAX_BYTES" >/dev/null
+    # The cheapest possible incremental: nothing in the source changed. Shows
+    # whether scanning cost is proportional to the tree or to the churn.
+    measure backup-incremental-noop "$CLOUDSTIC_BIN" backup $flags -source "local:$data" -quiet
 
-    measure backup-incremental "$CLOUDSTIC_BIN" backup $flags -source "local:$data" -quiet
+    # An exact count rather than a fraction: "1 file" and "1000 changed" have
+    # to mean the same thing at every tree size, which -fraction cannot
+    # express without its shape changing with the tree.
+    "$GENTREE_BIN" -churn "$data" -profile "$profile" -seed "$(( sample * 100 + 1 ))" \
+        -count 1 -max-bytes "$MAX_BYTES" >/dev/null
+    measure backup-incremental-1 "$CLOUDSTIC_BIN" backup $flags -source "local:$data" -quiet
+
+    "$GENTREE_BIN" -churn "$data" -profile "$profile" -seed "$(( sample * 100 + 2 ))" \
+        -count 1000 -max-bytes "$MAX_BYTES" >/dev/null
+    measure backup-incremental-1000 "$CLOUDSTIC_BIN" backup $flags -source "local:$data" -quiet
+
+    # Growth rather than modification: brand new content the repository has
+    # never seen, sized to a fixed budget independent of the sweep's tree size.
+    #
+    # -max-bytes only ever scales a tree *down* to fit a budget (see
+    # fitToBudget in gentree/main.go) — it never pads a naturally smaller one
+    # up to fill it, which is the right behaviour for the main dataset but
+    # means the file count here has to be large enough that every profile's
+    # natural size already clears 200MB before scaling kicks in. 20000 clears
+    # it for the smallest-mean profile (source, ~18KB/file) with margin to
+    # spare for mixed and media, whose means are larger still.
+    #
+    # $data is regenerated once per (profile, size) and reused across every
+    # sample and backend, so this directory already exists from an earlier
+    # iteration; removing it first keeps -out writing a fresh, deterministic
+    # tree instead of layering another batch of names into it.
+    rm -rf "$data/bench-added-200mb"
+    "$GENTREE_BIN" -out "$data/bench-added-200mb" -profile "$profile" -files 20000 \
+        -seed "$sample" -max-bytes $(( 200 * 1024 * 1024 )) >/dev/null
+    measure backup-add-200mb "$CLOUDSTIC_BIN" backup $flags -source "local:$data" -quiet
+
+    # Backing up content the repository already holds, end to end: the repo
+    # should barely grow even though a whole directory's worth of bytes was
+    # logically presented to it again.
+    #
+    # Removed first for the same reason as above: cp -R into an already-
+    # existing directory nests a copy inside it rather than replacing it,
+    # which would otherwise grow one directory deeper every sample.
+    local dedup_src
+    dedup_src=$(find "$data" -mindepth 1 -maxdepth 1 -type d | sort | head -1)
+    rm -rf "$data/bench-dedup-copy"
+    cp -R "$dedup_src" "$data/bench-dedup-copy"
+    measure backup-dedup "$CLOUDSTIC_BIN" backup $flags -source "local:$data" -quiet
+
     measure check   "$CLOUDSTIC_BIN" check $flags -quiet
     measure restore "$CLOUDSTIC_BIN" restore $flags -output "$restore" latest -quiet
-    measure prune   "$CLOUDSTIC_BIN" prune $flags -quiet
+    # Restore without the per-file content-hash check, which separates what
+    # verification costs from what fetching and writing cost.
+    measure restore-no-verify "$CLOUDSTIC_BIN" restore $flags \
+        -output "$restore_no_verify" -no-verify latest -quiet
+    measure prune "$CLOUDSTIC_BIN" prune $flags -quiet
+
+    measure_summary
 }
 
 # ---------------------------------------------------------------------------
@@ -239,7 +349,7 @@ backend_csv() {
 # columns ride along without the renderer needing to know about them. "tool" is
 # constant here and present only because the renderer labels rows with it.
 for backend in $BACKENDS; do
-    echo "tool,backend,profile,scale,sample,operation,seconds,peak_mb,alloc_mb,requests,sent_mb,by_api" >"$(backend_csv "$backend")"
+    echo "tool,backend,profile,scale,sample,operation,seconds,peak_mb,alloc_mb,requests,sent_mb,by_api,repo_delta" >"$(backend_csv "$backend")"
 done
 
 export CLOUDSTIC_PASSWORD="$PASSWORD"

--- a/scripts/benchmark/lib.sh
+++ b/scripts/benchmark/lib.sh
@@ -64,14 +64,24 @@ get_repo_size_kb() {
     if [ -n "$BENCH_REPO_DIR" ] && [ -d "$BENCH_REPO_DIR" ]; then
         du -sk "$BENCH_REPO_DIR" | awk '{print $1}'
     elif [ -n "$BENCH_S3_PREFIX" ]; then
-        local bytes endpoint_args
+        local endpoint_args listing bytes
         endpoint_args=()
         [ -n "$BENCH_S3_ENDPOINT" ] && endpoint_args=(--endpoint-url "$BENCH_S3_ENDPOINT")
-        # An empty prefix is normal right after `init` and must not be fatal:
-        # under pipefail, aws printing no "Total Size" line makes grep exit 1,
-        # which would otherwise abort the whole sweep under set -e.
-        bytes=$(aws "${endpoint_args[@]}" s3 ls "$BENCH_S3_PREFIX" --summarize --recursive 2>/dev/null \
-            | grep "Total Size" | awk '{print $3}') || true
+
+        # `aws s3 ls --summarize --recursive` exits 1 even on a *successful*
+        # listing of zero objects (a fresh prefix right after `init`), so its
+        # exit code cannot tell that apart from a real failure — bad endpoint,
+        # bad credentials, a missing bucket — and is deliberately not checked
+        # here. Only a genuine failure skips the "Total Size" line entirely,
+        # so that line's presence is the signal used instead: treating a real
+        # failure as "empty" would put a silently wrong repo_delta and final
+        # size in every row from this point on.
+        listing=$(aws "${endpoint_args[@]}" s3 ls "$BENCH_S3_PREFIX" --summarize --recursive 2>&1) || true
+        if ! bytes=$(echo "$listing" | grep "Total Size" | awk '{print $3}'); then
+            echo "get_repo_size_kb: aws s3 ls $BENCH_S3_PREFIX did not complete:" >&2
+            echo "$listing" >&2
+            return 1
+        fi
         echo $(( ${bytes:-0} / 1024 ))
     else
         echo 0

--- a/scripts/benchmark/lib.sh
+++ b/scripts/benchmark/lib.sh
@@ -15,9 +15,12 @@
 
 # BENCH_REPO_DIR (local) or BENCH_S3_PREFIX (s3://bucket/prefix/) enable
 # repository-growth tracking. A script sets whichever applies before its first
-# run_bench.
+# run_bench. BENCH_S3_ENDPOINT points the S3 prefix at a non-AWS endpoint —
+# MinIO in particular — and is empty for real S3, where the default endpoint
+# is correct.
 BENCH_REPO_DIR=""
 BENCH_S3_PREFIX=""
+BENCH_S3_ENDPOINT=""
 
 # CURRENT_TOOL labels rows in the CSV. compare.sh reassigns it per tool;
 # cloudstic.sh leaves it alone.
@@ -61,9 +64,14 @@ get_repo_size_kb() {
     if [ -n "$BENCH_REPO_DIR" ] && [ -d "$BENCH_REPO_DIR" ]; then
         du -sk "$BENCH_REPO_DIR" | awk '{print $1}'
     elif [ -n "$BENCH_S3_PREFIX" ]; then
-        local bytes
-        bytes=$(aws s3 ls "$BENCH_S3_PREFIX" --summarize --recursive 2>/dev/null \
-            | grep "Total Size" | awk '{print $3}')
+        local bytes endpoint_args
+        endpoint_args=()
+        [ -n "$BENCH_S3_ENDPOINT" ] && endpoint_args=(--endpoint-url "$BENCH_S3_ENDPOINT")
+        # An empty prefix is normal right after `init` and must not be fatal:
+        # under pipefail, aws printing no "Total Size" line makes grep exit 1,
+        # which would otherwise abort the whole sweep under set -e.
+        bytes=$(aws "${endpoint_args[@]}" s3 ls "$BENCH_S3_PREFIX" --summarize --recursive 2>/dev/null \
+            | grep "Total Size" | awk '{print $3}') || true
         echo $(( ${bytes:-0} / 1024 ))
     else
         echo 0


### PR DESCRIPTION
## Summary
- Add an exact-count churn mode to gentree (`-count`, overrides `-fraction` when > 0, capped at the tree's file count) — "1000 changed" has to mean the same thing at every tree size, which `-fraction` cannot express.
- Restore the six scenarios `bench.sh` dropped when `cloudstic.sh`/`memory.sh`/`s3.sh` collapsed into it: `backup-incremental-noop`, `backup-incremental-1`, `backup-incremental-1000`, `backup-add-200mb`, `backup-dedup`, and `restore-no-verify`.
- Wire `repo_delta` into every measured row via `lib.sh`'s `get_repo_size_kb()`/`format_size_kb()` rather than a second implementation, and give `get_repo_size_kb()` an optional S3 endpoint override so it works against MinIO, not just real S3.
- Emit `Final Repo Size` and `Logical / Stored` summary rows once per pipeline run (the headline dedup/compression number).
- Teach `internal/benchreport` to exclude those two summary rows from the per-operation time/memory tables and charts, rendering them in their own `### Repository` section instead (a table keyed by tree size for a scaling sweep, plain lines for a single-size run).
- Update `docs/benchmark-results.md`'s description of what `bench.sh` measures.

Closes #467

## Verification
- `go test -count=1 ./scripts/benchmark/gentree ./internal/benchreport` passes
- `golangci-lint run ./scripts/... ./internal/benchreport/... ./internal/cmd/benchreport/...` passes (0 issues)
- `go test -count=1 ./internal/...` passes
- `SIZES=2000 SAMPLES=1 ./scripts/benchmark/bench.sh` runs clean, populates `repo_delta` and the two summary rows, and renders correctly via `benchreport render`
- Same command with `BACKENDS=minio` runs clean, including `repo_delta` tracked through the MinIO S3 prefix
- A multi-size run (`SIZES="200 500"`) confirmed the scaling-report path (per-size `### Repository` table, no empty columns elsewhere)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Benchmark reports now show final repository size and logical-to-stored size ratios.
  * Benchmarks measure repository growth and include expanded operation, storage, and request metrics.
  * Added support for generating an exact number of changed files during benchmark setup.
  * Added support for configurable S3-compatible endpoints.

* **Bug Fixes**
  * Improved handling of missing repository measurements and empty storage prefixes.

* **Documentation**
  * Expanded benchmark documentation to explain the updated pipeline and reported metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->