### PR TITLE
perf(engine): fetch restore metadata in pack order, not walk order

### DIFF
--- a/internal/engine/restore.go
+++ b/internal/engine/restore.go
@@ -755,11 +755,13 @@ func (rm *RestoreManager) resolveSnapshot(ctx context.Context, ref string) (*cor
 // collectMetadata loads every entry in the snapshot, and reports the order the
 // tree walk yielded them in as well as the entries themselves.
 //
-// The order matters to what comes after. Objects are laid out in packfiles in
-// the order backup wrote them, and the walk yields them in that same order, so
-// reading in walk order touches each pack once. Restoring in some other order
-// scatters reads across every pack instead — measured at 55% pack-cache misses
-// against 0.6% for this phase (RFC 0023).
+// The order matters to what comes after, and the two orders are different.
+// Restore *writes* in walk order, because that is the order backup laid entries
+// out and writing in any other scatters reads across every pack — measured at
+// 55% pack-cache misses against 0.6% (RFC 0023). Restore *fetches* in whatever
+// order the store says is cheapest, which on a repository built by several
+// backups is not walk order at all: each backup's entries sit in its own packs,
+// so the walk interleaves them. See the grouping below.
 func (rm *RestoreManager) collectMetadata(ctx context.Context, root string) (map[string]core.FileMeta, []string, error) {
 	var refs []string
 	err := rm.tree.Walk(ctx, root, func(_, valueRef string) error {
@@ -784,9 +786,41 @@ func (rm *RestoreManager) collectMetadata(ctx context.Context, root string) (map
 	walkOrder := make([]string, len(refs))
 	var mu sync.Mutex
 
+	// Fetch in the order the store says is cheapest, which is not the order the
+	// walk produced. Walk order matches the layout of whichever backup wrote
+	// each entry, so on a repository built by several backups it interleaves
+	// packs — and a pack read in pieces spread across the fetch is transferred,
+	// evicted and transferred again. Handing the whole set over first lets
+	// PackStore group it, because it is the layer that knows where objects live
+	// and this is the one moment the full set is known in advance.
+	//
+	// walkOrder is unaffected: it is filled by index below, so the order results
+	// are *fetched* in is independent of the order restore *writes* in, which
+	// must stay walk order (RFC 0023 §5).
+	order := make([]int, len(refs))
+	for i := range refs {
+		order[i] = i
+	}
+	if len(refs) > 1 {
+		byRef := make(map[string][]int, len(refs))
+		for i, ref := range refs {
+			byRef[ref] = append(byRef[ref], i)
+		}
+		order = order[:0]
+		for _, ref := range store.GroupByLocality(rm.store, refs) {
+			// A ref can appear more than once when two entries share a
+			// filemeta object; each occurrence gets its own index, and the
+			// grouped list names the ref once per occurrence.
+			idx := byRef[ref]
+			order = append(order, idx[0])
+			byRef[ref] = idx[1:]
+		}
+	}
+
 	g, gCtx := errgroup.WithContext(ctx)
 	g.SetLimit(store.GetConcurrencyHint(rm.store, 10))
-	for i, ref := range refs {
+	for _, i := range order {
+		ref := refs[i]
 		g.Go(func() error {
 			fm, err := rm.metas.load(gCtx, ref)
 			if err != nil {

--- a/internal/storelayer/pack.go
+++ b/internal/storelayer/pack.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 
@@ -490,6 +491,67 @@ const (
 	// fine.
 	packMissWindow = 64
 )
+
+// GroupByLocality orders keys so that objects sharing a packfile are read
+// consecutively, implementing store.LocalityGrouper.
+//
+// A pack is transferred as a unit once enough of it is wanted (see
+// packPromoteAfter), and stays cached only while it is the recently-used one.
+// Reading a pack's keys scattered among other packs' keys therefore transfers
+// it, evicts it, and transfers it again; reading them consecutively transfers
+// it once and serves the rest from memory. The keys are the same either way —
+// only the order changes, and only the caller knows the whole set in advance.
+//
+// Ordering is by (pack ref, offset), so reads also run forwards through each
+// pack rather than seeking around inside it.
+//
+// Keys with no catalog entry — large objects stored standalone, anything not
+// packed — keep their relative order and follow the packed ones. They are
+// unaffected by pack locality, so there is nothing to gain by moving them
+// relative to each other, and a caller may hand over a mixed set without
+// having to know which is which.
+//
+// This is a hint, not a contract: the result is always a permutation of the
+// input, so a caller that ignores it reads exactly the same objects.
+func (s *PackStore) GroupByLocality(keys []string) []string {
+	if len(keys) < 2 {
+		return keys
+	}
+
+	type placed struct {
+		key   string
+		entry PackEntry
+	}
+	packed := make([]placed, 0, len(keys))
+	loose := make([]string, 0)
+
+	s.mu.RLock()
+	for _, key := range keys {
+		if entry, ok := s.catalog.Get(key); ok {
+			packed = append(packed, placed{key: key, entry: entry})
+		} else {
+			loose = append(loose, key)
+		}
+	}
+	s.mu.RUnlock()
+
+	// The catalog is consulted without loading it. Grouping is an optimisation,
+	// and forcing a catalog load here would turn a hint into an I/O dependency
+	// on a path that has not asked to read anything yet; an unloaded catalog
+	// simply yields the input order back.
+	sort.SliceStable(packed, func(i, j int) bool {
+		if packed[i].entry.PackRef != packed[j].entry.PackRef {
+			return packed[i].entry.PackRef < packed[j].entry.PackRef
+		}
+		return packed[i].entry.Offset < packed[j].entry.Offset
+	})
+
+	out := make([]string, 0, len(keys))
+	for _, p := range packed {
+		out = append(out, p.key)
+	}
+	return append(out, loose...)
+}
 
 // rangesNatively reports whether a ranged read on s reaches a backend that
 // serves it as a ranged read, rather than one that emulates it by transferring

--- a/internal/storelayer/packlocality_test.go
+++ b/internal/storelayer/packlocality_test.go
@@ -1,0 +1,222 @@
+package storelayer
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/cloudstic/cli/pkg/store"
+	"github.com/cloudstic/cli/pkg/store/local"
+)
+
+// assertPermutation is the invariant every other property rests on: grouping is
+// a reordering and nothing else. A caller hands over the keys it intends to
+// read, so dropping one silently loses an object and duplicating one reads it
+// twice.
+func assertPermutation(t *testing.T, in, out []string) {
+	t.Helper()
+	if len(in) != len(out) {
+		t.Fatalf("grouping returned %d keys for %d input keys", len(out), len(in))
+	}
+	a := append([]string(nil), in...)
+	b := append([]string(nil), out...)
+	sort.Strings(a)
+	sort.Strings(b)
+	for i := range a {
+		if a[i] != b[i] {
+			t.Fatalf("grouping is not a permutation: %q became %q", a[i], b[i])
+		}
+	}
+}
+
+// seedPacks writes perPack objects into each of packs packfiles and returns the
+// keys in the order they were written.
+func seedPacks(t *testing.T, ctx context.Context, base store.ObjectStore, packs, perPack int) ([]string, *PackStore) {
+	t.Helper()
+	w, err := NewPackStore(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := bytes.Repeat([]byte("p"), 4*1024)
+	var keys []string
+	for p := 0; p < packs; p++ {
+		for i := 0; i < perPack; i++ {
+			key := fmt.Sprintf("filemeta/%064x", p*1000+i)
+			if err := w.Put(ctx, key, payload); err != nil {
+				t.Fatal(err)
+			}
+			keys = append(keys, key)
+		}
+		if err := w.Flush(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return keys, w
+}
+
+// The property the change exists for: keys that share a pack come out adjacent,
+// so a reader working through the result transfers each pack once instead of
+// returning to it.
+func TestPackStore_GroupByLocalityClustersKeysSharingAPack(t *testing.T) {
+	ctx := context.Background()
+	base, err := local.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	const packs, perPack = 5, 8
+	keys, w := seedPacks(t, ctx, base, packs, perPack)
+
+	// Interleave across packs, which is what a walk over a repository built by
+	// several backups produces.
+	var scattered []string
+	for i := 0; i < perPack; i++ {
+		for p := 0; p < packs; p++ {
+			scattered = append(scattered, keys[p*perPack+i])
+		}
+	}
+
+	got := w.GroupByLocality(scattered)
+	assertPermutation(t, scattered, got)
+
+	// Count how many times the result crosses from one pack to another. Grouped
+	// perfectly that is packs-1; scattered it is close to len(keys)-1.
+	packOf := func(key string) string {
+		entry, ok := w.catalog.Get(key)
+		if !ok {
+			t.Fatalf("key %s is not in the catalog", key)
+		}
+		return entry.PackRef
+	}
+	transitions := 0
+	for i := 1; i < len(got); i++ {
+		if packOf(got[i]) != packOf(got[i-1]) {
+			transitions++
+		}
+	}
+	if transitions != packs-1 {
+		t.Errorf("result crosses packs %d times, want %d (one run per pack)", transitions, packs-1)
+	}
+	if before := packs*perPack - 1; transitions >= before {
+		t.Errorf("grouping did not reduce pack transitions at all (%d vs %d scattered)", transitions, before)
+	}
+}
+
+// Within a pack, reads should run forwards rather than seeking around.
+func TestPackStore_GroupByLocalityOrdersByOffsetWithinAPack(t *testing.T) {
+	ctx := context.Background()
+	base, err := local.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	keys, w := seedPacks(t, ctx, base, 1, 12)
+
+	reversed := make([]string, len(keys))
+	for i, k := range keys {
+		reversed[len(keys)-1-i] = k
+	}
+
+	got := w.GroupByLocality(reversed)
+	assertPermutation(t, reversed, got)
+
+	last := int64(-1)
+	for _, k := range got {
+		entry, ok := w.catalog.Get(k)
+		if !ok {
+			t.Fatalf("key %s is not in the catalog", k)
+		}
+		if entry.Offset < last {
+			t.Fatalf("offsets are not ascending within the pack: %d after %d", entry.Offset, last)
+		}
+		last = entry.Offset
+	}
+}
+
+// Keys the catalog knows nothing about must survive, so a caller can hand over
+// a mixed set without first working out which is which.
+func TestPackStore_GroupByLocalityKeepsUnknownKeys(t *testing.T) {
+	ctx := context.Background()
+	base, err := local.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	keys, w := seedPacks(t, ctx, base, 2, 4)
+
+	mixed := []string{"chunk/unknown-a", keys[3], "chunk/unknown-b", keys[0], "chunk/unknown-c"}
+	got := w.GroupByLocality(mixed)
+	assertPermutation(t, mixed, got)
+
+	// Unknown keys keep their relative order among themselves.
+	var unknown []string
+	for _, k := range got {
+		if _, packed := w.catalog.Get(k); !packed {
+			unknown = append(unknown, k)
+		}
+	}
+	want := []string{"chunk/unknown-a", "chunk/unknown-b", "chunk/unknown-c"}
+	for i := range want {
+		if unknown[i] != want[i] {
+			t.Fatalf("unknown keys reordered: got %v, want %v", unknown, want)
+		}
+	}
+}
+
+// A store that cannot group returns the caller's order, and the helper has to
+// find PackStore underneath the wrappers that sit above it in the real chain.
+func TestGroupByLocality_WalksTheWrapperChain(t *testing.T) {
+	ctx := context.Background()
+	base, err := local.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	keys, w := seedPacks(t, ctx, base, 3, 6)
+
+	// No grouper anywhere in the chain: the input comes back untouched.
+	if got := store.GroupByLocality(base, keys); len(got) != len(keys) {
+		t.Fatalf("plain backend changed the key count")
+	} else {
+		for i := range keys {
+			if got[i] != keys[i] {
+				t.Fatalf("plain backend reordered keys at %d", i)
+			}
+		}
+	}
+
+	// PackStore under the wrappers it really runs under.
+	chain := NewCompressedStore(NewEncryptedStore(w, testKey(t)))
+	scattered := []string{keys[12], keys[0], keys[6], keys[13], keys[1]}
+	got := store.GroupByLocality(chain, scattered)
+	assertPermutation(t, scattered, got)
+
+	direct := w.GroupByLocality(scattered)
+	for i := range direct {
+		if got[i] != direct[i] {
+			t.Fatalf("grouping through the chain differs from grouping directly: %v vs %v", got, direct)
+		}
+	}
+}
+
+// Grouping must not force a catalog load. It is a hint issued before any read,
+// and turning it into I/O would make a caller pay for advice it can ignore.
+func TestPackStore_GroupByLocalityDoesNotLoadTheCatalog(t *testing.T) {
+	base, err := local.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader, err := NewPackStore(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	in := []string{"filemeta/a", "filemeta/b", "filemeta/c"}
+	got := reader.GroupByLocality(in)
+	assertPermutation(t, in, got)
+	if reader.catalogLoaded {
+		t.Error("grouping loaded the catalog; it must stay a no-I/O hint")
+	}
+	for i := range in {
+		if got[i] != in[i] {
+			t.Fatalf("with no catalog loaded the input order should survive, got %v", got)
+		}
+	}
+}

--- a/pkg/store/interface.go
+++ b/pkg/store/interface.go
@@ -47,6 +47,46 @@ type RangeGetter interface {
 	GetRange(ctx context.Context, key string, offset, length int64) ([]byte, error)
 }
 
+// LocalityGrouper is an optional interface for stores that know something about
+// where objects physically live, and can say which order is cheapest to read a
+// set of them in.
+//
+// A caller that knows every key it is about to read — a restore has its whole
+// plan before it fetches anything — can hand them over and get back a cheaper
+// ordering. The store that benefits is one bundling many objects per transfer:
+// reading a bundle's keys consecutively transfers it once, where reading them
+// scattered among other bundles' keys can transfer it repeatedly.
+//
+// Implementations return a permutation: the same keys, once each, no additions
+// and no drops. Keys the store knows nothing about keep their relative order,
+// so a partially-known set is still safe to hand over wholesale.
+//
+// Backends with no such structure simply do not implement it, and callers get
+// their own order back — correct everywhere, merely no faster.
+type LocalityGrouper interface {
+	GroupByLocality(keys []string) []string
+}
+
+// GroupByLocality walks the store wrapper chain and applies the first
+// LocalityGrouper it finds, returning keys unchanged if none exists.
+//
+// The walk matters: PackStore is the store that knows about locality, and it
+// sits beneath CompressedStore, EncryptedStore and MeteredStore, so a caller
+// holding the outermost wrapper cannot see it directly.
+func GroupByLocality(s ObjectStore, keys []string) []string {
+	for s != nil {
+		if g, ok := s.(LocalityGrouper); ok {
+			return g.GroupByLocality(keys)
+		}
+		if u, ok := s.(Unwrapper); ok {
+			s = u.Unwrap()
+		} else {
+			break
+		}
+	}
+	return keys
+}
+
 // GetConcurrencyHint walks the store wrapper chain and returns the first
 // ConcurrencyHint it finds, defaulting to defaultConcurrency if none exists.
 func GetConcurrencyHint(s ObjectStore, defaultConcurrency int) int {


### PR DESCRIPTION
## Summary

`restore` knows every ref it will read before it reads any of them —
`collectMetadata` builds `refs[]` from the tree walk, then dispatches them. It was
dispatching in **walk order**, which matches the layout of whichever backup wrote
each entry, so on a repository built by several backups it interleaves packs and a
pack is transferred, evicted, and transferred again.

- Adds `store.LocalityGrouper`, an optional capability alongside `ConcurrencyHinter`
  and `RangeGetter`, with a chain-walking helper mirroring `GetConcurrencyHint` —
  `PackStore` knows where objects live but sits under `CompressedStore`,
  `EncryptedStore` and `MeteredStore`, so a caller holding the outermost wrapper
  can't reach it.
- `PackStore` orders by `(PackRef, Offset)`. Keys with no catalog entry keep their
  relative order and follow, so a caller can hand over a mixed set without
  classifying it first. It's a hint: always a permutation, never I/O.
- `collectMetadata` applies it to the **fetch** order only. `walkOrder` is filled by
  index, so restore still *writes* in walk order (#455 preserved, not traded).

Closes part of #480.

## Measurements

MinIO, 5,000 files, full benchmark pipeline:

| | before | after | |
|---|---|---|---|
| `restore` | 10,650 req | **5,666 req** | −47% |
| `restore-no-verify` | 10,593 req | **4,133 req** | −61% |

`check` and `prune` are untouched by construction — `GroupByLocality` has one call
site and `collectMetadata` has one caller. (A single-sample `prune` delta appeared
in the same run; that path is unreachable from this change, and `prune` was already
noted as bimodal in #458.)

## The null result matters more than the win

This was framed as the cheap test of RFC 0025's premise, and **it corrected the
premise.**

On a repository whose packs fit the cache — 9 packs against an 8-pack budget —
grouping changed *nothing*: 112 requests before and after, byte-identical output,
with **6,375 of 6,376 refs genuinely reordered**. Ordering prevents a pack being
*re*-fetched; when the working set fits, there is no re-fetch to prevent.

So the **+9 requests per contributing backup is a first-contact cost** — the
`packPromoteAfter` probe sequence — **not a re-contact cost.** Ordering cannot touch
it; only knowing demand up front can.

That inverts what I predicted when proposing this. RFC 0025 §1 (order) and §2
(demand counting) address **different** costs rather than overlapping:

- **§1 ordering** pays off only once the working set overruns the cache
- **§2 demand counting** is the only thing that removes the probe sequence

It also means the heuristic cluster (`packPromoteAfter`, `packPenalized`) **cannot**
be retired by ordering alone, which was the hoped-for simplification. I'll fold this
into RFC 0025.

## Verification

- `go test -race ./internal/... ./pkg/... .` passes
- `golangci-lint run ./internal/... ./pkg/...` — 0 issues
- New `packlocality_test.go`: permutation invariant, pack clustering (transitions
  drop to exactly `packs-1`), offset ordering within a pack, unknown-key survival,
  chain walking, and that grouping forces no catalog load
- Restore output verified byte-identical (same tree hash) before and after, on a
  repository built by seven backups

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Improved restore operations by grouping packed-object reads by storage locality.
  - Preserved restore write order while optimizing concurrent metadata loading.
  - Ordered objects within packs by location for more efficient access.

- **Reliability**
  - Duplicate references are retained and processed independently.
  - Unknown or unsupported objects continue to preserve their original order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->