### PR TITLE
chore(github): add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -1,0 +1,110 @@
+name: Bug report
+description: Report reproducible behavior that is incorrect or unsafe
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Search existing issues before filing a new one. For a security
+        vulnerability, use the private security-reporting link in the template
+        chooser instead of this form.
+
+        Use a specific title with no trailing period. Do not include passwords,
+        access keys, recovery keys, tokens, or unredacted debug output.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What were you trying to do, and why?
+      placeholder: Describe the command, workflow, source, and store involved.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Provide the smallest repeatable sequence that demonstrates the problem.
+      placeholder: |
+        1. Configure ...
+        2. Run `cloudstic ...`
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened? Include the exact error when one was reported.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead?
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Cloudstic version
+      description: Paste the version and build information reported by Cloudstic.
+      placeholder: cloudstic version ...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: operating-system
+    attributes:
+      label: Operating system
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Relevant configuration
+      description: |
+        Include source/store types and relevant flags. Redact credentials and
+        private paths. Say whether the repository uses encryption or packfiles
+        when that could matter.
+      placeholder: |
+        Source: local
+        Store: S3-compatible
+        Packfiles: enabled
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or additional evidence
+      description: |
+        Add a minimal redacted log, stack trace, benchmark, or screenshot. The
+        `-debug` flag may expose paths and backend details, so inspect its output
+        before posting it.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: Optional concrete checks that would prove the bug is fixed and remains fixed.
+      placeholder: |
+        - A regression test reproduces the failure on the current release.
+        - The same sequence completes successfully after the fix.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/02-work-item.yml
+++ b/.github/ISSUE_TEMPLATE/02-work-item.yml
@@ -1,0 +1,95 @@
+name: Work item or proposal
+description: Propose a feature, refactor, performance improvement, test, or tracking issue
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This form follows the structure used by existing Cloudstic issues:
+        context, goal, scope, and acceptance criteria.
+
+        Use an imperative title such as “Add …” or “Separate …”, or an area
+        prefix such as “TUI: …”. Do not use a conventional-commit prefix or a
+        trailing period.
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Kind of work
+      options:
+        - Feature or enhancement
+        - Performance or scaling
+        - Refactor or technical debt
+        - Test, CI, documentation, or maintenance
+        - Tracking issue or RFC
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Explain the current behavior, evidence, constraints, and why the work matters now.
+      placeholder: Link relevant code, issues, RFCs, measurements, or prior decisions where useful.
+    validations:
+      required: true
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: State the outcome in terms of observable behavior, not an implementation detail.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Describe the work that belongs in this issue and the important design constraints.
+      placeholder: |
+        - Change ...
+        - Preserve ...
+        - Document ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope
+      description: Record nearby work or tempting expansions that this issue should not include.
+    validations:
+      required: false
+
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Repository compatibility
+      description: |
+        If this may change bytes written to a store, explain how old repositories
+        remain readable and whether the repository format version must change.
+        Otherwise write “No repository format change.”
+      placeholder: No repository format change.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: List specific, verifiable outcomes, including focused tests and lint commands.
+      placeholder: |
+        - The new behavior is covered by a regression test.
+        - `go test -count=1 ./path/to/package` passes.
+        - `golangci-lint run ./path/to/package/...` passes.
+    validations:
+      required: true
+
+  - type: textarea
+    id: related
+    attributes:
+      label: Related work
+      description: Link parent, child, blocked, superseded, or otherwise related issues and RFCs.
+      placeholder: "Related to #123."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/Cloudstic/cli/security/advisories/new
+    about: Report vulnerabilities privately instead of opening a public issue.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,53 @@
+<!--
+PR titles become squash-merge commit subjects. Use a Conventional Commit title:
+`type(scope): imperative summary` (for example, `fix(store): reject truncated
+pack footers`). Keep it concise, lowercase the summary after the colon, and omit
+the trailing period.
+-->
+
+## Summary
+
+<!--
+Explain what changed and why. Prefer a short set of concrete bullets. Add
+measurements, design rationale, screenshots, or scope notes below when they help
+a reviewer evaluate this particular change.
+-->
+
+-
+
+## Related issues
+
+<!-- Use `Closes #123` when merging this PR should close an issue. -->
+
+Closes #
+
+## Repository compatibility
+
+<!--
+If this changes anything written to a store, explain the legacy read path, safe
+failure behavior for older builds, and any repository-format version decision.
+Read docs/compatibility.md before making such a change. Otherwise keep the line
+below.
+-->
+
+No repository format change.
+
+## Verification
+
+<!--
+List the exact automated and manual checks run, with their result. Include a
+focused regression test when fixing a bug. For performance-sensitive changes,
+include before/after measurements and consider adding the `benchmark` label.
+-->
+
+- `go test -count=1 ./...`
+- `golangci-lint run ./...`
+
+## Documentation
+
+<!--
+Describe documentation changes, or explain why none are needed. Exported API
+changes should be paired with an update to the separate Cloudstic docs repo.
+-->
+
+No documentation change required.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -427,9 +427,30 @@ One set of rules for commit, PR, and issue titles (derived from repo history).
 
 ## Creating GitHub Issues
 
