### PR TITLE
feat(ci): split the Benchmark workflow by backend, render MinIO columns

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,14 +1,18 @@
 name: Benchmark
 
-# One sweep over the pipeline: wall time, peak RSS, allocation, and — when a
-# MinIO backend is selected — requests and bytes.
+# Two sweeps over the pipeline. The local one, on macos-latest, is what the
+# headline numbers — wall time, peak RSS, allocation — have always come from,
+# and stays there so they remain comparable to every run before it. The MinIO
+# one needs Docker, which macos-latest does not have, so it runs on
+# ubuntu-latest instead; a different runner means its own timings are not
+# comparable to the local job's, which is why it reports requests and bytes
+# rather than wall time as its headline.
 #
-# There used to be two workflows here. They ran different scripts asking
-# different questions, which justified the split; once bench.sh collapsed those
-# scripts into one matrix they became the same job with different parameters,
-# started by the same label, one of them a strict subset of the other. A second
-# entry in the checks list is not free — it is a second thing to read, wait for
-# and explain.
+# There used to be two workflows here for a different reason — cloudstic.sh
+# and memory.sh ran different scripts asking different questions. Once
+# bench.sh collapsed those into one matrix they became the same job with
+# different parameters; splitting by backend now is not that same split come
+# back, it is the one thing this job cannot do on a single runner.
 #
 # Deliberately not part of the ordinary CI run: it builds several synthetic
 # trees and backs each one up, which costs minutes rather than seconds. Two ways
@@ -24,7 +28,7 @@ on:
         default: main
         type: string
       sizes:
-        description: Space-separated tree sizes to measure
+        description: Space-separated tree sizes to measure locally
         required: false
         default: "5000 20000 50000"
         type: string
@@ -39,14 +43,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  benchmark:
+  benchmark-local:
     # On a pull request this runs only while the `benchmark` label is on it, so
     # an unrelated label does not start a ten-minute job, and pushing more
     # commits to an already-labelled PR re-measures without another click.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'benchmark')
-    name: Benchmark
+    name: Benchmark (local)
     runs-on: macos-latest
     steps:
       - name: Checkout target ref
@@ -75,7 +79,7 @@ jobs:
           set -euo pipefail
           go run ./internal/cmd/benchreport render \
             -in benchmark-results/bench.csv \
-            -title "Benchmark" >> "$GITHUB_STEP_SUMMARY"
+            -title "Benchmark (local)" >> "$GITHUB_STEP_SUMMARY"
           {
             echo ""
             echo "<details><summary>Run log</summary>"
@@ -92,7 +96,75 @@ jobs:
       - name: Upload results
         uses: actions/upload-artifact@v7
         with:
-          name: benchmark-results
+          name: benchmark-results-local
+          path: |
+            benchmark-results/bench.csv
+            benchmark-results/bench.log
+
+  benchmark-minio:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'benchmark')
+    name: Benchmark (MinIO)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout target ref
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      # One size, one sample — deliberately, not just for CI minutes. bench.sh
+      # regenerates the source tree once per (profile, size) and reuses it
+      # across every sample in that cell, and several of its steps (the
+      # incremental churns, the dedup copy) mutate that tree in place. A
+      # second sample therefore backs up a tree that already carries the
+      # first sample's changes, not a repeat of the same measurement — its
+      # request and byte counts would reflect a bigger, different repository,
+      # not sampling noise. One sample per cell is the only way to get a
+      # number that means what it says; a wider size matrix would only spend
+      # more CI minutes confirming the same thing.
+
+      - name: Measure
+        shell: bash
+        env:
+          SIZES: "5000"
+          PROFILES: source
+          BACKENDS: minio
+          SAMPLES: "1"
+        run: |
+          set -euo pipefail
+          mkdir -p benchmark-results
+          ./scripts/benchmark/bench.sh | tee benchmark-results/bench.log
+
+      - name: Publish summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          go run ./internal/cmd/benchreport render \
+            -in benchmark-results/bench.csv \
+            -title "Benchmark (MinIO)" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo ""
+            echo "<details><summary>Run log</summary>"
+            echo ""
+            echo '```text'
+            cat benchmark-results/bench.log
+            echo '```'
+            echo ""
+            echo "</details>"
+            echo ""
+            echo "Ref \`${{ github.event.inputs.ref || github.ref }}\` on \`${{ runner.os }}\`."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload results
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-results-minio
           path: |
             benchmark-results/bench.csv
             benchmark-results/bench.log

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -75,6 +75,8 @@ jobs:
 
       - name: Publish summary
         shell: bash
