### PR TITLE
refactor(store): give pack admission one name and one home

### DIFF
--- a/internal/storelayer/pack.go
+++ b/internal/storelayer/pack.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"sync"
 
-	lru "github.com/hashicorp/golang-lru/v2"
-
 	"github.com/cloudstic/cli/internal/core"
 	"github.com/cloudstic/cli/internal/logger"
 	"github.com/cloudstic/cli/pkg/crypto"
@@ -75,24 +73,9 @@ type PackStore struct {
 	// LRU cache for recently downloaded packfiles to accelerate Get() and HAMT walks
 	packCache *packBodyCache
 
-	// Misses per pack since it was last cached, used to decide when reading one
-	// object at a time is no longer the cheaper option. See resolveFromPack.
-	packMisses *lru.Cache[string, int]
-
-	// Hits served from a pack since it was promoted into packCache, read by
-	// onPackEvicted to tell a promotion that paid for itself from one that
-	// didn't. See packPenalized.
-	packHits *lru.Cache[string, int]
-
-	// Packs whose last promotion was evicted before serving packPromoteAfter
-	// hits — cheaper to have left as ranged reads. A pack in here is never
-	// promoted again until it ages out of this bounded structure, which is
-	// what keeps a working set bigger than packCache from paying a whole-pack
-	// transfer over and over: the cost per object converges to a ranged read,
-	// bounded by object size, rather than staying bounded by pack size no
-	// matter how much the true working set overruns the cache. See
-	// onPackEvicted and resolveFromPack.
-	packPenalized *lru.Cache[string, struct{}]
+	// Whether a pack is worth transferring whole, estimated from read history.
+	// See packadmission.go, including why it is expected to be deleted.
+	admission *packAdmission
 }
 
 // PackEntry represents the location of a small object within a packfile.
