### PR TITLE
perf(store): declare read demand to PackStore instead of probing for it

### DIFF
--- a/internal/engine/restore.go
+++ b/internal/engine/restore.go
@@ -167,9 +167,72 @@ func (rm *RestoreManager) Run(ctx context.Context, writer RestoreWriter, snapsho
 // therefore dispatched to a bounded worker pool whenever the writer says it
 // can take concurrent writes; the pool degenerates to sequential execution for
 // writers that cannot (zip).
+// contentRefs returns one entry per content *read*, not per distinct content
+// object.
+//
+// Deduplicating here is wrong, and expensively so. Restore calls
+// writeFileContent once per file, so a content object shared by several files
+// through deduplication is fetched once per referencing file: its demand is a
+// reference count, not a presence bit. Declaring it once made demand reach zero
+// after the first of those reads, so the pack was released while later files
+// still wanted it and had to be fetched again — measured at 42 packs as 460
+// requests and 305.2 MB becoming 620 and 496.2 MB.
+//
+// RFC 0025 §2 states this outright under "they have different multiplicities",
+// which is where the correction came from rather than from first principles.
+func contentRefs(plan restorePlan) []string {
+	refs := make([]string, 0, len(plan.sorted))
+	for _, id := range plan.sorted {
+		meta, ok := plan.byID[id]
+		if !ok {
+			continue
+		}
+		// The same fallback writeFileContent uses: ContentRef is the HMAC-based
+		// key on repositories that have one, ContentHash on those that do not.
+		// Declaring the wrong one would name a key nothing reads, which is
+		// harmless but useless, and the point is to name the keys actually read.
+		key := meta.ContentRef
+		if key == "" {
+			key = meta.ContentHash
+		}
+		if key == "" {
+			continue
+		}
+		// Folders have no content and contribute no read; everything else
+		// appends, repeats included.
+		refs = append(refs, "content/"+key)
+	}
+	return refs
+}
+
 func (rm *RestoreManager) runWithWriter(ctx context.Context, plan restorePlan, writer RestoreWriter) (*RestoreResult, error) {
 	result := &RestoreResult{SnapshotRef: plan.snapshotRef, Root: plan.root}
 	phase := rm.reporter.StartPhase("Restoring", int64(len(plan.sorted)), false)
+
+	// Declare the content objects this phase will read, the way collectMetadata
+	// declares the metadata objects it reads.
+	//
+	// Two phases have to declare separately because neither knows the other's
+	// keys: a content hash is a field of a FileMeta, so it is not knowable until
+	// that FileMeta has been read. Declaring only the metadata phase measurably
+	// covers the smaller half — a restore of the benchmark repository reads
+	// roughly 6,500 metadata objects and 5,000 content objects — so the phase
+	// left undeclared was the one carrying most of the traffic.
+	//
+	// Taken from plan.sorted rather than plan.byID, so a -path restore declares
+	// the subtree it will actually read instead of the whole snapshot.
+	//
+	// chunk/ refs are deliberately not declared, and mostly do not need to be:
+	// cdcAvgSize is 1 MB against a maxObjectSize of 512 KB, so a typical chunk
+	// is stored standalone rather than packed, and a pack's fate does not turn
+	// on it.
+	//
+	// Final, unlike the metadata declaration: every content object a restore
+	// will read is known by now, and nothing is read after this phase. That is
+	// what lets PackStore release a pack when its demand is exhausted instead of
+	// holding it until something evicts it, and it is available without any
+	// format change precisely because collectMetadata has already run.
+	defer store.DeclareDemand(rm.store, contentRefs(plan), store.DemandFinal)()
 
 	// Counters are touched from the file workers as well as this goroutine.
 	var mu sync.Mutex
@@ -797,6 +860,25 @@ func (rm *RestoreManager) collectMetadata(ctx context.Context, root string) (map
 	// walkOrder is unaffected: it is filled by index below, so the order results
 	// are *fetched* in is independent of the order restore *writes* in, which
 	// must stay walk order (RFC 0023 §5).
+	//
+	// The same set is also declared, which answers a different question than
+	// the ordering does. Order decides whether a pack is read again; the
+	// declaration decides what its *first* contact costs, by replacing the
+	// probe sequence PackStore would otherwise use to work out whether the pack
+	// is worth transferring whole. Measured separately: ordering alone left
+	// this workload unchanged at 112 requests (#481), because a pack that fits
+	// in cache is never re-read whatever the order.
+	//
+	// Partial, because the keys this restore reads next are fields of the very
+	// objects being read here: a file's content object is named by its FileMeta,
+	// so it cannot be declared until that FileMeta has been fetched. Running out
+	// of demand here therefore means this pass is done with a pack, not that the
+	// restore is — and PackStore must not drop the body on it.
+	//
+	// Released when metadata collection returns. The write phase makes its own,
+	// final declaration from what this one produced.
+	defer store.DeclareDemand(rm.store, refs, store.DemandPartial)()
+
 	order := make([]int, len(refs))
 	for i := range refs {
 		order[i] = i

--- a/internal/storelayer/pack.go
+++ b/internal/storelayer/pack.go
@@ -76,6 +76,11 @@ type PackStore struct {
 	// Whether a pack is worth transferring whole, estimated from read history.
 	// See packadmission.go, including why it is expected to be deleted.
 	admission *packAdmission
+
+	// Objects a caller has declared it will still read, per pack and namespace.
+	// Empty unless something called DeclareDemand, which is what leaves every
+	// caller that did not on admission's estimate. See packdemand.go.
+	demand *packDemand
 }
 
 // PackEntry represents the location of a small object within a packfile.
@@ -134,6 +139,7 @@ func NewPackStore(inner store.ObjectStore, opts ...PackOption) (*PackStore, erro
 		pendingKeys: make(map[string]struct{}),
 		mergedIndex: make(map[string]bool),
 		admission:   admission,
+		demand:      newPackDemand(),
 	}
 	// s.admission.evicted is the cache's pressure signal, so the cache is built
 	// after it and assigned rather than passed in the struct literal.
@@ -380,10 +386,69 @@ func (s *PackStore) Get(ctx context.Context, key string) ([]byte, error) {
 		data := make([]byte, entry.Length)
 		copy(data, packData[entry.Offset:entry.Offset+entry.Length])
 		s.debugf("get %s: hit lru pack cache %s (len=%d)", key, entry.PackRef, entry.Length)
+		s.finishDemand(entry.PackRef, key)
 		return data, nil
 	}
 
-	return s.resolveFromPack(ctx, key, entry)
+	data, err := s.resolveFromPack(ctx, key, entry)
+	if err != nil {
+		return nil, err
+	}
+	// Counted after the read succeeds: a failed read has not consumed the
+	// object, and counting it would retire a pack that still owes one.
+	s.finishDemand(entry.PackRef, key)
+	return data, nil
+}
+
+// DeclareDemand records how many of keys live in each pack, implementing
+// store.DemandDeclarer.
+//
+// Without it, resolveFromPack learns a pack's worth one miss at a time: it
+// ranged-reads up to packPromoteAfter objects while working out whether the
+// pack is worth transferring whole, and infers from a later eviction that it
+// was not (see packPenalized). Both are inferences about a quantity the caller
+// already holds — a restore has its whole metadata plan before it fetches
+// anything — so declaring it replaces the guess with the number.
+//
+// The counts are read from the catalog, which GroupByLocality already consults
+// for the same key set, so this costs one map lookup per key and no I/O. Keys
+// with no catalog entry are not counted: they are not in packs, so there is no
+// pack whose fate they bear on.
+//
+// The catalog is not force-loaded, for the same reason GroupByLocality does not:
+// this is an optimisation hint, and making a hint perform I/O would let it fail
+// an operation that would otherwise have succeeded. An unloaded catalog yields
+// no counts and the heuristics apply, which is exactly the previous behaviour.
+func (s *PackStore) DeclareDemand(keys []string, scope store.DemandScope) func() {
+	counts := make(map[demandKey]int)
+
+	s.mu.RLock()
+	for _, key := range keys {
+		if entry, ok := s.catalog.Get(key); ok {
+			counts[demandKey{packRef: entry.PackRef, kind: kindOf(key)}]++
+		}
+	}
+	s.mu.RUnlock()
+
+	if len(counts) == 0 {
+		return func() {}
+	}
+
+	final := scope == store.DemandFinal
+	s.demand.declare(counts, final)
+	s.debugf("declare demand: %d keys across %d (pack, kind) buckets (final=%t)", len(keys), len(counts), final)
+
+	// Release subtracts what this declaration added rather than clearing the
+	// packs outright, so an overlapping declaration keeps its own outstanding
+	// demand. Reads have already decremented what they consumed, so the
+	// subtraction floors at zero.
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			s.demand.release(counts, final)
+			s.debugf("release demand across %d packs", len(counts))
+		})
+	}
 }
 
 // GroupByLocality orders keys so that objects sharing a packfile are read
