### PR TITLE
fix(store): keep a pack's hit tally with the pack body

### DIFF
--- a/internal/storelayer/pack.go
+++ b/internal/storelayer/pack.go
@@ -379,7 +379,6 @@ func (s *PackStore) Get(ctx context.Context, key string) ([]byte, error) {
 		}
 		data := make([]byte, entry.Length)
 		copy(data, packData[entry.Offset:entry.Offset+entry.Length])
-		s.admission.served(entry.PackRef)
 		s.debugf("get %s: hit lru pack cache %s (len=%d)", key, entry.PackRef, entry.Length)
 		return data, nil
 	}

--- a/internal/storelayer/packadmission.go
+++ b/internal/storelayer/packadmission.go
@@ -44,10 +44,6 @@ type packAdmission struct {
 	// object at a time is no longer the cheaper option.
 	misses *lru.Cache[string, int]
 
-	// Hits served from a pack since it was promoted, read by evicted() to tell
-	// a promotion that paid for itself from one that didn't.
-	hits *lru.Cache[string, int]
-
 	// Packs whose last promotion was evicted before serving packPromoteAfter
 	// hits -- cheaper to have left as ranged reads. A pack in here is never
 	// promoted again until it ages out of this bounded structure, which is what
@@ -81,23 +77,19 @@ const (
 	// to matter more than the bytes saved.
 	packPromoteAfter = 8
 
-	// packMissWindow bounds the miss counter, the hit counter and the penalty
-	// set. Each only has to span the packs in flight around a given moment, and
-	// none may become a second unbounded per-repository structure -- which is
-	// the thing RFC 0023 is about.
+	// packMissWindow bounds the miss counter and the penalty set. Each only has
+	// to span the packs in flight around a given moment, and neither may become
+	// a second unbounded per-repository structure -- which is the thing RFC 0023
+	// is about.
 	//
-	// It has to stay above the number of packs the body cache holds at once. A
-	// hit counter evicted from this window while its pack is still resident
-	// reads as zero hits on the next eviction and penalizes a pack that was
-	// serving fine.
-	//
-	// 64 does not actually guarantee that, and the comment here used to claim it
-	// did. The figure it was chosen against -- packBodyCacheBudget /
+	// It deliberately does *not* bound a hit counter any more. That one had to
+	// outlive its pack's residency to be correct, and this window could not
+	// promise it: the figure it was sized against -- packBodyCacheBudget /
 	// maxPackSize, or 8 -- assumes every pack is maximal, while packBodyCache
-	// bounds bytes rather than entries, so a repository of small incremental
-	// packs can hold far more than 64 resident. Latent rather than active at
-	// measured scale: at 82 packs roughly 32 are resident, and raising this to
-	// 512 there moved nothing. See #494 for the fix, which is behavioural.
+	// bounds bytes, so a repository of small incremental packs holds far more
+	// than 64 resident. Hits now live in the cached body itself (#494), where
+	// the lifetimes cannot diverge, so no arithmetic has to hold for the
+	// penalty to be correct.
 	packMissWindow = 64
 )
 
@@ -106,15 +98,11 @@ func newPackAdmission() (*packAdmission, error) {
 	if err != nil {
 		return nil, fmt.Errorf("pack miss counter init: %w", err)
 	}
-	hits, err := lru.New[string, int](packMissWindow)
-	if err != nil {
-		return nil, fmt.Errorf("pack hit counter init: %w", err)
-	}
 	penalized, err := lru.New[string, struct{}](packMissWindow)
 	if err != nil {
 		return nil, fmt.Errorf("pack penalty tracker init: %w", err)
 	}
-	return &packAdmission{misses: misses, hits: hits, penalized: penalized}, nil
+	return &packAdmission{misses: misses, penalized: penalized}, nil
 }
 
 // recordMiss counts one miss against packRef and reports whether the pack has
@@ -149,15 +137,6 @@ func (a *packAdmission) cached(packRef string) {
 	a.misses.Remove(packRef)
 }
 
-// served records one object served from a cached pack, read back by evicted.
-func (a *packAdmission) served(packRef string) {
-	hits := 0
-	if n, ok := a.hits.Get(packRef); ok {
-		hits = n
-	}
-	a.hits.Add(packRef, hits+1)
-}
-
 // evicted records that a cached pack was dropped because the cache ran out of
 // room -- not that one was removed deliberately, which carries no such meaning
 // (see newPackBodyCache).
@@ -178,12 +157,7 @@ func (a *packAdmission) served(packRef string) {
 // penalty set's own bounded window, so a pack that becomes worth caching again
 // -- the working set shrinks, or access moves on -- gets another chance rather
 // than being penalized permanently on one bad measurement.
-func (a *packAdmission) evicted(packRef string) {
-	hits := 0
-	if n, ok := a.hits.Get(packRef); ok {
-		hits = n
-	}
-	a.hits.Remove(packRef)
+func (a *packAdmission) evicted(packRef string, hits int) {
 	if hits < packPromoteAfter {
 		a.penalized.Add(packRef, struct{}{})
 	}

--- a/internal/storelayer/packbodycache.go
+++ b/internal/storelayer/packbodycache.go
@@ -49,6 +49,21 @@ import (
 // access order, the way #455 did for restore's write phase — see #478.
 const packBodyCacheBudget = 8 * maxPackSize
 
+// packBody is a cached packfile body together with the number of objects served
+// from it since it was cached.
+//
+// The count lives with the body rather than in a structure of its own, and that
+// is the entire point of it being here. They are one lifecycle: a body that is
+// resident has a count, and a body that leaves takes its count with it. Held
+// apart — which is how this worked until #494 — the two were bounded by
+// different rules, so the count could be forgotten while the body was still
+// resident, and the next eviction would read zero hits and penalize a pack that
+// had been serving perfectly well.
+type packBody struct {
+	data []byte
+	hits int
+}
+
 // packBodyCache is an LRU of packfile bodies bounded by total bytes.
 //
 // hashicorp/golang-lru bounds by entry count, so the byte accounting lives here:
@@ -56,13 +71,13 @@ const packBodyCacheBudget = 8 * maxPackSize
 // the tail until the budget is met.
 type packBodyCache struct {
 	mu     sync.Mutex
-	lru    *lru.Cache[string, []byte]
+	lru    *lru.Cache[string, *packBody]
 	bytes  int
 	budget int
 
 	// Called for a body dropped because the cache ran out of room, and only
-	// for that. See newPackBodyCache.
-	onPressureEvict func(key string)
+	// for that, with the hits it served while cached. See newPackBodyCache.
+	onPressureEvict func(key string, hits int)
 }
 
 // newPackBodyCache returns a cache holding at most budget bytes of pack bodies.
@@ -70,7 +85,7 @@ type packBodyCache struct {
 // onPressureEvict, if non-nil, is called when a body is dropped *because the
 // cache ran out of room* — never when one is removed deliberately. PackStore
 // reads that signal as "this promotion did not pay for itself" (see
-// PackStore.onPackEvicted), and a pack removed because it was deleted or its
+// packAdmission.evicted), and a pack removed because it was deleted or its
 // upload was discarded carries no such meaning: it is gone, not thrashing.
 // Conflating the two marked deleted packs as not worth promoting and spent
 // slots in a bounded window that exists to track live ones.
@@ -79,13 +94,13 @@ type packBodyCache struct {
 // the only place a body is dropped under pressure, so it is the only place the
 // signal is raised. The underlying LRU's own callback stays responsible for
 // byte accounting, which every removal needs.
-func newPackBodyCache(budget int, onPressureEvict func(key string)) (*packBodyCache, error) {
+func newPackBodyCache(budget int, onPressureEvict func(key string, hits int)) (*packBodyCache, error) {
 	c := &packBodyCache{budget: budget, onPressureEvict: onPressureEvict}
 	// The entry limit only has to be beyond what the budget can hold. A pack is
 	// never smaller than one object, so this cannot be reached before the byte
 	// budget is.
-	inner, err := lru.NewWithEvict(1<<20, func(_ string, v []byte) {
-		c.bytes -= len(v)
+	inner, err := lru.NewWithEvict(1<<20, func(_ string, v *packBody) {
+		c.bytes -= len(v.data)
 	})
 	if err != nil {
 		return nil, err
@@ -94,10 +109,21 @@ func newPackBodyCache(budget int, onPressureEvict func(key string)) (*packBodyCa
 	return c, nil
 }
 
+// Get returns a cached body and counts the read against it.
+//
+// Counting here rather than in a separate call is what makes the tally
+// inseparable from the body: every Get is a hit by definition, since the only
+// caller reads an object out of what it returns.
 func (c *packBodyCache) Get(key string) ([]byte, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.lru.Get(key)
+
+	body, ok := c.lru.Get(key)
+	if !ok {
+		return nil, false
+	}
+	body.hits++
+	return body.data, true
 }
 
 // Add stores data under key and evicts from the tail until the cache is within
@@ -114,13 +140,13 @@ func (c *packBodyCache) Add(key string, data []byte) {
 		// The eviction callback adjusts the count for the value being replaced.
 		c.lru.Remove(key)
 	}
-	c.lru.Add(key, data)
+	c.lru.Add(key, &packBody{data: data})
 	c.bytes += len(data)
 
 	for c.bytes > c.budget && c.lru.Len() > 1 {
-		evicted, _, ok := c.lru.RemoveOldest()
+		evicted, body, ok := c.lru.RemoveOldest()
 		if ok && c.onPressureEvict != nil {
-			c.onPressureEvict(evicted)
+			c.onPressureEvict(evicted, body.hits)
 		}
 	}
 }

--- a/internal/storelayer/packbodycache_test.go
+++ b/internal/storelayer/packbodycache_test.go
@@ -85,7 +85,7 @@ func TestPackBodyCache_ReplaceAndRemoveAccountForBytes(t *testing.T) {
 // and a prune deleting many packs could flush out real penalties.
 func TestPackBodyCache_PressureSignalIsNotRaisedByDeliberateRemoval(t *testing.T) {
 	var evicted []string
-	c, err := newPackBodyCache(1000, func(key string) { evicted = append(evicted, key) })
+	c, err := newPackBodyCache(1000, func(key string, _ int) { evicted = append(evicted, key) })
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +110,7 @@ func TestPackBodyCache_PressureSignalIsNotRaisedByDeliberateRemoval(t *testing.T
 // count honest.
 func TestPackBodyCache_ReplacingAnEntryRaisesNoPressureSignal(t *testing.T) {
 	var evicted []string
-	c, err := newPackBodyCache(10000, func(key string) { evicted = append(evicted, key) })
+	c, err := newPackBodyCache(10000, func(key string, _ int) { evicted = append(evicted, key) })
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -295,5 +295,71 @@ func TestPackStore_ThrashingPackStopsBeingRepromoted(t *testing.T) {
 		t.Errorf("fullGets = %d over %d passes, want at most %d (one promotion per pack, ever); "+
 			"a thrashing pack is still being repromoted instead of falling back to ranged reads",
 			counting.fullGets, passes, packs)
+	}
+}
+
+// A resident body keeps its hit tally however many other packs are read
+// alongside it.
+//
+// This is the property #494 was filed for. The tally used to live in an LRU
+// bounded by packMissWindow while the body lived in one bounded by bytes, so a
+// repository of small packs could hold far more bodies than the tally window had
+// room for. Reading past the window forgot the tally while the body was still
+// resident, and the next pressure eviction then read zero hits and penalized a
+// pack that had been serving fine — the exact failure that window's comment
+// claimed to prevent.
+//
+// The reproduction needs all three conditions together, which is why it is
+// spelled out rather than folded into an existing test: the bodies must fit
+// (so nothing is evicted early), every filler must be *read* (so it occupies a
+// tally slot), and the earner must be evicted last (so its tally is consulted
+// after the window has overflowed).
+func TestPackBodyCache_ResidentBodyKeepsItsHitsPastTheMissWindow(t *testing.T) {
+	const fillers = packMissWindow * 3
+	const bodySize = 16
+
+	var penalized []string
+	// Roomy enough that every small body stays resident; the final oversized
+	// Add is what forces an eviction.
+	c, err := newPackBodyCache((fillers+2)*bodySize, func(key string, hits int) {
+		if hits < packPromoteAfter {
+			penalized = append(penalized, key)
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c.Add("packs/earner", bytes.Repeat([]byte("e"), bodySize))
+	for range packPromoteAfter {
+		if _, ok := c.Get("packs/earner"); !ok {
+			t.Fatal("earner left the cache while it was being read")
+		}
+	}
+
+	// Every filler is read once, so each takes a tally slot. Past
+	// packMissWindow of them, a window-bounded tally has dropped the earner's.
+	for i := range fillers {
+		key := fmt.Sprintf("packs/filler-%03d", i)
+		c.Add(key, bytes.Repeat([]byte("f"), bodySize))
+		if _, ok := c.Get(key); !ok {
+			t.Fatalf("%s left the cache while it was being read", key)
+		}
+	}
+	// Deliberately not read again here: a Get would refresh its recency and put
+	// it at the head, and the eviction below takes from the tail. The earner has
+	// to be the oldest entry for its tally to be the one consulted.
+
+	// Blow the budget so the tail is evicted and the tallies are consulted.
+	c.Add("packs/flood", bytes.Repeat([]byte("x"), (fillers+2)*bodySize))
+
+	for _, key := range penalized {
+		if key == "packs/earner" {
+			t.Fatalf("a pack that served %d hits was penalized after %d other packs were read",
+				packPromoteAfter, fillers)
+		}
+	}
+	if len(penalized) == 0 {
+		t.Fatal("nothing was penalized, so the eviction path never ran and this test proves nothing")
 	}
 }


### PR DESCRIPTION
## Summary

Closes #494. The fix **deletes** a structure rather than adding one.

The tally deciding whether a promotion paid for itself lived in an LRU bounded by `packMissWindow`; the body it described lived in one bounded by bytes. Two bounds, two lifetimes. `packBodyCache`'s inner entry limit is `1<<20` — deliberately beyond what the byte budget can hold — so a repository of small incremental packs keeps far more than 64 bodies resident. Past that, the tally is forgotten while its body is still cached, and the next pressure eviction reads zero hits and penalises a pack that was serving fine.

That is exactly the failure `packMissWindow`'s own comment claimed the constant prevented.

**Store the count with the body.** `packBody` carries `data` and `hits`, `Get` counts the read against the entry it returns, and the pressure-eviction callback hands the count to `packAdmission.evicted` instead of having it look one up. The lifetimes cannot diverge because there is only one.

Net effect on the machinery:

- `packAdmission` goes from **three LRUs to two**, and loses its `served` method
- `packMissWindow` no longer has to satisfy an arithmetic relationship with the cache budget for the penalty to be correct — the invariant is structural now, not asserted

## The regression test needs three conditions at once

Stated explicitly in the test, because any one missing makes it pass vacuously — and two of them did while I was writing it:

1. every body must fit, so nothing is evicted early
2. every filler must be **read**, so it occupies a tally slot
3. the earner must stay the oldest entry, so its tally is the one consulted

My first attempt missed (2) and passed on `main`. My second added a `Get` to assert the earner was still resident — which refreshed its recency, so it was never the eviction victim, and it passed on `main` too.

With all three, it fails against `main` with:

```
a pack that served 8 hits was penalized after 192 other packs were read
```

It also asserts something *was* penalised, so the test cannot pass by the eviction path never running.

## Measurements

Behavioural, so measured. `aging.sh`, 5,000-file tree, MinIO:

| @42 packs | `main` (2 samples) | this branch |
|---|---|---|
| `restore` requests | 507 / 501 | 515 |
| `restore` bytes | 320.8 / 316.5 MB | 328.6 MB |
| `check` requests | 385 / 385 | **385** |

The benchmark repository holds roughly 32 packs resident — **below** the window — so it does not enter the regime this fixes. These numbers are here to show the fix does not disturb the regime it does not fix. `restore` request counts are non-deterministic (concurrent metadata fetch); `main` alone spans 507–501, and 515 sits just outside that on a single sample, which I would not read as a regression but am not going to hide either.

The regime that *is* fixed — many small packs, i.e. daily backups of a rarely-changing tree — is not reachable with the current benchmark profile, which is why the reproduction is a unit test.

## Related issues

Closes #494, found by CodeRabbit review on #492. Pre-existing; #492 only moved the code and its comment.

## Repository compatibility

No repository format change. In-process cache policy only; nothing written to a store differs.

## Verification

```bash
go test -race -count=1 ./internal/... ./pkg/... .
go test -count=1 ./e2e
golangci-lint run ./...
```

All pass, `gofmt` clean.

## Documentation

No user-facing or exported-API change. `packBody`, `packBodyCache` and `packAdmission` are all unexported.