### PR TITLE
perf(engine): build the scan parent index only where it is read (RFC 0025)

### DIFF
--- a/internal/engine/backup.go
+++ b/internal/engine/backup.go
@@ -131,8 +131,18 @@ type BackupManager struct {
 	newMetas     map[string]core.FileMeta
 	metas        *metaLoader
 	pendingMetas map[string][]byte // deferred filemeta PUTs (ref → JSON)
-	parentIndex  map[string]string // fileID → primary parent fileID (for AffinityKey lookups)
-	hmacKey      []byte
+
+	// parentIndex maps fileID → primary parent fileID, so lookupMetaByFileID can
+	// build an AffinityKey instead of walking the tree. It is allocated by
+	// scanIncremental and stays nil on the full-scan path: its only reader is
+	// reached from processEntry's len(meta.Paths) == 0 branch, which a full Walk
+	// never takes because every source populates Paths there. Holding two strings
+	// per scanned entry for a map nothing reads is what the nil avoids.
+	//
+	// A nil map reads as empty, and a miss is answered by LookupByKey — so the
+	// gate can only cost a slower lookup, never a wrong one.
+	parentIndex map[string]string
+	hmacKey     []byte
 }
 
 func NewBackupManager(d Deps, src source.Source, opts ...BackupOption) *BackupManager {
@@ -159,7 +169,6 @@ func NewBackupManager(d Deps, src source.Source, opts ...BackupOption) *BackupMa
 		newMetas:     make(map[string]core.FileMeta),
 		metas:        newMetaLoader(keyCache),
 		pendingMetas: make(map[string][]byte),
-		parentIndex:  make(map[string]string),
 		hmacKey:      d.HMACKey,
 	}
 }

--- a/internal/engine/backup.go
+++ b/internal/engine/backup.go
@@ -133,14 +133,19 @@ type BackupManager struct {
 	pendingMetas map[string][]byte // deferred filemeta PUTs (ref → JSON)
 
 	// parentIndex maps fileID → primary parent fileID, so lookupMetaByFileID can
-	// build an AffinityKey instead of walking the tree. It is allocated by
-	// scanIncremental and stays nil on the full-scan path: its only reader is
-	// reached from processEntry's len(meta.Paths) == 0 branch, which a full Walk
-	// never takes because every source populates Paths there. Holding two strings
-	// per scanned entry for a map nothing reads is what the nil avoids.
+	// build an AffinityKey instead of walking the tree. scanIncremental allocates
+	// it; scan leaves it nil.
 	//
-	// A nil map reads as empty, and a miss is answered by LookupByKey — so the
-	// gate can only cost a slower lookup, never a wrong one.
+	// Its only reader is reached from processEntry's len(meta.Paths) == 0 branch.
+	// Every source in this module populates Paths in Walk, so a full scan was
+	// writing two strings per scanned entry into a map it would then never read;
+	// a change feed is what can deliver an entry with no path at all.
+	//
+	// The gate does not rest on that staying true, because it is a fast path
+	// rather than a requirement: a nil map reads as empty and a miss falls
+	// through to LookupByKey, so an entry that does arrive pathless under a full
+	// scan still resolves, just by walking the tree. MockSource emits exactly
+	// such entries, which is how the engine tests cover that fallback.
 	parentIndex map[string]string
 	hmacKey     []byte
 }

--- a/internal/engine/backup_scan.go
+++ b/internal/engine/backup_scan.go
@@ -57,7 +57,12 @@ func (bm *BackupManager) processEntry(ctx context.Context, meta *core.FileMeta, 
 	}
 
 	// Record this entry's parent so lookupMetaByFileID can use AffinityKey.