+        env:
+          BENCHMARK_REF: ${{ github.event.inputs.ref || github.ref }}
         run: |
           set -euo pipefail
           go run ./internal/cmd/benchreport render \
@@ -90,7 +92,7 @@ jobs:
             echo ""
             echo "</details>"
             echo ""
-            echo "Ref \`${{ github.event.inputs.ref || github.ref }}\` on \`${{ runner.os }}\`."
+            printf 'Ref `%s` on `%s`.\n' "$BENCHMARK_REF" "$RUNNER_OS"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload results
@@ -143,6 +145,8 @@ jobs:
 
       - name: Publish summary
         shell: bash
+        env:
+          BENCHMARK_REF: ${{ github.event.inputs.ref || github.ref }}
         run: |
           set -euo pipefail
           go run ./internal/cmd/benchreport render \
@@ -158,7 +162,7 @@ jobs:
             echo ""
             echo "</details>"
             echo ""
-            echo "Ref \`${{ github.event.inputs.ref || github.ref }}\` on \`${{ runner.os }}\`."
+            printf 'Ref `%s` on `%s`.\n' "$BENCHMARK_REF" "$RUNNER_OS"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload results

--- a/docs/benchmark-results.md
+++ b/docs/benchmark-results.md
@@ -37,8 +37,16 @@ Requirements: Go toolchain; `bc`; docker, `aws` and `curl` only for
 `BACKENDS=minio`.
 
 Render a CSV as a table with `go run ./internal/cmd/benchreport render -in
-benchmark-results/bench.csv -title Benchmark`. The `Benchmark` workflow runs the
-same sweep on demand, or on a pull request labelled `benchmark`.
+benchmark-results/bench.csv -title Benchmark`. The `Benchmark` workflow runs
+this on demand, or on a pull request labelled `benchmark`, as two jobs: a local
+sweep on `macos-latest` — the one the headline time and memory figures have
+always come from — and a single-size, single-sample MinIO sweep on
+`ubuntu-latest`, since `macos-latest` has no Docker. One sample there, not
+three: several steps (the incremental churns, the dedup copy) mutate the
+source tree in place, and the tree is reused across every sample in a cell, so
+a second sample would back up an already-different, bigger tree rather than
+repeat the same measurement — its request and byte counts would reflect that
+growth, not run-to-run noise.
 
 ## Comparing against other tools — `compare.sh`
 

--- a/internal/cmd/benchreport/csv.go
+++ b/internal/cmd/benchreport/csv.go
@@ -1,4 +1,4 @@
-package benchreport
+package main
 
 import (
 	"encoding/csv"

--- a/internal/cmd/benchreport/main.go
+++ b/internal/cmd/benchreport/main.go
@@ -14,8 +14,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-
-	"github.com/cloudstic/cli/internal/benchreport"
 )
 
 func main() {
@@ -80,7 +78,7 @@ func runCmd(args []string) error {
 		stdout, stderr = nil, nil
 	}
 
-	seconds, peakMB, err := benchreport.Measure(rest[0], rest[1:], stdout, stderr)
+	seconds, peakMB, err := Measure(rest[0], rest[1:], stdout, stderr)
 	if err != nil {
 		return err
 	}
@@ -92,12 +90,12 @@ func runCmd(args []string) error {
 	// nothing".
 	var allocMB float64
 	if *allocFrom != "" {
-		if allocMB, err = benchreport.ReadAllocMB(*allocFrom); err != nil {
+		if allocMB, err = ReadAllocMB(*allocFrom); err != nil {
 			return err
 		}
 	}
 
-	if err := benchreport.AppendRow(*out, benchreport.Row{
+	if err := AppendRow(*out, Row{
 		Tool:      *tool,
 		Operation: *op,
 		Scale:     *scale,
@@ -148,7 +146,7 @@ func rowCmd(args []string) error {
 	if *op == "" || *out == "" {
 		return fmt.Errorf("-op and -out are required")
 	}
-	return benchreport.AppendRow(*out, benchreport.Row{
+	return AppendRow(*out, Row{
 		Tool:      *tool,
 		Operation: *op,
 		Scale:     *scale,
@@ -175,9 +173,9 @@ func renderCmd(args []string) error {
 	}
 	defer func() { _ = f.Close() }()
 
-	rep, err := benchreport.Parse(f)
+	rep, err := Parse(f)
 	if err != nil {
 		return err
 	}
-	return benchreport.Render(os.Stdout, rep, *title)
+	return Render(os.Stdout, rep, *title)
 }

--- a/internal/cmd/benchreport/measure.go
+++ b/internal/cmd/benchreport/measure.go
@@ -1,4 +1,4 @@
-package benchreport
+package main
 
 import (
 	"encoding/json"

--- a/internal/cmd/benchreport/render.go
+++ b/internal/cmd/benchreport/render.go
@@ -1,4 +1,4 @@
-package benchreport
+package main
 
 import (
 	"fmt"

--- a/internal/cmd/benchreport/render.go
+++ b/internal/cmd/benchreport/render.go
@@ -41,6 +41,21 @@ func Render(w io.Writer, rep *Report, title string) error {
 				"stops allocating something it did not need.\n\n")
 			renderScalingTable(b, rep, AllocMB)
 		}
+
+		// Against MinIO, request latency rather than bandwidth sets the pace,
+		// and egress is billed — so these are the columns that matter for a
+		// remote store, the way peak RSS matters for a local one.
+		if rep.hasS3() {
+			b.WriteString("\n### Requests\n\n")
+			b.WriteString("How many calls each operation made against the backend — the number\n" +
+				"that decides whether an operation is usable over a network at all.\n\n")
+			renderScalingTable(b, rep, Requests)
+
+			b.WriteString("\n### Sent (MB)\n\n")
+			b.WriteString("Bytes the backend sent back — downloads on a restore or check, a\n" +
+				"pack body cache undersized enough to force re-reads.\n\n")
+			renderScalingTable(b, rep, SentMB)
+		}
 	case KindComparison:
 		if len(rep.Tools()) > 1 {
 			b.WriteString("Each tool over the same dataset. Times on a shared runner carry several\n" +
@@ -56,6 +71,7 @@ func Render(w io.Writer, rep *Report, title string) error {
 	}
 
 	renderRepoSummary(b, rep)
+	renderByAPI(b, rep)
 
 	// A comparison of one tool has nothing to chart — a single bar compares
 	// nothing — so the heading is written only if something follows it.
@@ -153,6 +169,13 @@ func renderComparisonTable(b *strings.Builder, rep *Report) {
 	// it is the column that shows churn peak RSS cannot.
 	withAlloc := len(tools) == 1 && rep.hasAlloc()
 
+	// Requests and bytes are gated the same way again: only a MinIO run
+	// measures them, and a cross-tool comparison never points at a backend
+	// that reports its own counters, so this and withAlloc never both apply
+	// to a run this harness produces — but the gate stays independent of
+	// withAlloc for the same reason withAlloc is independent of withDelta.
+	withRequests := len(tools) == 1 && rep.hasS3()
+
 	b.WriteString("| Operation |")
 	for _, t := range tools {
 		fmt.Fprintf(b, " %s |", t)
@@ -162,6 +185,9 @@ func renderComparisonTable(b *strings.Builder, rep *Report) {
 	}
 	if withDelta {
 		b.WriteString(" Repo added |")
+	}
+	if withRequests {
+		b.WriteString(" Requests | Sent |")
 	}
 	b.WriteString("\n|---|")
 	for range tools {
@@ -173,11 +199,14 @@ func renderComparisonTable(b *strings.Builder, rep *Report) {
 	if withDelta {
 		b.WriteString("---:|")
 	}
+	if withRequests {
+		b.WriteString("---:|---:|")
+	}
 	b.WriteString("\n")
 
 	for _, op := range rep.Operations() {
 		fmt.Fprintf(b, "| `%s` |", op)
-		var delta, alloc string
+		var delta, alloc, requests, sentMB string
 		for _, t := range tools {
 			c, ok := rep.cell(t, op, scale)
 			if !ok {
@@ -188,6 +217,10 @@ func renderComparisonTable(b *strings.Builder, rep *Report) {
 			delta = c.RepoDelta
 			if c.HasAlloc {
 				alloc = statCell(c.AllocMB) + " MB"
+			}
+			if c.HasS3 {
+				requests = statCell(c.Requests)
+				sentMB = statCell(c.SentMB) + " MB"
 			}
 		}
 		if withAlloc {
@@ -202,11 +235,23 @@ func renderComparisonTable(b *strings.Builder, rep *Report) {
 			}
 			fmt.Fprintf(b, " %s |", delta)
 		}
+		if withRequests {
+			if requests == "" {
+				requests = "-"
+			}
+			if sentMB == "" {
+				sentMB = "-"
+			}
+			fmt.Fprintf(b, " %s | %s |", requests, sentMB)
+		}
 		b.WriteString("\n")
 	}
 	b.WriteString("\nEach cell is wall time and peak RSS.")
 	if withAlloc {
 		b.WriteString(" `Allocated` is cumulative bytes allocated,\nfreed or not — the column that moves when an operation stops allocating\nsomething it did not need.")
+	}
+	if withRequests {
+		b.WriteString(" `Sent` is bytes the backend sent back —\ndownloads on a restore or check.")
 	}
 	b.WriteString("\n")
 }
@@ -256,6 +301,48 @@ func renderRepoSummary(b *strings.Builder, rep *Report) {
 			b.WriteString(" - |\n")
 		}
 	}
+}
+
+// renderByAPI collapses the per-API request breakdown into a details block.
+//
+// It is long — every API name and its count, for every operation and, on a
+// scaling sweep, every size — and would dominate a summary whose headline
+// numbers are the Requests and Sent columns above it. A reader who wants the
+// breakdown opens the block; one who does not is not made to scroll past it.
+func renderByAPI(b *strings.Builder, rep *Report) {
+	if !rep.hasS3() {
+		return
+	}
+	scaling := rep.Kind() == KindScaling
+
+	var rows strings.Builder
+	any := false
+	for _, op := range rep.Operations() {
+		for _, s := range rep.Scales() {
+			c, ok := rep.cell("", op, s)
+			if !ok || c.ByAPI == "" {
+				continue
+			}
+			any = true
+			if scaling {
+				fmt.Fprintf(&rows, "| `%s` | %s files | %s |\n", op, humanInt(s), c.ByAPI)
+			} else {
+				fmt.Fprintf(&rows, "| `%s` | %s |\n", op, c.ByAPI)
+			}
+		}
+	}
+	if !any {
+		return
+	}
+
+	b.WriteString("\n<details>\n<summary>Requests by API</summary>\n\n")
+	if scaling {
+		b.WriteString("| Operation | Size | By API |\n|---|---|---|\n")
+	} else {
+		b.WriteString("| Operation | By API |\n|---|---|\n")
+	}
+	b.WriteString(rows.String())
+	b.WriteString("\n</details>\n")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/cmd/benchreport/report.go
+++ b/internal/cmd/benchreport/report.go
@@ -1,10 +1,4 @@
-// Package benchreport turns benchmark measurements into a Markdown report.
-//
-// The measurement scripts orchestrate external binaries, which is what shell is
-// good at. Everything after that — arithmetic, grouping, table and chart
-// layout — is what shell is worst at, and is here instead: it is typed, it is
-// tested, and it does not fork bc to divide two numbers.
-package benchreport
+package main
 
 import (
 	"encoding/csv"

--- a/internal/cmd/benchreport/report.go
+++ b/internal/cmd/benchreport/report.go
@@ -43,6 +43,17 @@ type Row struct {
 	PeakMB    float64
 	AllocMB   float64 // cumulative bytes allocated, including freed; 0 when unmeasured
 	RepoDelta string  // human-formatted, passed through untouched
+
+	// S3 columns: only a MinIO backend row carries these. Requests and
+	// SentMB can each be a genuine zero — a no-op incremental backup can
+	// still issue zero uploads, an upload-heavy step can send zero bytes
+	// back — so zero cannot double as "unmeasured" the way it does for
+	// AllocMB. HasS3 is the presence flag, true whenever the row's CSV record
+	// had a requests column at all.
+	Requests int
+	SentMB   float64
+	ByAPI    string // "GetObject=8;HeadObject=3;…", passed through untouched
+	HasS3    bool
 }
 
 // Stat summarises repeated samples of one measurement.
@@ -86,6 +97,11 @@ type Cell struct {
 	AllocMB   Stat
 	HasAlloc  bool
 	RepoDelta string
+
+	Requests Stat
+	SentMB   Stat
+	HasS3    bool
+	ByAPI    string // last non-empty sample, like RepoDelta
 }
 
 // Report is a parsed measurement set.
@@ -171,6 +187,21 @@ func Parse(r io.Reader) (*Report, error) {
 				return nil, fmt.Errorf("row %d: alloc_mb %q: %w", n+2, v, err)
 			}
 		}
+		// requests is the presence flag for every S3 column: bench.sh leaves
+		// it (and sent_mb, by_api) empty on a local-backend row and always
+		// fills it on a MinIO one, even when the true count is zero.
+		if v := get(rec, "requests"); v != "" {
+			row.HasS3 = true
+			if row.Requests, err = strconv.Atoi(v); err != nil {
+				return nil, fmt.Errorf("row %d: requests %q: %w", n+2, v, err)
+			}
+			if v := get(rec, "sent_mb"); v != "" {
+				if row.SentMB, err = strconv.ParseFloat(v, 64); err != nil {
+					return nil, fmt.Errorf("row %d: sent_mb %q: %w", n+2, v, err)
+				}
+			}
+			row.ByAPI = get(rec, "by_api")
+		}
 		rep.Rows = append(rep.Rows, row)
 	}
 	if len(rep.Rows) == 0 {
@@ -251,7 +282,7 @@ func distinct(rows []Row, key func(Row) string) []string {
 // are that sample, so the single-sample and repeated-sample paths are the same
 // code.
 func (r *Report) cell(tool, op string, scale int) (Cell, bool) {
-	var seconds, peak, alloc []float64
+	var seconds, peak, alloc, requests, sentMB []float64
 	var c Cell
 	for _, row := range r.Rows {
 		if row.Operation != op || row.Scale != scale || (tool != "" && row.Tool != tool) {
@@ -267,12 +298,24 @@ func (r *Report) cell(tool, op string, scale int) (Cell, bool) {
 		if row.RepoDelta != "" {
 			c.RepoDelta = row.RepoDelta
 		}
+		// Unlike AllocMB, presence rather than a positive value is the gate:
+		// a genuine zero request or byte count must still be averaged in, not
+		// dropped as if it were a local-backend row that never measured it.
+		if row.HasS3 {
+			requests = append(requests, float64(row.Requests))
+			sentMB = append(sentMB, row.SentMB)
+			if row.ByAPI != "" {
+				c.ByAPI = row.ByAPI
+			}
+		}
 	}
 	if len(peak) == 0 {
 		return Cell{}, false
 	}
 	c.Seconds, c.PeakMB, c.AllocMB = newStat(seconds), newStat(peak), newStat(alloc)
 	c.HasAlloc = len(alloc) > 0
+	c.Requests, c.SentMB = newStat(requests), newStat(sentMB)
+	c.HasS3 = len(requests) > 0
 	return c, true
 }
 
@@ -293,6 +336,18 @@ func (r *Report) hasRepoDelta() bool {
 func (r *Report) hasAlloc() bool {
 	for _, row := range r.Rows {
 		if row.AllocMB > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// hasS3 reports whether any row measured requests and bytes against a MinIO
+// backend. A local-backend run must not grow empty request/byte columns
+// because of it.
+func (r *Report) hasS3() bool {
+	for _, row := range r.Rows {
+		if row.HasS3 {
 			return true
 		}
 	}
@@ -322,7 +377,9 @@ type Metric struct {
 }
 
 var (
-	PeakMB  = Metric{Name: "Peak RSS", Unit: "MB", Value: func(c Cell) Stat { return c.PeakMB }}
-	AllocMB = Metric{Name: "Total allocated", Unit: "MB", Value: func(c Cell) Stat { return c.AllocMB }}
-	Seconds = Metric{Name: "Time", Unit: "s", Value: func(c Cell) Stat { return c.Seconds }}
+	PeakMB   = Metric{Name: "Peak RSS", Unit: "MB", Value: func(c Cell) Stat { return c.PeakMB }}
+	AllocMB  = Metric{Name: "Total allocated", Unit: "MB", Value: func(c Cell) Stat { return c.AllocMB }}
+	Seconds  = Metric{Name: "Time", Unit: "s", Value: func(c Cell) Stat { return c.Seconds }}
+	Requests = Metric{Name: "Requests", Unit: "", Value: func(c Cell) Stat { return c.Requests }}
+	SentMB   = Metric{Name: "Sent", Unit: "MB", Value: func(c Cell) Stat { return c.SentMB }}
 )

--- a/internal/cmd/benchreport/report_test.go
+++ b/internal/cmd/benchreport/report_test.go
@@ -1,4 +1,4 @@
-package benchreport
+package main
 
 import (
 	"os"

--- a/internal/cmd/benchreport/report_test.go
+++ b/internal/cmd/benchreport/report_test.go
@@ -29,6 +29,23 @@ restic,Full Restore,0,9.90,280.4,-
 borg,Full Restore,0,14.20,190.2,-
 `
 
