### PR TITLE
fix(benchreport): render wall time in the scaling report

### DIFF
--- a/internal/cmd/benchreport/render.go
+++ b/internal/cmd/benchreport/render.go
@@ -20,14 +20,25 @@ func Render(w io.Writer, rep *Report, title string) error {
 
 	switch rep.Kind() {
 	case KindScaling:
-		b.WriteString("Measurements of the real binary, per operation, at each tree size. A row\n" +
-			"that stays flat holds a working set; one that tracks the file count holds a\n" +
-			"per-entry structure, and will eventually meet a repository it cannot open.\n\n")
+		b.WriteString("Measurements of the real binary, per operation, at each tree size.\n\n")
 		writeSampleNote(b, rep)
 
-		b.WriteString("### Peak RSS (MB)\n\n")
+		// Wall time leads because it is the headline this sweep exists to
+		// produce. It was measured all along — bench.sh parses it from time(1)
+		// and writes it to the CSV — but for a while only the comparison
+		// renderer printed it, so a scaling run uploaded its timings in the
+		// artifact and showed none of them in the summary.
+		b.WriteString("### Wall time (s)\n\n")
+		b.WriteString("How long each operation took. A shared runner carries several percent of\n" +
+			"noise and its hardware differs from the next runner's, so read a column\n" +
+			"against the others in the same run rather than against another run's.\n\n")
+		renderScalingTable(b, rep, Seconds)
+
+		b.WriteString("\n### Peak RSS (MB)\n\n")
 		b.WriteString("The largest amount live at once — what decides whether an operation fits\n" +
-			"in the memory available.\n\n")
+			"in the memory available. A row that stays flat holds a working set; one that\n" +
+			"tracks the file count holds a per-entry structure, and will eventually meet a\n" +
+			"repository it cannot open.\n\n")
 		renderScalingTable(b, rep, PeakMB)
 
 		// Peak RSS is blind to allocation that is freed again, which is most of
@@ -359,7 +370,9 @@ func renderByAPI(b *strings.Builder, rep *Report) {
 func renderCharts(b *strings.Builder, rep *Report) {
 	switch rep.Kind() {
 	case KindScaling:
-		metrics := []Metric{PeakMB}
+		// Same order as the tables above, so a reader scrolling from one to the
+		// other meets the metrics in the same sequence.
+		metrics := []Metric{Seconds, PeakMB}
 		if rep.hasAlloc() {
 			metrics = append(metrics, AllocMB)
 		}

--- a/internal/cmd/benchreport/report_test.go
+++ b/internal/cmd/benchreport/report_test.go
@@ -97,6 +97,42 @@ func TestScalingTableReportsGrowth(t *testing.T) {
 	}
 }
 
+// Wall time is the headline a scaling sweep exists to produce, and it was
+// measured all along — but only the comparison renderer used to print it, so a
+// multi-size run wrote its timings to the CSV and showed none of them in the
+// summary. The chart matters as much as the table: without it, time is the one
+// metric a reader cannot see the shape of.
+func TestScalingReportShowsWallTime(t *testing.T) {
+	var b strings.Builder
+	if err := Render(&b, parse(t, scalingCSV), "T"); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := b.String()
+
+	if !strings.Contains(out, "### Wall time (s)") {
+		t.Errorf("wall time table missing; got:\n%s", out)
+	}
+	// backup-initial's timings, which appear nowhere else in this report.
+	for _, want := range []string{"| 0.5 |", "| 1.2 |", "| 5.49 |"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("wall time cell %q missing; got:\n%s", want, out)
+		}
+	}
+	// 5.49 / 0.50 = 10.98
+	if !strings.Contains(out, "10.98x") {
+		t.Errorf("wall time growth column missing or wrong; got:\n%s", out)
+	}
+	if !strings.Contains(out, `title "backup-initial — time (s)"`) {
+		t.Errorf("wall time chart missing; got:\n%s", out)
+	}
+
+	// Time leads; memory follows. A reader scanning the summary should meet
+	// the headline before the diagnostics.
+	if secs, peak := strings.Index(out, "### Wall time"), strings.Index(out, "### Peak RSS"); secs > peak {
+		t.Errorf("peak RSS precedes wall time; got:\n%s", out)
+	}
+}
+
 // The table has to precede the charts and survive on its own: a renderer that
 // does not know xychart-beta shows the chart as source text, and the numbers
 // still have to be readable.


### PR DESCRIPTION
## Summary

- Add a `Wall time (s)` section to the scaling report, rendered first — before Peak RSS and Total allocated. It uses the existing `Seconds` metric through `renderScalingTable`, so it gets the same median/band cells and `Growth` column as every other table.
- Add `Seconds` to the scaling chart metrics, ahead of `PeakMB`, so the charts appear in the same order as the tables.
- Move the "a row that stays flat holds a working set…" sentence out of the section intro and into the Peak RSS prose. It is an argument about memory, and it read as a claim about wall time once time led the report; the new time prose carries the runner-noise caveat in its place.

### Why

`bench.sh` has always measured wall time — it parses it from `time(1)` and writes the `seconds` column — but `Render`'s `KindScaling` path emitted tables only for peak RSS, allocation, and (on a MinIO run) requests and bytes. Seconds was rendered exclusively by the comparison path, in the `time · peak RSS` cell and its bar charts. So every scaling run uploaded its timings in the CSV artifact and showed none of them in the job summary.

That also explains why the two `Benchmark` jobs produce such different-looking summaries. `Report.Kind()` is inferred from how many distinct tree sizes are in the data, not from the backend: the local job runs `SIZES: 5000 20000 50000` and lands in `KindScaling`, the MinIO job runs a single size and lands in `KindComparison`. The MinIO summary appeared to report wall time and the local one did not purely because of which branch each fell into — and the local job is the one the workflow header names as the source of the headline wall-time numbers.

With this change the metric coverage lines up: both reports carry time, peak RSS, allocation and the repository summary, and MinIO adds requests/sent on top. The remaining shape difference is the deliberate one-size/one-sample MinIO matrix documented in `.github/workflows/benchmark.yml`.

Sample of the new section, from a synthetic three-size CSV:

```
### Wall time (s)

| Operation | 5,000 files | 20,000 files | 50,000 files | Growth |
|---|---:|---:|---:|---:|
| `init` | 0.05 | 0.06 | 0.06 | 1.20x |
| `backup` | 12.3 | 48.1 | 131.44 | 10.69x |
```

### Note for a reviewer

Because `Kind()` is derived from the data, dispatching the local job with a single value in `sizes` still flips it to the comparison layout. Nothing is lost when that happens — time is reported either way now — but the summary changes shape. Passing the kind explicitly rather than deriving it would fix that; left out of scope here.

## Related issues

None

## Repository compatibility

No repository format change. `benchreport` is a reporting tool over CSV produced by the benchmark harness; it reads and writes nothing in a repository.

## Verification

- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./internal/cmd/benchreport` — passes, including the new `TestScalingReportShowsWallTime`, which pins the table heading, the cell values, the growth factor, the chart title, and the time-before-memory ordering.
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./internal/cmd/benchreport/...` — 0 issues.
- Rendered a synthetic three-size CSV through `go run ./internal/cmd/benchreport render` and read the output; excerpt above.

## Documentation

No documentation change required. No exported API changed, and `AGENTS.md`'s description of `bench.sh` already states that wall time is among the metrics a run collects — this makes the rendered report match that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scaling reports now display wall-time measurements before Peak RSS.
  * Added explanatory text and tables for wall-time results, including timing values and growth ratios.
  * Scaling charts now include wall-time and allocation metrics.

* **Documentation**
  * Updated Peak RSS descriptions to emphasize memory fit and working-set behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->