-Create issues with `gh issue create` against `Cloudstic/cli`. Match the existing house style (see #155, #250–#253 as references).
+Create issues with `gh issue create` against `Cloudstic/cli`. The forms under
+`.github/ISSUE_TEMPLATE/` are the source of truth even when the CLI bypasses the
+web template chooser. Match the existing house style (see #155, #250–#253 as
+references).
 
-**Body structure** — use these four Markdown sections, in order:
+Never open a public issue for a suspected vulnerability. Direct it to the
+repository's private security-advisory form, as configured in
+`.github/ISSUE_TEMPLATE/config.yml`.
+
+**Bug reports** — follow `01-bug-report.yml`. Include these sections in order:
+
+- `Context`
+- `Reproduction`
+- `Actual behavior`
+- `Expected behavior`
+- `Cloudstic version`
+- `Operating system`
+- `Relevant configuration` when it matters
+- `Logs or additional evidence` when available, with secrets and private paths
+  redacted
+- `Acceptance criteria` when the regression has concrete proof conditions
+
+**Work items and proposals** — follow `02-work-item.yml`. Use these core
+Markdown sections in order:
 
 ```markdown
 ## Context
@@ -442,6 +463,10 @@ One or two sentences on the desired end state.
 
 ## Scope
 - bullet list of the concrete changes to make
+
+## Repository compatibility
+State how old repositories remain readable and whether the format version must
+change, or write "No repository format change."
 
 ## Acceptance Criteria
 - bullet list of verifiable outcomes
@@ -462,27 +487,42 @@ Do not invent new labels — reuse what `gh label list` returns.
 
 ## Creating Pull Requests
 
-Open PRs with `gh pr create` against `Cloudstic/cli`. Match the existing house style (see #214, #228, #236, #237 as references).
+Open PRs with `gh pr create` against `Cloudstic/cli`. Use
+`.github/pull_request_template.md` as the source of truth even when constructing
+the body non-interactively. Match the existing house style (see #214, #228,
+and #236–#237 as references).
 
 **Branch names** — `<type>/<kebab-slug>`, where the type mirrors the label vocabulary: `feat/`, `refactor/`, `test/`, `chore/`, `fix/`, `docs/` (e.g. `feat/tui-profile-history`, `refactor/tui-profile-modal-state`). Dependabot branches (`dependabot/...`) are machine-generated — leave them alone.
 
 **Titles** — see Naming Conventions above. Use a Conventional Commit prefix (`type: …` or `type(scope): …`) matching the branch type; because PRs squash-merge, the title becomes the commit subject.
 
-**Body structure** — two Markdown sections:
+**Body structure** — use these Markdown sections:
 
 ```markdown
 ## Summary
 - bullet list of the concrete changes, imperative voice
 
-<link line: `Closes #NNN`, `Part of #NNN`, or `Fixes #NNN`>
+## Related issues
+<`Closes #NNN`, `Part of #NNN`, `Fixes #NNN`, or `None`>
+
+## Repository compatibility
+<compatibility and version-gate decision, or `No repository format change.`>
 
 ## Verification
 - <exact test command run, scoped to the touched packages>
 - <exact lint command run, scoped to the touched packages>
+
+## Documentation
+<documentation changes, or `No documentation change required.`>
 ```
 
 - Keep the `Summary` bullets high-signal — what changed and why, not a file-by-file diff.
-- The link line ties the PR to its issue; omit it only for standalone work.
+- `Related issues` ties the PR to its issue; write `None` only for standalone work.
+- Read `docs/compatibility.md` before changing anything written to a store. The
+  compatibility section must identify the legacy read path, safe failure
+  behavior for older builds, and repository-format version decision.
+- Exported API changes must be paired with an update to the separate Cloudstic
+  docs repository; say so in `Documentation`.
 - Under `Verification`, paste the **exact commands you ran**, scoped to the packages you touched, using the repo's cache-env prefixes so they reproduce in CI:
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -398,6 +398,29 @@ clearer failure.
 - Use `-race` flag during development to catch race conditions.
 - Hermetic tests (default) use local filesystem + containers; no cloud credentials needed.
 
+## Commit Hygiene
+
+Treat the staged file list as a security and release boundary. Ad-hoc build
+binaries (`cs` and `cs439`, about 90 MB combined) reached main in the past; a
+matching `.gitignore` rule is a backstop, not a substitute for reviewing what a
+commit contains.
+
+- Run `git status --short` before staging and account for every modified and
+  untracked path. Existing changes may belong to the user or another workstream.
+- Stage only explicit paths that were intentionally created or modified for the
+  current task. Never use `git add .`, `git add -A`, a directory-wide add, or a
+  wildcard that can sweep up files you have not reviewed.
+- Never add a binary file. Do not commit compiled executables, archives,
+  profiles, coverage output, scratch data, credentials, tokens, or other build
+  and runtime artifacts.
+- Before committing, inspect `git diff --cached --name-status` and
+  `git diff --cached --stat`, then review the staged diff for every text file.
+  Use `file -- <path>` when a file's type is not obvious. Every staged path must
+  be known, intentional, and explainable.
+- Run `git diff --cached --check`. If anything unexpected is staged, unstage it
+  without deleting the working-tree file, investigate how it got there, and do
+  not commit until the index contains only reviewed files.
+
 ## Naming Conventions
 
 One set of rules for commit, PR, and issue titles (derived from repo history).


### PR DESCRIPTION
## Summary

- Add a structured bug-report form covering reproduction, expected and actual behavior, environment details, redacted evidence, and acceptance criteria.
- Add a general work-item form that follows the Context, Goal, Scope, and Acceptance Criteria structure used throughout the existing issue history.
- Configure the issue chooser to direct vulnerability reports to private security advisories while retaining blank issues for maintainers.
- Add a pull request template covering related issues, repository compatibility, verification, and documentation, with the project title convention included as author guidance.
- Update `AGENTS.md` so CLI-created issues and PRs follow the same templates, security path, compatibility checks, and documentation expectations.
- Require agents to stage only explicit reviewed paths, inspect every staged file and diff, and never commit binaries or unknown build/runtime artifacts; record the prior accidental `cs`/`cs439` binaries as the reason for the rule.

## Related issues

None.

## Repository compatibility

No repository format change.

## Verification

- `yamllint -f parsable -c .yamllint.yml .github/ISSUE_TEMPLATE` — passes
- Ruby YAML safe parsing of every issue-template file — passes
- `npx --yes markdownlint-cli2 AGENTS.md .github/pull_request_template.md` — 0 issues
- `git diff --check` and `git diff --cached --check` — pass
- Reviewed `git diff --cached --name-status`, `git diff --cached --stat`, the complete staged `AGENTS.md` diff, and `file -- AGENTS.md` before committing

## Documentation

Updated `AGENTS.md` with the template workflow and commit-hygiene rules; no user-facing documentation change required.