### PR TITLE
fix(store): load the pack catalog before answering Exists

### DIFF
--- a/internal/storelayer/pack.go
+++ b/internal/storelayer/pack.go
@@ -556,7 +556,7 @@ func (s *PackStore) Exists(ctx context.Context, key string) (bool, error) {
 
 	if hasPackablePrefix(key) {
 		if err := s.ensureCatalogLoaded(ctx); err != nil {
-			return false, err
+			return false, fmt.Errorf("look up %s: %w", key, err)
 		}
 		s.mu.RLock()
 		packed := s.catalog.Has(key)

--- a/internal/storelayer/pack.go
+++ b/internal/storelayer/pack.go
@@ -279,6 +279,19 @@ var packablePrefixes = []string{
 	"content/",
 }
 
+// hasPackablePrefix reports whether key lives in a namespace this store
+// bundles, and so may be recorded in the catalog rather than stored as a
+// standalone backend object. A key outside them is never in the catalog, so a
+// lookup for one needs no catalog at all.
+func hasPackablePrefix(key string) bool {
+	for _, prefix := range packablePrefixes {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // isSmallObject determines if a key/data pair should be bundled into a packfile.
 func (s *PackStore) isSmallObject(key string, data []byte) bool {
 	// We only pack metadata and small blobs to keep large data files randomly
@@ -286,12 +299,7 @@ func (s *PackStore) isSmallObject(key string, data []byte) bool {
 	if len(data) > maxObjectSize {
 		return false
 	}
-	for _, prefix := range packablePrefixes {
-		if strings.HasPrefix(key, prefix) {
-			return true
-		}
-	}
-	return false
+	return hasPackablePrefix(key)
 }
 
 // prepareFlushLocked takes the current buffer, prepares a pack object, updates the catalog,
@@ -520,6 +528,20 @@ func (s *PackStore) resolveFromPack(ctx context.Context, key string, entry PackE
 }
 
 // Exists checks the un-flushed buffer, the catalog, or falls back to inner.
+//
+// The catalog is loaded before the fallback, for the same reason Delete loads
+// it: a packed object has no standalone copy in the backend, so asking an
+// unloaded store about one finds it in neither the buffer nor the (empty)
+// catalog, forwards the question down, and reports (false, nil) for an object
+// the repository holds. That is the permissive direction this package refuses
+// everywhere else — loadCatalogLocked and loadShardsLocked exist so that
+// "cannot read the index" is never answered as "there is nothing packed", and a
+// catalog that has not been read yet is no more evidence of absence than one
+// that failed to decode.
+//
+// Only keys under a packable prefix pay for the load. Nothing else can be in
+// the catalog, so lock, key-slot and index lookups keep forwarding straight to
+// the backend.
 func (s *PackStore) Exists(ctx context.Context, key string) (bool, error) {
 	s.mu.RLock()
 	if _, ok := s.packKeys[key]; ok {
@@ -531,6 +553,18 @@ func (s *PackStore) Exists(ctx context.Context, key string) (bool, error) {
 		return true, nil
 	}
 	s.mu.RUnlock()
+
+	if hasPackablePrefix(key) {
+		if err := s.ensureCatalogLoaded(ctx); err != nil {
+			return false, err
+		}
+		s.mu.RLock()
+		packed := s.catalog.Has(key)
+		s.mu.RUnlock()
+		if packed {
+			return true, nil
+		}
+	}
 
 	return s.ObjectStore.Exists(ctx, key)
 }

--- a/internal/storelayer/pack_catalog_test.go
+++ b/internal/storelayer/pack_catalog_test.go
@@ -134,6 +134,47 @@ func TestPackStore_GetFailsWhenCatalogUnreadable(t *testing.T) {
 	}
 }
 
+// And for existence checks, where the permissive answer is the dangerous one.
+// Get and List fail loudly when the catalog cannot be read; Exists could
+// instead fall through to the backend and answer (false, nil), which is
+// indistinguishable from "this object was never written" to a caller like
+// copy's putIfMissing. A transient backend error must not become an object
+// silently rewritten -- or, on a caller that treats absence as deletion, an
+// object silently lost.
+func TestPackStore_ExistsFailsWhenCatalogUnreadable(t *testing.T) {
+	ctx := context.Background()
+	faulty, inner := newCatalogTestStore(t)
+	seedPackedRepo(t, inner, "filemeta/a")
+
+	faulty.failsLeft = 1
+	ps := newPackStoreT(t, faulty)
+
+	ok, err := ps.Exists(ctx, "filemeta/a")
+	if err == nil {
+		t.Fatalf("Exists succeeded (= %v); want an error when the catalog is unreadable", ok)
+	}
+	if ok {
+		t.Error("Exists reported true alongside an error; the answer must not be trusted")
+	}
+	if faulty.injected == 0 {
+		t.Fatal("fault was never injected")
+	}
+	if !errors.Is(err, errCatalogUnavailable) {
+		t.Errorf("error should wrap the backend failure, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "filemeta/a") {
+		t.Errorf("error should name the key that was looked up, got: %v", err)
+	}
+
+	// The failure is not sticky: once the backend recovers, the same store
+	// answers correctly rather than caching a half-loaded catalog.
+	if ok, err := ps.Exists(ctx, "filemeta/a"); err != nil {
+		t.Errorf("Exists after recovery: %v", err)
+	} else if !ok {
+		t.Error("Exists(filemeta/a) = false after the backend recovered")
+	}
+}
+
 // Auto-flush adds authoritative local entries before the stored catalog is
 // loaded. A later load failure must discard only streamed remote entries: the
 // local objects remain readable without depending on an unrelated bad shard.

--- a/internal/storelayer/pack_compact_test.go
+++ b/internal/storelayer/pack_compact_test.go
@@ -91,7 +91,21 @@ func TestCompactCatalog_EmptiedCatalogRemovesItsShards(t *testing.T) {
 		}
 	}
 
-	// A fresh reader must not resurrect the deleted entries.
+	// A fresh reader answers the same way through every path.
+	//
+	// It answers "present". Compaction emptied the index, and an index that
+	// lists nothing is indistinguishable from one that was lost, so the load
+	// heals from the pack's own footer -- which still names both objects,
+	// because the now-orphaned pack has not been repacked away. That is
+	// TestPackStore_HealsWhenLegacyCatalogIsEmpty's deliberate behaviour, not an
+	// artefact here: reading an empty index as authoritative is what made a
+	// packed object report missing while its pack was intact.
+	//
+	// What this pins is that the three paths agree. Exists used to answer
+	// "absent" here purely because it was the one read path that never loaded
+	// the catalog, so it fell through to the backend, where a packed object has
+	// no standalone copy -- while List and Get, on the same store and the same
+	// key, both said "present".
 	fresh, err := NewPackStore(mem)
 	if err != nil {
 		t.Fatal(err)
@@ -99,9 +113,19 @@ func TestCompactCatalog_EmptiedCatalogRemovesItsShards(t *testing.T) {
 	for _, k := range keys {
 		if ok, err := fresh.Exists(ctx, k); err != nil {
 			t.Errorf("Exists(%s): %v", k, err)
-		} else if ok {
-			t.Errorf("%s came back after compaction removed it", k)
+		} else if !ok {
+			t.Errorf("Exists(%s) = false, but Get and List both resolve it", k)
 		}
+		if _, err := fresh.Get(ctx, k); err != nil {
+			t.Errorf("Get(%s): %v", k, err)
+		}
+	}
+	listed, err := fresh.List(ctx, "filemeta/")
+	if err != nil {
+		t.Fatalf("List(filemeta/): %v", err)
+	}
+	if len(listed) != len(keys) {
+		t.Errorf("List(filemeta/) = %v, want the %d healed keys", listed, len(keys))
 	}
 }
 

--- a/internal/storelayer/pack_exists_test.go
+++ b/internal/storelayer/pack_exists_test.go
@@ -1,0 +1,102 @@
+package storelayer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cloudstic/cli/pkg/store/local"
+)
+
+// TestPackStore_ExistsLoadsCatalogOnFirstCall pins the one thing a packed
+// object's presence must not depend on: whether something else happened to read
+// the catalog first.
+//
+// A packed object has no standalone copy in the backend, so a PackStore that
+// has not loaded its catalog finds the key in neither the active buffer nor the
+// empty catalog and forwards the question to the backend, which correctly
+// reports that no such object is stored there. The composite answer — (false,
+// nil) for an object the repository holds — is wrong in the permissive
+// direction, and callers such as copy's putIfMissing treat it as "not there
+// yet" and rewrite the object.
+//
+// Exists is called before anything else here on purpose. Every other read path
+// loads the catalog, so any prior call would arm this one and hide the bug.
+func TestPackStore_ExistsLoadsCatalogOnFirstCall(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	backend, err := local.New(dir)
+	if err != nil {
+		t.Fatalf("create local store: %v", err)
+	}
+
+	// Write and seal a pack through one store, so the backend holds the object
+	// only inside a packfile plus the index describing it.
+	writer, err := NewPackStore(backend)
+	if err != nil {
+		t.Fatalf("init writer pack store: %v", err)
+	}
+	const key = "filemeta/deadbeef"
+	if err := writer.Put(ctx, key, []byte("packed metadata")); err != nil {
+		t.Fatalf("put %s: %v", key, err)
+	}
+	if err := writer.Flush(ctx); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	// The object is genuinely packed: no standalone backend object by that name.
+	if standalone, err := backend.Exists(ctx, key); err != nil {
+		t.Fatalf("backend exists %s: %v", key, err)
+	} else if standalone {
+		t.Fatalf("precondition failed: %s was stored standalone, so this test "+
+			"would pass without the catalog being consulted", key)
+	}
+
+	// A fresh store, as a new process would have. Exists is its first call.
+	reader, err := NewPackStore(backend)
+	if err != nil {
+		t.Fatalf("init reader pack store: %v", err)
+	}
+	exists, err := reader.Exists(ctx, key)
+	if err != nil {
+		t.Fatalf("exists %s: %v", key, err)
+	}
+	if !exists {
+		t.Errorf("Exists(%s) = false on a freshly constructed PackStore; the packed "+
+			"object is reported absent because the catalog was never loaded", key)
+	}
+}
+
+// TestPackStore_ExistsUnpackedKeyNeedsNoCatalog checks the other half of the
+// rule: keys outside the packable namespaces can never be in the catalog, so
+// answering for one must not pull the index in. index/latest is the case that
+// matters — prune probes it, and it is rewritten on every backup.
+func TestPackStore_ExistsUnpackedKeyNeedsNoCatalog(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	backend, err := local.New(dir)
+	if err != nil {
+		t.Fatalf("create local store: %v", err)
+	}
+
+	s, err := NewPackStore(backend)
+	if err != nil {
+		t.Fatalf("init pack store: %v", err)
+	}
+	if err := backend.Put(ctx, "index/latest", []byte("snapshot/abc")); err != nil {
+		t.Fatalf("put index/latest: %v", err)
+	}
+
+	exists, err := s.Exists(ctx, "index/latest")
+	if err != nil {
+		t.Fatalf("exists index/latest: %v", err)
+	}
+	if !exists {
+		t.Error("Exists(index/latest) = false, want true")
+	}
+	if s.catalogLoaded {
+		t.Error("Exists on an unpackable key loaded the pack catalog; nothing under " +
+			"index/ is ever packed, so the load is pure cost")
+	}
+}


### PR DESCRIPTION
## Summary

- `PackStore.Exists` was the one read path that never called `ensureCatalogLoaded`. `Get`, `List`, `Flush`, `Delete` and `Repack` all do.
- A packed object has no standalone copy in the backend. On a store whose catalog has not been read, the key is in neither the active buffer nor the empty catalog, so the question is forwarded to the backend and answered `(false, nil)` — for an object the repository holds.
- That is the permissive direction this package refuses everywhere else. `loadCatalogLocked` and `loadShardsLocked` exist so that "cannot read the index" is never answered as "there is nothing packed"; a catalog that has not been read yet is no more evidence of absence than one that failed to decode. `Delete` already carries a comment about exactly this hazard and loads for it — `Exists` was missed.
- The load is gated on a new `hasPackablePrefix`, factored out of `isSmallObject` so it tracks `packablePrefixes` automatically. Keys outside those namespaces can never be in the catalog, so lock, key-slot and `index/` probes keep forwarding straight to the backend and pay nothing.

### Reachability

No command reaches it today — but only incidentally, and every guard sits in another package:

| Caller | Key | Why it is safe today |
|---|---|---|
| `internal/engine/copy.go` (`putIfMissing`, `copyContent`) | `content/`, `filemeta/`, `snapshot/` on the **destination** | preceded by `cm.dstCatalog.load()`, which runs `List("snapshot/")` on the *same* store instance |
| `internal/engine/chunker.go`, `backup_upload.go` | `chunk/`, `content/` | go through `KeyCacheStore` after `PreloadKeys`, whose `List` loads the catalog |
| `prune.go`, `repolock.go`, `keychain.go`, root `copy.go` | `index/`, `lock/`, `keys/` | never packed |

Copy is the case that comes closest: it asks the destination about `filemeta/` and `snapshot/` keys, which are packed and never preloaded, and is saved only by an unrelated snapshot-catalog read happening first. A `(false, nil)` there would make copy rewrite objects the destination already holds.

### A pre-existing behaviour this surfaced

`TestCompactCatalog_EmptiedCatalogRemovesItsShards` asserted that a fresh reader would not resurrect entries a compaction had removed. **That claim was already false through `List` and `Get`** — verified directly: after `CompactCatalog` empties the index, a fresh store's `List("filemeta/")` returns both deleted keys and `Get` returns their bytes.

The cause is deliberate. Compaction leaves an index listing nothing, and `loadCatalogLocked` treats zero entries as *lost* rather than authoritative-empty, so it heals from the orphaned pack's footer — the behaviour `TestPackStore_HealsWhenLegacyCatalogIsEmpty` pins on purpose, because reading an empty index as authoritative is what made a packed object report missing while its pack was intact. `Exists` alone said "absent", and only because it was blind.

Weakening the heal is the permissive direction this package refuses, and out of scope here, so the test now pins that the three paths agree rather than papering over it. In the real `prune` flow `Repack` deletes the orphaned pack, so there is normally nothing left to heal from; the window is a compaction that lands without its repack.

## Related issues

None.

## Repository compatibility

No repository format change. Nothing written to a store changes: this only affects when an existing on-disk catalog is read. The change is strictly less permissive — a key that was reported absent may now be reported present — so no older build can misread anything this one writes, and `docs/compatibility.md`'s rule against treating "cannot decode" as "empty" is what the change extends to "have not read yet".

## Verification

- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./internal/storelayer` passes
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./internal/storelayer/...` passes (0 issues)
- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 ./...` passes

New regression tests in `internal/storelayer/pack_exists_test.go`:

- `TestPackStore_ExistsLoadsCatalogOnFirstCall` — seals a pack through one store, asserts the object is genuinely *not* standalone in the backend (so it cannot pass vacuously), then constructs a fresh `PackStore` and makes `Exists` its first call. Confirmed failing against the pre-fix code.
- `TestPackStore_ExistsUnpackedKeyNeedsNoCatalog` — pins the other half: `Exists("index/latest")` must resolve without loading the catalog.

## Documentation

No documentation change required. No exported API changes; `PackStore` is internal, and its behaviour is now what the surrounding comments in `pack.go` already describe.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Packed objects are now found correctly when checking their existence after a fresh store startup.
  * Empty catalogs can recover packed object information, allowing `Exists`, `Get`, and `List` operations to resolve previously stored objects.
  * Non-packable keys continue to be checked directly without unnecessary catalog loading.
  * Catalog read failures are now reported instead of returning potentially incorrect existence results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->