@@ -113,7 +96,7 @@ type PackOption func(*PackStore)
 // large enough to do that with the real budget.
 func withPackBodyCacheBudget(budget int) PackOption {
 	return func(s *PackStore) {
-		cache, err := newPackBodyCache(budget, s.onPackEvicted)
+		cache, err := newPackBodyCache(budget, s.admission.evicted)
 		if err != nil {
 			panic(err) // test-only option; a bad budget here is a test bug
 		}
@@ -138,34 +121,23 @@ func WithPackIndexKey(key []byte) PackOption {
 
 // NewPackStore initializes a new MicroPackStore over an existing store.ObjectStore.
 func NewPackStore(inner store.ObjectStore, opts ...PackOption) (*PackStore, error) {
-	misses, err := lru.New[string, int](packMissWindow)
+	admission, err := newPackAdmission()
 	if err != nil {
-		return nil, fmt.Errorf("pack miss counter init: %w", err)
-	}
-	hits, err := lru.New[string, int](packMissWindow)
-	if err != nil {
-		return nil, fmt.Errorf("pack hit counter init: %w", err)
-	}
-	penalized, err := lru.New[string, struct{}](packMissWindow)
-	if err != nil {
-		return nil, fmt.Errorf("pack penalty tracker init: %w", err)
+		return nil, err
 	}
 
 	s := &PackStore{
-		ObjectStore:   inner,
-		packBuffer:    new(bytes.Buffer),
-		packKeys:      make(map[string]PackEntry),
-		catalog:       newPackCatalog(),
-		pendingKeys:   make(map[string]struct{}),
-		mergedIndex:   make(map[string]bool),
-		packMisses:    misses,
-		packHits:      hits,
-		packPenalized: penalized,
+		ObjectStore: inner,
+		packBuffer:  new(bytes.Buffer),
+		packKeys:    make(map[string]PackEntry),
+		catalog:     newPackCatalog(),
+		pendingKeys: make(map[string]struct{}),
+		mergedIndex: make(map[string]bool),
+		admission:   admission,
 	}
-	// s.onPackEvicted needs packHits and packPenalized, both set above, so the
-	// cache is built after them and assigned rather than passed in the struct
-	// literal.
-	cache, err := newPackBodyCache(packBodyCacheBudget, s.onPackEvicted)
+	// s.admission.evicted is the cache's pressure signal, so the cache is built
+	// after it and assigned rather than passed in the struct literal.
+	cache, err := newPackBodyCache(packBodyCacheBudget, s.admission.evicted)
 	if err != nil {
 		return nil, fmt.Errorf("pack cache init: %w", err)
 	}
@@ -407,90 +379,13 @@ func (s *PackStore) Get(ctx context.Context, key string) ([]byte, error) {
 		}
 		data := make([]byte, entry.Length)
 		copy(data, packData[entry.Offset:entry.Offset+entry.Length])
-		s.recordPackHit(entry.PackRef)
+		s.admission.served(entry.PackRef)
 		s.debugf("get %s: hit lru pack cache %s (len=%d)", key, entry.PackRef, entry.Length)
 		return data, nil
 	}
 
 	return s.resolveFromPack(ctx, key, entry)
 }
-
-// recordPackHit counts one object served from a cached pack, read back by
-// onPackEvicted when that pack leaves the cache.
-func (s *PackStore) recordPackHit(packRef string) {
-	hits := 0
-	if n, ok := s.packHits.Get(packRef); ok {
-		hits = n
-	}
-	s.packHits.Add(packRef, hits+1)
-}
-
-// onPackEvicted runs when a pack body is dropped because the cache ran out of
-// room — not when one is removed deliberately, which carries no such meaning
-// (see newPackBodyCache).
-//
-// A promotion (see resolveFromPack) pays for a whole-pack transfer up front,
-// betting it back on the hits the pack serves while cached. That bet loses
-// when the working set is bigger than the cache: the pack is evicted to make
-// room for another before it has served enough hits to be worth what it cost,
-// and the next miss on the same pack would promote it again, pay the same
-// transfer, and lose the same bet — forever, at a cost bounded by pack size no
-// matter how much larger the true working set is than the cache.
-//
-// Recording the loss here is what breaks that cycle. A pack that didn't earn
-// back its promotion is marked in packPenalized, and resolveFromPack serves it
-// with ranged reads from then on rather than promoting it again — bounding the
-// cost per object by object size instead, which holds regardless of how large
-// the repository or how mismatched the cache is to it. The mark expires when
-// it ages out of packPenalized's own bounded window, so a pack that becomes
-// worth caching again — the working set shrinks, or access moves on — gets
-// another chance rather than being penalized permanently on one bad measurement.
-func (s *PackStore) onPackEvicted(packRef string) {
-	hits := 0
-	if n, ok := s.packHits.Get(packRef); ok {
-		hits = n
-	}
-	s.packHits.Remove(packRef)
-	if hits < packPromoteAfter {
-		s.packPenalized.Add(packRef, struct{}{})
-	}
-}
-
-const (
-	// packPromoteAfter is how many times a pack may be read one object at a time
-	// before the whole thing is fetched and cached instead.
-	//
-	// The two access patterns this sits between were measured (RFC 0023). A scan
-	// -- check, ls, prune -- walks a pack's objects consecutively, so one transfer
-	// serves thousands of reads and ranged reads would be thousands of round
-	// trips instead of one. A scattered read -- restore's write phase, or a cat
-	// of a single file -- touches a pack once or twice, so fetching up to
-	// maxPackSize to return a few hundred bytes is nearly all waste.
-	//
-	// The threshold is asymmetric in what it costs each pattern, which is why it
-	// is not 2. A scan pays at most packPromoteAfter-1 extra small requests per
-	// pack visit -- a few hundred across a repository, against transfers it makes
-	// anyway. A scattered read pays one whole pack per packPromoteAfter misses,
-	// which is bytes, and bytes are what a remote backend bills for.
-	//
-	// Measured on a 51-pack tree, restore's whole-pack transfers against this
-	// value: 2857 at 2, 1419 at 4, 719 at 8, 358 at 16, 179 at 32. Most of the
-	// benefit is captured by 8, and beyond it the round trips traded away start
-	// to matter more than the bytes saved.
-	packPromoteAfter = 8
-
-	// packMissWindow bounds the miss counter, the hit counter and the penalty
-	// set. Each only has to span the packs in flight around a given moment, and
-	// none may become a second unbounded per-repository structure -- which is
-	// the thing RFC 0023 is about.
-	//
-	// It has to stay comfortably above the number of packs the body cache can
-	// hold (packBodyCacheBudget / maxPackSize, currently 8). A hit counter
-	// evicted from this window while its pack is still resident would read as
-	// zero hits on the next eviction and penalize a pack that was serving
-	// fine.
-	packMissWindow = 64
-)
 
 // GroupByLocality orders keys so that objects sharing a packfile are read
 // consecutively, implementing store.LocalityGrouper.
@@ -586,28 +481,15 @@ func rangesNatively(s store.ObjectStore) bool {
 //
 // Reading the whole pack to return a slice of it is right when the pack is being
 // scanned and wrong when it is being sampled, and the two are indistinguishable
-// at the first miss. So the first misses are served by ranged reads, and a pack
-// that keeps missing is fetched whole and cached -- see packPromoteAfter. A pack
-// whose last promotion was evicted before earning it back stays on ranged reads
-// regardless of miss count -- see packPenalized and onPackEvicted.
+// at the first miss. Which of the two this is, is packAdmission's judgement;
+// whether the backend can serve a ranged read at all is this function's.
 func (s *PackStore) resolveFromPack(ctx context.Context, key string, entry PackEntry) ([]byte, error) {
 	ranger, canRange := s.ObjectStore.(store.RangeGetter)
 	canRange = canRange && rangesNatively(s.ObjectStore)
 
-	misses := 0
-	if n, ok := s.packMisses.Get(entry.PackRef); ok {
-		misses = n
-	}
-	misses++
-	s.packMisses.Add(entry.PackRef, misses)
+	misses, fetchWhole := s.admission.recordMiss(entry.PackRef)
 
-	// Peek, not Get: checking the penalty must not refresh its recency, or a
-	// pack read every miss (which a penalized one is, by definition) would
-	// keep itself permanently fresh in packPenalized and never age out for
-	// the second chance the comment on that field promises.
-	_, penalized := s.packPenalized.Peek(entry.PackRef)
-
-	if canRange && (misses < packPromoteAfter || penalized) {
+	if canRange && !fetchWhole {
 		data, err := ranger.GetRange(ctx, entry.PackRef, entry.Offset, entry.Length)
 		if err != nil {
 			return nil, fmt.Errorf("read %s from pack %s: %w", key, entry.PackRef, err)
@@ -627,8 +509,7 @@ func (s *PackStore) resolveFromPack(ctx context.Context, key string, entry PackE
 	}
 
 	s.packCache.Add(entry.PackRef, packData)
-	// The pack is cached now, so the misses that led here are spent.
-	s.packMisses.Remove(entry.PackRef)
+	s.admission.cached(entry.PackRef)
 
 	if int64(len(packData)) < entry.Offset+entry.Length {
 		return nil, fmt.Errorf("downloaded packfile %s is too small", entry.PackRef)

--- a/internal/storelayer/pack.go
+++ b/internal/storelayer/pack.go
@@ -123,7 +123,7 @@ func WithPackIndexKey(key []byte) PackOption {
 func NewPackStore(inner store.ObjectStore, opts ...PackOption) (*PackStore, error) {
 	admission, err := newPackAdmission()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("pack admission init: %w", err)
 	}
 
 	s := &PackStore{

--- a/internal/storelayer/packadmission.go
+++ b/internal/storelayer/packadmission.go
@@ -25,8 +25,20 @@ import (
 // surgery across four call sites -- which is what it was before this type
 // existed.
 //
-// Not safe for concurrent use on its own; PackStore serialises access the same
-// way it did when these were three of its own fields.
+// Concurrency, stated accurately because the obvious reading is wrong in both
+// directions. The three caches are individually safe for concurrent use --
+// hashicorp/golang-lru guards each with its own mutex -- and PackStore does
+// *not* serialise these calls: Get invokes served and recordMiss after
+// releasing its own lock, and the body cache invokes evicted from wherever the
+// eviction happened.
+//
+// What is not atomic is the read-modify-write inside recordMiss and served: two
+// concurrent misses on the same pack can both read n and both write n+1, losing
+// one. That is a lost update on an estimate that is approximate by
+// construction, costing at most a one-miss delay to a promotion, and it is the
+// behaviour these fields already had. Making it atomic would change promotion
+// timing under concurrency, which is a behavioural change and not what this
+// type's extraction is.
 type packAdmission struct {
 	// Misses per pack since it was last cached, used to decide when reading one
 	// object at a time is no longer the cheaper option.
@@ -74,11 +86,18 @@ const (
 	// none may become a second unbounded per-repository structure -- which is
 	// the thing RFC 0023 is about.
 	//
-	// It has to stay comfortably above the number of packs the body cache can
-	// hold (packBodyCacheBudget / maxPackSize, currently 8). A hit counter
-	// evicted from this window while its pack is still resident would read as
-	// zero hits on the next eviction and penalize a pack that was serving
-	// fine.
+	// It has to stay above the number of packs the body cache holds at once. A
+	// hit counter evicted from this window while its pack is still resident
+	// reads as zero hits on the next eviction and penalizes a pack that was
+	// serving fine.
+	//
+	// 64 does not actually guarantee that, and the comment here used to claim it
+	// did. The figure it was chosen against -- packBodyCacheBudget /
+	// maxPackSize, or 8 -- assumes every pack is maximal, while packBodyCache
+	// bounds bytes rather than entries, so a repository of small incremental
+	// packs can hold far more than 64 resident. Latent rather than active at
+	// measured scale: at 82 packs roughly 32 are resident, and raising this to
+	// 512 there moved nothing. See #494 for the fix, which is behavioural.
 	packMissWindow = 64
 )
 

--- a/internal/storelayer/packadmission.go
+++ b/internal/storelayer/packadmission.go
@@ -1,0 +1,171 @@
+package storelayer
+
+import (
+	"fmt"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+)
+
+// packAdmission decides whether a pack is worth transferring whole, from
+// nothing but the history of reads against it.
+//
+// It is an *estimator*, and that is the important thing about it. The quantity
+// it approximates -- how many objects this operation will read from this pack
+// -- is one a caller frequently knows outright: a restore holds its whole
+// metadata plan before it fetches anything. Probing estimates that number
+// forward, one miss at a time; the penalty estimates it backward from an
+// eviction that already happened. Both exist because nothing tells the store
+// the number.
+//
+// So this type is scaffolding with a demolition date. When callers state their
+// demand (RFC 0025 §2) or compaction keeps working sets inside the body cache
+// (RFC 0025 §4), the estimate stops earning its keep, and this type and the one
+// field holding it are the whole of what has to be deleted. Keeping it in one
+// place, behind one entry point, is what makes that a small change rather than
+// surgery across four call sites -- which is what it was before this type
+// existed.
+//
+// Not safe for concurrent use on its own; PackStore serialises access the same
+// way it did when these were three of its own fields.
+type packAdmission struct {
+	// Misses per pack since it was last cached, used to decide when reading one
+	// object at a time is no longer the cheaper option.
+	misses *lru.Cache[string, int]
+
+	// Hits served from a pack since it was promoted, read by evicted() to tell
+	// a promotion that paid for itself from one that didn't.
+	hits *lru.Cache[string, int]
+
+	// Packs whose last promotion was evicted before serving packPromoteAfter
+	// hits -- cheaper to have left as ranged reads. A pack in here is never
+	// promoted again until it ages out of this bounded structure, which is what
+	// keeps a working set bigger than the body cache from paying a whole-pack
+	// transfer over and over: the cost per object converges to a ranged read,
+	// bounded by object size, rather than staying bounded by pack size no
+	// matter how much the true working set overruns the cache.
+	penalized *lru.Cache[string, struct{}]
+}
+
+const (
+	// packPromoteAfter is how many times a pack may be read one object at a time
+	// before the whole thing is fetched and cached instead.
+	//
+	// The two access patterns this sits between were measured (RFC 0023). A scan
+	// -- check, ls, prune -- walks a pack's objects consecutively, so one transfer
+	// serves thousands of reads and ranged reads would be thousands of round
+	// trips instead of one. A scattered read -- restore's write phase, or a cat
+	// of a single file -- touches a pack once or twice, so fetching up to
+	// maxPackSize to return a few hundred bytes is nearly all waste.
+	//
+	// The threshold is asymmetric in what it costs each pattern, which is why it
+	// is not 2. A scan pays at most packPromoteAfter-1 extra small requests per
+	// pack visit -- a few hundred across a repository, against transfers it makes
+	// anyway. A scattered read pays one whole pack per packPromoteAfter misses,
+	// which is bytes, and bytes are what a remote backend bills for.
+	//
+	// Measured on a 51-pack tree, restore's whole-pack transfers against this
+	// value: 2857 at 2, 1419 at 4, 719 at 8, 358 at 16, 179 at 32. Most of the
+	// benefit is captured by 8, and beyond it the round trips traded away start
+	// to matter more than the bytes saved.
+	packPromoteAfter = 8
+
+	// packMissWindow bounds the miss counter, the hit counter and the penalty
+	// set. Each only has to span the packs in flight around a given moment, and
+	// none may become a second unbounded per-repository structure -- which is
+	// the thing RFC 0023 is about.
+	//
+	// It has to stay comfortably above the number of packs the body cache can
+	// hold (packBodyCacheBudget / maxPackSize, currently 8). A hit counter
+	// evicted from this window while its pack is still resident would read as
+	// zero hits on the next eviction and penalize a pack that was serving
+	// fine.
+	packMissWindow = 64
+)
+
+func newPackAdmission() (*packAdmission, error) {
+	misses, err := lru.New[string, int](packMissWindow)
+	if err != nil {
+		return nil, fmt.Errorf("pack miss counter init: %w", err)
+	}
+	hits, err := lru.New[string, int](packMissWindow)
+	if err != nil {
+		return nil, fmt.Errorf("pack hit counter init: %w", err)
+	}
+	penalized, err := lru.New[string, struct{}](packMissWindow)
+	if err != nil {
+		return nil, fmt.Errorf("pack penalty tracker init: %w", err)
+	}
+	return &packAdmission{misses: misses, hits: hits, penalized: penalized}, nil
+}
+
+// recordMiss counts one miss against packRef and reports whether the pack has
+// now missed often enough to be worth transferring whole, along with the miss
+// count itself for logging.
+//
+// Counting and deciding are one call because they are one event: every miss
+// both advances the estimate and consults it, and splitting them would let a
+// caller consult without advancing, which is how a promotion threshold never
+// fires.
+func (a *packAdmission) recordMiss(packRef string) (misses int, fetchWhole bool) {
+	if n, ok := a.misses.Get(packRef); ok {
+		misses = n
+	}
+	misses++
+	a.misses.Add(packRef, misses)
+
+	// Peek, not Get: checking the penalty must not refresh its recency, or a
+	// pack read every miss (which a penalized one is, by definition) would
+	// keep itself permanently fresh in penalized and never age out for the
+	// second chance the comment on that field promises.
+	_, penalized := a.penalized.Peek(packRef)
+
+	// Worth transferring whole once it has missed enough to look like a scan,
+	// unless a previous promotion was evicted before paying for itself.
+	return misses, misses >= packPromoteAfter && !penalized
+}
+
+// cached records that packRef is now held whole in the body cache, so the
+// misses that led there are spent.
+func (a *packAdmission) cached(packRef string) {
+	a.misses.Remove(packRef)
+}
+
+// served records one object served from a cached pack, read back by evicted.
+func (a *packAdmission) served(packRef string) {
+	hits := 0
+	if n, ok := a.hits.Get(packRef); ok {
+		hits = n
+	}
+	a.hits.Add(packRef, hits+1)
+}
+
+// evicted records that a cached pack was dropped because the cache ran out of
+// room -- not that one was removed deliberately, which carries no such meaning
+// (see newPackBodyCache).
+//
+// A promotion pays for a whole-pack transfer up front, betting it back on the
+// hits the pack serves while cached. That bet loses when the working set is
+// bigger than the cache: the pack is evicted to make room for another before it
+// has served enough hits to be worth what it cost, and the next miss on the
+// same pack would promote it again, pay the same transfer, and lose the same
+// bet -- forever, at a cost bounded by pack size no matter how much larger the
+// true working set is than the cache.
+//
+// Recording the loss here is what breaks that cycle. A pack that didn't earn
+// back its promotion is marked, and recordMiss serves it with ranged reads from
+// then on rather than promoting it again -- bounding the cost per object by
+// object size instead, which holds regardless of how large the repository or
+// how mismatched the cache is to it. The mark expires when it ages out of the
+// penalty set's own bounded window, so a pack that becomes worth caching again
+// -- the working set shrinks, or access moves on -- gets another chance rather
+// than being penalized permanently on one bad measurement.
+func (a *packAdmission) evicted(packRef string) {
+	hits := 0
+	if n, ok := a.hits.Get(packRef); ok {
+		hits = n
+	}
+	a.hits.Remove(packRef)
+	if hits < packPromoteAfter {
+		a.penalized.Add(packRef, struct{}{})
+	}
+}


### PR DESCRIPTION
## Summary

Structural only. Whether a pack is worth transferring whole was one decision spread across four places — three LRUs on `PackStore`, plus `recordPackHit`, `onPackEvicted`, and the promotion branch of `resolveFromPack`. It becomes one `packAdmission` type with one entry point.

- `PackStore` drops from **four cache-related fields to two** (`packCache`, `admission`)
- `recordMiss` counts a miss *and* returns the decision, because they are one event
- `cached` / `served` / `evicted` record the events that inform it
- `resolveFromPack` keeps the question it can answer — can this backend range-read — and delegates the one it was estimating

Nothing else in the package touched those three fields, so the extraction is clean: zero leakage outside the four sites.

## Why, given the line count is roughly flat

The point is the **demolition date**, not the diff size.

`packAdmission` estimates a quantity callers frequently know outright — a restore holds its whole metadata plan before it fetches anything. When declaration (RFC 0025 §2) or compaction (§4) makes the estimate unnecessary, deleting it becomes *removing one type and one field* rather than surgery across four call sites. The type comment says this out loud so the next reader doesn't have to reconstruct it.

This is the enabling step for the simplification the pack layer needs; it deliberately does not take it, because deleting the estimator is a **behavioural** change requiring measurement, and mixing that with a structural move would make both harder to review.

Every rationale comment moves with the code it explains, including the measured justification for `packPromoteAfter = 8` and why the penalty is `Peek`ed rather than `Get`. staticcheck's De Morgan suggestion is taken, which also states the rule more directly: fetch whole once it has missed enough **and** is not penalized.

## Verification

| | `main` sample 1 | `main` sample 2 | this branch |
|---|---|---|---|
| `check` requests @42 packs | 385 | 385 | **385** |
| `restore` requests @42 packs | 507 | 501 | 504 |
| `restore` bytes | 320.8 MB | 316.5 MB | 316.6 MB |

`check` is sequential and therefore deterministic — identical across all three, which is the real behaviour-preservation evidence.

**`restore` is not deterministic**, and this is worth recording: it fetches metadata through an `errgroup`, so which pack is touched first depends on goroutine scheduling, and that decides miss counts and promotion. `main` alone spans 507–501. This branch's 504 sits inside its own baseline's spread.

That also corrects an assumption used earlier in this workstream: restore request deltas smaller than roughly 6 at this scale are not distinguishable from scheduling noise on a single sample.

```bash
go test -race -count=1 ./internal/... ./pkg/... .
go test -count=1 ./e2e
golangci-lint run ./...
```

All pass; `gofmt` clean.

## Related issues

Groundwork for the pack-layer simplification discussed against #486 and #487. Deletes nothing and decides nothing — those are separate, behavioural, and evidence-gated.

## Repository compatibility

No repository format change. Nothing written to a store differs, and no read path changes what it accepts.

## Documentation

No user-facing or exported-API change. `packAdmission` is unexported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved pack caching decisions based on recent cache misses, cache hits, and evictions.
  * Frequently requested packs can now be promoted for whole-pack transfer more effectively.
  * Reduced unnecessary whole-pack downloads when cached packs do not demonstrate sufficient usage.
  * Improved transfer efficiency by adapting caching behavior to actual pack demand over time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->