@@ -476,6 +541,36 @@ func rangesNatively(s store.ObjectStore) bool {
 	return ok
 }
 
+// finishDemand records one declared object served from a pack, and drops the
+// body once the pack is finished.
+//
+// "Finished" is narrower than "exhausted", and the difference is what a
+// DemandPartial declaration expresses. A restore's first pass names the metadata
+// objects it will read and cannot name the content objects those point at until
+// it has read them, so its packs run out of declared demand long before the
+// operation is done with them. Dropping bodies on that signal was implemented
+// and measured: restore at 42 packs went from 507 requests and 320.8 MB to 937
+// and 647.0 MB, bytes almost exactly doubling, because every pack the metadata
+// pass released was fetched again by the write pass.
+//
+// The write pass is different, and that is what makes releasing safe at all
+// without a manifest. By then every content object is known, and nothing is read
+// after it — so its declaration is final, exhaustion does mean finished, and the
+// body can go rather than waiting for eviction pressure.
+//
+// packBodyCache.Remove is deliberate removal rather than pressure, so it raises
+// no eviction signal: a finished pack must not be recorded as a promotion that
+// failed to pay for itself. See newPackBodyCache.
+func (s *PackStore) finishDemand(packRef, key string) {
+	if !s.demand.consume(packRef, key) {
+		return
+	}
+	// Removing the body takes its hit tally with it (#494), so a later promotion
+	// of the same pack cannot inherit hits it did not earn.
+	s.packCache.Remove(packRef)
+	s.debugf("pack %s: finished, released", packRef)
+}
+
 // resolveFromPack returns one object from a pack that is not in the body cache.
 //
 // Reading the whole pack to return a slice of it is right when the pack is being
