### PR TITLE
feat(ci): lint YAML and shell scripts alongside golangci-lint

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -92,6 +92,8 @@ jobs:
             echo ""
             echo "</details>"
             echo ""
+            # Literal format string for printf, not interpolation.
+            # shellcheck disable=SC2016
             printf 'Ref `%s` on `%s`.\n' "$BENCHMARK_REF" "$RUNNER_OS"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -162,6 +164,8 @@ jobs:
             echo ""
             echo "</details>"
             echo ""
+            # Literal format string for printf, not interpolation.
+            # shellcheck disable=SC2016
             printf 'Ref `%s` on `%s`.\n' "$BENCHMARK_REF" "$RUNNER_OS"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,19 @@ jobs:
         with:
           version: v2.12.2
           args: --timeout=5m
+      # golangci-lint only covers Go; these run once (not per-GOOS, they don't
+      # depend on it) to lint the workflows and shell scripts alongside it.
+      - name: Run yamllint
+        if: matrix.goos == 'linux'
+        run: |
+          pip install --quiet "yamllint==1.38.0"
+          yamllint -c .yamllint.yml .
+      - name: Run actionlint
+        if: matrix.goos == 'linux'
+        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+      - name: Run shellcheck
+        if: matrix.goos == 'linux'
+        run: find scripts -name '*.sh' -print0 | xargs -0 shellcheck --rcfile=.shellcheckrc
 
   vulncheck:
     name: Vulnerabilities
@@ -91,6 +104,8 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
+          # Package paths never contain whitespace.
+          # shellcheck disable=SC2046
           go test -json ${{ matrix.race }} -shuffle=on -coverprofile=unit.out -count=1 \
             $(go list ./... | grep -v '/e2e') | tee test-output.json
       - name: Test report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,10 @@ jobs:
         run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
       - name: Run shellcheck
         if: matrix.goos == 'linux'
-        run: find scripts -name '*.sh' -print0 | xargs -0 shellcheck --rcfile=.shellcheckrc
+        # Relies on shellcheck's automatic .shellcheckrc discovery (repo
+        # root, where this step's cwd already is) rather than --rcfile:
+        # the runner's bundled shellcheck build doesn't support that flag.
+        run: find scripts -name '*.sh' -print0 | xargs -0 shellcheck
 
   vulncheck:
     name: Vulnerabilities

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,6 @@
+# SC2086 (double-quote to prevent globbing/word splitting) fires on every
+# `$flags`-style variable these scripts split intentionally into multiple CLI
+# arguments — quoting it would break the behavior the script wants. Real bugs
+# (redirect order, unset vars in destructive commands, unused vars) are
+# different checks and stay enabled.
+disable=SC2086

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,17 @@
+# Config for `yamllint`, run against every tracked YAML file (workflows,
+# GoReleaser, golangci-lint, Codecov, Dependabot, and any others added later).
+extends: default
+
+rules:
+  # None of the YAML here is multi-document, and GitHub's own workflow
+  # examples never carry a `---` marker — requiring one would fight the
+  # convention every file already follows.
+  document-start: disable
+  # YAML 1.1 treats bare `on`/`off` as booleans, but GitHub Actions requires
+  # the literal mapping key `on:` for the workflow trigger. check-keys: false
+  # limits the truthy check to values, where a stray `yes`/`no` typo is still
+  # worth catching.
+  truthy:
+    check-keys: false
+  line-length:
+    max: 130

