### PR TITLE
fix(benchmark): stop closing sort's pipe early in the dedup step

### DIFF
--- a/scripts/benchmark/bench.sh
+++ b/scripts/benchmark/bench.sh
@@ -292,8 +292,16 @@ run_pipeline() {
     # Removed first for the same reason as above: cp -R into an already-
     # existing directory nests a copy inside it rather than replacing it,
     # which would otherwise grow one directory deeper every sample.
-    local dedup_src
-    dedup_src=$(find "$data" -mindepth 1 -maxdepth 1 -type d | sort | head -1)
+    # Piping sort straight into `head -1` lets head close the pipe the moment
+    # it has its first line; once the tree is big enough that sort's full
+    # output does not fit in one pipe write, sort's next write gets SIGPIPE
+    # and pipefail fails the whole script. Capturing the whole listing first
+    # — a single command substitution waits for the pipeline to finish rather
+    # than closing it early — and then taking the first line with a bash
+    # parameter expansion avoids the pipe entirely for that step.
+    local all_dirs dedup_src
+    all_dirs=$(find "$data" -mindepth 1 -maxdepth 1 -type d | sort)
+    dedup_src=${all_dirs%%$'\n'*}
     rm -rf "$data/bench-dedup-copy"
     cp -R "$dedup_src" "$data/bench-dedup-copy"
     measure backup-dedup "$CLOUDSTIC_BIN" backup $flags -source "local:$data" -quiet


### PR DESCRIPTION
## Summary
- Fix the `Benchmark` CI failure: `dedup_src=$(find ... | sort | head -1)` lets `head` exit as soon as it has one line, closing the pipe while `sort` is still writing. Once the directory listing is large enough that `sort`'s output doesn't fit in one pipe write — which only happens at the 50000-file size, not the smaller ones — `sort`'s next write gets `SIGPIPE`, and `pipefail` fails the whole script with `sort: Broken pipe`.
- Not a memory problem: the failing run's own peak RSS topped out under 1GB against the runner's 7GB, so a bigger runner would not have fixed this — it reproduces on any runner once the listing is large enough.
- Fix: capture the full listing with one command substitution (which waits for the pipeline to finish rather than closing it early), then take the first line with a bash parameter expansion instead of piping into a second process.

## Verification
- Reproduced the bug directly against a 20000-entry directory listing: the old pattern fails with exit 141 (SIGPIPE), the new one doesn't.
- `shellcheck scripts/benchmark/bench.sh` — no new issues.
- `SIZES=50000 SAMPLES=1 ./scripts/benchmark/bench.sh` — previously died at exactly this step in CI (see the [failing run](https://github.com/Cloudstic/cli/actions/runs/31251529791)); now runs clean end to end, including through `backup-dedup`, `check`, `restore`, `restore-no-verify`, and `prune`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved benchmark script reliability by preventing failures caused by premature pipeline termination.
  * Ensured deduplication source selection works correctly when strict shell error handling is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->