+// A single-size MinIO run: one tool, requests and bytes populated. "check"
+// carries a genuine zero request count — an already-verified repository can
+// legitimately issue no calls — which the report must still show as 0, not as
+// an unmeasured dash.
+const minioComparisonCSV = `tool,operation,scale,seconds,peak_mb,repo_delta,requests,sent_mb,by_api
+cloudstic,backup,5000,1.10,204.2,24.6 MB,25,0,GetObject=8;HeadObject=3;ListObjectsV2=8;PutObject=5
+cloudstic,check,5000,3.50,276.7,0 KB,0,0,
+`
+
+// The same measurements, but as a scaling sweep across tree sizes.
+const minioScalingCSV = `tool,operation,scale,seconds,peak_mb,repo_delta,requests,sent_mb,by_api
+cloudstic,backup,5000,1.10,204.2,24.6 MB,25,0,GetObject=8;HeadObject=3;PutObject=5
+cloudstic,backup,20000,4.32,366.9,100.0 MB,60,0.9,GetObject=17;HeadObject=3;PutObject=13
+cloudstic,restore,5000,11.20,537.2,0 KB,151,505.8,GetObject=143;HeadObject=3;ListObjectsV2=3
+cloudstic,restore,20000,20.46,755.9,0 KB,280,1200.4,GetObject=260;HeadObject=3;ListObjectsV2=3
+`
+
 func parse(t *testing.T, csv string) *Report {
 	t.Helper()
 	rep, err := Parse(strings.NewReader(csv))
@@ -538,6 +555,154 @@ func TestReadAllocMBConvertsToMegabytes(t *testing.T) {
 	}
 	if got != 35 {
 		t.Errorf("got %v MB, want 35", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// S3 columns (requests, bytes, per-API breakdown)
+// ---------------------------------------------------------------------------
+
+// Parse must read the three S3 columns and set HasS3 from their presence,
+// not from whether the values happen to be non-zero.
+func TestParseReadsS3Columns(t *testing.T) {
+	rep := parse(t, minioComparisonCSV)
+	c, ok := rep.cell("cloudstic", "backup", 5000)
+	if !ok {
+		t.Fatal("cell not found")
+	}
+	if !c.HasS3 {
+		t.Fatal("HasS3 should be true for a row with a requests column")
+	}
+	if c.Requests.Median != 25 {
+		t.Errorf("requests = %v, want 25", c.Requests.Median)
+	}
+	if c.ByAPI != "GetObject=8;HeadObject=3;ListObjectsV2=8;PutObject=5" {
+		t.Errorf("by_api = %q", c.ByAPI)
+	}
+}
+
+// A zero request count is a real measurement — an already-verified repository
+// can legitimately issue no calls to check itself — and must render as 0, not
+// as the dash used for a backend that was never measured at all.
+func TestZeroRequestsIsARealMeasurementNotADash(t *testing.T) {
+	rep := parse(t, minioComparisonCSV)
+	c, ok := rep.cell("cloudstic", "check", 5000)
+	if !ok {
+		t.Fatal("cell not found")
+	}
+	if !c.HasS3 {
+		t.Fatal("a row with requests=0 must still count as measured")
+	}
+	if c.Requests.Median != 0 {
+		t.Errorf("requests = %v, want 0", c.Requests.Median)
+	}
+
+	var b strings.Builder
+	if err := Render(&b, rep, "T"); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	line := lineContaining(t, b.String(), "`check`")
+	if !strings.Contains(line, "| 0 |") {
+		t.Errorf("zero requests should render as 0, not a dash:\n%s", line)
+	}
+}
+
+// A malformed requests value is an error, matching every other numeric column:
+// a silent zero in a performance table is indistinguishable from a real zero.
+func TestParseRejectsMalformedRequests(t *testing.T) {
+	_, err := Parse(strings.NewReader(
+		"tool,operation,scale,seconds,peak_mb,requests\ncloudstic,backup,5000,1.0,200.0,many\n"))
+	if err == nil {
+		t.Fatal("expected an error for a non-numeric requests value")
+	}
+	if !strings.Contains(err.Error(), "requests") {
+		t.Errorf("error should name the offending column, got: %v", err)
+	}
+}
+
+// A single-size MinIO run must show requests and bytes in the comparison
+// table, gated the same way alloc and repo_delta are.
+func TestComparisonTableShowsRequestsAndSent(t *testing.T) {
+	var b strings.Builder
+	if err := Render(&b, parse(t, minioComparisonCSV), "T"); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := b.String()
+	if !strings.Contains(out, "Requests |") || !strings.Contains(out, "Sent |") {
+		t.Errorf("requests/sent columns missing; got:\n%s", out)
+	}
+	line := lineContaining(t, out, "`backup`")
+	if !strings.Contains(line, "| 25 |") {
+		t.Errorf("request count missing from backup row; got:\n%s", line)
+	}
+}
+
+// A local-only run — no requests/sent_mb/by_api columns at all — must render
+// exactly as it did before S3 columns existed: no empty Requests/Sent columns,
+// no empty by-API block.
+func TestComparisonTableOmitsRequestsWhenUnmeasured(t *testing.T) {
+	var b strings.Builder
+	if err := Render(&b, parse(t, comparisonCSV), "T"); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := b.String()
+	if strings.Contains(out, "Requests") || strings.Contains(out, "Sent |") {
+		t.Errorf("requests/sent columns rendered for a run that measured neither:\n%s", out)
+	}
+	if strings.Contains(out, "Requests by API") {
+		t.Errorf("by-API block rendered with nothing to show:\n%s", out)
+	}
+}
+
+// A scaling sweep against MinIO gets its own Requests and Sent tables,
+// alongside Peak RSS — the same treatment AllocMB gets.
+func TestScalingReportShowsRequestsAndSentTables(t *testing.T) {
+	var b strings.Builder
+	if err := Render(&b, parse(t, minioScalingCSV), "T"); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := b.String()
+	if !strings.Contains(out, "### Requests") {
+		t.Errorf("requests table missing; got:\n%s", out)
+	}
+	if !strings.Contains(out, "### Sent (MB)") {
+		t.Errorf("sent table missing; got:\n%s", out)
+	}
+	// backup: 60 requests at 20000 files, 25 at 5000 -> 2.40x.
+	if !strings.Contains(out, "2.40x") {
+		t.Errorf("requests growth column missing or wrong; got:\n%s", out)
+	}
+}
+
+// The per-API breakdown is long, so it belongs in a collapsed block rather
+// than a column — but it still has to reach the page.
+func TestByAPIRendersInACollapsedBlock(t *testing.T) {
+	var b strings.Builder
+	if err := Render(&b, parse(t, minioComparisonCSV), "T"); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := b.String()
+	if !strings.Contains(out, "<details>") || !strings.Contains(out, "Requests by API") {
+		t.Errorf("by-API details block missing; got:\n%s", out)
+	}
+	if !strings.Contains(out, "GetObject=8;HeadObject=3;ListObjectsV2=8;PutObject=5") {
+		t.Errorf("by-API breakdown missing; got:\n%s", out)
+	}
+}
+
+// A run with no S3 data must not grow an empty by-API block — the memory
+// sweep and every cross-tool comparison land here.
+func TestByAPIOmittedWhenNoS3Data(t *testing.T) {
+	for name, csv := range map[string]string{"scaling": scalingCSV, "comparison": comparisonCSV} {
+		t.Run(name, func(t *testing.T) {
+			var b strings.Builder
+			if err := Render(&b, parse(t, csv), "T"); err != nil {
+				t.Fatalf("Render: %v", err)
+			}
+			if strings.Contains(b.String(), "Requests by API") {
+				t.Errorf("by-API block rendered with nothing to show:\n%s", b.String())
+			}
+		})
 	}
 }
 

--- a/internal/cmd/benchreport/rusage_other.go
+++ b/internal/cmd/benchreport/rusage_other.go
@@ -1,6 +1,6 @@
 //go:build !unix
 
-package benchreport
+package main
 
 import (
 	"fmt"

--- a/internal/cmd/benchreport/rusage_unix.go
+++ b/internal/cmd/benchreport/rusage_unix.go
@@ -1,6 +1,6 @@
 //go:build unix
 
-package benchreport
+package main
 
 import (
 	"fmt"

--- a/scripts/benchmark/bench.sh
+++ b/scripts/benchmark/bench.sh
@@ -145,7 +145,14 @@ measure() {
     local requests="" sent_mb="" by_api=""
     if [ "$backend" = minio ]; then
         requests=$(( $(minio_requests) - req_before ))
-        sent_mb=$(echo "scale=1; ($(minio_sent_bytes) - sent_before) / 1048576" | bc)
+        # sent_before must be dollar-prefixed here: unlike the arithmetic
+        # context above, this string is parsed by bc, not bash, and bc treats
+        # a bare "sent_before" as its own uninitialized variable — silently 0
+        # — rather than an error. That turned every sample after the first
+        # into the cumulative sent-bytes total since the container started,
+        # not that operation's own delta, since the missing "$" made the
+        # subtraction a no-op.
+        sent_mb=$(echo "scale=1; ($(minio_sent_bytes) - $sent_before) / 1048576" | bc)
         minio_api_counts >"$WORK/api-after"
         by_api=$(minio_api_delta "$WORK/api-before" "$WORK/api-after")
     fi


### PR DESCRIPTION
## Summary
- Fold `internal/benchreport` into `internal/cmd/benchreport` (separate first commit): nothing outside its own CLI wrapper imported it as a library, so the split paid for nothing.
- Split `.github/workflows/benchmark.yml` into two jobs: the existing local sweep stays on `macos-latest` unchanged, and a new MinIO sweep runs on `ubuntu-latest` (confirmed to ship `aws`, `curl` and Docker already — `macos-latest` has none).
- One size, one sample for the MinIO job — deliberately, and stronger than "request counts don't need repeats": `bench.sh` reuses and mutates the same source tree across every sample in a cell (churn, the dedup copy), so a second sample backs up an already-different, bigger tree rather than repeating the measurement — its request/byte counts would reflect that growth, not noise. Confirmed by literally running the same cell twice, as the issue asked before committing to a sample count.
- Teach `internal/cmd/benchreport` the S3 columns: `Requests` and `Sent` get their own gated table columns (mirroring how `AllocMB` and `repo_delta` are gated) and their own scaling-sweep tables alongside Peak RSS. Presence (`HasS3`), not a positive value, is the "measured" signal — a genuine zero request count is real (an already-verified repo can issue none) and must render as `0`, not a dash. The per-API breakdown is long, so it renders in a collapsed `<details>` block rather than a column.
- **Found and fixed a real, pre-existing bug** while doing the "run the same cell twice" check the issue asked for: `bench.sh`'s `sent_mb` calculation referenced `sent_before` *without* a `$` inside the string handed to `bc`, which parses a bare `sent_before` as its own uninitialized variable (silently `0`) rather than bash substituting the value first. Every sample after the first therefore reported the *cumulative* sent-bytes total since the MinIO container started, not that operation's own delta. This has been wrong since MinIO measurement was first added (#465); it was invisible with `SAMPLES=1` because the wrongness only compounds across samples, which is exactly why the determinism check the issue asked for caught it.

Flagged separately (out of scope here): the same verification run showed `restore`/`check` transferring ~40-280x the repository's actual size from MinIO — a possible recurrence of the "pack body cache undersized" issue (#458) referenced in `minio.sh`'s own comments. That's a `cloudstic` performance question, not a benchmark-harness one.

## Verification
- `go build ./...` passes
- `go test ./internal/cmd/benchreport/...` passes, with new cases covering a CSV that carries the S3 columns and one that does not, both scaling and single-size report shapes, and the zero-requests-is-not-a-dash case
- `go test ./internal/cmd/gentree/...` and `go test ./internal/...` pass (consolidation didn't touch behavior)
- `golangci-lint run ./internal/cmd/benchreport/... ./scripts/...` — 0 issues
- `shellcheck scripts/benchmark/bench.sh` — no new issues
- Real runs against MinIO (`SIZES=200` and `SIZES=2000`, `SAMPLES=2`) confirm the `sent_mb` fix: a second sample no longer inherits the first sample's cumulative total
- `.github/workflows/benchmark.yml` parses as valid YAML; the local job's steps are otherwise unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Benchmark reports now include MinIO request counts, transferred data, and per-API activity.
  - Scaling and comparison summaries display storage-related metrics when available, with expandable API breakdowns.
  - Benchmark automation now runs separate local and MinIO performance sweeps with backend-specific results.

- **Bug Fixes**
  - Corrected MinIO transfer measurements so each benchmark sample reports its own bytes sent rather than a cumulative total.

- **Documentation**
  - Updated benchmark documentation to explain local and MinIO runs and their sampling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->