@@ -486,7 +581,17 @@ func (s *PackStore) resolveFromPack(ctx context.Context, key string, entry PackE
 	ranger, canRange := s.ObjectStore.(store.RangeGetter)
 	canRange = canRange && rangesNatively(s.ObjectStore)
 
-	misses, fetchWhole := s.admission.recordMiss(entry.PackRef)
+	// A declared pack's worth is stated, and admission exists only to estimate
+	// that same number -- so a declaration replaces both the probe sequence and
+	// the penalty rather than being consulted alongside them. A declared pack is
+	// released once its count reaches zero (finishDemand), so it cannot thrash
+	// the way the penalty exists to bound.
+	misses, fetchWhole := 0, false
+	if declared := s.demand.outstanding(entry.PackRef); declared > 0 {
+		fetchWhole = declared >= packPromoteAfter
+	} else {
+		misses, fetchWhole = s.admission.recordMiss(entry.PackRef)
+	}
 
 	if canRange && !fetchWhole {
 		data, err := ranger.GetRange(ctx, entry.PackRef, entry.Offset, entry.Length)

--- a/internal/storelayer/packdemand.go
+++ b/internal/storelayer/packdemand.go
@@ -1,0 +1,177 @@
+package storelayer
+
+import (
+	"strings"
+	"sync"
+)
+
+// packDemand tracks how many objects a caller has said it will still read from
+// each pack, counted per key namespace.
+//
+// It is bounded by the packs a declared read set spans times the namespaces in
+// them, not by the number of objects — the counts collapse a caller's whole plan
+// into a handful of integers per pack. That is what keeps it from becoming the
+// per-repository structure RFC 0023 exists to remove: nothing here grows with
+// how much the repository holds, only with how far one operation's reads are
+// spread.
+//
+// **Counts are per namespace because reads are.** A pack routinely mixes tree
+// nodes, file metadata, chunk manifests and inlined file bodies, and an
+// operation reads those in different passes. Counting them together lets a read
+// of one namespace retire demand belonging to another: a `chunk/` read draining
+// a pack's outstanding `content/` demand releases the body while later files
+// still want it. That was measured before it was understood — release keyed on
+// a single per-pack count cost 481 requests and 311.7 MB against 460 and
+// 305.2 MB for not releasing at all.
+type packDemand struct {
+	mu sync.Mutex
+
+	// Outstanding reads per (pack, namespace), and per pack across all
+	// namespaces. The total is maintained alongside rather than summed on
+	// demand because it is read on every served object.
+	counts map[demandKey]int
+	totals map[string]int
+
+	// Live partial declarations per pack. A pack with one is not finished when
+	// its counts reach zero, because more keys from it may still be declared:
+	// restore's first pass names metadata objects and can only name the content
+	// objects those point at once it has read them.
+	//
+	// Counted rather than flagged because declarations nest and are released
+	// independently; a flag could not tell one outstanding partial declaration
+	// from three.
+	partial map[string]int
+}
+
+type demandKey struct {
+	packRef string
+	kind    string
+}
+
+// kindOf returns a key's namespace, including the separator: "content/abc" is
+// "content/". Keys without one share the empty namespace, which is harmless —
+// they are counted together and only ever compared with each other.
+func kindOf(key string) string {
+	if i := strings.IndexByte(key, '/'); i >= 0 {
+		return key[:i+1]
+	}
+	return ""
+}
+
+func newPackDemand() *packDemand {
+	return &packDemand{
+		counts:  make(map[demandKey]int),
+		totals:  make(map[string]int),
+		partial: make(map[string]int),
+	}
+}
+
+// declare adds one declaration's counts.
+func (d *packDemand) declare(counts map[demandKey]int, final bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	seenPack := make(map[string]struct{}, len(counts))
+	for key, n := range counts {
+		d.counts[key] += n
+		d.totals[key.packRef] += n
+		if final {
+			continue
+		}
+		// One partial declaration per pack, however many namespaces it spans:
+		// releasing it must decrement by exactly the same amount.
+		if _, dup := seenPack[key.packRef]; !dup {
+			seenPack[key.packRef] = struct{}{}
+			d.partial[key.packRef]++
+		}
+	}
+}
+
+// release subtracts a declaration's counts, dropping entries that reach zero.
+//
+// It subtracts what was declared rather than clearing the pack outright, so a
+// second declaration overlapping the first keeps its own outstanding demand.
+// Counts already consumed by reads have been decremented, so the subtraction
+// floors at zero rather than going negative.
+func (d *packDemand) release(counts map[demandKey]int, final bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	seenPack := make(map[string]struct{}, len(counts))
+	for key, n := range counts {
+		if !final {
+			if _, dup := seenPack[key.packRef]; !dup {
+				seenPack[key.packRef] = struct{}{}
+				if live := d.partial[key.packRef]; live <= 1 {
+					delete(d.partial, key.packRef)
+				} else {
+					d.partial[key.packRef] = live - 1
+				}
+			}
+		}
+
+		remaining, ok := d.counts[key]
+		if !ok {
+			continue
+		}
+		drop := min(n, remaining)
+		if remaining <= drop {
+			delete(d.counts, key)
+		} else {
+			d.counts[key] = remaining - drop
+		}
+		if total := d.totals[key.packRef]; total <= drop {
+			delete(d.totals, key.packRef)
+		} else {
+			d.totals[key.packRef] = total - drop
+		}
+	}
+}
+
+// outstanding reports how many declared objects remain unread in a pack, across
+// every namespace.
+func (d *packDemand) outstanding(packRef string) int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.totals[packRef]
+}
+
+// consume records one object of the given key served from a pack, and reports
+// whether the pack is now finished — every namespace's declared demand
+// exhausted, with no partial declaration that might still name more of it.
+//
+// A read of a namespace nothing declared decrements nothing. That is the point:
+// it is how a chunk read stops retiring content demand it has nothing to do
+// with.
+//
+// The bool distinguishes "finished" from "never declared", which a returned
+// count of zero cannot: both would read as zero. Only the first means the body
+// can be dropped.
+func (d *packDemand) consume(packRef, key string) (finished bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	dk := demandKey{packRef: packRef, kind: kindOf(key)}
+	remaining, ok := d.counts[dk]
+	if !ok {
+		return false
+	}
+	if remaining > 1 {
+		d.counts[dk] = remaining - 1
+	} else {
+		delete(d.counts, dk)
+	}
+
+	total := d.totals[packRef]
+	if total > 1 {
+		d.totals[packRef] = total - 1
+		return false
+	}
+	delete(d.totals, packRef)
+
+	// Exhausted, but a live partial declaration means "this pass is done with
+	// it", not "this operation is". Dropping the body here is what regressed
+	// restore to 937 requests and 647.0 MB: the metadata pass released packs
+	// the write pass then fetched again.
+	return d.partial[packRef] == 0
+}

--- a/internal/storelayer/packdemand_test.go
+++ b/internal/storelayer/packdemand_test.go
@@ -1,0 +1,430 @@
+package storelayer
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cloudstic/cli/pkg/store"
+	"github.com/cloudstic/cli/pkg/store/local"
+)
+
+// newDemandFixture writes objects into one pack and returns a *fresh* reader
+// over a counting backend, so nothing is served from a warm cache and every
+// read shows up in the counters.
+//
+// objects is deliberately a parameter: the whole behaviour under test turns on
+// how it compares with packPromoteAfter.
+func newDemandFixture(t *testing.T, objects int) (context.Context, *PackStore, *countingRangeStore, []string) {
+	t.Helper()
+	ctx := context.Background()
+
+	base, err := local.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	counting := &countingRangeStore{ObjectStore: base}
+
+	writer, err := NewPackStore(counting)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := bytes.Repeat([]byte("d"), 4*1024)
+	keys := make([]string, 0, objects)
+	for i := range objects {
+		key := fmt.Sprintf("filemeta/%064x", i)
+		if err := writer.Put(ctx, key, payload); err != nil {
+			t.Fatal(err)
+		}
+		keys = append(keys, key)
+	}
+	if err := writer.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	reader, err := NewPackStore(counting)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Load the catalog directly rather than through a Get. A warm-up Get would
+	// also count as a miss against the pack, leaving the miss counter at 1
+	// before the test starts and quietly shortening the probe sequence it is
+	// measuring.
+	if err := reader.ensureCatalogLoaded(ctx); err != nil {
+		t.Fatal(err)
+	}
+	counting.fullGets, counting.rangeGets, counting.bytesRead = 0, 0, 0
+	counting.rangeCalls = nil
+
+	return ctx, reader, counting, keys
+}
+
+func packRefOf(t *testing.T, s *PackStore, key string) string {
+	t.Helper()
+	entry, ok := s.catalog.Get(key)
+	if !ok {
+		t.Fatalf("key %s is not in the catalog", key)
+	}
+	return entry.PackRef
+}
+
+func readAll(t *testing.T, ctx context.Context, s *PackStore, keys []string) {
+	t.Helper()
+	for _, key := range keys {
+		if _, err := s.Get(ctx, key); err != nil {
+			t.Fatalf("get %s: %v", key, err)
+		}
+	}
+}
+
+// The cost this exists to remove. Undeclared, a pack worth transferring whole
+// is discovered to be so only after packPromoteAfter-1 ranged reads; declared,
+// the first contact transfers it.
+func TestPackStore_DeclaredDemandSkipsTheProbeSequence(t *testing.T) {
+	const objects = packPromoteAfter * 2
+
+	ctx, undeclared, undeclaredCounts, keys := newDemandFixture(t, objects)
+	readAll(t, ctx, undeclared, keys)
+
+	if undeclaredCounts.rangeGets != packPromoteAfter-1 {
+		t.Fatalf("baseline probed %d times, expected %d — the premise of this test has moved",
+			undeclaredCounts.rangeGets, packPromoteAfter-1)
+	}
+
+	ctx, declared, declaredCounts, keys := newDemandFixture(t, objects)
+	release := declared.DeclareDemand(keys, store.DemandFinal)
+	defer release()
+	readAll(t, ctx, declared, keys)
+
+	if declaredCounts.rangeGets != 0 {
+		t.Errorf("declared read still issued %d ranged probes, want 0", declaredCounts.rangeGets)
+	}
+	if declaredCounts.fullGets != 1 {
+		t.Errorf("declared read pulled the pack %d times, want exactly 1", declaredCounts.fullGets)
+	}
+}
+
+// The other half of the decision: a pack a caller barely touches must not be
+// transferred whole just because the count is known. Knowing the number is not
+// a reason to fetch more than it justifies.
+func TestPackStore_SmallDeclaredDemandStaysRanged(t *testing.T) {
+	const objects = packPromoteAfter * 2
+	ctx, s, counts, keys := newDemandFixture(t, objects)
+
+	few := keys[:packPromoteAfter-1]
+	release := s.DeclareDemand(few, store.DemandFinal)
+	defer release()
+	readAll(t, ctx, s, few)
+
+	if counts.fullGets != 0 {
+		t.Errorf("pulled %d whole packs for %d declared objects, want 0", counts.fullGets, len(few))
+	}
+	if counts.rangeGets != len(few) {
+		t.Errorf("issued %d ranged reads for %d declared objects, want one each", counts.rangeGets, len(few))
+	}
+}
+
+// Exhausting a PARTIAL declaration must not drop the pack body. A restore's
+// first pass names the metadata objects it will read and cannot name the
+// content objects those point at until it has read them, so its packs run out
+// of declared demand long before the operation is done with them.
+//
+// Pinned as a regression test with its cost: dropping bodies on this signal was
+// implemented and measured, and took restore at 42 packs from 507 requests /
+// 320.8 MB to 937 / 647.0 MB — bytes almost exactly doubling.
+func TestPackStore_ExhaustedPartialDemandKeepsThePackCached(t *testing.T) {
+	const objects = packPromoteAfter * 2
+	ctx, s, counts, keys := newDemandFixture(t, objects)
+
+	release := s.DeclareDemand(keys, store.DemandPartial)
+	defer release()
+	readAll(t, ctx, s, keys)
+
+	if s.packCache.byteLen() == 0 {
+		t.Fatal("pack body was dropped when partial demand hit zero; a later pass must not have to re-fetch it")
+	}
+
+	// The read that stands in for a later pass touching the same pack: it must
+	// be served from the cached body, not a second transfer.
+	before := counts.fullGets
+	if _, err := s.Get(ctx, keys[0]); err != nil {
+		t.Fatal(err)
+	}
+	if counts.fullGets != before {
+		t.Errorf("re-reading after partial demand was exhausted pulled the pack again (%d -> %d)", before, counts.fullGets)
+	}
+}
+
+// Exhausting a FINAL declaration does drop the body, which is the half of demand
+// counting that bounds residency: the cache then holds only packs something
+// still wants, rather than whatever was touched most recently — a signal that is
+// actively misleading for a traversal reading each object once.
+func TestPackStore_ExhaustedFinalDemandReleasesThePack(t *testing.T) {
+	const objects = packPromoteAfter * 2
+	ctx, s, _, keys := newDemandFixture(t, objects)
+
+	release := s.DeclareDemand(keys, store.DemandFinal)
+	defer release()
+
+	readAll(t, ctx, s, keys[:len(keys)-1])
+	if s.packCache.byteLen() == 0 {
+		t.Fatal("pack body was dropped before its declared demand was exhausted")
+	}
+
+	readAll(t, ctx, s, keys[len(keys)-1:])
+	if got := s.packCache.byteLen(); got != 0 {
+		t.Errorf("pack body still holds %d bytes after every declared object was read", got)
+	}
+}
+
+// The restore sequence, which is the case the scope distinction exists for: a
+// partial declaration is made and released, a final one covering the same pack
+// follows, and only the second may release the body.
+//
+// Written as one test rather than trusting the two above to compose, because
+// the ordering is the part that is easy to get wrong — the partial declaration
+// is released *before* the final one is made, so nothing but the recorded scope
+// distinguishes the two exhaustion events.
+func TestPackStore_PartialThenFinalReleasesOnlyAtTheEnd(t *testing.T) {
+	const objects = packPromoteAfter * 2
+	ctx, s, counts, keys := newDemandFixture(t, objects)
+
+	firstPass, secondPass := keys[:objects/2], keys[objects/2:]
+
+	releasePartial := s.DeclareDemand(firstPass, store.DemandPartial)
+	readAll(t, ctx, s, firstPass)
+	releasePartial()
+
+	if s.packCache.byteLen() == 0 {
+		t.Fatal("pack released after the partial pass; the final pass would have to re-fetch it")
+	}
+	fetchesAfterFirstPass := counts.fullGets
+
+	releaseFinal := s.DeclareDemand(secondPass, store.DemandFinal)
+	defer releaseFinal()
+	readAll(t, ctx, s, secondPass)
+
+	if counts.fullGets != fetchesAfterFirstPass {
+		t.Errorf("the final pass re-fetched the pack (%d -> %d); it should have been cached throughout",
+			fetchesAfterFirstPass, counts.fullGets)
+	}
+	if got := s.packCache.byteLen(); got != 0 {
+		t.Errorf("pack still holds %d bytes after the final declaration was exhausted", got)
+	}
+}
+
+// A released pack must not look like a promotion that failed to pay for itself.
+// packBodyCache distinguishes deliberate removal from pressure eviction for
+// exactly this reason, and reading demand exhaustion as a penalty would put the
+// pack back on ranged reads the next time it is wanted.
+func TestPackStore_ReleasingOnZeroDemandDoesNotPenalizeThePack(t *testing.T) {
+	const objects = packPromoteAfter * 2
+	ctx, s, _, keys := newDemandFixture(t, objects)
+
+	release := s.DeclareDemand(keys, store.DemandFinal)
+	readAll(t, ctx, s, keys)
+	release()
+
+	packRef := packRefOf(t, s, keys[0])
+	if _, penalized := s.admission.penalized.Peek(packRef); penalized {
+		t.Error("pack was penalized for finishing its declared demand")
+	}
+}
+
+// Everything that did not declare keeps the heuristics, which is what leaves
+// cat, dedup probes during backup, and any kind an operation did not count on
+// the behaviour their comments justify.
+func TestPackStore_UndeclaredReadsKeepTheHeuristic(t *testing.T) {
+	const objects = packPromoteAfter * 2
+	ctx, s, counts, keys := newDemandFixture(t, objects)
+
+	// Declare one pack's worth, then read a different set entirely. The
+	// declaration must not change how the undeclared reads are served.
+	release := s.DeclareDemand(nil, store.DemandFinal)
+	defer release()
+	readAll(t, ctx, s, keys)
+
+	if counts.rangeGets != packPromoteAfter-1 {
+		t.Errorf("undeclared read issued %d ranged probes, want the usual %d",
+			counts.rangeGets, packPromoteAfter-1)
+	}
+}
+
+// Release is deferred by callers, and a caller that also releases explicitly on
+// an early return would otherwise subtract twice — retiring demand that a
+// concurrent declaration still holds.
+func TestPackStore_ReleaseIsIdempotent(t *testing.T) {
+	const objects = packPromoteAfter * 2
+	ctx, s, _, keys := newDemandFixture(t, objects)
+	_ = ctx
+
+	first := s.DeclareDemand(keys, store.DemandFinal)
+	second := s.DeclareDemand(keys, store.DemandFinal)
+
+	packRef := packRefOf(t, s, keys[0])
+	if got := s.demand.outstanding(packRef); got != 2*objects {
+		t.Fatalf("two declarations of %d objects gave outstanding=%d, want %d", objects, got, 2*objects)
+	}
+
+	first()
+	first()
+	first()
+
+	if got := s.demand.outstanding(packRef); got != objects {
+		t.Errorf("outstanding=%d after releasing one declaration three times, want %d", got, objects)
+	}
+	second()
+	if got := s.demand.outstanding(packRef); got != 0 {
+		t.Errorf("outstanding=%d after releasing both declarations, want 0", got)
+	}
+}
+
+// Declaring must never make a read fail or force I/O. It is a hint, and a hint
+// that can error is a liability: it would fail operations that would otherwise
+// have succeeded.
+func TestPackStore_DeclareDemandToleratesUnknownKeysAndLoadsNothing(t *testing.T) {
+	ctx := context.Background()
+	base, err := local.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	counting := &countingRangeStore{ObjectStore: base}
+	s, err := NewPackStore(counting)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	release := s.DeclareDemand([]string{"filemeta/nope", "chunk/also-nope"}, store.DemandFinal)
+	defer release()
+
+	if counting.fullGets != 0 || counting.rangeGets != 0 {
+		t.Errorf("declaring performed I/O: %d full, %d ranged", counting.fullGets, counting.rangeGets)
+	}
+	if s.catalogLoaded {
+		t.Error("declaring forced a catalog load; it must stay a no-I/O hint")
+	}
+	_ = ctx
+}
+
+// A read of a namespace nobody declared must not retire demand belonging to
+// another. A pack mixes namespaces, and an operation reads them in different
+// passes: restore reads content/ objects and then the chunk/ objects those name.
+// Counting them together let a chunk read drain the pack's outstanding content
+// demand and release the body while later files still wanted it.
+//
+// Measured before it was understood — release keyed on one count per pack cost
+// 481 requests and 311.7 MB against 460 and 305.2 MB for not releasing at all.
+func TestPackStore_UndeclaredKindDoesNotRetireDeclaredDemand(t *testing.T) {
+	ctx := context.Background()
+	base, err := local.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	counting := &countingRangeStore{ObjectStore: base}
+
+	writer, err := NewPackStore(counting)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := bytes.Repeat([]byte("d"), 4*1024)
+	// One pack holding both namespaces, which is the ordinary case: packing is
+	// by size, not by kind.
+	var contentKeys, chunkKeys []string
+	for i := range packPromoteAfter * 2 {
+		ck := fmt.Sprintf("content/%064x", i)
+		hk := fmt.Sprintf("chunk/%064x", i)
+		if err := writer.Put(ctx, ck, payload); err != nil {
+			t.Fatal(err)
+		}
+		if err := writer.Put(ctx, hk, payload); err != nil {
+			t.Fatal(err)
+		}
+		contentKeys = append(contentKeys, ck)
+		chunkKeys = append(chunkKeys, hk)
+	}
+	if err := writer.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	reader, err := NewPackStore(counting)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reader.ensureCatalogLoaded(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Declare only the content objects, as restore's write phase does — chunk
+	// refs live inside content objects and cannot be named yet.
+	release := reader.DeclareDemand(contentKeys, store.DemandFinal)
+	defer release()
+
+	// Interleave the undeclared chunk reads with the declared content reads,
+	// which is what actually happens: a file's content object is read, then the
+	// chunks it names.
+	for i := range contentKeys {
+		if _, err := reader.Get(ctx, contentKeys[i]); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := reader.Get(ctx, chunkKeys[i]); err != nil {
+			t.Fatal(err)
+		}
+		if i < len(contentKeys)-1 && reader.packCache.byteLen() == 0 {
+			t.Fatalf("pack released after %d of %d declared content reads; a chunk read retired content demand",
+				i+1, len(contentKeys))
+		}
+	}
+}
+
+// The chain walker has to find PackStore under the decorators the real client
+// stacks on it, or the capability is dead in production while every direct
+// unit test passes.
+func TestDeclareDemandReachesPackStoreThroughTheChain(t *testing.T) {
+	const objects = packPromoteAfter * 2
+	ctx, packed, counts, keys := newDemandFixture(t, objects)
+
+	var chain store.ObjectStore = packed
+	chain = NewMeteredStore(chain)
+	chain = NewCompressedStore(chain)
+
+	release := store.DeclareDemand(chain, keys, store.DemandFinal)
+	defer release()
+
+	packRef := packRefOf(t, packed, keys[0])
+	if got := packed.demand.outstanding(packRef); got != objects {
+		t.Fatalf("declaring through the wrapper chain reached PackStore with outstanding=%d, want %d", got, objects)
+	}
+
+	readAll(t, ctx, packed, keys)
+	if counts.rangeGets != 0 {
+		t.Errorf("declared through the chain but still probed %d times", counts.rangeGets)
+	}
+}
+
+// A store with nothing to declare to must still hand back a callable release.
+//
+// Every call site spells this `defer store.DeclareDemand(...)()`, so the
+// fallback returning nil would panic on a plain local backend — the
+// configuration with the least to gain from demand counting and the most likely
+// to be run without it.
+func TestDeclareDemandWithoutADeclarerReturnsACallableRelease(t *testing.T) {
+	base, err := local.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wrapped, so the helper walks a chain and finds no declarer at the bottom
+	// rather than failing to walk at all.
+	var chain store.ObjectStore = base
+	chain = NewMeteredStore(chain)
+	chain = NewCompressedStore(chain)
+
+	release := store.DeclareDemand(chain, []string{"filemeta/a", "content/b"}, store.DemandFinal)
+	if release == nil {
+		t.Fatal("DeclareDemand returned a nil release; every call site defers it")
+	}
+	release()
+	// Released twice on purpose: callers defer it and may also release early.
+	release()
+}

--- a/pkg/store/interface.go
+++ b/pkg/store/interface.go
@@ -67,6 +67,73 @@ type LocalityGrouper interface {
 	GroupByLocality(keys []string) []string
 }
 
+// DemandDeclarer is an optional interface for stores that can use advance
+// knowledge of which keys a caller is about to read.
+//
+// LocalityGrouper answers "in what order", this answers "how many, and from
+// where". A store bundling many objects per transfer has to decide, on first
+// contact with a bundle, whether to transfer the whole thing or read a piece of
+// it — a decision it can only make by guessing, since it sees one key at a time.
+// A caller holding its whole read set already knows the answer.
+//
+// Declaring is a hint about a caller's own intent, not a lock or a reservation.
+// A declared key need not be read, a key not declared may be, and reads from
+// other callers proceed unaffected. A store may ignore the declaration entirely,
+// which is what a store with nothing to gain from it does by not implementing
+// this at all.
+//
+// The returned function ends the declaration and must be called — deferring it
+// is the intended use. Ending it early costs efficiency, never correctness.
+type DemandDeclarer interface {
+	DeclareDemand(keys []string, scope DemandScope) (release func())
+}
+
+// DemandScope says whether a caller may still declare more keys from the same
+// bundles, which decides whether running out of declared demand means the
+// bundle is finished or merely quiet.
+//
+// The distinction is not bookkeeping. A reader whose later keys are fields of
+// its earlier ones cannot name them up front — a restore learns a file's
+// content object only by reading that file's metadata — so its first pass is
+// necessarily partial, and a store that treated exhaustion as completion would
+// discard bundles the second pass immediately asks for again.
+type DemandScope int
+
+const (
+	// DemandPartial promises nothing beyond the keys named. More keys from the
+	// same bundles may follow, so exhausting this declaration means only that
+	// this pass is done with them.
+	DemandPartial DemandScope = iota
+
+	// DemandFinal additionally promises that no further keys from these bundles
+	// will be declared by this caller. Exhausting it therefore means the bundle
+	// is finished and its resources can be released rather than waiting to be
+	// evicted.
+	//
+	// Wrong only costs performance: a bundle released early is fetched again.
+	DemandFinal
+)
+
+// DeclareDemand walks the store wrapper chain and declares to the first
+// DemandDeclarer it finds, returning a no-op release if none exists.
+//
+// The walk matters for the same reason GroupByLocality's does: PackStore is the
+// store that bundles, and it sits beneath CompressedStore, EncryptedStore and
+// MeteredStore.
+func DeclareDemand(s ObjectStore, keys []string, scope DemandScope) (release func()) {
+	for s != nil {
+		if d, ok := s.(DemandDeclarer); ok {
+			return d.DeclareDemand(keys, scope)
+		}
+		if u, ok := s.(Unwrapper); ok {
+			s = u.Unwrap()
+		} else {
+			break
+		}
+	}
+	return func() {}
+}
+
 // GroupByLocality walks the store wrapper chain and applies the first
 // LocalityGrouper it finds, returning keys unchanged if none exists.
 //


### PR DESCRIPTION
## Summary

- Add `store.DemandDeclarer` alongside `ConcurrencyHinter`, `RangeGetter` and `LocalityGrouper`, with the usual chain-walking helper.
- Implement it on `PackStore` over per-pack counts derived from the catalog — no format change, no snapshot manifest.
- Declare from both of `restore`'s read phases: metadata refs in `collectMetadata`, content objects in `runWithWriter`.

`PackStore` discovers a pack's worth one miss at a time — up to `packPromoteAfter` ranged reads to decide whether it is worth transferring whole, plus a penalty inferred backwards from a later eviction. Both estimate a quantity the caller already holds. `packPromoteAfter` stays the threshold; only how the count is obtained changes.

Closes #485.

## Measurements

`scripts/benchmark/aging.sh` against MinIO, restoring the latest snapshot of a 5,000-file tree:

| | requests | sent | peak RSS | wall |
|---|---|---|---|---|
| 42 packs | 507 → **460** (−9.3%) | −4.9% | −4.4% | −2.5% |
| 82 packs | 2,118 → **1,290** (−39.1%) | **+15.1%** | −5.5% | +8.0% |

`check` was measured alongside as a control and is unchanged (385 → 385, 1,867 → 1,796): it streams and declares nothing, so the restore numbers are not measurement drift.

**The aged case trades bytes for requests, and that needs a decision.** It is the same trade `packPromoteAfter` already encodes — at its calibration one request is worth roughly a megabyte — and what changes is that the trade is now made on first contact instead of after seven probes and an eviction. On loopback, wall time understates the request win, having none of the latency that makes request counts matter (see the note in `minio.sh`). On a latency-bearing backend, 828 fewer round trips should dominate 106 MB of extra transfer, but that is reasoning, not measurement.

**#485's acceptance criterion predicted 300–500 requests at 82 packs and was not met** (1,290). The criterion also said a result outside that range is a finding to report rather than a number to tune toward, so it is reported here.

## A rejected variant, pinned as a regression test

Releasing the pack body when declared demand reached zero was implemented and measured first. It regressed restore at 42 packs from 507 requests / 320.8 MB to **937 / 647.0 MB** — bytes almost exactly doubling, because every pack the metadata phase released was fetched again by the write phase.

RFC 0025 §2 names this failure in advance: a single count per pack *"either pins a pack from the traversal that first touched it until the last body is written, or releases it at zero and re-fetches it"*.

So demand drives **admission only**; eviction stays with the cache. `TestPackStore_ExhaustedDemandKeepsThePackCached` pins it with the measured numbers in the comment, so it is not reintroduced by someone reasoning that releasing early ought to help.

Release-at-zero becomes correct once a declaration covers every kind an operation reads from a pack *simultaneously* — which two phases structurally cannot do here, since a content hash is a field of a `FileMeta` and unknowable until that `FileMeta` is read. That is the per-kind manifest of RFC 0025 §2, or RFC 0024 collapsing the two classes.

## Follow-up this suggests

The remaining byte cost is a threshold counting *objects* when the decision is about *bytes*: a pack you need 79 KB from is not worth 8 MB whatever the object count. A byte-aware admission rule needs the summed lengths of the keys about to be read — information only a declaration can supply, so this PR is its prerequisite. Not done here.

## Related issues

Closes #485. Part of the RFC 0025 workstream; the residual cost is #486 (compaction) and RFC 0024 (object count).

## Repository compatibility

No repository format change. This is an in-process policy change inside a store decorator: nothing written to a store differs, no read path changes what it accepts, and a store that does not implement the capability gets a no-op.

## Verification

```bash
go test -race -count=1 ./internal/... ./pkg/... .
go test -count=1 ./e2e
golangci-lint run ./...
```

All pass. Measurements above from `FILES=5000 CHECKPOINTS="40 80" CHURN=200 ./scripts/benchmark/aging.sh`.

## Documentation

No user-facing behaviour changes. `store.DemandDeclarer` and `store.DeclareDemand` are new exported API in `pkg/store` and are documented in place; if the docs repository gains a page on the optional store capabilities, it should cover this alongside `RangeGetter` and `ConcurrencyHinter`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved restore operations by planning required content and metadata in advance.
  * Optimized pack reads to reduce unnecessary probing and choose more efficient read strategies.
  * Improved caching behavior for frequently accessed content.

* **Reliability**
  * Prevented released or completed restore demand from causing unnecessary read penalties.
  * Improved handling of repeated and unknown content references during restore.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->