--- a/scripts/benchmark/bench.sh
+++ b/scripts/benchmark/bench.sh
@@ -79,9 +79,7 @@ detect_time() {
 TIME_FLAVOUR=$(detect_time)
 [ "$TIME_FLAVOUR" = none ] && { echo "need BSD or GNU time(1)" >&2; exit 2; }
 
-for tool in bc; do
-    command -v "$tool" >/dev/null 2>&1 || { echo "bench.sh needs $tool" >&2; exit 2; }
-done
+command -v bc >/dev/null 2>&1 || { echo "bench.sh needs bc" >&2; exit 2; }
 
 # ---------------------------------------------------------------------------
 # Measurement

--- a/scripts/benchmark/compare.sh
+++ b/scripts/benchmark/compare.sh
@@ -215,7 +215,7 @@ fi
 
 # Reset DATA_DIR to a clean copy of the template
 reset_data_dir() {
-    rm -rf "$DATA_DIR"/*
+    rm -rf "${DATA_DIR:?}"/*
     cp -a "$DATA_TEMPLATE"/ "$DATA_DIR/"
 }
 

--- a/scripts/benchmark/minio.sh
+++ b/scripts/benchmark/minio.sh
@@ -47,8 +47,7 @@ minio_start() {
         -e "MINIO_PROMETHEUS_AUTH_TYPE=public" \
         "$MINIO_IMAGE" server /data >/dev/null || return 1
 
-    local i
-    for i in $(seq 1 60); do
+    for _ in $(seq 1 60); do
         if curl -fs --max-time "$MINIO_CURL_TIMEOUT" "$(minio_endpoint)/minio/health/live" >/dev/null 2>&1; then
             return 0
         fi

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -24,6 +24,18 @@ for goos in linux darwin windows; do
   GOOS=$goos golangci-lint run ./...
 done
 
+echo "==> Running yamllint..."
+pip install --quiet "yamllint==1.38.0"
+yamllint -c .yamllint.yml .
+
+echo "==> Running actionlint..."
+go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+
+# Not go-installable (it's Haskell); install via your package manager
+# (e.g. `brew install shellcheck`, `apt install shellcheck`).
+echo "==> Running shellcheck..."
+find scripts -name '*.sh' -print0 | xargs -0 shellcheck --rcfile=.shellcheckrc
+
 echo "==> Running markdownlint..."
 npx markdownlint-cli2 "**/*.md"
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -34,7 +34,7 @@ go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
 # Not go-installable (it's Haskell); install via your package manager
 # (e.g. `brew install shellcheck`, `apt install shellcheck`).
 echo "==> Running shellcheck..."
-find scripts -name '*.sh' -print0 | xargs -0 shellcheck --rcfile=.shellcheckrc
+find scripts -name '*.sh' -print0 | xargs -0 shellcheck
 
 echo "==> Running markdownlint..."
 npx markdownlint-cli2 "**/*.md"

--- a/scripts/tests/test_hamt.sh
+++ b/scripts/tests/test_hamt.sh
@@ -123,9 +123,9 @@ echo ""
 echo "=== Test 5: Prune + HAMT Integrity ==="
 
 echo "third-change" > "$TMP_DIR/data/file_1.txt"
-$CLI backup $STORE_FLAGS $SOURCE_FLAGS 2>&1 > /dev/null
+$CLI backup $STORE_FLAGS $SOURCE_FLAGS >/dev/null 2>&1
 
-$CLI forget $STORE_FLAGS --keep-last 1 2>&1 > /dev/null
+$CLI forget $STORE_FLAGS --keep-last 1 >/dev/null 2>&1
 PRUNE_OUTPUT=$($CLI prune $STORE_FLAGS --debug 2>&1)
 
 echo "  $(echo "$PRUNE_OUTPUT" | grep -i "repack" | head -3 || true)"
@@ -140,7 +140,7 @@ check "ls after prune shows all 50 files (got $POST_PRUNE_COUNT)" "[ '$POST_PRUN
 echo ""
 echo "=== Test 6: Restore Integrity ==="
 
-$CLI restore $STORE_FLAGS -output "$TMP_DIR/restored.zip" 2>&1 > /dev/null
+$CLI restore $STORE_FLAGS -output "$TMP_DIR/restored.zip" >/dev/null 2>&1
 RESTORED_COUNT=$(unzip -l "$TMP_DIR/restored.zip" 2>/dev/null | grep -c "file_" || true)
 check "restore ZIP contains all 50 files (got $RESTORED_COUNT)" "[ '$RESTORED_COUNT' -eq 50 ]"
 

--- a/scripts/tests/test_repack.sh
+++ b/scripts/tests/test_repack.sh
@@ -48,20 +48,20 @@ for i in $(seq 1 20); do
 done
 
 echo "  initial backup..."
-$CLI backup $STORE1 $SOURCE1 2>&1 > /dev/null
+$CLI backup $STORE1 $SOURCE1 >/dev/null 2>&1
 
 for change in $(seq 1 3); do
   for i in $(seq 1 20); do
     echo "Change $change for file $i" > "$TMP_DIR/data/file_$i.txt"
   done
   echo "  backup $change..."
-  $CLI backup $STORE1 $SOURCE1 2>&1 > /dev/null
+  $CLI backup $STORE1 $SOURCE1 >/dev/null 2>&1
 done
 
-PACKS_BEFORE=$(ls "$TMP_DIR/repo/packs/" 2>/dev/null | wc -l | tr -d ' ')
+PACKS_BEFORE=$(find "$TMP_DIR/repo/packs/" -mindepth 1 -maxdepth 1 2>/dev/null | wc -l | tr -d ' ')
 echo "  packs before prune: $PACKS_BEFORE"
 
-$CLI forget $STORE1 --keep-last 1 2>&1 > /dev/null
+$CLI forget $STORE1 --keep-last 1 >/dev/null 2>&1
 PRUNE_OUTPUT=$($CLI prune $STORE1 --verbose --debug 2>&1)
 PRUNE_CLEAN=$(echo "$PRUNE_OUTPUT" | strip_ansi)
 
@@ -70,7 +70,7 @@ echo "  orphaned packs deleted: $ORPHANS_DELETED"
 
 check "at least 1 orphaned pack deleted (got $ORPHANS_DELETED)" "[ '$ORPHANS_DELETED' -ge 1 ]"
 
-PACKS_AFTER=$(ls "$TMP_DIR/repo/packs/" 2>/dev/null | wc -l | tr -d ' ')
+PACKS_AFTER=$(find "$TMP_DIR/repo/packs/" -mindepth 1 -maxdepth 1 2>/dev/null | wc -l | tr -d ' ')
 echo "  packs after prune: $PACKS_AFTER"
 check "fewer packs after prune ($PACKS_AFTER < $PACKS_BEFORE)" "[ '$PACKS_AFTER' -lt '$PACKS_BEFORE' ]"
 
@@ -95,15 +95,15 @@ for i in $(seq 1 100); do echo "A content $i" > "$TMP_DIR/data2/A_$i.txt"; done
 for i in $(seq 1 100); do echo "B content $i" > "$TMP_DIR/data2/B_$i.txt"; done
 
 echo "  snap 1 (A + B)..."
-$CLI backup $STORE2 $SOURCE2 2>&1 > /dev/null
+$CLI backup $STORE2 $SOURCE2 >/dev/null 2>&1
 
 rm "$TMP_DIR/data2"/B_*.txt
 for i in $(seq 1 100); do echo "C content $i" > "$TMP_DIR/data2/C_$i.txt"; done
 
 echo "  snap 2 (A + C)..."
-$CLI backup $STORE2 $SOURCE2 2>&1 > /dev/null
+$CLI backup $STORE2 $SOURCE2 >/dev/null 2>&1
 
-$CLI forget $STORE2 --keep-last 1 2>&1 > /dev/null
+$CLI forget $STORE2 --keep-last 1 >/dev/null 2>&1
 
 PRUNE2_OUTPUT=$($CLI prune $STORE2 --verbose --debug 2>&1)
 PRUNE2_CLEAN=$(echo "$PRUNE2_OUTPUT" | strip_ansi)
@@ -129,7 +129,7 @@ check "ls shows 100 C files (got $C_COUNT)" "[ '$C_COUNT' -eq 100 ]"
 echo ""
 echo "=== Test 3: Restore Integrity After Repack ==="
 
-$CLI restore $STORE2 -output "$TMP_DIR/restored.zip" 2>&1 > /dev/null
+$CLI restore $STORE2 -output "$TMP_DIR/restored.zip" >/dev/null 2>&1
 RESTORED_A=$(unzip -l "$TMP_DIR/restored.zip" 2>/dev/null | grep -c "A_" || true)
 RESTORED_C=$(unzip -l "$TMP_DIR/restored.zip" 2>/dev/null | grep -c "C_" || true)
 RESTORED_B=$(unzip -l "$TMP_DIR/restored.zip" 2>/dev/null | grep -c "B_" || true)

--- a/scripts/tests/test_selective_restore.sh
+++ b/scripts/tests/test_selective_restore.sh
@@ -44,7 +44,7 @@ $CLI backup $STORE -source gdrive 2>&1 | strip_ansi | tail -5
 
 # Verify backup created a snapshot
 LS_OUTPUT=$($CLI ls $STORE 2>&1)
-TOTAL_FILES=$(echo "$LS_OUTPUT" | strip_ansi | grep -v "^$" | grep -v "Listing" | grep -v "entries listed" | wc -l | tr -d ' ')
+TOTAL_FILES=$(echo "$LS_OUTPUT" | strip_ansi | grep -v "^$" | grep -v "Listing" | grep -vc "entries listed")
 echo "  total entries in snapshot: $TOTAL_FILES"
 check "backup has at least 1 entry" "[ '$TOTAL_FILES' -ge 1 ]"
 
@@ -91,7 +91,7 @@ if [ -n "$FOLDER" ]; then
   check "subtree restore is smaller than full" "[ '$SUBTREE_COUNT' -le '$FULL_COUNT' ]"
 
   # Verify all entries are under the selected folder.
-  OUTSIDE=$(zip_entries "$TMP_DIR/subtree.zip" | grep -v "^${FOLDER}" | wc -l | tr -d ' ')
+  OUTSIDE=$(zip_entries "$TMP_DIR/subtree.zip" | grep -vc "^${FOLDER}")
   check "no files outside subtree (got $OUTSIDE)" "[ '$OUTSIDE' -eq 0 ]"
 else
   echo ""
@@ -106,7 +106,7 @@ if [ -n "$FILE" ]; then
   echo "=== Step 4: Selective Restore — Single File ($FILE) ==="
 
   $CLI restore $STORE -output "$TMP_DIR/single.zip" -path "$FILE" 2>&1 | strip_ansi | tail -3
-  SINGLE_FILES=$(zip_entries "$TMP_DIR/single.zip" | grep -v '/$' | wc -l | tr -d ' ')
+  SINGLE_FILES=$(zip_entries "$TMP_DIR/single.zip" | grep -vc '/$')
   echo "  files in single-file restore: $SINGLE_FILES"
   check "single-file restore has exactly 1 file" "[ '$SINGLE_FILES' -eq 1 ]"
 


### PR DESCRIPTION
## Summary
- Add `yamllint` for every YAML file, `actionlint` (with its shellcheck integration) for the GitHub Actions workflows, and `shellcheck` for `scripts/*.sh`, all running once per CI run on the linux leg of the existing `Lint` job's GOOS matrix — golangci-lint only ever covered Go.
- Config: `.yamllint.yml` (disables `document-start`, since no file here uses `---`, and limits `truthy` to values so the required `on:` workflow-trigger key doesn't false-positive) and `.shellcheckrc` (disables only SC2086, the intentional unquoted `$flags`-splitting idiom used throughout these scripts).
- Fix the two real issues actionlint's shellcheck integration found: a word-splitting warning on the package list piped into `go test` in `ci.yml`, and a false positive on the literal backtick format string in `benchmark.yml`'s `printf` (from the recent template-injection fix in 71a35fe) — both annotated with a `# shellcheck disable` and a reason comment.
- Fix real bugs shellcheck found while adopting it: `test_hamt.sh`/`test_repack.sh` redirected `2>&1 > /dev/null`, which — because redirect order matters — sent stdout to `/dev/null` but left stderr on the terminal; fixed to `>/dev/null 2>&1`. `compare.sh`'s `reset_data_dir` ran `rm -rf "$DATA_DIR"/*` with no guard against `DATA_DIR` ever being empty; guarded with `"${DATA_DIR:?}"`. Also swapped a couple of `ls | wc -l` / `grep -v | wc -l` pipelines for `find` and `grep -vc`, dropped an unused loop variable, and collapsed a for-loop that only ever ran once.
- `scripts/check.sh`, the local mirror of CI, now runs all three so a green `./scripts/check.sh` matches a green PR check.

## Verification
- `go build ./...`
- `golangci-lint run ./...`
- `yamllint -c .yamllint.yml .`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- `find scripts -name '*.sh' -print0 | xargs -0 shellcheck --rcfile=.shellcheckrc`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved benchmark cleanup safety by preventing deletion when the data directory is unset or empty.
  * Made test output suppression and file-count checks more reliable across environments.
  * Simplified dependency validation for benchmark scripts.

* **Chores**
  * Added automated validation for YAML, GitHub Actions workflows, and shell scripts.
  * Added consistent linting rules and inline documentation for workflow commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->