-	bm.parentIndex[meta.FileID] = primaryParentID(meta)
+	// Only scanIncremental allocates the index, because only its entries can
+	// arrive without Paths and so reach that lookup; on a full scan the map
+	// stays nil and this write is skipped rather than run once per file.
+	if bm.parentIndex != nil {
+		bm.parentIndex[meta.FileID] = primaryParentID(meta)
+	}
 
 	// Resolve Paths when the source hasn't populated it (incremental/changes
 	// sources only emit changed entries and can't build a full path map).
@@ -111,6 +116,9 @@ func (bm *BackupManager) scan(ctx context.Context, oldRoot string) (pending []co
 func (bm *BackupManager) scanIncremental(ctx context.Context, oldRoot string, incSrc source.IncrementalSource, token string) (pending []core.FileMeta, totalBytes int64, newToken string, err error) {
 	phase := bm.reporter.StartPhase("Scanning (incremental)", 0, false)
 	bm.txn = bm.tree.Edit(oldRoot)
+	// A change may legitimately arrive with no Paths, so this is the one scan
+	// strategy whose entries reach lookupMetaByFileID and can use the index.
+	bm.parentIndex = make(map[string]string)
 	s := &scanState{}
 
 	newToken, walkErr := incSrc.WalkChanges(ctx, token, func(fc source.FileChange) error {
@@ -357,7 +365,8 @@ func (bm *BackupManager) buildPathFromTree(ctx context.Context, meta *core.FileM
 // lookupMetaByFileID resolves a FileID to its FileMeta via the HAMT tree.
 // It checks newMetas (just inserted this scan) first, then falls back to the store.
 // Uses parentIndex to resolve the affinity routing key; falls back to a full-tree walk
-// for entries not yet seen in this scan (e.g. incremental backups).
+// for entries not yet seen in this scan (e.g. incremental backups), and for every
+// entry on the full-scan path, where the index is nil because nothing populates it.
 func (bm *BackupManager) lookupMetaByFileID(ctx context.Context, fileID string) *core.FileMeta {
 	parentID := bm.parentIndex[fileID]
 	ref, err := bm.txn.Lookup(ctx, AffinityKey(parentID, fileID), fileID)

--- a/internal/engine/backup_scan.go
+++ b/internal/engine/backup_scan.go
@@ -56,10 +56,12 @@ func (bm *BackupManager) processEntry(ctx context.Context, meta *core.FileMeta, 
 		meta.Size = 0
 	}
 
-	// Record this entry's parent so lookupMetaByFileID can use AffinityKey.
-	// Only scanIncremental allocates the index, because only its entries can
-	// arrive without Paths and so reach that lookup; on a full scan the map
-	// stays nil and this write is skipped rather than run once per file.
+	// Record this entry's parent so lookupMetaByFileID can use AffinityKey
+	// rather than walking the tree. Only scanIncremental allocates the index,
+	// since its changes are the ones that routinely arrive without Paths; a full
+	// scan skips the write instead of running it once per file for a map whose
+	// reader it does not reach. A nil index costs a slower lookup at most — see
+	// the field comment on BackupManager.
 	if bm.parentIndex != nil {
 		bm.parentIndex[meta.FileID] = primaryParentID(meta)
 	}

--- a/internal/engine/backup_scan_test.go
+++ b/internal/engine/backup_scan_test.go
@@ -330,10 +330,13 @@ func pendingByID(pending []core.FileMeta, fileID string) (core.FileMeta, bool) {
 	return core.FileMeta{}, false
 }
 
-// A full scan never reads parentIndex: every source populates Paths in Walk, so
-// processEntry's path-resolution branch is not taken and lookupMetaByFileID is
-// never reached. Writing the index anyway costs two strings per scanned file for
-// a map with no reader, so scan leaves it nil.
+// No source in this module leaves Paths empty in Walk, so a full scan has no
+// reader for parentIndex and leaves it nil instead of writing two strings per
+// scanned file into it.
+//
+// MockSource does emit entries without Paths, which is what lets this test cover
+// the other half: with the index nil, path resolution falls through to
+// LookupByKey and must still reach the right answer.
 func TestScan_LeavesParentIndexUnpopulated(t *testing.T) {
 	ctx := context.Background()
 	mgr := NewBackupManager(Deps{Store: NewMockStore(), Reporter: ui.NewNoOpReporter()}, nestedMockSource())
@@ -346,8 +349,10 @@ func TestScan_LeavesParentIndexUnpopulated(t *testing.T) {
 	if !usedFullScan {
 		t.Fatal("expected the full-scan strategy for a non-incremental source")
 	}
-	if len(mgr.parentIndex) != 0 {
-		t.Errorf("full scan populated parentIndex with %d entries; nothing reads it on this path", len(mgr.parentIndex))
+	// Asserted as nil, not as empty: an index allocated but left unwritten would
+	// pass a length check while still contradicting the documented contract.
+	if mgr.parentIndex != nil {
+		t.Errorf("full scan left parentIndex allocated with %d entries; nothing reads it on this path", len(mgr.parentIndex))
 	}
 
 	// MockSource emits no Paths, so this scan does resolve paths through the

--- a/internal/engine/backup_scan_test.go
+++ b/internal/engine/backup_scan_test.go
@@ -301,6 +301,112 @@ func TestScanIncremental_DeleteWithoutParentUsesExistingMetadataParent(t *testin
 	}
 }
 
+// nestedMockSource builds folder/sub/a.txt. MockSource.Walk emits no Paths, so
+// a scan over it exercises buildPathFromTree — and the two-level nesting is
+// load-bearing: resolving "sub" needs a parent other than the root, which is
+// the only case where the affinity key differs from the parentIndex-less guess.
+func nestedMockSource() *MockSource {
+	src := NewMockSource()
+	src.Files["FOLDER_1"] = MockFile{Meta: core.FileMeta{FileID: "FOLDER_1", Name: "folder", Type: core.FileTypeFolder}}
+	src.Files["SUB_1"] = MockFile{Meta: core.FileMeta{
+		FileID: "SUB_1", Name: "sub", Type: core.FileTypeFolder, Parents: []string{"FOLDER_1"},
+	}}
+	src.Files["FILE_1"] = MockFile{
+		Meta: core.FileMeta{
+			FileID: "FILE_1", Name: "a.txt", Type: core.FileTypeFile,
+			Parents: []string{"SUB_1"}, Size: 3,
+		},
+		Content: []byte("abc"),
+	}
+	return src
+}
+
+func pendingByID(pending []core.FileMeta, fileID string) (core.FileMeta, bool) {
+	for _, m := range pending {
+		if m.FileID == fileID {
+			return m, true
+		}
+	}
+	return core.FileMeta{}, false
+}
+
+// A full scan never reads parentIndex: every source populates Paths in Walk, so
+// processEntry's path-resolution branch is not taken and lookupMetaByFileID is
+// never reached. Writing the index anyway costs two strings per scanned file for
+// a map with no reader, so scan leaves it nil.
+func TestScan_LeavesParentIndexUnpopulated(t *testing.T) {
+	ctx := context.Background()
+	mgr := NewBackupManager(Deps{Store: NewMockStore(), Reporter: ui.NewNoOpReporter()}, nestedMockSource())
+	mgr.stats = &backupStats{} // Run installs these before scanning; scanSource is driven directly here.
+
+	pending, _, _, usedFullScan, err := mgr.scanSource(ctx, "", "")
+	if err != nil {
+		t.Fatalf("scanSource: %v", err)
+	}
+	if !usedFullScan {
+		t.Fatal("expected the full-scan strategy for a non-incremental source")
+	}
+	if len(mgr.parentIndex) != 0 {
+		t.Errorf("full scan populated parentIndex with %d entries; nothing reads it on this path", len(mgr.parentIndex))
+	}
+
+	// MockSource emits no Paths, so this scan does resolve paths through the
+	// tree — proving the LookupByKey fallback still answers correctly without
+	// the index, rather than that the branch was skipped.
+	file, ok := pendingByID(pending, "FILE_1")
+	if !ok {
+		t.Fatalf("FILE_1 missing from pending %v", pending)
+	}
+	if got := file.Paths; len(got) != 1 || got[0] != "folder/sub/a.txt" {
+		t.Errorf("resolved paths = %v, want [folder/sub/a.txt]", got)
+	}
+}
+
+// An incremental scan is where a change can legitimately arrive with no Paths
+// (see pkg/source/gdrive/changes.go), so it is the one strategy whose entries
+// reach lookupMetaByFileID — and the one that populates the index.
+func TestScanIncremental_PopulatesParentIndexAndResolvesPathsWithoutPaths(t *testing.T) {
+	ctx := context.Background()
+	base := nestedMockSource()
+	inc := &mockIncrementalSource{MockSource: base, startToken: "tok-1", newToken: "tok-2"}
+	dest := NewMockStore()
+
+	first, err := NewBackupManager(Deps{Store: dest, Reporter: ui.NewNoOpReporter()}, inc).Run(ctx)
+	if err != nil {
+		t.Fatalf("first backup failed: %v", err)
+	}
+
+	// A new file under folder/sub, delivered as a change with no Paths at all.
+	inc.changes = []source.FileChange{{
+		Type: source.ChangeUpsert,
+		Meta: core.FileMeta{
+			FileID: "FILE_2", Name: "b.txt", Type: core.FileTypeFile,
+			Parents: []string{"SUB_1"}, Size: 5,
+		},
+	}}
+
+	mgr := NewBackupManager(Deps{Store: dest, Reporter: ui.NewNoOpReporter()}, inc)
+	mgr.stats = &backupStats{}
+	pending, _, _, usedFullScan, err := mgr.scanSource(ctx, first.Root, "tok-1")
+	if err != nil {
+		t.Fatalf("scanSource: %v", err)
+	}
+	if usedFullScan {
+		t.Fatal("expected the incremental strategy given a change token")
+	}
+	if got := mgr.parentIndex["FILE_2"]; got != "SUB_1" {
+		t.Errorf("parentIndex[FILE_2] = %q, want %q", got, "SUB_1")
+	}
+
+	file, ok := pendingByID(pending, "FILE_2")
+	if !ok {
+		t.Fatalf("FILE_2 missing from pending %v", pending)
+	}
+	if got := file.Paths; len(got) != 1 || got[0] != "folder/sub/b.txt" {
+		t.Errorf("resolved paths = %v, want [folder/sub/b.txt]", got)
+	}
+}
+
 func TestMetadataEqual_ExtendedFields(t *testing.T) {
 	base := core.FileMeta{
 		Name:  "test.txt",


### PR DESCRIPTION
## Summary

- `BackupManager.parentIndex` was written once per scanned entry in `processEntry` and held for the entire run, but **on the full-scan path it had no reader at all**. `scanIncremental` now allocates it and `processEntry` writes only when it is non-nil, so the allocation lives at the one site that can read it.
- The reader chain is single-caller the whole way down, and I confirmed it rather than assuming it:
  - `parentIndex` is read only by `lookupMetaByFileID` (`internal/engine/backup_scan.go`).
  - `lookupMetaByFileID` is called only by `buildPathFromTree`.
  - `buildPathFromTree` is called only from `processEntry`'s `len(meta.Paths) == 0` branch.
- Every `Source.Walk` populates `Paths` unconditionally — `pkg/source/local/source.go:225`, `pkg/source/sftp/source.go:223`, `pkg/source/gdrive/source.go:804`, `pkg/source/onedrive/source.go:572` (the last two assign `[]string{p}` with `p` defaulting to `meta.Name`, so it is never empty). Those are the only non-test implementations in the module, so a full `Walk` never takes that branch.
- The index *is* genuinely needed on the incremental path: a change can legitimately arrive with no path (`pkg/source/gdrive/changes.go:279`), and that lands in `scanIncremental`.
- **The gate is safe by construction.** A nil map reads as empty, and a miss already falls through to `bm.txn.LookupByKey`, so the worst case is a slower lookup, never a wrong answer. I verified the fallback is genuinely reachable rather than accidentally equivalent: `hamt.Tree.Lookup` requires the routing key an entry was inserted under, so a nil index does miss for any non-root parent.

### On the size of the win — no benchmark is claimed

This is justified by the reader analysis alone, and deliberately not by a measurement. The term is roughly two strings per scanned file: single-digit MB at the benchmark's 5,000-file size, against the ±60 MB run-to-run peak-RSS spread documented in `AGENTS.md`. `scripts/benchmark/bench.sh` structurally cannot resolve it, and a number from it would be noise dressed as evidence. What the change fixes is a structural O(files) term with a run-length lifetime — the same lifetime problem `newMetas` was fixed for at `internal/engine/backup.go:270`, where it is released before the upload phase.

### Note on the premise

The full-scan branch is dead for every *real* source, but not for the in-repo test double: `MockSource.Walk` (`internal/engine/mock_test.go:211`) emits no `Paths`, so engine tests do exercise `buildPathFromTree` on the full-scan path and now take the `LookupByKey` fallback. That makes the fallback a tested path rather than a theoretical one, and the first test below leans on it. No test builds a mock tree large enough for the O(N) fallback to matter.

## Related issues

None. Came out of the request-and-memory pass on `backup` (RFC 0025); there is no tracking issue for that RFC.

## Repository compatibility

No repository format change. `parentIndex` is a process-local lookup cache built during a scan and never written to a store, so no object, index, or snapshot field is affected and the format version gate is untouched.

## Verification

- `env GOCACHE=/tmp/cloudstic-gocache go test -count=1 -race ./internal/engine` — passes (`ok ... 11.132s`)
- `env GOCACHE=/tmp/cloudstic-gocache GOLANGCI_LINT_CACHE=/tmp/cloudstic-golangci-lint golangci-lint run ./internal/engine/...` — passes (`0 issues`)

Two new tests in `internal/engine/backup_scan_test.go`:

- `TestScan_LeavesParentIndexUnpopulated` — a full scan leaves the index empty **and** still resolves `folder/sub/a.txt`. The two-level nesting is load-bearing: a root-level parent resolves identically with or without the index, so only `sub` (parent `FOLDER_1`) actually forces the fallback.
- `TestScanIncremental_PopulatesParentIndexAndResolvesPathsWithoutPaths` — an upsert with `Paths` empty populates `parentIndex[FILE_2] = SUB_1` and still resolves `folder/sub/b.txt`.

I checked the first test is not vacuous by temporarily restoring the unconditional write: it fails with the index holding 3 entries. Both tests set `mgr.stats` because `Run`, not the constructor, installs it, and they drive `scanSource` directly to observe the returned `pending` — resolved `Paths` are stripped by `persistedFileMeta` before storage, so they are not observable from a completed snapshot.

A full `go test ./...` also passes except `e2e/TestCLI_Feature_FindDeltaScanMatchesFullScan`, which fails on Docker container startup (MinIO "No such container", SFTP readiness timeout) — environmental, unrelated to this change.

## Documentation

No documentation change required. No exported API changes; the affected field and methods are unexported within `internal/engine`. The reasoning is recorded in the code, as a comment on the `parentIndex` field explaining why it stays nil on the full-scan path and why the gate cannot produce a wrong answer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup scan path resolution for nested files during full and incremental scans.
  * Prevented unnecessary parent-index creation during full scans.
  * Ensured pathless changes in incremental scans resolve to the correct nested paths.

* **Tests**
  * Added coverage for full-scan and incremental-scan path resolution and index behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->